### PR TITLE
Feature/draft extraction ability tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@ wheels/
 # Virtual environments
 .venv
 
+# Downloaded hero portrait icons — fetched by scripts/fetch_hero_icons.py, not committed
+src/gem/data/hero_icons/
+
+# Generated HTML output files (e.g. draft_summary, match_report)
+*.html
+
 # Replay files — too large to commit
 tests/fixtures/*.dem
 # Truncated fixtures ARE committed (small, used for unit tests)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,8 +161,50 @@ Key message classes used throughout the parser:
 - `dota_commonmessages_pb2` — `CMsgDOTACombatLogEntry`
 - `dota_usermessages_pb2` — `CDOTAUserMsg_*`
 
-## Tests
+## Implementation status
 
-Tests are written against the public API of each module and fail with `ModuleNotFoundError` until the corresponding module is implemented. This is by design — the test suite drives implementation phase by phase.
+| Phase | Scope | Status |
+|---|---|---|
+| 1 | `reader.py`, `stream.py` | ✅ Complete |
+| 2 | `sendtable.py`, `field_decoder.py`, `field_path.py` | ✅ Complete |
+| 3 | `string_table.py`, `entities.py`, `game_events.py`, `combatlog.py`, `parser.py` | ✅ Complete |
+| 4 | `constants.py` + bundled `src/gem/data/` JSON assets | ✅ Complete |
+| 5 | `extractors/players.py`, `objectives.py`, `wards.py` | ✅ Complete |
+| 6 | `models.py`, `__init__.py` (`parse()`/`parse_to_dataframe()`), `__main__.py` (CLI) | ✅ Complete |
+| 7 | Rune pickups, buybacks, aegis, lane heatmaps, chat, purchase log, movement heatmap example | ✅ Complete |
+| 8 | `extractors/courier.py`, `extractors/draft.py`, ability levels on snapshots, stun duration | ✅ Complete |
+| 9 | Teamfights | 🔲 Planned |
 
-Fixtures (small binary blobs for unit tests) go in `tests/fixtures/`. Real `.dem` files for integration tests should be fetched with `scripts/fetch_replays.py` and are marked `@pytest.mark.integration`.
+## Test files
+
+| File | Covers |
+|---|---|
+| `test_reader.py` | `BitReader` primitives |
+| `test_stream.py` | `DemoStream` outer message loop |
+| `test_sendtable.py` | Send table / serializer parsing |
+| `test_field_decoder.py` | All field type decoders |
+| `test_field_path.py` | Huffman field path ops |
+| `test_string_table.py` | String table create/update |
+| `test_entities.py` | Entity lifecycle and typed getters |
+| `test_game_events.py` | Game event schema and dispatch |
+| `test_combatlog.py` | S1 and S2 combat log paths |
+| `test_extractors.py` | `PlayerExtractor`, `ObjectivesExtractor`, `WardsExtractor` |
+| `test_ability_courier_draft_stuns.py` | Ability levels, `CourierExtractor`, `DraftExtractor`, stun duration |
+
+Fixtures go in `tests/fixtures/`. Real `.dem` files for integration tests are marked `@pytest.mark.integration` and `@pytest.mark.slow`.
+
+## Examples
+
+| Script | Description |
+|---|---|
+| `examples/extraction_demo.py` | Combat log summary + entity state snapshots |
+| `examples/ward_smoke_rosh.py` | Ward placements with coords, smoke groups, Roshan kills |
+| `examples/movement_heatmap.py` | Interactive Plotly heatmap — hero positions, ability levels, stun dealt |
+| `examples/draft_summary.py` | Self-contained HTML draft summary with hero portrait icons |
+| `examples/match_report.py` | Full match report (WIP) |
+
+Hero icons for `draft_summary.py` are downloaded separately — not committed or shipped in the package:
+
+```bash
+python scripts/fetch_hero_icons.py   # downloads to src/gem/data/hero_icons/
+```

--- a/README.md
+++ b/README.md
@@ -2,53 +2,44 @@
 
 ![Python](https://img.shields.io/badge/python-3.10%2B-blue?logo=python&logoColor=white)
 ![License](https://img.shields.io/badge/license-MIT-green?logo=opensourceinitiative&logoColor=white)
-![Phase](https://img.shields.io/badge/phase-4%20of%206-orange)
+![Phase](https://img.shields.io/badge/phase-8%20of%209-orange)
 ![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)
 ![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)
 
 **Gem of True Sight** — a Python Dota 2 replay parser.
 
-Reads Source 2 `.dem` binary replay files and exposes structured output: per-tick entity state, combat events, ward placements, smoke usage, Roshan kills, gold/XP timelines, and more.
+Reads Source 2 `.dem` binary replay files and exposes structured output: per-tick hero state, combat events, ward placements, smoke usage, Roshan kills, gold/XP timelines, draft picks/bans, courier state, ability levels, and more.
 
 ---
 
 ## Why gem?
 
-Existing parsers (Clarity, Manta, OpenDota/parser) are built for backend services in Java or Go. `gem` brings that to Python without touching JVM toolchains or writing binary parsers from scratch.
+Existing parsers (Clarity, Manta, OpenDota/parser) are built for backend services in Java or Go. `gem` brings that to Python without touching JVM toolchains — with a clean API designed for data science and ML workflows.
 
 ```python
-from gem.parser import ReplayParser
-from gem.constants import hero_display
+import gem
 
-# Combat log — who dealt the most damage?
-damage: dict[str, int] = {}
+match = gem.parse("my_replay.dem")
 
-def on_entry(entry):
-    if entry.log_type == "DAMAGE" and entry.attacker_is_hero:
-        damage[entry.attacker_name] = damage.get(entry.attacker_name, 0) + entry.value
+# Draft — who was picked and banned?
+for event in match.draft:
+    action = "PICK" if event.is_pick else "BAN"
+    print(f"{action}: {gem.constants.hero_display(event.hero_name)}")
 
-parser = ReplayParser("my_replay.dem")
-parser.on_combat_log_entry(on_entry)
-parser.parse()
-
-for npc, total in sorted(damage.items(), key=lambda x: -x[1])[:5]:
-    print(f"{hero_display(npc)}: {total:,} dmg")
+# Per-player summary
+for player in match.players:
+    print(
+        f"{player.player_name} ({gem.constants.hero_display(player.hero_name)}): "
+        f"{player.kills}/{player.deaths}/{player.assists}  "
+        f"{player.net_worth:,} NW  {player.stuns_dealt:.1f}s stuns"
+    )
 ```
 
 ```python
-# Entity state — read hero HP/position/level every tick
-from gem.parser import ReplayParser
-from gem.entities import EntityOp
-
-parser = ReplayParser("my_replay.dem")
-
-def on_entity(entity, op):
-    if op & EntityOp.CREATED and "Hero" in entity.get_class_name():
-        hp, _ = entity.get_int32("m_iHealth")
-        print(f"{entity.get_class_name()}: {hp} HP")
-
-parser.on_entity(on_entity)
-parser.parse()
+# Gold/XP timeline as DataFrames
+dfs = gem.parse_to_dataframe("my_replay.dem")
+snapshots = dfs["snapshots"]   # one row per player per sample tick
+combat    = dfs["combat_log"]  # all combat log entries
 ```
 
 ---
@@ -59,26 +50,36 @@ parser.parse()
 |---|---|---|
 | 1 | `BitReader`, `DemoStream` — binary frame iteration | ✅ Complete |
 | 2 | `sendtable`, `field_decoder`, `field_path` — schema layer | ✅ Complete |
-| 3 | String tables, entity lifecycle | ✅ Complete |
-| 4 | Game events, combat log, `gem.constants` | ✅ Complete |
-| 5 | Gold/XP timelines, teamfights, objectives | 🔲 Planned |
-| 6 | `gem.parse()` — full match output, DataFrame export | 🔲 Planned |
+| 3 | String tables, entity lifecycle, game events, combat log | ✅ Complete |
+| 4 | `gem.constants` — bundled hero/item/ability display names | ✅ Complete |
+| 5 | Extractors — player timelines, objectives, ward coordinates | ✅ Complete |
+| 6 | `gem.parse()` — `ParsedMatch`/`ParsedPlayer`, DataFrame export, CLI | ✅ Complete |
+| 7 | Rune pickups, buybacks, aegis, lane heatmaps, chat, purchase log, movement heatmap | ✅ Complete |
+| 8 | Ability levels, courier state, draft extraction, stun duration | ✅ Complete |
+| 9 | Teamfights | 🔲 Planned |
 
 ---
 
-## What you can extract today (Phase 4)
+## What you can extract (Phase 8)
 
-| Data | Source |
+| Data | Field / Source |
 |---|---|
-| Damage, heals, kills per hero | Combat log `DAMAGE` / `HEAL` / `DEATH` |
-| Abilities cast, items used | Combat log `ABILITY` / `ITEM` |
-| Gold and XP gained with reason codes | Combat log `GOLD` / `XP` |
-| Ward placements (who, when, ~where) | Combat log `ITEM` + entity coords |
-| Smoke of Deceit activations + groups | Combat log `ITEM` + `MODIFIER_ADD` |
-| Roshan kills + respawn windows | Combat log `DEATH` |
-| Hero HP, mana, position, level per tick | Entity state polling |
-| Tower health over time | Entity state polling |
-| Hero display names, item names, ability names | `gem.constants` (bundled) |
+| Hero picks and bans with timestamps | `ParsedMatch.draft` |
+| Courier state snapshots per team | `ParsedMatch.courier_snapshots` |
+| Ability levels per hero per tick | `PlayerStateSnapshot.ability_levels` |
+| Stun seconds dealt per player | `ParsedPlayer.stuns_dealt` |
+| Damage, heals, kills, assists, deaths | `ParsedPlayer.damage` etc. |
+| Gold and net worth over time | `ParsedPlayer.snapshots` |
+| Ward placements with exact coordinates | `ParsedMatch.wards` |
+| Smoke of Deceit activations + groups | `ParsedMatch.wards` (smoke entries) |
+| Roshan kills + aegis events | `ParsedMatch.roshans`, `.aegis_events` |
+| Rune pickups per player | `ParsedPlayer.runes_log` |
+| Buybacks per player | `ParsedPlayer.buyback_log` |
+| Tower and barracks kills | `ParsedMatch.towers`, `.barracks` |
+| Lane position heatmaps | `ParsedPlayer.lane_pos` |
+| Chat messages | `ParsedMatch.chat` |
+| Purchase log per player | `ParsedPlayer.purchase_log` |
+| Hero display names, item/ability names | `gem.constants` |
 
 ---
 
@@ -100,11 +101,16 @@ uv sync
 # Full replay summary — combat log + entity snapshots
 python examples/extraction_demo.py path/to/your.dem
 
-# Focused vision/objective report — wards, smokes, Roshan
+# Ward placements, smoke groups, Roshan kills
 python examples/ward_smoke_rosh.py path/to/your.dem
-```
 
-Both scripts work without arguments and use the bundled test fixture.
+# Interactive movement heatmap (Plotly)
+python examples/movement_heatmap.py path/to/your.dem
+
+# HTML draft summary with hero icons
+python scripts/fetch_hero_icons.py          # one-time icon download
+python examples/draft_summary.py path/to/your.dem
+```
 
 ---
 
@@ -116,12 +122,13 @@ Full concepts, tutorials, and API reference at the project docs site (built with
 uv run mkdocs serve
 ```
 
-Topics covered: DEM binary format, varint encoding, Protocol Buffers, the entity delta system, combat log ingestion, and known data limitations (ward coordinate coverage, smoke edge cases).
+Topics covered: DEM binary format, varint encoding, Protocol Buffers, the entity delta system, combat log ingestion, and known data limitations.
 
 ---
 
 ## Known limitations
 
-- **Ward coordinates** — 100% of placements have exact entity coordinates. Match combat log `ITEM` events to entity events within ±60 ticks without globally consuming entity records (slots are reused).
-- **Smoke empty groups** — if a smoke breaks instantly on activation (sentry ward truesight), the group list is empty. This is correct game behaviour.
-- **Roshan drops** — Aegis, Cheese, and other Roshan drops are not in the combat log. Planned for Phase 5.
+- **Roshan drops** — Aegis, Cheese, and other Roshan drops are not in the combat log; tracked via chat events instead.
+- **Smoke empty groups** — if a smoke breaks instantly on activation (hero inside sentry truesight), the group list is empty. This is correct game behaviour.
+- **Hero icons** — not bundled in the package. Run `python scripts/fetch_hero_icons.py` to download them locally for use with `examples/draft_summary.py`.
+- **Hero IDs in draft** — modern replays store pick/ban IDs as `api_id * 2`; resolved via live entity map + halving fallback (see `extractors/draft.py`).

--- a/examples/draft_summary.py
+++ b/examples/draft_summary.py
@@ -1,0 +1,288 @@
+"""Draft extraction example — generate an HTML draft summary from a replay.
+
+Parses a .dem replay file and produces a self-contained HTML page showing
+hero picks and bans with portrait icons, player nicknames, and timestamps.
+
+Hero icons must be downloaded first::
+
+    python scripts/fetch_hero_icons.py
+
+Usage::
+
+    python examples/draft_summary.py <replay.dem> [--out <output.html>]
+
+Example::
+
+    python examples/draft_summary.py tests/fixtures/ti14_finals_g1_xg_vs_falcons.dem
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import gem
+from gem.constants import hero_display, league_name
+
+_ICON_DIR = Path(__file__).parent.parent / "src" / "gem" / "data" / "hero_icons"
+_GAME_MODE = {
+    2: "Captains Mode",
+    22: "All Draft",
+    23: "Turbo",
+}
+
+# Placeholder icon (1×1 grey PNG) used when icon file is missing
+_PLACEHOLDER_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+
+
+def _icon_b64(short: str) -> str:
+    path = _ICON_DIR / f"{short}.png"
+    if path.exists():
+        return base64.b64encode(path.read_bytes()).decode()
+    return _PLACEHOLDER_B64
+
+
+def _short(npc_name: str) -> str:
+    return npc_name.removeprefix("npc_dota_hero_")
+
+
+def _fmt_tick(tick: int) -> str:
+    secs = tick // 30
+    return f"{secs // 60:02d}:{secs % 60:02d}"
+
+
+# ---------------------------------------------------------------------------
+# HTML rendering
+# ---------------------------------------------------------------------------
+
+_CSS = """
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+    background: #0d1117;
+    color: #e6edf3;
+    font-family: 'Segoe UI', system-ui, sans-serif;
+    padding: 24px;
+}
+h1 { font-size: 1.4rem; color: #58a6ff; margin-bottom: 4px; }
+.subtitle { color: #8b949e; font-size: 0.9rem; margin-bottom: 32px; }
+.section-title {
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: #8b949e;
+    margin: 28px 0 12px;
+    border-bottom: 1px solid #21262d;
+    padding-bottom: 6px;
+}
+/* Hero card */
+.card {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    width: 90px;
+    margin: 6px;
+    border-radius: 8px;
+    overflow: hidden;
+    border: 2px solid transparent;
+    transition: border-color 0.15s;
+}
+.card:hover { border-color: #58a6ff; }
+.card img {
+    width: 90px;
+    height: 52px;
+    object-fit: cover;
+    display: block;
+}
+.card .hero-name {
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-align: center;
+    padding: 3px 4px 2px;
+    width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.card .player-name {
+    font-size: 0.6rem;
+    color: #8b949e;
+    text-align: center;
+    padding-bottom: 4px;
+}
+.card .timestamp {
+    font-size: 0.55rem;
+    color: #484f58;
+    padding-bottom: 4px;
+    font-family: monospace;
+}
+/* Ban cards — greyed out with red tint */
+.ban .card { filter: grayscale(60%); }
+.ban .card { background: #1c1217; border-color: #3d1f1f; }
+.ban .card .hero-name { color: #f87171; }
+/* Pick cards */
+.radiant .card { background: #111c18; border-color: #1a3a2a; }
+.radiant .card .hero-name { color: #4ade80; }
+.dire .card { background: #1c1117; border-color: #3a1a1a; }
+.dire .card .hero-name { color: #f87171; }
+/* Row labels */
+.team-row { margin-bottom: 8px; }
+.team-label {
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    margin-bottom: 6px;
+}
+.radiant .team-label { color: #4ade80; }
+.dire .team-label { color: #f87171; }
+.no-draft {
+    color: #8b949e;
+    font-style: italic;
+    padding: 12px 0;
+}
+"""
+
+
+def _card_html(
+    npc_name: str,
+    player_name: str = "",
+    tick: int = 0,
+    is_pick: bool = True,
+) -> str:
+    short = _short(npc_name) if npc_name.startswith("npc_") else npc_name
+    icon = _icon_b64(short)
+    name = hero_display(npc_name) if npc_name.startswith("npc_") else npc_name
+    ts = _fmt_tick(tick) if tick else ""
+    player_html = f'<div class="player-name">{player_name}</div>' if player_name else ""
+    ts_html = f'<div class="timestamp">{ts}</div>' if ts else ""
+    return (
+        f'<div class="card">'
+        f'<img src="data:image/png;base64,{icon}" alt="{name}" title="{name}" />'
+        f'<div class="hero-name">{name}</div>'
+        f"{player_html}"
+        f"{ts_html}"
+        f"</div>"
+    )
+
+
+def build_html(match: gem.ParsedMatch, dem_stem: str) -> str:
+    mid = str(match.match_id) if match.match_id else dem_stem
+    mode = _GAME_MODE.get(match.game_mode, f"Mode {match.game_mode}")
+    league_str = ""
+    if match.leagueid:
+        lname = league_name(match.leagueid)
+        league_str = f"  ·  {lname or f'League {match.leagueid}'}"
+
+    hero_to_player: dict[str, gem.ParsedPlayer] = {
+        pp.hero_name: pp for pp in match.players if pp.hero_name
+    }
+
+    bans = [e for e in match.draft if not e.is_pick]
+    picks = [e for e in match.draft if e.is_pick]
+    radiant_picks = [
+        e for e in picks if hero_to_player.get(e.hero_name, gem.ParsedPlayer(0)).team == 2
+    ]
+    dire_picks = [
+        e for e in picks if hero_to_player.get(e.hero_name, gem.ParsedPlayer(0)).team == 3
+    ]
+
+    # Bans section
+    if bans:
+        bans_html = (
+            '<div class="ban">'
+            + "".join(_card_html(e.hero_name, tick=e.tick, is_pick=False) for e in bans)
+            + "</div>"
+        )
+    else:
+        bans_html = '<p class="no-draft">No bans detected (All Pick / Turbo mode).</p>'
+
+    # Picks section — Radiant
+    def _picks_row(events: list, team_cls: str, team_label: str) -> str:
+        if not events:
+            return ""
+        cards = "".join(
+            _card_html(
+                e.hero_name,
+                player_name=hero_to_player[e.hero_name].player_name
+                if e.hero_name in hero_to_player and hero_to_player[e.hero_name].player_name
+                else "",
+                tick=e.tick,
+                is_pick=True,
+            )
+            for e in events
+        )
+        return (
+            f'<div class="team-row {team_cls}">'
+            f'<div class="team-label">{team_label}</div>'
+            f"{cards}"
+            f"</div>"
+        )
+
+    radiant_html = _picks_row(radiant_picks, "radiant", "Radiant")
+    dire_html = _picks_row(dire_picks, "dire", "Dire")
+
+    # No-picks fallback
+    if not picks:
+        picks_html = '<p class="no-draft">No picks detected.</p>'
+    else:
+        picks_html = radiant_html + dire_html
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Draft — Match {mid}</title>
+<style>{_CSS}</style>
+</head>
+<body>
+<h1>Match {mid}  ·  {mode}</h1>
+<div class="subtitle">{league_str.lstrip(" ·") if league_str else "Public match"}</div>
+
+<div class="section-title">Bans ({len(bans)})</div>
+{bans_html}
+
+<div class="section-title">Picks ({len(picks)})</div>
+{picks_html}
+</body>
+</html>"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="HTML draft summary from a Dota 2 replay.")
+    parser.add_argument("replay", help="Path to .dem replay file")
+    parser.add_argument(
+        "--out", default=None, help="Output HTML file (default: <match_id>_draft.html)"
+    )
+    args = parser.parse_args()
+
+    if not _ICON_DIR.exists() or not any(_ICON_DIR.glob("*.png")):
+        print(
+            "Warning: hero icons not found. Run 'python scripts/fetch_hero_icons.py' first.\n"
+            "         Placeholder icons will be used.",
+            file=sys.stderr,
+        )
+
+    print(f"Parsing {args.replay} ...")
+    match = gem.parse(args.replay)
+    dem_stem = Path(args.replay).stem
+
+    print("Building draft summary ...")
+    html = build_html(match, dem_stem)
+
+    if args.out:
+        out_path = Path(args.out)
+    else:
+        stem = str(match.match_id) if match.match_id else dem_stem
+        project_root = Path(__file__).parent.parent
+        out_path = project_root / f"{stem}_draft.html"
+
+    out_path.write_text(html, encoding="utf-8")
+    print(f"Saved → {out_path}  ({out_path.stat().st_size // 1024} KB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/movement_heatmap.py
+++ b/examples/movement_heatmap.py
@@ -27,7 +27,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 import plotly.graph_objects as go
 
 import gem
-from gem.constants import hero_display, item_display, league_name
+from gem.constants import ability_display, hero_display, item_display, league_name
 
 # ---------------------------------------------------------------------------
 # Dota 2 map coordinate system
@@ -101,22 +101,26 @@ _ACTIVITY_WINDOW = 150  # ticks (~5 seconds) to look back for recent activity
 _MAX_ACTIVITY = 5  # max recent events to show in hover
 
 
-def _build_hover_cache(match: gem.ParsedMatch) -> dict[int, dict]:
+def _build_hover_cache(
+    match: gem.ParsedMatch, player_snapshots: dict[int, list]
+) -> dict[int, dict]:
     """Pre-build per-player lookup structures for enriched hover text.
 
     Returns a dict keyed by player_id containing:
       - ``times``: sorted list of sample ticks
       - ``gold_t``, ``lh_t``, ``xp_t``: parallel lists
-      - ``items_by_tick``: dict[tick -> list[str]] — cumulative item names at each tick
+      - ``purchase_by_tick``: sorted list of (tick, item_name)
       - ``combat``: list of (tick, str) recent activity strings, sorted by tick
+      - ``ability_levels_by_tick``: list of (tick, dict[name, level]) snapshots
+      - ``stuns_dealt``: total stun duration in seconds
 
     Args:
         match: Parsed match data.
+        player_snapshots: player_id → list of PlayerStateSnapshot (from extractor).
 
     Returns:
         Dict mapping player_id to precomputed hover data.
     """
-    # Pre-index combat log by attacker hero name for O(1) per-player lookup
     from collections import defaultdict
 
     combat_by_hero: dict[str, list] = defaultdict(list)
@@ -129,13 +133,11 @@ def _build_hover_cache(match: gem.ParsedMatch) -> dict[int, dict]:
         if not pp.position_log:
             continue
 
-        # Gold/XP/LH lookup by tick
         times = pp.times
         gold_t = pp.gold_t
         lh_t = pp.lh_t
         xp_t = pp.xp_t
 
-        # Cumulative items at each sample tick (from purchase log)
         purchase_by_tick: list[tuple[int, str]] = sorted(
             (e.tick, e.value_name) for e in pp.purchase_log if e.value_name
         )
@@ -147,12 +149,19 @@ def _build_hover_cache(match: gem.ParsedMatch) -> dict[int, dict]:
             combat.append((e.tick, f"Kill: {target}"))
         for e in combat_by_hero.get(pp.hero_name.lower(), []):
             if e.log_type == "ABILITY" and e.inflictor_name:
-                aname = e.inflictor_name.replace("_", " ").title()
+                aname = ability_display(e.inflictor_name)
                 combat.append((e.tick, f"Ability: {aname}"))
             elif e.log_type == "DAMAGE" and e.value > 0:
                 target = e.target_name.removeprefix("npc_dota_hero_").replace("_", " ").title()
                 combat.append((e.tick, f"Damage: {target} -{e.value}"))
         combat.sort(key=lambda x: x[0])
+
+        # Ability level snapshots: list of (tick, {ability_name: level})
+        ability_levels_by_tick: list[tuple[int, dict[str, int]]] = [
+            (snap.tick, snap.ability_levels)
+            for snap in player_snapshots.get(pp.player_id, [])
+            if snap.ability_levels
+        ]
 
         cache[pp.player_id] = {
             "times": times,
@@ -161,6 +170,8 @@ def _build_hover_cache(match: gem.ParsedMatch) -> dict[int, dict]:
             "xp_t": xp_t,
             "purchase_by_tick": purchase_by_tick,
             "combat": combat,
+            "ability_levels_by_tick": ability_levels_by_tick,
+            "stuns_dealt": pp.stuns_dealt,
         }
     return cache
 
@@ -201,12 +212,28 @@ def _hover_text(pp: gem.ParsedPlayer, tick: int, cache: dict, label: str, team: 
         for t, name in d["purchase_by_tick"]
         if t <= tick and not name.startswith("item_recipe")
     ]
-    items_str = "  ".join(items[-6:]) if items else "—"  # show last 6
+    items_str = "  ".join(items[-6:]) if items else "—"
+
+    # Ability levels at nearest snapshot tick
+    ability_snap: dict[str, int] = {}
+    for t, levels in d["ability_levels_by_tick"]:
+        if t <= tick:
+            ability_snap = levels
+        else:
+            break
+    abilities_str = (
+        "  ".join(f"{ability_display(n)} Lv{lv}" for n, lv in sorted(ability_snap.items()))
+        if ability_snap
+        else "—"
+    )
+
+    # Stun duration dealt (cumulative for the whole match)
+    stuns = d["stuns_dealt"]
+    stuns_str = f"{stuns:.1f}s" if stuns > 0 else "—"
 
     # Recent combat activity in the window before this tick
     window_start = tick - _ACTIVITY_WINDOW
     recent = [text for t, text in d["combat"] if window_start <= t <= tick]
-    # Deduplicate consecutive identical events (e.g. repeated ability casts)
     seen: list[str] = []
     for r in reversed(recent):
         if not seen or seen[-1] != r:
@@ -221,19 +248,30 @@ def _hover_text(pp: gem.ParsedPlayer, tick: int, cache: dict, label: str, team: 
         f"<br>"
         f"Gold: {gold:,}  LH: {lh}  XP: {xp:,}<br>"
         f"Items: {items_str}<br>"
+        f"Abilities: {abilities_str}<br>"
+        f"Stuns dealt: {stuns_str}<br>"
         f"<br>"
         f"<i>Recent (±5s):</i><br>"
         f"{recent_str}"
     )
 
 
-def build_figure(match: gem.ParsedMatch, map_path: Path, dem_stem: str) -> go.Figure:
+def build_figure(
+    match: gem.ParsedMatch,
+    map_path: Path,
+    dem_stem: str,
+    player_snapshots: dict[int, list] | None = None,
+) -> go.Figure:
     """Build the Plotly figure with map background and animated hero traces.
 
     Args:
         match: Parsed match data.
         map_path: Path to the map image file.
         dem_stem: Replay filename stem used as fallback title.
+        player_snapshots: Optional mapping of player_id → list of
+            ``PlayerStateSnapshot`` objects, used to populate ability levels
+            in hover text. Pass the result of grouping
+            ``PlayerExtractor.snapshots`` by player_id.
 
     Returns:
         A Plotly ``Figure`` ready to be written to HTML.
@@ -247,7 +285,7 @@ def build_figure(match: gem.ParsedMatch, map_path: Path, dem_stem: str) -> go.Fi
     active_players = [pp for pp in match.players if pp.position_log]
 
     # Pre-build hover data cache (done once, not per frame)
-    hover_cache = _build_hover_cache(match)
+    hover_cache = _build_hover_cache(match, player_snapshots or {})
 
     fig = go.Figure()
 
@@ -614,7 +652,27 @@ def main() -> None:
         sys.exit(1)
 
     print(f"Parsing {args.replay} ...")
+    from collections import defaultdict
+
+    from gem.extractors.players import PlayerExtractor
+    from gem.parser import ReplayParser
+
+    p = ReplayParser(args.replay)
+    player_ext = PlayerExtractor()
+    player_ext.attach(p)
+
+    # Use gem.parse internals via the public API but also retain snapshots
     match = gem.parse(args.replay)
+
+    # Re-run a lightweight parse just for snapshots (ability levels)
+    p2 = ReplayParser(args.replay)
+    player_ext2 = PlayerExtractor()
+    player_ext2.attach(p2)
+    p2.parse()
+    player_snapshots: dict[int, list] = defaultdict(list)
+    for snap in player_ext2.snapshots:
+        player_snapshots[snap.player_id].append(snap)
+
     total_positions = sum(len(pp.position_log) for pp in match.players)
     print(
         f"Done — match {match.match_id or 'unknown'}  |  {len(match.players)} players  |  {total_positions} position samples"
@@ -622,7 +680,7 @@ def main() -> None:
 
     print("Building figure ...")
     dem_stem = Path(args.replay).stem
-    fig = build_figure(match, map_path, dem_stem)
+    fig = build_figure(match, map_path, dem_stem, player_snapshots=dict(player_snapshots))
 
     if args.out:
         out_path = Path(args.out)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ build-backend = "uv_build"
 
 [tool.uv.build-backend]
 module-name = "gem"
+# Hero icons are downloaded locally by scripts/fetch_hero_icons.py and must
+# not be shipped in the published wheel.
+exclude-packages = ["gem.data.hero_icons"]
 
 [dependency-groups]
 dev = [

--- a/scripts/fetch_hero_icons.py
+++ b/scripts/fetch_hero_icons.py
@@ -1,0 +1,96 @@
+"""Download hero portrait icons from the Dota 2 CDN.
+
+Icons are saved as PNG files to ``src/gem/data/hero_icons/`` using the short
+hero name (e.g. ``axe.png``, ``anti_mage.png``).
+
+CDN URL pattern::
+
+    https://cdn.dota2.com/apps/dota2/images/heroes/{short}_icon.png
+
+where ``{short}`` is derived from the NPC name by stripping ``npc_dota_hero_``.
+
+Usage::
+
+    python scripts/fetch_hero_icons.py           # skip already-downloaded
+    python scripts/fetch_hero_icons.py --force   # re-download all
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import ssl
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+_HEROES_JSON = Path(__file__).parent.parent / "src" / "gem" / "data" / "heroes.json"
+_OUT_DIR = Path(__file__).parent.parent / "src" / "gem" / "data" / "hero_icons"
+_CDN_PRIMARY = "https://steamcdn-a.akamaihd.net/apps/dota2/images/heroes/{short}_icon.png"
+_CDN_FALLBACK = "https://cdn.dota2.com/apps/dota2/images/heroes/{short}_icon.png"
+_CDN_STRATZ = "https://cdn.stratz.com/images/dota2/heroes/{short}_icon.png"
+# Some heroes use a different short name on the CDN
+_CDN_OVERRIDES: dict[str, str] = {
+    "dawnbreaker": "dawnbreaker",
+    "kez": "kez",
+    "marci": "marci",
+    "muerta": "muerta",
+    "primal_beast": "primal_beast",
+    "ringmaster": "ringmaster",
+    "void_spirit": "void_spirit",
+}
+
+
+def _short(npc_name: str) -> str:
+    return npc_name.removeprefix("npc_dota_hero_")
+
+
+def fetch(force: bool = False) -> None:
+    _OUT_DIR.mkdir(parents=True, exist_ok=True)
+    heroes: dict = json.loads(_HEROES_JSON.read_text(encoding="utf-8"))
+
+    # macOS doesn't use system certs by default; disable verification for CDN
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+
+    ok = failed = skipped = 0
+    for npc_name in sorted(heroes):
+        short = _short(npc_name)
+        out_path = _OUT_DIR / f"{short}.png"
+        if out_path.exists() and not force:
+            skipped += 1
+            continue
+
+        cdn_short = _CDN_OVERRIDES.get(short, short)
+        urls = [
+            _CDN_PRIMARY.format(short=cdn_short),
+            _CDN_FALLBACK.format(short=cdn_short),
+            _CDN_STRATZ.format(short=cdn_short),
+        ]
+        fetched = False
+        for url in urls:
+            try:
+                req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+                with urllib.request.urlopen(req, timeout=10, context=ctx) as resp:
+                    out_path.write_bytes(resp.read())
+                print(f"  OK  {short}")
+                ok += 1
+                fetched = True
+                time.sleep(0.05)
+                break
+            except Exception:
+                continue
+        if not fetched:
+            print(f"  FAIL {short}", file=sys.stderr)
+            failed += 1
+
+    print(f"\nDone — {ok} downloaded, {skipped} skipped, {failed} failed → {_OUT_DIR}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Download Dota 2 hero icons.")
+    parser.add_argument("--force", action="store_true", help="Re-download existing files")
+    args = parser.parse_args()
+    fetch(force=args.force)

--- a/src/gem/__init__.py
+++ b/src/gem/__init__.py
@@ -69,6 +69,8 @@ def parse(path: str | Path) -> ParsedMatch:
     Returns:
         A :class:`ParsedMatch` with all extracted data populated.
     """
+    from gem.extractors.courier import CourierExtractor
+    from gem.extractors.draft import DraftExtractor
     from gem.extractors.objectives import ObjectivesExtractor
     from gem.extractors.players import PlayerExtractor
     from gem.extractors.wards import WardsExtractor
@@ -78,10 +80,14 @@ def parse(path: str | Path) -> ParsedMatch:
     player_ext = PlayerExtractor()
     obj_ext = ObjectivesExtractor()
     ward_ext = WardsExtractor()
+    courier_ext = CourierExtractor()
+    draft_ext = DraftExtractor()
 
     player_ext.attach(p)
     obj_ext.attach(p)
     ward_ext.attach(p)
+    courier_ext.attach(p)
+    draft_ext.attach(p)
 
     # Aggregate combat log entries per player
     _combat_aggregator = _CombatAggregator(player_ext)
@@ -96,6 +102,9 @@ def parse(path: str | Path) -> ParsedMatch:
 
     p.parse()
 
+    # Backfill hero names for draft events recorded before hero entities spawned.
+    draft_ext.finalize()
+
     match = ParsedMatch(
         match_id=p.match_id,
         game_mode=p.game_mode,
@@ -107,6 +116,8 @@ def parse(path: str | Path) -> ParsedMatch:
         wards=ward_ext.ward_events,
         combat_log=all_entries,
         chat=chat_entries,
+        courier_snapshots=courier_ext.snapshots,
+        draft=draft_ext.draft_events,
     )
 
     # Post-process buybacks (7b).
@@ -159,6 +170,7 @@ def parse(path: str | Path) -> ParsedMatch:
             )
             pp.runes_log = agg.runes_log
             pp.buyback_log = agg.buyback_log
+            pp.stuns_dealt = agg.stuns_dealt
 
         # Lane position heatmap (7d) — post-process existing snapshots
         for snap in player_ext.snapshots:
@@ -320,6 +332,7 @@ class _ParsedPlayerAgg:
         "purchase_log",
         "runes_log",
         "buyback_log",
+        "stuns_dealt",
     )
 
     def __init__(self) -> None:
@@ -334,6 +347,7 @@ class _ParsedPlayerAgg:
         self.purchase_log: list = []
         self.runes_log: list = []
         self.buyback_log: list = []
+        self.stuns_dealt: float = 0.0
 
 
 class _CombatAggregator:
@@ -374,6 +388,11 @@ class _CombatAggregator:
             and entry.log_type in ("GOLD", "XP", "PURCHASE")
         ):
             target_pid = self._hero_to_pid(entry.target_name)
+
+        # Accumulate stun duration dealt by the attacker (8d).
+        if entry.stun_duration > 0 and attacker_pid is not None:
+            self._agg(attacker_pid).stuns_dealt += entry.stun_duration
+
         match entry.log_type:
             case "DAMAGE":
                 if attacker_pid is not None:

--- a/src/gem/combatlog.py
+++ b/src/gem/combatlog.py
@@ -97,6 +97,7 @@ class CombatLogEntry:
         gold_reason: Gold reason code (for GOLD events).
         xp_reason: XP reason code (for XP events).
         value_name: Resolved name for the value field (PURCHASE events: item name).
+        stun_duration: Duration of stun applied by this event in seconds (S2 only; 0.0 if none).
     """
 
     tick: int
@@ -113,6 +114,7 @@ class CombatLogEntry:
     gold_reason: int = 0
     xp_reason: int = 0
     value_name: str = ""
+    stun_duration: float = 0.0
 
 
 CombatLogHandler = Callable[[CombatLogEntry], None]
@@ -289,6 +291,8 @@ class CombatLogProcessor:
         raw_value = msg.value
         value = raw_value if raw_value < 0x80000000 else raw_value - 0x100000000
 
+        stun_duration = msg.stun_duration if msg.HasField("stun_duration") else 0.0
+
         entry = CombatLogEntry(
             tick=tick,
             log_type=log_type,
@@ -304,5 +308,6 @@ class CombatLogProcessor:
             gold_reason=msg.gold_reason,
             xp_reason=msg.xp_reason,
             value_name=value_name,
+            stun_duration=stun_duration,
         )
         self._emit(entry)

--- a/src/gem/extractors/__init__.py
+++ b/src/gem/extractors/__init__.py
@@ -23,6 +23,8 @@ Example:
     >>> print(players.time_series(player_id=0))
 """
 
+from gem.extractors.courier import CourierExtractor, CourierSnapshot
+from gem.extractors.draft import DraftEvent, DraftExtractor
 from gem.extractors.objectives import BarracksKill, ObjectivesExtractor, RoshanKill, TowerKill
 from gem.extractors.players import PlayerExtractor, PlayerStateSnapshot, PlayerTimeSeries
 from gem.extractors.wards import WardEvent, WardsExtractor
@@ -37,4 +39,8 @@ __all__ = [
     "BarracksKill",
     "WardsExtractor",
     "WardEvent",
+    "CourierExtractor",
+    "CourierSnapshot",
+    "DraftExtractor",
+    "DraftEvent",
 ]

--- a/src/gem/extractors/courier.py
+++ b/src/gem/extractors/courier.py
@@ -1,0 +1,116 @@
+"""Courier state extractor for Dota 2 replays.
+
+Tracks ``CDOTA_Unit_Courier`` entities and snapshots their position and state
+at configurable tick intervals.
+
+Reference: refs/parser/src/main/java/opendota/Parse.java (entity polling pattern)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from gem.entities import Entity, EntityOp
+from gem.extractors.players import _pos
+
+if TYPE_CHECKING:
+    from gem.parser import ReplayParser
+
+
+@dataclass
+class CourierSnapshot:
+    """A single courier state sample at one tick.
+
+    Attributes:
+        tick: Game tick of this sample.
+        team: Team number (2=Radiant, 3=Dire).
+        state: ``m_iCourierState`` integer value (0 = idle, varies by version).
+        flying: True if the courier is in flying form.
+        x: World x coordinate, or ``None`` if unavailable.
+        y: World y coordinate, or ``None`` if unavailable.
+    """
+
+    tick: int
+    team: int
+    state: int
+    flying: bool
+    x: float | None
+    y: float | None
+
+
+class CourierExtractor:
+    """Polls courier entity state and accumulates snapshots.
+
+    Attach to a ``ReplayParser`` before calling ``parse()``:
+
+    Example:
+        >>> extractor = CourierExtractor()
+        >>> extractor.attach(parser)
+        >>> parser.parse()
+        >>> print(extractor.snapshots[:3])
+
+    Attributes:
+        snapshots: All collected ``CourierSnapshot`` objects in chronological order.
+    """
+
+    snapshots: list[CourierSnapshot]
+
+    def __init__(self, sample_interval: int = 150) -> None:
+        """Initialise the extractor.
+
+        Args:
+            sample_interval: Minimum tick gap between successive snapshots.
+                Default 150 ticks ≈ 5 seconds at 30 ticks/sec.
+        """
+        self._sample_interval = sample_interval
+        self._parser: ReplayParser | None = None
+        self._last_sample: int = -sample_interval
+        self._couriers: dict[int, Entity] = {}
+        self.snapshots = []
+
+    def attach(self, parser: ReplayParser) -> None:
+        """Register callbacks with the parser.
+
+        Args:
+            parser: The ``ReplayParser`` instance to attach to.
+        """
+        self._parser = parser
+        parser.on_entity(self._on_entity)
+
+    def _on_entity(self, entity: Entity, op: EntityOp) -> None:
+        cls = entity.get_class_name()
+        if not cls.startswith("CDOTA_Unit_Courier"):
+            return
+        idx = entity.get_index()
+        if op.has(EntityOp.DELETED):
+            self._couriers.pop(idx, None)
+        else:
+            self._couriers[idx] = entity
+            self._maybe_sample()
+
+    def _maybe_sample(self) -> None:
+        if self._parser is None:
+            return
+        tick = self._parser.tick
+        if tick - self._last_sample < self._sample_interval:
+            return
+        self._last_sample = tick
+        self._sample(tick)
+
+    def _sample(self, tick: int) -> None:
+        for entity in self._couriers.values():
+            team, _ = entity.get_int32("m_iTeamNum")
+            state, _ = entity.get_int32("m_iCourierState")
+            flying, _ = entity.get_bool("m_bFlyingCourier")
+            pos = _pos(entity)
+            self.snapshots.append(
+                CourierSnapshot(
+                    tick=tick,
+                    team=team,
+                    state=state,
+                    flying=flying,
+                    x=pos[0] if pos else None,
+                    y=pos[1] if pos else None,
+                )
+            )

--- a/src/gem/extractors/draft.py
+++ b/src/gem/extractors/draft.py
@@ -1,0 +1,236 @@
+"""Draft / hero pick extractor for Dota 2 replays.
+
+Polls ``CDOTAGamerulesProxy`` entity for hero bans and picks during the draft
+phase and emits ``DraftEvent`` records in order of assignment.
+
+Hero name resolution follows the reference implementation
+(refs/parser/src/main/java/opendota/Parse.java lines 509-574, 736-739):
+for picks, the NPC name is derived from the hero entity class name obtained by
+resolving the player's ``m_hSelectedHero`` handle.  The static ``heroes.json``
+mapping is used as a fallback for heroes whose entities do not yet exist (bans
+or draft-phase picks before the entity spawns).
+
+Reference: refs/parser/src/main/java/opendota/Parse.java lines 509-574
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from gem.constants import HEROES
+from gem.entities import Entity, EntityOp
+
+if TYPE_CHECKING:
+    from gem.parser import ReplayParser
+
+# Build reverse mapping: hero_id (int) → npc_name (str) from bundled data.
+# This only covers heroes present in heroes.json (IDs ≤ 155 as of the bundled
+# snapshot).  Newer heroes are resolved at parse time from entity class names.
+_HERO_ID_TO_NPC: dict[int, str] = {v["id"]: k for k, v in HEROES.items() if "id" in v}
+
+# Converts a hero entity class name to two candidate NPC name forms, matching
+# the reference implementation logic:
+#   "CDOTA_Unit_Hero_Anti_Mage" → "npc_dota_hero_anti_mage" (lowercase + _)
+#   "CDOTA_Unit_Hero_AntiMage"  → "npc_dota_hero_antimage"  (camelCase fold)
+_PREFIX = "CDOTA_Unit_Hero_"
+_CAMEL_RE = re.compile(r"([A-Z])")
+
+
+def _class_to_npc_names(class_name: str) -> tuple[str, str]:
+    """Return the two candidate NPC names for a hero entity class name."""
+    ending = class_name[len(_PREFIX) :]
+    name1 = "npc_dota_hero_" + ending.lower()
+    name2 = "npc_dota_hero" + _CAMEL_RE.sub(r"_\1", ending).lower()
+    return name1, name2
+
+
+def _class_to_npc(class_name: str) -> str:
+    """Resolve a hero entity class name to an NPC name, or empty string."""
+    n1, n2 = _class_to_npc_names(class_name)
+    return n1 if n1 in HEROES else (n2 if n2 in HEROES else n1)
+
+
+# Number of ban slots (indices 0-13) and pick slots (indices 0-9) in draft
+_BAN_SLOTS = 14
+_PICK_SLOTS = 10
+
+
+@dataclass
+class DraftEvent:
+    """A single hero ban or pick in the draft.
+
+    Attributes:
+        tick: Game tick when the assignment was detected.
+        slot_index: Draft order index — 0-13 for bans, 0-9 for picks.
+        hero_id: Dota 2 internal hero ID.
+        hero_name: NPC hero name (e.g. ``"npc_dota_hero_axe"``), or ``""`` if unknown.
+        is_pick: True for a pick, False for a ban.
+    """
+
+    tick: int
+    slot_index: int
+    hero_id: int
+    hero_name: str
+    is_pick: bool
+
+
+class DraftExtractor:
+    """Detects hero picks and bans by polling ``CDOTAGamerulesProxy``.
+
+    Hero names for picks are resolved by following the ``m_hSelectedHero``
+    handle from ``CDOTA_PlayerResource`` to the hero entity class name, then
+    converting the class name to an NPC name (e.g. ``CDOTA_Unit_Hero_Sven``
+    → ``npc_dota_hero_sven``).  This matches the reference implementation and
+    works for heroes not present in the bundled ``heroes.json``.
+
+    Bans have no hero entity; their names are resolved from a live
+    ``hero_id → npc_name`` map built from picked heroes, with the static
+    ``heroes.json`` mapping as a final fallback.
+
+    Attach to a ``ReplayParser`` before calling ``parse()``:
+
+    Example:
+        >>> extractor = DraftExtractor()
+        >>> extractor.attach(parser)
+        >>> parser.parse()
+        >>> picks = [e for e in extractor.draft_events if e.is_pick]
+
+    Attributes:
+        draft_events: All detected ``DraftEvent`` objects in order of detection.
+    """
+
+    draft_events: list[DraftEvent]
+
+    def __init__(self) -> None:
+        self._parser: ReplayParser | None = None
+        self._grp: Entity | None = None
+        # Track which (is_pick, slot_index, hero_id) tuples have been emitted
+        # to make processing idempotent across repeated entity updates.
+        self._seen: set[tuple[bool, int, int]] = set()
+        self.draft_events = []
+        # Live hero_id → npc_name map built from hero entities at parse time.
+        # Populated by _on_entity when CDOTA_PlayerResource provides handles.
+        self._live_id_to_npc: dict[int, str] = {}
+
+    def attach(self, parser: ReplayParser) -> None:
+        """Register callbacks with the parser.
+
+        Args:
+            parser: The ``ReplayParser`` instance to attach to.
+        """
+        self._parser = parser
+        parser.on_entity(self._on_entity)
+
+    def _resolve_name(self, hero_id: int) -> str:
+        """Resolve a hero_id to an NPC name.
+
+        Resolution order:
+        1. Live map built from hero entity class names (most accurate; populated
+           by ``_update_live_map`` once hero entities spawn in the game phase).
+        2. ``heroes.json`` lookup with ``hero_id // 2`` — modern Dota 2 replays
+           store pick/ban IDs as ``api_id * 2`` in entity fields.  Only applied
+           when the halved value resolves to a hero AND the full ID does not (to
+           avoid misidentifying legacy direct-ID bans such as axe=2 or pudge=14).
+        3. Static ``heroes.json`` direct lookup — for legacy replays or IDs that
+           genuinely match the public hero ID (e.g. low-numbered ban slots).
+        """
+        if hero_id in self._live_id_to_npc:
+            return self._live_id_to_npc[hero_id]
+        half = hero_id // 2
+        # Prefer //2 only when direct ID is NOT in the static dict, so that
+        # genuinely direct-ID bans (axe=2, pudge=14, riki=32, …) are not
+        # misidentified via halving.
+        if hero_id not in _HERO_ID_TO_NPC and half in _HERO_ID_TO_NPC:
+            return _HERO_ID_TO_NPC[half]
+        return _HERO_ID_TO_NPC.get(hero_id, "")
+
+    def _update_live_map(self, pr: Entity) -> None:
+        """Scan CDOTA_PlayerResource handles and update the live hero_id → npc map."""
+        if self._parser is None or self._parser.entity_manager is None:
+            return
+        em = self._parser.entity_manager
+        for i in range(_PICK_SLOTS):
+            hid, ok = pr.get_int32(f"m_vecPlayerTeamData.{i:04d}.m_nSelectedHeroID")
+            if not ok or hid <= 0 or hid in self._live_id_to_npc:
+                continue
+            handle, ok2 = pr.get_uint32(f"m_vecPlayerTeamData.{i:04d}.m_hSelectedHero")
+            if not ok2:
+                continue
+            hero_entity = em.find_by_handle(handle)
+            if hero_entity is None:
+                continue
+            cls = hero_entity.get_class_name()
+            if cls.startswith(_PREFIX):
+                npc = _class_to_npc(cls)
+                self._live_id_to_npc[hid] = npc
+
+    def _on_entity(self, entity: Entity, op: EntityOp) -> None:
+        cls = entity.get_class_name()
+        if cls == "CDOTA_PlayerResource" and not op.has(EntityOp.DELETED):
+            self._update_live_map(entity)
+            return
+        if cls != "CDOTAGamerulesProxy":
+            return
+        if op.has(EntityOp.DELETED):
+            self._grp = None
+            return
+        self._grp = entity
+        self._check_draft(entity)
+
+    def _check_draft(self, entity: Entity) -> None:
+        tick = self._parser.tick if self._parser else 0
+
+        # Bans: m_pGameRules.m_BannedHeroes.0000-0013
+        for i in range(_BAN_SLOTS):
+            hero_id, ok = entity.get_int32(f"m_pGameRules.m_BannedHeroes.{i:04d}")
+            if not ok or hero_id <= 0:
+                continue
+            key = (False, i, hero_id)
+            if key in self._seen:
+                continue
+            self._seen.add(key)
+            self.draft_events.append(
+                DraftEvent(
+                    tick=tick,
+                    slot_index=i,
+                    hero_id=hero_id,
+                    hero_name=self._resolve_name(hero_id),
+                    is_pick=False,
+                )
+            )
+
+        # Picks: m_pGameRules.m_SelectedHeroes.0000-0009
+        for i in range(_PICK_SLOTS):
+            hero_id, ok = entity.get_int32(f"m_pGameRules.m_SelectedHeroes.{i:04d}")
+            if not ok or hero_id <= 0:
+                continue
+            key = (True, i, hero_id)
+            if key in self._seen:
+                continue
+            self._seen.add(key)
+            self.draft_events.append(
+                DraftEvent(
+                    tick=tick,
+                    slot_index=i,
+                    hero_id=hero_id,
+                    hero_name=self._resolve_name(hero_id),
+                    is_pick=True,
+                )
+            )
+
+    def finalize(self) -> None:
+        """Re-resolve all hero names using the fully-populated live map.
+
+        During the draft phase hero entities have not yet spawned, so picks are
+        recorded with whatever the static fallback yields — which may be wrong
+        (e.g. direct-ID lookup returns ``kotl`` when the correct hero is
+        ``pugna`` because the replay stores ``api_id * 2``).  Call this after
+        ``parser.parse()`` completes so that the live map (populated once hero
+        entities appear) takes priority and corrects any mismatches.
+        """
+        for event in self.draft_events:
+            resolved = self._resolve_name(event.hero_id)
+            if resolved:
+                event.hero_name = resolved

--- a/src/gem/extractors/players.py
+++ b/src/gem/extractors/players.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 # Slots 0-5 = main inventory, 6-8 = backpack, 9-16 = stash
 # Reference: refs/parser/src/main/java/opendota/Parse.java getHeroItem() comment
 _ITEM_SLOTS = 17  # total slots to scan (0-16)
+_ABILITY_SLOTS = 32  # m_hAbilities.0000-0031 per hero entity
 _NULL_HANDLE = 0xFFFFFF  # empty slot sentinel
 
 # ---------------------------------------------------------------------------
@@ -142,6 +143,7 @@ class PlayerStateSnapshot:
         max_mana: Maximum mana.
         x: World x coordinate, or ``None`` if unavailable.
         y: World y coordinate, or ``None`` if unavailable.
+        ability_levels: Ability name → level mapping for learned abilities.
     """
 
     tick: int
@@ -160,6 +162,7 @@ class PlayerStateSnapshot:
     max_mana: float
     x: float | None
     y: float | None
+    ability_levels: dict[str, int] = field(default_factory=dict)
 
 
 @dataclass
@@ -393,8 +396,56 @@ class PlayerExtractor:
                 dn, ok_dn = data_entity.get_int32(f"{prefix}.m_iDenyCount")
                 if ok_dn and dn > 0:
                     snap.dn = dn
+            snap.ability_levels = self._read_abilities(entity)
             self.snapshots.append(snap)
             self._diff_inventory(entity, snap.player_id, snap.npc_name, tick)
+
+    def _read_abilities(self, hero: Entity) -> dict[str, int]:
+        """Read current ability names and levels from a hero entity.
+
+        Iterates ``m_hAbilities.0000``–``m_hAbilities.0031``, falling back to
+        ``m_vecAbilities.*`` for older replays. Resolves each handle to an
+        ability entity and reads ``m_iLevel`` and the name from the
+        ``EntityNames`` string table.
+
+        Args:
+            hero: The hero entity to read from.
+
+        Returns:
+            Mapping of ability name → level for all abilities with level > 0.
+        """
+        if self._parser is None:
+            return {}
+        em = self._parser.entity_manager
+        if em is None:
+            return {}
+        entity_names = self._parser.string_tables.get_by_name("EntityNames")
+        if entity_names is None:
+            return {}
+
+        result: dict[str, int] = {}
+        for slot in range(_ABILITY_SLOTS):
+            handle, ok = hero.get_uint32(f"m_hAbilities.{slot:04d}")
+            if not ok:
+                handle, ok = hero.get_uint32(f"m_vecAbilities.{slot:04d}")
+            if not ok or handle == _NULL_HANDLE:
+                continue
+            ability_entity = em.find_by_handle(handle)
+            if ability_entity is None:
+                continue
+            name_idx, ok2 = ability_entity.get_int32("m_pEntity.m_nameStringableIndex")
+            if not ok2 or name_idx < 0:
+                continue
+            item = entity_names.items.get(name_idx)
+            if item is None:
+                continue
+            name = item[0] if isinstance(item, tuple) else str(item)
+            if not name:
+                continue
+            level, _ = ability_entity.get_int32("m_iLevel")
+            if level > 0:
+                result[name] = level
+        return result
 
     def _read_inventory(self, hero: Entity) -> dict[int, str]:
         """Read current item names from a hero entity's item slots.

--- a/src/gem/models.py
+++ b/src/gem/models.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from gem.combatlog import CombatLogEntry
+from gem.extractors.courier import CourierSnapshot
+from gem.extractors.draft import DraftEvent
 from gem.extractors.objectives import AegisEvent, BarracksKill, RoshanKill, TowerKill
 from gem.extractors.wards import WardEvent
 
@@ -68,6 +70,7 @@ class ParsedPlayer:
         position_log: Time-ordered ``(tick, x, y)`` tuples sampled at the
             extractor's interval. Useful for movement time-series and
             animated visualisations.
+        stuns_dealt: Total stun duration dealt (seconds) accumulated from combat log.
     """
 
     player_id: int
@@ -94,6 +97,7 @@ class ParsedPlayer:
     buyback_log: list[CombatLogEntry] = field(default_factory=list)
     lane_pos: dict[str, int] = field(default_factory=dict)
     position_log: list[tuple[int, float, float]] = field(default_factory=list)
+    stuns_dealt: float = 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -119,6 +123,8 @@ class ParsedMatch:
         radiant_xp_adv: Radiant XP advantage at each minute boundary.
         combat_log: All raw combat log entries (unfiltered).
         chat: All chat messages in chronological order.
+        courier_snapshots: Courier state snapshots at each sample interval.
+        draft: Hero pick and ban events from the draft phase.
     """
 
     match_id: int = 0
@@ -136,3 +142,5 @@ class ParsedMatch:
     radiant_xp_adv: list[int] = field(default_factory=list)
     combat_log: list[CombatLogEntry] = field(default_factory=list)
     chat: list[ChatEntry] = field(default_factory=list)
+    courier_snapshots: list[CourierSnapshot] = field(default_factory=list)
+    draft: list[DraftEvent] = field(default_factory=list)

--- a/tests/test_ability_courier_draft_stuns.py
+++ b/tests/test_ability_courier_draft_stuns.py
@@ -1,0 +1,443 @@
+"""Tests for ability levels, courier state, draft extraction, and stun duration.
+
+Unit tests use fake objects. Integration tests parse a real .dem fixture and
+verify plausible output.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+FIXTURE = Path(__file__).parent / "fixtures" / "ti14_finals_g1_xg_vs_falcons.dem"
+
+
+# ---------------------------------------------------------------------------
+# Shared fake helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeClass:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.class_id = 1
+        self.serializer = None
+
+
+def _make_entity(class_name: str, state: dict | None = None):
+    from gem.entities import Entity
+
+    e = Entity(index=0, serial=0, cls=FakeClass(class_name))
+    if state:
+        e._state.update(state)
+    return e
+
+
+class FakeParser:
+    def __init__(self, tick: int = 0) -> None:
+        self.tick = tick
+        self._entity_handlers = []
+        self.entity_manager = None
+        self.string_tables = type("ST", (), {"get_by_name": lambda self, n: None})()
+
+    def on_entity(self, handler) -> None:
+        self._entity_handlers.append(handler)
+
+    def fire_entity(self, entity, op) -> None:
+        for h in self._entity_handlers:
+            h(entity, op)
+
+
+# ---------------------------------------------------------------------------
+# 8a — Ability levels (PlayerStateSnapshot field)
+# ---------------------------------------------------------------------------
+
+
+class TestAbilityLevels:
+    def test_snapshot_has_ability_levels_field(self):
+        from gem.extractors.players import PlayerStateSnapshot
+
+        snap = PlayerStateSnapshot(
+            tick=0,
+            player_id=0,
+            npc_name="npc_dota_hero_axe",
+            team=2,
+            level=5,
+            xp=1000,
+            gold=500,
+            net_worth=500,
+            lh=10,
+            dn=0,
+            hp=800,
+            max_hp=1000,
+            mana=200.0,
+            max_mana=300.0,
+            x=None,
+            y=None,
+        )
+        assert snap.ability_levels == {}
+
+    def test_snapshot_ability_levels_can_be_set(self):
+        from gem.extractors.players import PlayerStateSnapshot
+
+        snap = PlayerStateSnapshot(
+            tick=0,
+            player_id=0,
+            npc_name="npc_dota_hero_axe",
+            team=2,
+            level=5,
+            xp=1000,
+            gold=500,
+            net_worth=500,
+            lh=10,
+            dn=0,
+            hp=800,
+            max_hp=1000,
+            mana=200.0,
+            max_mana=300.0,
+            x=None,
+            y=None,
+            ability_levels={"axe_berserkers_call": 3, "axe_battle_hunger": 2},
+        )
+        assert snap.ability_levels["axe_berserkers_call"] == 3
+
+
+# ---------------------------------------------------------------------------
+# 8b — CourierExtractor
+# ---------------------------------------------------------------------------
+
+
+class TestCourierExtractor:
+    def _make(self):
+        from gem.extractors.courier import CourierExtractor
+
+        ext = CourierExtractor(sample_interval=1)
+        parser = FakeParser(tick=100)
+        ext.attach(parser)
+        return ext, parser
+
+    def test_attach_registers_entity_callback(self):
+        _, parser = self._make()
+        assert len(parser._entity_handlers) == 1
+
+    def test_non_courier_entity_ignored(self):
+        ext, parser = self._make()
+        from gem.entities import EntityOp
+
+        entity = _make_entity("CDOTA_Unit_Hero_Axe", {"m_iTeamNum": 2})
+        parser.fire_entity(entity, EntityOp.CREATED)
+        assert ext.snapshots == []
+
+    def test_courier_entity_creates_snapshot(self):
+        ext, parser = self._make()
+        from gem.entities import EntityOp
+
+        entity = _make_entity(
+            "CDOTA_Unit_Courier",
+            {"m_iTeamNum": 2, "m_iCourierState": 1, "m_bFlyingCourier": False},
+        )
+        parser.fire_entity(entity, EntityOp.CREATED)
+        assert len(ext.snapshots) == 1
+        snap = ext.snapshots[0]
+        assert snap.tick == 100
+        assert snap.team == 2
+        assert snap.state == 1
+        assert snap.flying is False
+        assert snap.x is None
+        assert snap.y is None
+
+    def test_courier_deleted_removes_from_tracking(self):
+        ext, parser = self._make()
+        from gem.entities import EntityOp
+
+        entity = _make_entity("CDOTA_Unit_Courier", {"m_iTeamNum": 2})
+        entity_idx = entity.get_index()
+        parser.fire_entity(entity, EntityOp.CREATED)
+        assert len(ext._couriers) == 1
+
+        parser.fire_entity(entity, EntityOp.DELETED)
+        assert entity_idx not in ext._couriers
+
+    def test_sample_interval_throttles_snapshots(self):
+        from gem.extractors.courier import CourierExtractor
+
+        ext = CourierExtractor(sample_interval=100)
+        parser = FakeParser(tick=0)
+        ext.attach(parser)
+
+        from gem.entities import EntityOp
+
+        entity = _make_entity("CDOTA_Unit_Courier", {"m_iTeamNum": 2})
+        parser.fire_entity(entity, EntityOp.CREATED)
+        assert len(ext.snapshots) == 1  # first sample always fires
+
+        # Advance tick slightly — below interval, no new snapshot
+        parser.tick = 50
+        parser.fire_entity(entity, EntityOp.UPDATED)
+        assert len(ext.snapshots) == 1
+
+        # Advance past interval — new snapshot
+        parser.tick = 101
+        parser.fire_entity(entity, EntityOp.UPDATED)
+        assert len(ext.snapshots) == 2
+
+
+# ---------------------------------------------------------------------------
+# 8c — DraftExtractor
+# ---------------------------------------------------------------------------
+
+
+class TestDraftExtractor:
+    def _make(self):
+        from gem.extractors.draft import DraftExtractor
+
+        ext = DraftExtractor()
+        parser = FakeParser(tick=500)
+        ext.attach(parser)
+        return ext, parser
+
+    def test_attach_registers_entity_callback(self):
+        _, parser = self._make()
+        assert len(parser._entity_handlers) == 1
+
+    def test_non_grp_entity_ignored(self):
+        ext, parser = self._make()
+        from gem.entities import EntityOp
+
+        entity = _make_entity("CDOTA_Unit_Hero_Axe")
+        parser.fire_entity(entity, EntityOp.CREATED)
+        assert ext.draft_events == []
+
+    def test_ban_detected(self):
+        ext, parser = self._make()
+        from gem.entities import EntityOp
+
+        entity = _make_entity(
+            "CDOTAGamerulesProxy",
+            {"m_pGameRules.m_BannedHeroes.0000": 1},  # hero_id=1
+        )
+        parser.fire_entity(entity, EntityOp.UPDATED)
+        bans = [e for e in ext.draft_events if not e.is_pick]
+        assert len(bans) == 1
+        assert bans[0].hero_id == 1
+        assert bans[0].slot_index == 0
+        assert bans[0].is_pick is False
+        assert bans[0].tick == 500
+
+    def test_pick_detected(self):
+        ext, parser = self._make()
+        from gem.entities import EntityOp
+
+        entity = _make_entity(
+            "CDOTAGamerulesProxy",
+            {"m_pGameRules.m_SelectedHeroes.0000": 2},  # hero_id=2
+        )
+        parser.fire_entity(entity, EntityOp.UPDATED)
+        picks = [e for e in ext.draft_events if e.is_pick]
+        assert len(picks) == 1
+        assert picks[0].hero_id == 2
+        assert picks[0].is_pick is True
+
+    def test_idempotent_no_duplicate_events(self):
+        ext, parser = self._make()
+        from gem.entities import EntityOp
+
+        entity = _make_entity(
+            "CDOTAGamerulesProxy",
+            {"m_pGameRules.m_SelectedHeroes.0000": 5},
+        )
+        # Fire same entity state multiple times
+        parser.fire_entity(entity, EntityOp.UPDATED)
+        parser.fire_entity(entity, EntityOp.UPDATED)
+        parser.fire_entity(entity, EntityOp.UPDATED)
+        assert len(ext.draft_events) == 1
+
+    def test_zero_hero_id_ignored(self):
+        ext, parser = self._make()
+        from gem.entities import EntityOp
+
+        entity = _make_entity(
+            "CDOTAGamerulesProxy",
+            {"m_pGameRules.m_BannedHeroes.0000": 0},
+        )
+        parser.fire_entity(entity, EntityOp.UPDATED)
+        assert ext.draft_events == []
+
+    def test_deleted_clears_grp(self):
+        ext, parser = self._make()
+        from gem.entities import EntityOp
+
+        entity = _make_entity("CDOTAGamerulesProxy")
+        parser.fire_entity(entity, EntityOp.CREATED)
+        parser.fire_entity(entity, EntityOp.DELETED)
+        assert ext._grp is None
+
+    def test_hero_name_resolved_from_constants(self):
+        from gem.extractors.draft import _HERO_ID_TO_NPC
+
+        # The mapping should be non-empty
+        assert len(_HERO_ID_TO_NPC) > 100
+        # All values should be npc_dota_hero_* strings
+        for npc in _HERO_ID_TO_NPC.values():
+            assert npc.startswith("npc_dota_hero_")
+
+
+# ---------------------------------------------------------------------------
+# 8d — Stun duration
+# ---------------------------------------------------------------------------
+
+
+class TestStunDuration:
+    def test_combat_log_entry_has_stun_duration_default(self):
+        from gem.combatlog import CombatLogEntry
+
+        e = CombatLogEntry(tick=0, log_type="DAMAGE")
+        assert e.stun_duration == 0.0
+
+    def test_stun_duration_stored_on_entry(self):
+        from gem.combatlog import CombatLogEntry
+
+        e = CombatLogEntry(tick=100, log_type="DAMAGE", stun_duration=1.5)
+        assert e.stun_duration == 1.5
+
+    def test_s2_entry_with_stun_duration(self):
+        """process_s2_entry populates stun_duration via HasField."""
+        from gem.combatlog import CombatLogProcessor
+
+        class FakeMsg:
+            type = 0  # DAMAGE
+            attacker_name = 0
+            target_name = 0
+            inflictor_name = 0
+            value = 10
+            is_attacker_hero = True
+            is_target_hero = True
+            is_attacker_illusion = False
+            is_target_illusion = False
+            ability_level = 0
+            gold_reason = 0
+            xp_reason = 0
+            stun_duration = 2.5
+
+            def HasField(self, name):
+                return name == "stun_duration"
+
+        class FakeTable:
+            def get(self, idx, default=""):
+                return {1: "npc_dota_hero_axe", 2: "npc_dota_hero_lina"}.get(idx, default)
+
+        FakeMsg.attacker_name = 1
+        FakeMsg.target_name = 2
+
+        proc = CombatLogProcessor()
+        collected = []
+        proc.on_combat_log_entry(collected.append)
+        proc.process_s2_entry(FakeMsg(), FakeTable(), tick=1000)
+
+        assert len(collected) == 1
+        assert collected[0].stun_duration == 2.5
+
+    def test_s2_entry_without_stun_duration_defaults_zero(self):
+        from gem.combatlog import CombatLogProcessor
+
+        class FakeMsg:
+            type = 0
+            attacker_name = 0
+            target_name = 0
+            inflictor_name = 0
+            value = 5
+            is_attacker_hero = False
+            is_target_hero = False
+            is_attacker_illusion = False
+            is_target_illusion = False
+            ability_level = 0
+            gold_reason = 0
+            xp_reason = 0
+            stun_duration = 0.0
+
+            def HasField(self, name):
+                return False
+
+        class FakeTable:
+            def get(self, idx, default=""):
+                return default
+
+        proc = CombatLogProcessor()
+        collected = []
+        proc.on_combat_log_entry(collected.append)
+        proc.process_s2_entry(FakeMsg(), FakeTable(), tick=500)
+
+        assert collected[0].stun_duration == 0.0
+
+    def test_parsed_player_has_stuns_dealt(self):
+        from gem.models import ParsedPlayer
+
+        pp = ParsedPlayer(player_id=0)
+        assert pp.stuns_dealt == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+class TestPhase8Integration:
+    @pytest.fixture(scope="class")
+    def match(self):
+        import gem
+
+        return gem.parse(str(FIXTURE))
+
+    def test_ability_levels_populated(self, match):
+        from gem.extractors.players import PlayerExtractor
+
+        # Re-parse to access snapshots directly
+        from gem.parser import ReplayParser
+
+        p = ReplayParser(str(FIXTURE))
+        ext = PlayerExtractor()
+        ext.attach(p)
+        p.parse()
+        # At least one snapshot should have non-empty ability_levels
+        snaps_with_abilities = [s for s in ext.snapshots if s.ability_levels]
+        assert snaps_with_abilities, "Expected at least one snapshot with ability levels"
+        # All levels should be in valid range 0-7
+        for snap in snaps_with_abilities:
+            for level in snap.ability_levels.values():
+                assert 0 <= level <= 7, f"Unexpected ability level {level}"
+
+    def test_courier_snapshots_populated(self, match):
+        assert len(match.courier_snapshots) > 0
+
+    def test_courier_teams_valid(self, match):
+        for snap in match.courier_snapshots:
+            assert snap.team in (2, 3), f"Unexpected courier team {snap.team}"
+
+    def test_draft_events_populated(self, match):
+        # TI14 finals is CM — should have bans and picks
+        assert len(match.draft) > 0
+
+    def test_draft_picks_count(self, match):
+        picks = [e for e in match.draft if e.is_pick]
+        assert 1 <= len(picks) <= 10
+
+    def test_draft_bans_count(self, match):
+        bans = [e for e in match.draft if not e.is_pick]
+        assert len(bans) <= 14
+
+    def test_draft_hero_names_resolved(self, match):
+        picks = [e for e in match.draft if e.is_pick]
+        resolved = [e for e in picks if e.hero_name.startswith("npc_dota_hero_")]
+        assert len(resolved) > 0, "Expected at least some picks to have resolved hero names"
+
+    def test_stuns_dealt_non_negative(self, match):
+        for pp in match.players:
+            assert pp.stuns_dealt >= 0.0
+
+    def test_stuns_dealt_nonzero_for_some_players(self, match):
+        # In a real match at least some heroes deal stuns
+        total = sum(pp.stuns_dealt for pp in match.players)
+        assert total > 0, "Expected non-zero total stun duration in a real match"

--- a/tests/test_combatlog.py
+++ b/tests/test_combatlog.py
@@ -61,6 +61,7 @@ class FakeS2Entry:
         timestamp=0.0,
         is_ability_toggle_on=False,
         is_ability_toggle_off=False,
+        stun_duration=0.0,
     ):
         self.type = type
         self.attacker_name = attacker_name
@@ -78,6 +79,10 @@ class FakeS2Entry:
         self.timestamp = timestamp
         self.is_ability_toggle_on = is_ability_toggle_on
         self.is_ability_toggle_off = is_ability_toggle_off
+        self.stun_duration = stun_duration
+
+    def HasField(self, name: str) -> bool:
+        return name == "stun_duration" and self.stun_duration != 0.0
 
 
 class FakeBulkMsg:

--- a/tests/test_field_path.py
+++ b/tests/test_field_path.py
@@ -112,13 +112,25 @@ class TestFieldPath:
 
 class TestReadFieldPaths:
     def test_returns_list(self, read_field_paths, reader_cls):
-        # A stream with only FieldPathEncodeFinish should return empty list
-        # We need to know the Huffman encoding of FinishEncoding
-        # Since we can't easily hardcode it without running the tree, just
-        # verify the function returns a list without crashing on valid input.
-        # Use a pytest.skip if we can't construct a valid bit stream yet.
-        pytest.skip("Requires known Huffman bit sequences — add once tree is verified")
+        """read_field_paths returns a list (even a one-element list for PlusOne + Finish).
+
+        Huffman bit sequences (LSB-first, verified against the built tree):
+          PlusOne              = 0
+          FieldPathEncodeFinish = 10
+        """
+        # PlusOne (0) then FieldPathEncodeFinish (10), padded to a full byte: 0b00000100 = 0x04
+        data = _bits_to_bytes("010")
+        r = reader_cls(data)
+        result = read_field_paths(r)
+        assert isinstance(result, list)
+        assert len(result) == 1
 
     def test_empty_result_on_immediate_finish(self, read_field_paths, reader_cls):
-        """If the first op decoded is FinishEncoding, result should be empty."""
-        pytest.skip("Requires known Huffman encoding of FinishEncoding bit sequence")
+        """If the first op decoded is FinishEncoding, result should be empty.
+
+        FieldPathEncodeFinish = bits 1,0 (LSB-first).
+        """
+        data = _bits_to_bytes("10")
+        r = reader_cls(data)
+        result = read_field_paths(r)
+        assert result == []


### PR DESCRIPTION
- Ability levels: PlayerStateSnapshot now carries ability_levels: dict[str, int] (ability name → level at that  tick), populated by resolving m_hAbilities handles on hero entities during each sample                               
- Courier state: New CourierExtractor + CourierSnapshot(tick, team, state, flying, x, y) tracking CDOTA_Unit_Courier entities; surfaced as ParsedMatch.courier_snapshots                                               
- Draft extraction: New DraftExtractor polls CDOTAGamerulesProxy for m_BannedHeroes / m_SelectedHeroes; emits DraftEvent(tick, slot_index, hero_id, hero_name, is_pick); surfaced as ParsedMatch.draft                             
- Stun duration: CombatLogEntry gains stun_duration: float; accumulated per attacker as ParsedPlayer.stuns_dealt

                                                                                                                                                                                               
                                                                                                                       
  Modern replays store pick/ban hero IDs as api_id * 2 in entity fields, not the public API ID. Resolution uses three  
  tiers:                                                                                                             
                                                                                                                       
  1. Live entity map — CDOTA_PlayerResource.m_hSelectedHero handles → entity class name → NPC name (e.g.               
  CDOTA_Unit_Hero_Shadow_Demon → npc_dota_hero_shadow_demon). Bypasses ID encoding entirely for picks.
  2. hero_id // 2 halving — only when the raw ID is absent from heroes.json, covers doubled-ID bans.                   
  3. Static heroes.json direct lookup — fallback for a small number of bans that use the legacy direct API ID (e.g.    
  pudge=14, axe=2).                                                                                                    
                                                                                                                       
  DraftExtractor.finalize() is called after parse() to re-resolve all events using the fully populated live map,       
  correcting any wrong static lookups from the draft phase. 