### PR TITLE
refactor: pythonic quick-wins — defaultdict counters, dataclasses, named constants, repr

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,8 @@ This file provides guidance to agents (i.e., ADAL) when working with code in thi
 ## Project Snapshot
 
 - **Project**: `gem` — Source 2 Dota 2 replay parser (Python)
-- **Current state**: Core parser + extractors are implemented through **Phase 10**
-- **Current branch**: `feature/teamfights`
+- **Current state**: Core parser + extractors are implemented through **Phase 10**, with Phase 11b modularization landed (`match_builder.py`, `combat_aggregator.py`, `dataframes.py`)
+- **Current branch**: `validation`
 - **Package manager / env**: `uv` with local `.venv`
 - **Primary references**:
   - `refs/manta/` (Go; primary implementation/behavior reference)
@@ -88,7 +88,7 @@ Skipping this leads to common failures: wrong enum values, wrong message path, i
 ### End-to-end pipeline
 
 ```text
-stream.py → reader.py → sendtable.py → field_decoder.py → field_path.py → string_table.py → entities.py → parser.py → extractors/*
+stream.py → reader.py → sendtable.py → field_decoder.py → field_path.py → string_table.py → entities.py → parser.py → match_builder.py → combat_aggregator.py → dataframes.py → extractors/*
 ```
 
 ### Core modules
@@ -120,6 +120,7 @@ stream.py → reader.py → sendtable.py → field_decoder.py → field_path.py 
    - Packet entities create/update/delete lifecycle
    - Baseline + delta application
    - Entity state mutation hot path
+   - Field-state and field-reading logic remain in this module
 
 8. **`src/gem/game_events.py` + `src/gem/combatlog.py`**
    - Source1 game events
@@ -130,10 +131,20 @@ stream.py → reader.py → sendtable.py → field_decoder.py → field_path.py 
    - Handles outer + inner message dispatch
    - Maintains ordering constraints (string tables before packet entities)
 
-10. **`src/gem/extractors/`**
+10. **`src/gem/match_builder.py`**
+   - Assembles `ParsedMatch`
+   - Wires extraction outputs into final model fields (including teamfight integration)
+
+11. **`src/gem/combat_aggregator.py`**
+   - Aggregates combat-log-derived stats (damage/healing/purchases) for match/player outputs
+
+12. **`src/gem/dataframes.py`**
+   - Converts parsed match outputs into pandas DataFrames (`parse_to_dataframe` path)
+
+13. **`src/gem/extractors/`**
    - `players.py`, `objectives.py`, `wards.py`, `courier.py`, `draft.py`, `teamfights.py`
 
-11. **Public API**
+14. **Public API**
    - `gem.parse(path) -> ParsedMatch`
    - `gem.parse_to_dataframe(path) -> dict[str, pd.DataFrame]`
    - CLI: `python -m gem <replay.dem>`
@@ -143,8 +154,8 @@ stream.py → reader.py → sendtable.py → field_decoder.py → field_path.py 
 ## Implemented Scope Status
 
 - **Phases 1–10**: Completed (reader/stream, schema/decode, entities/string tables, events/combat log, extraction layer, output API, gap closures including teamfights, validation/fuzz baseline)
-- **Phase 11a**: Performance + Rust extension (planned/in progress)
-- **Phase 11b**: Refactor/cleanup for release quality (planned)
+- **Phase 11a**: Performance (Python optimizations complete; Rust extension planned/in progress)
+- **Phase 11b**: Refactor/cleanup for release quality (✅ completed: modularization into `match_builder.py`, `combat_aggregator.py`, `dataframes.py`)
 - **Phase 12**: Packaging/distribution (planned)
 
 ---
@@ -193,6 +204,8 @@ stream.py → reader.py → sendtable.py → field_decoder.py → field_path.py 
 | Field-path/entity decode issue | `field_path.py` + `entities.py` |
 | Combat-log mismatch | `string_table.py` + `combatlog.py` + `game_events.py` |
 | Teamfight discrepancy | `extractors/teamfights.py` + `tests/test_teamfights.py` |
+| Match assembly/output wiring | `parser.py` + `match_builder.py` + `dataframes.py` |
+| Combat aggregation mismatch | `combat_aggregator.py` + `combatlog.py` + `extractors/players.py` |
 | Proto generation issue | `scripts/compile_protos.py` |
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,13 @@ Filter `MODIFIER_ADD` by `target_is_hero = True` to exclude summoned units (e.g.
 
 Alternative approach (refs): read the `ActiveModifiers` string table directly — each entry is a `CDOTAModifierBuffTableEntry` protobuf with a `player_ids` field (comma-separated player slots). Would give the same result for empty-group cases. Not currently implemented; requires parsing an additional string table of protobufs.
 
+## Workflow preferences
+
+- **Never run Bash commands in the background.** Always run foreground (blocking) so output is visible immediately. Efficiency is less important than observability.
+- When writing temporary investigation scripts to `/tmp/`, delete them after use (`rm /tmp/script.py`).
+- Kills by summoned units (Warlock Golem, Undying zombie, Pugna Nether Ward, etc.) should be credited to the owning hero's kill count.
+- Deaths count all causes (hero, tower, creep, neutral, summon) — not just hero-dealt deaths.
+
 ## Code Style
 
 - **Not a direct translation** — code must be idiomatic Python, not Go/Java transliterated

--- a/scripts/validate_opendota.py
+++ b/scripts/validate_opendota.py
@@ -14,6 +14,28 @@ and the ``_min`` arrays at exact 60-second game-time boundaries.  A small
 residual difference (<5 %) between gem's last sample and OpenDota's final
 value is therefore expected and acceptable.
 
+OpenDota data availability
+--------------------------
+OpenDota has two data sources:
+
+1. **Steam API** (``GetMatchDetails``) — always available for any pub match.
+   Provides end-of-game scalars: kills, deaths, assists, net_worth, last_hits,
+   denies.  ``radiant_score`` / ``dire_score`` also come from here but can
+   disagree with the sum of per-player kills by ±1 (known API quirk); the
+   validator uses ``sum(player["kills"])`` instead.
+
+2. **OpenDota replay parser** — only runs when someone explicitly requests a
+   parse (POST ``/api/request/{match_id}`` or via the website).  Produces the
+   richer derived fields: ``radiant_gold_adv``, ``radiant_xp_adv``, teamfight
+   windows, ward placements, etc.  High-profile matches (e.g. TI finals) are
+   auto-parsed; ordinary pub matches are not.
+
+Consequence: for unanalysed pub replays the gold/XP advantage curve fields
+return ``null`` from the API.  The validator skips those comparisons rather
+than failing — this is an OpenDota data-availability limitation, not a gem
+bug.  To force a parse: ``curl -X POST https://api.opendota.com/api/request/{match_id}``
+then wait a few minutes and re-run.
+
 Usage:
     uv run python scripts/validate_opendota.py
     uv run python scripts/validate_opendota.py --match 8461735141
@@ -29,7 +51,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from gem.models import ParsedPlayer
+    pass
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -53,6 +75,7 @@ def _build_hero_id_map() -> dict[int, str]:
 REPLAYS: list[tuple[int, Path]] = [
     (8461735141, FIXTURES_DIR / "ti14_finals_g1_xg_vs_falcons.dem"),
     (8520062186, FIXTURES_DIR / "8520062186.dem"),
+    (8520014563, FIXTURES_DIR / "8520014563.dem"),
 ]
 
 
@@ -140,32 +163,6 @@ def _od_slot_to_gem_id(slot: int) -> int:
     return slot if slot < 128 else slot - 128 + 5
 
 
-def _gem_kills(gem_player: "ParsedPlayer", combat_log: list) -> int:
-    """Count kills credited to this hero via combat log DEATH events."""
-    hero = gem_player.hero_name
-    return sum(
-        1
-        for e in combat_log
-        if e.log_type == "DEATH"
-        and e.attacker_name == hero
-        and e.attacker_is_hero
-        and e.target_is_hero
-        and not e.target_is_illusion
-    )
-
-
-def _gem_deaths(gem_player: "ParsedPlayer", combat_log: list) -> int:
-    hero = gem_player.hero_name
-    return sum(
-        1
-        for e in combat_log
-        if e.log_type == "DEATH"
-        and e.target_name == hero
-        and e.target_is_hero
-        and not e.target_is_illusion
-    )
-
-
 # ---------------------------------------------------------------------------
 # Core validation
 # ---------------------------------------------------------------------------
@@ -207,12 +204,10 @@ def validate_match(match_id: int, fixture: Path) -> MatchResult:
     # Match-level fields
     # -----------------------------------------------------------------------
 
-    od_total_kills = od["radiant_score"] + od["dire_score"]
-    gem_total_kills = sum(
-        1
-        for e in m.combat_log
-        if e.log_type == "DEATH" and e.target_is_hero and not e.target_is_illusion
-    )
+    # Use sum of per-player kills rather than radiant_score+dire_score — OpenDota's
+    # team scores can disagree with their own per-player kills by ±1 (known API quirk).
+    od_total_kills = sum(p["kills"] for p in od["players"])
+    gem_total_kills = sum(p.kills for p in m.players)
     result.match_fields.append(FieldResult("total_kills", gem_total_kills, od_total_kills))
 
     # radiant_win is None for HLTV/tournament replays where CDemoFileInfo,
@@ -289,23 +284,58 @@ def validate_match(match_id: int, fixture: Path) -> MatchResult:
     gem_gold_adv = m.radiant_gold_adv or []
     gem_xp_adv = m.radiant_xp_adv or []
 
+    od_adv_missing = not od_gold_adv and not od_xp_adv
     result.match_fields.append(
-        FieldResult("radiant_gold_adv/length", len(gem_gold_adv), len(od_gold_adv))
+        FieldResult(
+            "radiant_gold_adv/length",
+            len(gem_gold_adv),
+            len(od_gold_adv),
+            skip=od_adv_missing,
+            note="OpenDota did not compute gold/XP advantage curves for this match."
+            if od_adv_missing
+            else "",
+        )
     )
     result.match_fields.append(
-        FieldResult("radiant_xp_adv/length", len(gem_xp_adv), len(od_xp_adv))
+        FieldResult(
+            "radiant_xp_adv/length",
+            len(gem_xp_adv),
+            len(od_xp_adv),
+            skip=od_adv_missing,
+            note="OpenDota did not compute gold/XP advantage curves for this match."
+            if od_adv_missing
+            else "",
+        )
     )
 
     # Final value comparison (last minute — most meaningful single scalar)
     gem_gold_final = gem_gold_adv[-1] if gem_gold_adv else None
     od_gold_final = od_gold_adv[-1] if od_gold_adv else None
     result.match_fields.append(
-        FieldResult("radiant_gold_adv/final", gem_gold_final, od_gold_final, tolerance=0.05)
+        FieldResult(
+            "radiant_gold_adv/final",
+            gem_gold_final,
+            od_gold_final,
+            tolerance=0.05,
+            skip=od_adv_missing,
+            note="OpenDota did not compute gold/XP advantage curves for this match."
+            if od_adv_missing
+            else "",
+        )
     )
     gem_xp_final = gem_xp_adv[-1] if gem_xp_adv else None
     od_xp_final = od_xp_adv[-1] if od_xp_adv else None
     result.match_fields.append(
-        FieldResult("radiant_xp_adv/final", gem_xp_final, od_xp_final, tolerance=0.05)
+        FieldResult(
+            "radiant_xp_adv/final",
+            gem_xp_final,
+            od_xp_final,
+            tolerance=0.05,
+            skip=od_adv_missing,
+            note="OpenDota did not compute gold/XP advantage curves for this match."
+            if od_adv_missing
+            else "",
+        )
     )
 
     # Max element-wise relative error across the curve (gem=actual %, ref=5% threshold).
@@ -400,12 +430,9 @@ def validate_match(match_id: int, fixture: Path) -> MatchResult:
         gem_dn_min = gp.dn_t_min[-1] if gp.dn_t_min else None
         fields.append(FieldResult(f"{label}/denies[min]", gem_dn_min, od_player["denies"]))
 
-        # kills / deaths via combat log
-        gem_k = _gem_kills(gp, m.combat_log)
-        fields.append(FieldResult(f"{label}/kills", gem_k, od_player["kills"]))
-
-        gem_d = _gem_deaths(gp, m.combat_log)
-        fields.append(FieldResult(f"{label}/deaths", gem_d, od_player["deaths"]))
+        # kills / deaths from server scoreboard (CDOTAPlayerResource)
+        fields.append(FieldResult(f"{label}/kills", gp.kills, od_player["kills"]))
+        fields.append(FieldResult(f"{label}/deaths", gp.deaths, od_player["deaths"]))
 
         result.player_fields.append(fields)
 

--- a/src/gem/__init__.py
+++ b/src/gem/__init__.py
@@ -12,71 +12,13 @@ Public API
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
+import gem.constants as constants  # re-export so `gem.constants.hero_display()` works
 from gem.models import ChatEntry, ParsedMatch, ParsedPlayer
 
 if TYPE_CHECKING:
     import pandas as pd
-
-# Lane position grid resolution in world units (7d)
-_LANE_GRID = 64
-
-
-def _dedup_purchase_log(entries: list, first_snap_tick: int | None, sample_interval: int) -> list:
-    """Deduplicate purchase log entries within the starting inventory window.
-
-    The inventory snapshot and the combat log stream may both emit PURCHASE
-    entries for the same item within the first sample window.  Outside that
-    window, duplicate item purchases are legitimate (e.g. buying two separate
-    Branches) and are kept as-is.
-
-    Args:
-        entries: Raw purchase log entries (unsorted).
-        first_snap_tick: Tick of the player's first inventory snapshot, or
-            ``None`` if no snapshot was taken.
-        sample_interval: Width of the starting-item window in ticks.
-
-    Returns:
-        Deduplicated list sorted by tick.
-    """
-    if first_snap_tick is None:
-        return sorted(entries, key=lambda e: e.tick)
-
-    cutoff = first_snap_tick + sample_interval
-    seen: set[tuple] = set()
-    result = []
-    for entry in sorted(entries, key=lambda e: e.tick):
-        if entry.tick <= cutoff:
-            key = (entry.tick, entry.value_name)
-            if key in seen:
-                continue
-            seen.add(key)
-        result.append(entry)
-    return result
-
-
-def _radiant_win_from_ancient(combat_log: list) -> bool | None:
-    """Infer radiant_win from ancient DEATH events in the combat log.
-
-    The destroying team is inferred from which ancient (fort) was killed:
-    - ``npc_dota_badguys_fort`` dies → Radiant wins
-    - ``npc_dota_goodguys_fort`` dies → Dire wins
-
-    Args:
-        combat_log: Full list of CombatLogEntry objects from the replay.
-
-    Returns:
-        True if Radiant won, False if Dire won, None if no ancient death found.
-    """
-    for e in combat_log:
-        if e.log_type != "DEATH":
-            continue
-        if e.target_name == "npc_dota_badguys_fort":
-            return True
-        if e.target_name == "npc_dota_goodguys_fort":
-            return False
-    return None
 
 
 def parse(path: str | Path) -> ParsedMatch:
@@ -92,11 +34,13 @@ def parse(path: str | Path) -> ParsedMatch:
     Returns:
         A :class:`ParsedMatch` with all extracted data populated.
     """
+    from gem.combat_aggregator import _CombatAggregator
     from gem.extractors.courier import CourierExtractor
     from gem.extractors.draft import DraftExtractor
     from gem.extractors.objectives import ObjectivesExtractor
     from gem.extractors.players import PlayerExtractor
     from gem.extractors.wards import WardsExtractor
+    from gem.match_builder import build_parsed_match
     from gem.parser import ReplayParser
 
     p = ReplayParser(path)
@@ -112,183 +56,29 @@ def parse(path: str | Path) -> ParsedMatch:
     courier_ext.attach(p)
     draft_ext.attach(p)
 
-    # Aggregate combat log entries per player
-    _combat_aggregator = _CombatAggregator(player_ext)
-    p.on_combat_log_entry(_combat_aggregator.on_entry)
+    combat_agg = _CombatAggregator(player_ext)
+    p.on_combat_log_entry(combat_agg.on_entry)
 
     all_entries: list = []
     p.on_combat_log_entry(all_entries.append)
 
-    # Collect chat messages (7e)
     chat_entries: list[ChatEntry] = []
     p.on_chat_message(chat_entries.append)
 
     p.parse()
-
-    # Backfill hero names for draft events recorded before hero entities spawned.
     draft_ext.finalize()
 
-    # radiant_win resolution — three tiers in priority order:
-    #   1. CDemoFileInfo.game_winner (set during parse, empty for HLTV replays)
-    #   2. m_pGameRules.m_nGameWinner entity field (set post-parse in parser.py)
-    #   3. Ancient DEATH in combat log — no API needed
-    radiant_win = p.radiant_win
-    if radiant_win is None:
-        radiant_win = _radiant_win_from_ancient(all_entries)
-
-    match = ParsedMatch(
-        match_id=p.match_id,
-        game_mode=p.game_mode,
-        leagueid=p.leagueid,
-        radiant_win=radiant_win,
-        towers=obj_ext.tower_kills,
-        barracks=obj_ext.barracks_kills,
-        roshans=obj_ext.roshan_kills,
-        aegis_events=obj_ext.aegis_events,
-        wards=ward_ext.ward_events,
-        combat_log=all_entries,
-        chat=chat_entries,
-        courier_snapshots=courier_ext.snapshots,
-        draft=draft_ext.draft_events,
+    return build_parsed_match(
+        parser=p,
+        player_ext=player_ext,
+        obj_ext=obj_ext,
+        ward_ext=ward_ext,
+        courier_ext=courier_ext,
+        draft_ext=draft_ext,
+        combat_agg=combat_agg,
+        all_entries=all_entries,
+        chat_entries=chat_entries,
     )
-
-    # Post-process buybacks (7b).
-    # For BUYBACK entries, entry.value = player slot (0-9).
-    # Reference: refs/parser/src/main/java/opendota/CreateParsedDataBlob.java handleBuyback()
-    for entry in all_entries:
-        if entry.log_type != "BUYBACK":
-            continue
-        pid = entry.value
-        if 0 <= pid < 10:
-            _combat_aggregator._agg(pid).buyback_log.append(entry)
-
-    # Build per-player time series and overlay combat log aggregates
-    for player_id in range(10):
-        ts = player_ext.time_series(player_id)
-        pp = match.players[player_id]
-        pp.player_id = player_id
-        pp.times = ts.ticks
-        pp.gold_t = ts.gold_t
-        pp.net_worth_t = ts.net_worth_t
-        pp.lh_t = ts.lh_t
-        pp.dn_t = ts.dn_t
-        pp.xp_t = ts.xp_t
-        mts = player_ext.minute_time_series(player_id)
-        pp.times_min = mts.ticks
-        pp.gold_t_min = mts.gold_t
-        pp.total_earned_gold_t_min = mts.total_earned_gold_t
-        pp.total_earned_xp_t_min = mts.total_earned_xp_t
-        pp.net_worth_t_min = mts.net_worth_t
-        pp.lh_t_min = mts.lh_t
-        pp.dn_t_min = mts.dn_t
-        pp.xp_t_min = mts.xp_t
-        pp.position_log = [
-            (snap.tick, snap.x, snap.y)
-            for snap in player_ext.snapshots
-            if snap.player_id == player_id and snap.x is not None and snap.y is not None
-        ]
-
-        # Resolve hero name from snapshots
-        for snap in player_ext.snapshots:
-            if snap.player_id == player_id:
-                pp.hero_name = snap.npc_name
-                pp.team = snap.team
-                break
-
-        agg = _combat_aggregator.players.get(player_id)
-        if agg is not None:
-            pp.damage = agg.damage
-            pp.damage_taken = agg.damage_taken
-            pp.healing = agg.healing
-            pp.ability_uses = agg.ability_uses
-            pp.item_uses = agg.item_uses
-            pp.gold_reasons = agg.gold_reasons
-            pp.xp_reasons = agg.xp_reasons
-            pp.kills_log = agg.kills_log
-            pp.purchase_log = _dedup_purchase_log(
-                agg.purchase_log,
-                player_ext.first_snapshot_tick.get(player_id),
-                player_ext._sample_interval,
-            )
-            pp.runes_log = agg.runes_log
-            pp.buyback_log = agg.buyback_log
-            pp.stuns_dealt = agg.stuns_dealt
-
-        kda = player_ext.scoreboard.get(player_id)
-        if kda is not None:
-            pp.kills, pp.deaths, pp.assists = kda
-
-        # Lane position heatmap (7d) — post-process existing snapshots
-        for snap in player_ext.snapshots:
-            if snap.player_id != player_id or snap.x is None or snap.y is None:
-                continue
-            cell = f"{int(snap.x) // _LANE_GRID}_{int(snap.y) // _LANE_GRID}"
-            pp.lane_pos[cell] = pp.lane_pos.get(cell, 0) + 1
-
-    # Extract player names from CDOTA_PlayerResource entity.
-    # Two field path variants: newer replays use m_vecPlayerData.{slot}.m_iszPlayerName,
-    # older replays use m_iszPlayerNames.{slot}.
-    # Reference: refs/manta/manta_test.go line ~703
-    if p.entity_manager is not None:
-        pr = p.entity_manager.find_by_class_name("CDOTA_PlayerResource")
-        if pr is not None:
-            for player_id in range(10):
-                slot = f"{player_id:04d}"
-                name, ok = pr.get_string(f"m_vecPlayerData.{slot}.m_iszPlayerName")
-                if not ok or not name:
-                    name, ok = pr.get_string(f"m_iszPlayerNames.{slot}")
-                if ok and name:
-                    match.players[player_id].player_name = name
-
-    # Attach ward logs per player
-    for ward in match.wards:
-        if 0 <= ward.player_id < 10:
-            pp = match.players[ward.player_id]
-            if ward.ward_type == "observer":
-                pp.obs_log.append(ward)
-            else:
-                pp.sen_log.append(ward)
-
-    # Compute radiant_gold_adv / radiant_xp_adv per game-minute boundary.
-    # For each minute index, sum gold_t_min (spendable gold) across all players:
-    # Radiant players contribute positively, Dire players negatively.
-    # Use the minimum series length across all players so all 10 contribute
-    # to every minute bucket — prevents partial sums from skewing the curve.
-    # Reference: refs/parser/src/main/java/opendota/CreateParsedDataBlob.java processAllPlayers()
-    active_players = [
-        pp for pp in match.players if pp.total_earned_gold_t_min and pp.total_earned_xp_t_min
-    ]
-    if active_players:
-        n_minutes = min(
-            min(len(pp.total_earned_gold_t_min), len(pp.total_earned_xp_t_min))
-            for pp in active_players
-        )
-        gold_adv = [0] * n_minutes
-        xp_adv = [0] * n_minutes
-        for pp in active_players:
-            sign = 1 if pp.team == 2 else -1  # 2=Radiant, 3=Dire
-            for i in range(n_minutes):
-                gold_adv[i] += sign * pp.total_earned_gold_t_min[i]
-                xp_adv[i] += sign * (
-                    pp.total_earned_xp_t_min[i] if i < len(pp.total_earned_xp_t_min) else 0
-                )
-        match.radiant_gold_adv = gold_adv
-        match.radiant_xp_adv = xp_adv
-
-    # Detect teamfights (Phase 9)
-    from gem.extractors.teamfights import detect_teamfights
-
-    hero_to_slot = {pp.hero_name: pp.player_id for pp in match.players if pp.hero_name}
-    player_snaps = {
-        pid: [s for s in player_ext.snapshots if s.player_id == pid] for pid in range(10)
-    }
-    match.teamfights = detect_teamfights(
-        all_entries,
-        hero_to_slot=hero_to_slot,
-        player_snapshots=player_snaps,
-    )
-
-    return match
 
 
 def parse_to_dataframe(path: str | Path) -> dict[str, pd.DataFrame]:
@@ -309,232 +99,10 @@ def parse_to_dataframe(path: str | Path) -> dict[str, pd.DataFrame]:
         - ``"objectives"``: one row per tower/barracks/roshan kill.
         - ``"chat"``: one row per chat message.
     """
-    import pandas as pd
+    from gem.dataframes import build_dataframes
 
-    match = parse(path)
-
-    # --- players ---
-    player_rows: list[dict] = []
-    for pp in match.players:
-        n = len(pp.times)
-        for i in range(n):
-            player_rows.append(
-                {
-                    "player_id": pp.player_id,
-                    "hero_name": pp.hero_name,
-                    "team": pp.team,
-                    "tick": pp.times[i],
-                    "gold": pp.gold_t[i] if i < len(pp.gold_t) else 0,
-                    "lh": pp.lh_t[i] if i < len(pp.lh_t) else 0,
-                    "dn": pp.dn_t[i] if i < len(pp.dn_t) else 0,
-                    "xp": pp.xp_t[i] if i < len(pp.xp_t) else 0,
-                }
-            )
-    players_df = pd.DataFrame(player_rows)
-
-    # --- combat_log ---
-    from dataclasses import asdict
-
-    combat_df = pd.DataFrame([asdict(e) for e in match.combat_log])
-
-    # --- wards ---
-    wards_df = pd.DataFrame([asdict(w) for w in match.wards]) if match.wards else pd.DataFrame()
-
-    # --- objectives ---
-    obj_rows: list[dict] = []
-    for t in match.towers:
-        obj_rows.append(
-            {
-                "type": "tower",
-                "tick": t.tick,
-                "team": t.team,
-                "name": t.tower_name,
-                "killer": t.killer,
-            }
-        )
-    for b in match.barracks:
-        obj_rows.append(
-            {
-                "type": "barracks",
-                "tick": b.tick,
-                "team": b.team,
-                "name": b.barracks_name,
-                "killer": b.killer,
-            }
-        )
-    for r in match.roshans:
-        obj_rows.append(
-            {"type": "roshan", "tick": r.tick, "team": 0, "name": "roshan", "killer": r.killer}
-        )
-    objectives_df = pd.DataFrame(obj_rows)
-
-    # --- positions ---
-    pos_rows: list[dict] = []
-    for pp in match.players:
-        for tick, x, y in pp.position_log:
-            pos_rows.append(
-                {
-                    "player_id": pp.player_id,
-                    "hero_name": pp.hero_name,
-                    "team": pp.team,
-                    "tick": tick,
-                    "x": x,
-                    "y": y,
-                }
-            )
-    positions_df = pd.DataFrame(pos_rows)
-
-    # --- chat ---
-    chat_df = pd.DataFrame([asdict(c) for c in match.chat]) if match.chat else pd.DataFrame()
-
-    return {
-        "players": players_df,
-        "positions": positions_df,
-        "combat_log": combat_df,
-        "wards": wards_df,
-        "objectives": objectives_df,
-        "chat": chat_df,
-    }
-
-
-# ---------------------------------------------------------------------------
-# Internal combat log aggregator
-# ---------------------------------------------------------------------------
-
-
-class _ParsedPlayerAgg:
-    """Mutable accumulator for per-player combat log aggregates."""
-
-    __slots__ = (
-        "damage",
-        "damage_taken",
-        "healing",
-        "ability_uses",
-        "item_uses",
-        "gold_reasons",
-        "xp_reasons",
-        "kills_log",
-        "purchase_log",
-        "runes_log",
-        "buyback_log",
-        "stuns_dealt",
-    )
-
-    def __init__(self) -> None:
-        self.damage: dict[str, int] = {}
-        self.damage_taken: dict[str, int] = {}
-        self.healing: dict[str, int] = {}
-        self.ability_uses: dict[str, int] = {}
-        self.item_uses: dict[str, int] = {}
-        self.gold_reasons: dict[str, int] = {}
-        self.xp_reasons: dict[str, int] = {}
-        self.kills_log: list = []
-        self.purchase_log: list = []
-        self.runes_log: list = []
-        self.buyback_log: list = []
-        self.stuns_dealt: float = 0.0
-
-
-class _CombatAggregator:
-    """Aggregates combat log entries into per-player buckets.
-
-    Uses the hero NPC-name → player_id mapping from ``PlayerExtractor``.
-    """
-
-    def __init__(self, player_ext: Any) -> None:
-        self._player_ext = player_ext
-        self.players: dict[int, _ParsedPlayerAgg] = {}
-
-    def _agg(self, player_id: int) -> _ParsedPlayerAgg:
-        if player_id not in self.players:
-            self.players[player_id] = _ParsedPlayerAgg()
-        return self.players[player_id]
-
-    def _hero_to_pid(self, npc_name: str) -> int | None:
-        entity = self._player_ext._heroes_by_npc.get(npc_name.lower())
-        if entity is None:
-            return None
-        pid, ok = entity.get_int32("m_nPlayerID")
-        if not ok:
-            pid, ok = entity.get_int32("m_iPlayerID")
-        if not ok or pid < 0:
-            return None
-        return pid // 2
-
-    def on_entry(self, entry: Any) -> None:
-        attacker_pid = self._hero_to_pid(entry.attacker_name) if entry.attacker_is_hero else None
-        target_pid = self._hero_to_pid(entry.target_name) if entry.target_is_hero else None
-
-        # For GOLD/XP/PURCHASE in S2 replays, target_is_hero is False even for hero targets.
-        # Fall back to name lookup unconditionally for those event types.
-        if (
-            target_pid is None
-            and entry.target_name
-            and entry.log_type in ("GOLD", "XP", "PURCHASE")
-        ):
-            target_pid = self._hero_to_pid(entry.target_name)
-
-        # Accumulate stun duration dealt by the attacker (8d).
-        if entry.stun_duration > 0 and attacker_pid is not None:
-            self._agg(attacker_pid).stuns_dealt += entry.stun_duration
-
-        match entry.log_type:
-            case "DAMAGE":
-                if attacker_pid is not None:
-                    agg = self._agg(attacker_pid)
-                    agg.damage[entry.target_name] = (
-                        agg.damage.get(entry.target_name, 0) + entry.value
-                    )
-                if target_pid is not None:
-                    agg = self._agg(target_pid)
-                    agg.damage_taken[entry.attacker_name] = (
-                        agg.damage_taken.get(entry.attacker_name, 0) + entry.value
-                    )
-            case "HEAL":
-                if attacker_pid is not None:
-                    agg = self._agg(attacker_pid)
-                    agg.healing[entry.target_name] = (
-                        agg.healing.get(entry.target_name, 0) + entry.value
-                    )
-            case "ABILITY":
-                if attacker_pid is not None and entry.inflictor_name:
-                    agg = self._agg(attacker_pid)
-                    agg.ability_uses[entry.inflictor_name] = (
-                        agg.ability_uses.get(entry.inflictor_name, 0) + 1
-                    )
-            case "ITEM":
-                if attacker_pid is not None and entry.inflictor_name:
-                    agg = self._agg(attacker_pid)
-                    agg.item_uses[entry.inflictor_name] = (
-                        agg.item_uses.get(entry.inflictor_name, 0) + 1
-                    )
-            case "GOLD":
-                if target_pid is not None:
-                    agg = self._agg(target_pid)
-                    reason = str(entry.gold_reason)
-                    agg.gold_reasons[reason] = agg.gold_reasons.get(reason, 0) + entry.value
-            case "XP":
-                if target_pid is not None:
-                    agg = self._agg(target_pid)
-                    reason = str(entry.xp_reason)
-                    agg.xp_reasons[reason] = agg.xp_reasons.get(reason, 0) + entry.value
-            case "DEATH":
-                if attacker_pid is not None:
-                    self._agg(attacker_pid).kills_log.append(entry)
-            case "PURCHASE":
-                # OpenDota uses targetname as the buyer unit for PURCHASE events
-                pid = attacker_pid if attacker_pid is not None else target_pid
-                if pid is not None:
-                    self._agg(pid).purchase_log.append(entry)
-            case "PICKUP_RUNE":
-                # entry.value = player slot (from CDOTAUserMsg_ChatEvent.playerid_1)
-                pid = entry.value
-                if 0 <= pid < 10:
-                    self._agg(pid).runes_log.append(entry)
-            case "BUYBACK":
-                # Populated via post-processing in parse() after full name map is built.
-                pass
+    return build_dataframes(parse(path))
 
 
 # Re-export for convenience
-__all__ = ["parse", "parse_to_dataframe", "ParsedMatch", "ParsedPlayer"]
+__all__ = ["parse", "parse_to_dataframe", "ParsedMatch", "ParsedPlayer", "constants"]

--- a/src/gem/combat_aggregator.py
+++ b/src/gem/combat_aggregator.py
@@ -1,0 +1,178 @@
+"""Per-player combat log aggregation for gem replay parsing.
+
+Accumulates combat log entries into per-player buckets during a parse,
+producing the damage, healing, ability use, gold/XP reason, kill, purchase,
+rune, and buyback tallies that populate ``ParsedPlayer``.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from gem.combatlog import CombatLogEntry
+    from gem.extractors.players import PlayerExtractor
+
+
+# ---------------------------------------------------------------------------
+# Per-player mutable accumulator
+# ---------------------------------------------------------------------------
+
+
+def _int_counter() -> defaultdict[str, int]:
+    return defaultdict(int)
+
+
+@dataclass(slots=True)
+class _ParsedPlayerAgg:
+    """Mutable accumulator for per-player combat log aggregates."""
+
+    damage: defaultdict[str, int] = field(default_factory=_int_counter)
+    damage_taken: defaultdict[str, int] = field(default_factory=_int_counter)
+    healing: defaultdict[str, int] = field(default_factory=_int_counter)
+    ability_uses: defaultdict[str, int] = field(default_factory=_int_counter)
+    item_uses: defaultdict[str, int] = field(default_factory=_int_counter)
+    gold_reasons: defaultdict[str, int] = field(default_factory=_int_counter)
+    xp_reasons: defaultdict[str, int] = field(default_factory=_int_counter)
+    kills_log: list[CombatLogEntry] = field(default_factory=list)
+    purchase_log: list[CombatLogEntry] = field(default_factory=list)
+    runes_log: list[CombatLogEntry] = field(default_factory=list)
+    buyback_log: list[CombatLogEntry] = field(default_factory=list)
+    stuns_dealt: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Purchase log deduplication
+# ---------------------------------------------------------------------------
+
+
+def _dedup_purchase_log(
+    entries: list[CombatLogEntry],
+    first_snap_tick: int | None,
+    sample_interval: int,
+) -> list[CombatLogEntry]:
+    """Deduplicate purchase log entries within the starting inventory window.
+
+    The inventory snapshot and the combat log stream may both emit PURCHASE
+    entries for the same item within the first sample window.  Outside that
+    window, duplicate item purchases are legitimate (e.g. buying two separate
+    Branches) and are kept as-is.
+
+    Args:
+        entries: Raw purchase log entries (unsorted).
+        first_snap_tick: Tick of the player's first inventory snapshot, or
+            ``None`` if no snapshot was taken.
+        sample_interval: Width of the starting-item window in ticks.
+
+    Returns:
+        Deduplicated list sorted by tick.
+    """
+    if first_snap_tick is None:
+        return sorted(entries, key=lambda e: e.tick)
+
+    cutoff = first_snap_tick + sample_interval
+    seen: set[tuple] = set()
+    result = []
+    for entry in sorted(entries, key=lambda e: e.tick):
+        if entry.tick <= cutoff:
+            key = (entry.tick, entry.value_name)
+            if key in seen:
+                continue
+            seen.add(key)
+        result.append(entry)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Aggregator
+# ---------------------------------------------------------------------------
+
+
+class _CombatAggregator:
+    """Aggregates combat log entries into per-player buckets.
+
+    Uses the hero NPC-name → player_id mapping from ``PlayerExtractor``.
+
+    Args:
+        player_ext: Attached ``PlayerExtractor`` instance.
+    """
+
+    def __init__(self, player_ext: PlayerExtractor) -> None:
+        self._player_ext = player_ext
+        self.players: dict[int, _ParsedPlayerAgg] = {}
+
+    def _agg(self, player_id: int) -> _ParsedPlayerAgg:
+        if player_id not in self.players:
+            self.players[player_id] = _ParsedPlayerAgg()
+        return self.players[player_id]
+
+    def _hero_to_pid(self, npc_name: str) -> int | None:
+        entity = self._player_ext._heroes_by_npc.get(npc_name.lower())
+        if entity is None:
+            return None
+        pid, ok = entity.get_int32("m_nPlayerID")
+        if not ok:
+            pid, ok = entity.get_int32("m_iPlayerID")
+        if not ok or pid < 0:
+            return None
+        return pid // 2
+
+    def on_entry(self, entry: Any) -> None:
+        """Process a single combat log entry, routing it to the right bucket.
+
+        Args:
+            entry: A ``CombatLogEntry`` instance.
+        """
+        attacker_pid = self._hero_to_pid(entry.attacker_name) if entry.attacker_is_hero else None
+        target_pid = self._hero_to_pid(entry.target_name) if entry.target_is_hero else None
+
+        # For GOLD/XP/PURCHASE in S2 replays, target_is_hero is False even for
+        # hero targets — fall back to name lookup unconditionally for those types.
+        if (
+            target_pid is None
+            and entry.target_name
+            and entry.log_type in ("GOLD", "XP", "PURCHASE")
+        ):
+            target_pid = self._hero_to_pid(entry.target_name)
+
+        if entry.stun_duration > 0 and attacker_pid is not None:
+            self._agg(attacker_pid).stuns_dealt += entry.stun_duration
+
+        match entry.log_type:
+            case "DAMAGE":
+                if attacker_pid is not None:
+                    self._agg(attacker_pid).damage[entry.target_name] += entry.value
+                if target_pid is not None:
+                    self._agg(target_pid).damage_taken[entry.attacker_name] += entry.value
+            case "HEAL":
+                if attacker_pid is not None:
+                    self._agg(attacker_pid).healing[entry.target_name] += entry.value
+            case "ABILITY":
+                if attacker_pid is not None and entry.inflictor_name:
+                    self._agg(attacker_pid).ability_uses[entry.inflictor_name] += 1
+            case "ITEM":
+                if attacker_pid is not None and entry.inflictor_name:
+                    self._agg(attacker_pid).item_uses[entry.inflictor_name] += 1
+            case "GOLD":
+                if target_pid is not None:
+                    self._agg(target_pid).gold_reasons[str(entry.gold_reason)] += entry.value
+            case "XP":
+                if target_pid is not None:
+                    self._agg(target_pid).xp_reasons[str(entry.xp_reason)] += entry.value
+            case "DEATH":
+                if attacker_pid is not None:
+                    self._agg(attacker_pid).kills_log.append(entry)
+            case "PURCHASE":
+                pid = attacker_pid if attacker_pid is not None else target_pid
+                if pid is not None:
+                    self._agg(pid).purchase_log.append(entry)
+            case "PICKUP_RUNE":
+                # entry.value = player slot (from CDOTAUserMsg_ChatEvent.playerid_1)
+                pid = entry.value
+                if 0 <= pid < 10:
+                    self._agg(pid).runes_log.append(entry)
+            case "BUYBACK":
+                # Populated via post-processing in match_builder after full name map is built.
+                pass

--- a/src/gem/dataframes.py
+++ b/src/gem/dataframes.py
@@ -1,0 +1,115 @@
+"""DataFrame conversion for :class:`ParsedMatch` output.
+
+Converts the structured output of :func:`gem.parse` into pandas DataFrames
+suitable for tabular analysis.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from gem.models import ParsedMatch
+
+
+def build_dataframes(match: ParsedMatch) -> dict[str, pd.DataFrame]:
+    """Convert a :class:`ParsedMatch` into a dict of pandas DataFrames.
+
+    Args:
+        match: Fully populated :class:`ParsedMatch`.
+
+    Returns:
+        Dictionary with keys:
+        - ``"players"``: one row per player per sample tick (wide format).
+        - ``"positions"``: one row per ``(player, tick)`` with x/y coordinates.
+        - ``"combat_log"``: one row per combat log entry.
+        - ``"wards"``: one row per ward placement.
+        - ``"objectives"``: one row per tower/barracks/roshan kill.
+        - ``"chat"``: one row per chat message.
+    """
+    from dataclasses import asdict
+
+    import pandas as pd
+
+    # --- players ---
+    player_rows: list[dict] = []
+    for pp in match.players:
+        n = len(pp.times)
+        for i in range(n):
+            player_rows.append(
+                {
+                    "player_id": pp.player_id,
+                    "hero_name": pp.hero_name,
+                    "team": pp.team,
+                    "tick": pp.times[i],
+                    "gold": pp.gold_t[i] if i < len(pp.gold_t) else 0,
+                    "lh": pp.lh_t[i] if i < len(pp.lh_t) else 0,
+                    "dn": pp.dn_t[i] if i < len(pp.dn_t) else 0,
+                    "xp": pp.xp_t[i] if i < len(pp.xp_t) else 0,
+                }
+            )
+    players_df = pd.DataFrame(player_rows)
+
+    # --- combat_log ---
+    combat_df = pd.DataFrame([asdict(e) for e in match.combat_log])
+
+    # --- wards ---
+    wards_df = pd.DataFrame([asdict(w) for w in match.wards]) if match.wards else pd.DataFrame()
+
+    # --- objectives ---
+    obj_rows: list[dict] = []
+    for t in match.towers:
+        obj_rows.append(
+            {
+                "type": "tower",
+                "tick": t.tick,
+                "team": t.team,
+                "name": t.tower_name,
+                "killer": t.killer,
+            }
+        )
+    for b in match.barracks:
+        obj_rows.append(
+            {
+                "type": "barracks",
+                "tick": b.tick,
+                "team": b.team,
+                "name": b.barracks_name,
+                "killer": b.killer,
+            }
+        )
+    for r in match.roshans:
+        obj_rows.append(
+            {"type": "roshan", "tick": r.tick, "team": 0, "name": "roshan", "killer": r.killer}
+        )
+    objectives_df = pd.DataFrame(obj_rows)
+
+    # --- positions ---
+    pos_rows: list[dict] = []
+    for pp in match.players:
+        for tick, x, y in pp.position_log:
+            pos_rows.append(
+                {
+                    "player_id": pp.player_id,
+                    "hero_name": pp.hero_name,
+                    "team": pp.team,
+                    "tick": tick,
+                    "x": x,
+                    "y": y,
+                }
+            )
+    positions_df = pd.DataFrame(pos_rows)
+
+    # --- chat ---
+    chat_df = pd.DataFrame([asdict(c) for c in match.chat]) if match.chat else pd.DataFrame()
+
+    return {
+        "players": players_df,
+        "positions": positions_df,
+        "combat_log": combat_df,
+        "wards": wards_df,
+        "objectives": objectives_df,
+        "chat": chat_df,
+    }

--- a/src/gem/entities.py
+++ b/src/gem/entities.py
@@ -16,6 +16,7 @@ import enum
 import math
 import re
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 from gem.field_path import FieldPath, read_field_paths
@@ -201,6 +202,7 @@ def read_fields(r: BitReader, serializer: Serializer, state: FieldState) -> None
 # ---------------------------------------------------------------------------
 
 
+@dataclass(slots=True)
 class ClassInfo:
     """Mapping of a class ID to its name and Serializer.
 
@@ -210,12 +212,9 @@ class ClassInfo:
         serializer: The associated Serializer schema, or None.
     """
 
-    __slots__ = ("class_id", "name", "serializer")
-
-    def __init__(self, class_id: int, name: str, serializer: Serializer | None) -> None:
-        self.class_id = class_id
-        self.name = name
-        self.serializer = serializer
+    class_id: int
+    name: str
+    serializer: Serializer | None
 
 
 # ---------------------------------------------------------------------------

--- a/src/gem/extractors/objectives.py
+++ b/src/gem/extractors/objectives.py
@@ -42,16 +42,16 @@ _BARRACKS_TEAM: dict[str, int] = {
     "npc_dota_badguys_range_rax": _TEAM_DIRE,
 }
 
+# CDOTAUserMsg_ChatEvent type → AegisEvent event_type string
+_AEGIS_EVENT_TYPE: dict[int, str] = {
+    _CHAT_MSG_AEGIS: "pickup",
+    _CHAT_MSG_AEGIS_STOLEN: "stolen",
+    _CHAT_MSG_DENIED_AEGIS: "denied",
+}
 
-def _tower_team(target_name: str) -> int:
-    for prefix, team in _TOWER_TEAM.items():
-        if target_name.startswith(prefix):
-            return team
-    return 0
 
-
-def _barracks_team(target_name: str) -> int:
-    for prefix, team in _BARRACKS_TEAM.items():
+def _find_team(target_name: str, mapping: dict[str, int]) -> int:
+    for prefix, team in mapping.items():
         if target_name.startswith(prefix):
             return team
     return 0
@@ -171,17 +171,10 @@ class ObjectivesExtractor:
         parser.on_chat_event(self._on_chat_event)
 
     def _on_chat_event(self, msg: Any, tick: int) -> None:
-        if msg.type == _CHAT_MSG_AEGIS:
+        event_type = _AEGIS_EVENT_TYPE.get(msg.type)
+        if event_type is not None:
             self.aegis_events.append(
-                AegisEvent(tick=tick, player_id=msg.playerid_1, event_type="pickup")
-            )
-        elif msg.type == _CHAT_MSG_AEGIS_STOLEN:
-            self.aegis_events.append(
-                AegisEvent(tick=tick, player_id=msg.playerid_1, event_type="stolen")
-            )
-        elif msg.type == _CHAT_MSG_DENIED_AEGIS:
-            self.aegis_events.append(
-                AegisEvent(tick=tick, player_id=msg.playerid_1, event_type="denied")
+                AegisEvent(tick=tick, player_id=msg.playerid_1, event_type=event_type)
             )
 
     def _on_combat_log(self, entry: CombatLogEntry) -> None:
@@ -202,7 +195,7 @@ class ObjectivesExtractor:
             self.tower_kills.append(
                 TowerKill(
                     tick=entry.tick,
-                    team=_tower_team(target),
+                    team=_find_team(target, _TOWER_TEAM),
                     killer=entry.attacker_name,
                     tower_name=target,
                 )
@@ -216,7 +209,7 @@ class ObjectivesExtractor:
             self.barracks_kills.append(
                 BarracksKill(
                     tick=entry.tick,
-                    team=_barracks_team(target),
+                    team=_find_team(target, _BARRACKS_TEAM),
                     killer=entry.attacker_name,
                     barracks_name=target,
                 )

--- a/src/gem/extractors/players.py
+++ b/src/gem/extractors/players.py
@@ -34,6 +34,7 @@ _NULL_HANDLE = 0xFFFFFF  # empty slot sentinel
 _CELL_SIZE = 128  # Source 2 world units per grid cell
 _TEAM_RADIANT = 2
 _TEAM_DIRE = 3
+_HERO_CLASS_PREFIX = "CDOTA_Unit_Hero_"
 
 
 # ---------------------------------------------------------------------------
@@ -95,7 +96,7 @@ def _snapshot_hero(entity: Entity, tick: int) -> PlayerStateSnapshot | None:
     # "CDOTA_Unit_Hero_Nyx_Assassin"   → "npc_dota_hero_nyx_assassin" (already underscored)
     # This matches dotaconstants keys and the combat log string table.
     # Reference: refs/parser/Parse.java combatLogName2
-    _ending = entity.get_class_name()[len("CDOTA_Unit_Hero_") :].replace("_", "")
+    _ending = entity.get_class_name()[len(_HERO_CLASS_PREFIX) :].replace("_", "")
     _npc_name = "npc_dota_hero" + re.sub(r"([A-Z])", r"_\1", _ending).lower()
     return PlayerStateSnapshot(
         tick=tick,
@@ -397,9 +398,9 @@ class PlayerExtractor:
     def _on_entity(self, entity: Entity, op: EntityOp) -> None:
         cls = entity.get_class_name()
 
-        if cls.startswith("CDOTA_Unit_Hero_"):
+        if cls.startswith(_HERO_CLASS_PREFIX):
             idx = entity.get_index()
-            ending = cls[len("CDOTA_Unit_Hero_") :]
+            ending = cls[len(_HERO_CLASS_PREFIX) :]
             # Register two name forms to cover inconsistent combat log names.
             # "combatLogName":  simple lowercase ("npc_dota_hero_templarassassin")
             # "combatLogName2": insert _ before each capital ("npc_dota_hero_templar_assassin")

--- a/src/gem/extractors/teamfights.py
+++ b/src/gem/extractors/teamfights.py
@@ -23,8 +23,12 @@ Reference: refs/parser/src/main/java/opendota/CreateParsedDataBlob.java
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from gem.combatlog import CombatLogEntry
+
+if TYPE_CHECKING:
+    from gem.extractors.players import PlayerStateSnapshot
 
 # 15 seconds × 30 ticks/second  (reference uses 15s cooldown)
 _COOLDOWN_TICKS: int = 15 * 30
@@ -81,7 +85,7 @@ class Teamfight:
 def detect_teamfights(
     combat_log: list[CombatLogEntry],
     hero_to_slot: dict[str, int] | None = None,
-    player_snapshots: dict[int, list] | None = None,
+    player_snapshots: dict[int, list[PlayerStateSnapshot]] | None = None,
 ) -> list[Teamfight]:
     """Detect teamfights from a match combat log.
 

--- a/src/gem/extractors/wards.py
+++ b/src/gem/extractors/wards.py
@@ -49,6 +49,11 @@ _WARD_CLASSES: frozenset[str] = frozenset(
     }
 )
 
+# Ward lifespan in ticks (~30 ticks/s at normal speed)
+_OBSERVER_LIFESPAN_TICKS = 720  # ~6 minutes
+_SENTRY_LIFESPAN_TICKS = 360  # ~3 minutes
+_EXPIRY_TOLERANCE_TICKS = 30  # grace window to classify natural expiry vs. kill
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -444,9 +449,10 @@ class WardsExtractor:
         killer = ""
 
         if spawn is not None and spawn.death_tick is not None:
-            natural_ticks = 720 if wp.ward_type == "observer" else 360
-            # Allow 30-tick tolerance for natural expiry
-            if spawn.death_tick >= spawn.spawn_tick + natural_ticks - 30:
+            natural_ticks = (
+                _OBSERVER_LIFESPAN_TICKS if wp.ward_type == "observer" else _SENTRY_LIFESPAN_TICKS
+            )
+            if spawn.death_tick >= spawn.spawn_tick + natural_ticks - _EXPIRY_TOLERANCE_TICKS:
                 expires_tick = spawn.death_tick
             else:
                 killed_tick = spawn.death_tick

--- a/src/gem/field_path.py
+++ b/src/gem/field_path.py
@@ -11,6 +11,7 @@ Reference: manta/field_path.go, manta/huffman.go
 from __future__ import annotations
 
 import heapq
+import struct
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -425,6 +426,66 @@ HUFF_TREE: _HNode = _build_huffman_tree([op.weight for op in FIELD_PATH_OPS])
 
 
 # ---------------------------------------------------------------------------
+# Flat Huffman decode table
+# ---------------------------------------------------------------------------
+
+
+def _build_decode_table(root: _HNode, table_bits: int) -> list[tuple[int, int]]:
+    """Build a flat O(1) decode table from the Huffman tree.
+
+    Each entry ``table[i] = (op_index, bits_consumed)`` covers all ``table_bits``-
+    bit integers whose leading bits match the Huffman code for ``op_index``.
+    Shorter codes fill multiple entries (one per possible suffix).
+
+    Args:
+        root: Root of the Huffman tree.
+        table_bits: Width of the table in bits (``2**table_bits`` entries).
+
+    Returns:
+        List of ``(op_index, bits_consumed)`` tuples, indexed by the
+        ``table_bits``-bit integer peeked from the bit stream.
+    """
+    size = 1 << table_bits
+    table: list[tuple[int, int]] = [(0, 0)] * size
+
+    stack: list[tuple[_HNode, int, int]] = [(root, 0, 0)]  # node, code, depth
+    while stack:
+        node, code, depth = stack.pop()
+        if node.is_leaf:
+            # Fill all entries whose top `depth` bits match `code`
+            suffix_count = 1 << (table_bits - depth)
+            for s in range(suffix_count):
+                table[code | (s << depth)] = (node.value, depth)
+        else:
+            if node.left is not None:
+                stack.append((node.left, code, depth + 1))
+            if node.right is not None:
+                stack.append((node.right, code | (1 << depth), depth + 1))
+
+    return table
+
+
+def _tree_depth(node: _HNode) -> int:
+    """Return the maximum depth of the Huffman tree.
+
+    Args:
+        node: Root node.
+
+    Returns:
+        int: Maximum leaf depth (root = depth 0).
+    """
+    if node.is_leaf:
+        return 0
+    left_d = _tree_depth(node.left) + 1 if node.left else 0
+    right_d = _tree_depth(node.right) + 1 if node.right else 0
+    return max(left_d, right_d)
+
+
+_HUFF_TABLE_BITS: int = _tree_depth(HUFF_TREE)
+_HUFF_DECODE_TABLE: list[tuple[int, int]] = _build_decode_table(HUFF_TREE, _HUFF_TABLE_BITS)
+
+
+# ---------------------------------------------------------------------------
 # Field path reading
 # ---------------------------------------------------------------------------
 
@@ -432,8 +493,13 @@ HUFF_TREE: _HNode = _build_huffman_tree([op.weight for op in FIELD_PATH_OPS])
 def read_field_paths(r: BitReader) -> list[FieldPath]:
     """Decode a Huffman-coded sequence of field paths from r.
 
-    Reads bits one at a time, traversing the Huffman tree until a leaf
-    operation is reached.  Repeats until ``FieldPathEncodeFinish`` is decoded.
+    Uses a flat O(1) decode table to resolve each Huffman op in a single
+    peek + skip rather than a per-bit tree walk.  The peek/skip/rem_bits
+    calls are inlined directly against BitReader's private attributes to
+    eliminate ~22M Python function calls per replay.
+
+    Falls back to the tree walk for the last few bits when fewer than
+    ``_HUFF_TABLE_BITS`` bits remain in the buffer.
 
     Args:
         r: BitReader positioned at the start of the field path sequence.
@@ -443,17 +509,46 @@ def read_field_paths(r: BitReader) -> list[FieldPath]:
         finish sentinel).
     """
     fp = FieldPath()
-    node = HUFF_TREE
     paths: list[FieldPath] = []
+    ops = FIELD_PATH_OPS
+    table = _HUFF_DECODE_TABLE
+    table_bits = _HUFF_TABLE_BITS
+    mask = (1 << table_bits) - 1
+
+    buf = r._buf
+    size = r._size
+    unpack_from = struct.unpack_from
 
     while not fp.done:
-        next_node = node.right if r.read_bits(1) else node.left
-        assert next_node is not None
-        node = next_node
-        if node.is_leaf:
-            FIELD_PATH_OPS[node.value].fn(r, fp)
-            if not fp.done:
-                paths.append(fp.copy())
+        # Inline rem_bits: (size - pos) * 8 + bit_count
+        if (size - r._pos) * 8 + r._bit_count >= table_bits:
+            # Inline peek_bits(table_bits): refill then read without consuming
+            while table_bits > r._bit_count:
+                remaining = size - r._pos
+                if remaining >= 4:
+                    r._bit_val |= unpack_from("<I", buf, r._pos)[0] << r._bit_count
+                    r._pos += 4
+                    r._bit_count += 32
+                elif remaining > 0:
+                    r._bit_val |= buf[r._pos] << r._bit_count
+                    r._pos += 1
+                    r._bit_count += 8
+                else:
+                    break
+            bits = r._bit_val & mask
+            op_idx, consumed = table[bits]
+            # Inline skip_bits(consumed)
+            r._bit_val >>= consumed
+            r._bit_count -= consumed
+        else:
+            # Fallback: tree walk for the last few bits
             node = HUFF_TREE
+            while not node.is_leaf:
+                node = node.right if r.read_bits(1) else node.left  # type: ignore[assignment]
+            op_idx = node.value
+
+        ops[op_idx].fn(r, fp)
+        if not fp.done:
+            paths.append(fp.copy())
 
     return paths

--- a/src/gem/match_builder.py
+++ b/src/gem/match_builder.py
@@ -1,0 +1,243 @@
+"""Match assembly — wires extractor outputs into a :class:`ParsedMatch`.
+
+Takes the raw extractor state after a completed parse and builds the fully
+populated :class:`ParsedMatch` returned by :func:`gem.parse`.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any
+
+from gem.models import ParsedMatch
+
+if TYPE_CHECKING:
+    from gem.combat_aggregator import _CombatAggregator
+    from gem.combatlog import CombatLogEntry
+    from gem.extractors.courier import CourierExtractor
+    from gem.extractors.draft import DraftExtractor
+    from gem.extractors.objectives import ObjectivesExtractor
+    from gem.extractors.players import PlayerExtractor
+    from gem.extractors.wards import WardsExtractor
+    from gem.models import ChatEntry
+    from gem.parser import ReplayParser
+
+# Lane position grid resolution in world units (7d)
+_LANE_GRID = 64
+
+
+def _radiant_win_from_ancient(combat_log: list[CombatLogEntry]) -> bool | None:
+    """Infer radiant_win from ancient DEATH events in the combat log.
+
+    The destroying team is inferred from which ancient (fort) was killed:
+    - ``npc_dota_badguys_fort`` dies → Radiant wins
+    - ``npc_dota_goodguys_fort`` dies → Dire wins
+
+    Args:
+        combat_log: Full list of CombatLogEntry objects from the replay.
+
+    Returns:
+        True if Radiant won, False if Dire won, None if no ancient death found.
+    """
+    for e in combat_log:
+        if e.log_type != "DEATH":
+            continue
+        if e.target_name == "npc_dota_badguys_fort":
+            return True
+        if e.target_name == "npc_dota_goodguys_fort":
+            return False
+    return None
+
+
+def build_parsed_match(
+    parser: ReplayParser,
+    player_ext: PlayerExtractor,
+    obj_ext: ObjectivesExtractor,
+    ward_ext: WardsExtractor,
+    courier_ext: CourierExtractor,
+    draft_ext: DraftExtractor,
+    combat_agg: _CombatAggregator,
+    all_entries: list[CombatLogEntry],
+    chat_entries: list[ChatEntry],
+) -> ParsedMatch:
+    """Assemble a :class:`ParsedMatch` from extractor state after a completed parse.
+
+    Handles radiant_win resolution (three-tier), per-player time series wiring,
+    player name extraction, ward-to-player assignment, gold/XP advantage curves,
+    and teamfight detection.
+
+    Args:
+        parser: Completed :class:`ReplayParser` instance.
+        player_ext: Attached :class:`PlayerExtractor`.
+        obj_ext: Attached :class:`ObjectivesExtractor`.
+        ward_ext: Attached :class:`WardsExtractor`.
+        courier_ext: Attached :class:`CourierExtractor`.
+        draft_ext: Attached :class:`DraftExtractor` (already finalized).
+        combat_agg: Populated :class:`_CombatAggregator`.
+        all_entries: All :class:`CombatLogEntry` objects from the replay.
+        chat_entries: All :class:`ChatEntry` objects from the replay.
+
+    Returns:
+        Fully populated :class:`ParsedMatch`.
+    """
+    from gem.combat_aggregator import _dedup_purchase_log
+    from gem.extractors.teamfights import detect_teamfights
+
+    # radiant_win resolution — three tiers in priority order:
+    #   1. CDemoFileInfo.game_winner (set during parse, empty for HLTV replays)
+    #   2. m_pGameRules.m_nGameWinner entity field (set post-parse in parser.py)
+    #   3. Ancient DEATH in combat log — no API needed
+    radiant_win = parser.radiant_win
+    if radiant_win is None:
+        radiant_win = _radiant_win_from_ancient(all_entries)
+
+    match = ParsedMatch(
+        match_id=parser.match_id,
+        game_mode=parser.game_mode,
+        leagueid=parser.leagueid,
+        radiant_win=radiant_win,
+        towers=obj_ext.tower_kills,
+        barracks=obj_ext.barracks_kills,
+        roshans=obj_ext.roshan_kills,
+        aegis_events=obj_ext.aegis_events,
+        wards=ward_ext.ward_events,
+        combat_log=all_entries,
+        chat=chat_entries,
+        courier_snapshots=courier_ext.snapshots,
+        draft=draft_ext.draft_events,
+    )
+
+    # Post-process buybacks (7b).
+    # For BUYBACK entries, entry.value = player slot (0-9).
+    # Reference: refs/parser/src/main/java/opendota/CreateParsedDataBlob.java handleBuyback()
+    for entry in all_entries:
+        if entry.log_type != "BUYBACK":
+            continue
+        pid = entry.value
+        if 0 <= pid < 10:
+            combat_agg._agg(pid).buyback_log.append(entry)
+
+    # Build per-player time series and overlay combat log aggregates
+    for player_id in range(10):
+        ts = player_ext.time_series(player_id)
+        pp = match.players[player_id]
+        pp.player_id = player_id
+        pp.times = ts.ticks
+        pp.gold_t = ts.gold_t
+        pp.net_worth_t = ts.net_worth_t
+        pp.lh_t = ts.lh_t
+        pp.dn_t = ts.dn_t
+        pp.xp_t = ts.xp_t
+        mts = player_ext.minute_time_series(player_id)
+        pp.times_min = mts.ticks
+        pp.gold_t_min = mts.gold_t
+        pp.total_earned_gold_t_min = mts.total_earned_gold_t
+        pp.total_earned_xp_t_min = mts.total_earned_xp_t
+        pp.net_worth_t_min = mts.net_worth_t
+        pp.lh_t_min = mts.lh_t
+        pp.dn_t_min = mts.dn_t
+        pp.xp_t_min = mts.xp_t
+        pp.position_log = [
+            (snap.tick, snap.x, snap.y)
+            for snap in player_ext.snapshots
+            if snap.player_id == player_id and snap.x is not None and snap.y is not None
+        ]
+
+        # Resolve hero name from snapshots
+        for snap in player_ext.snapshots:
+            if snap.player_id == player_id:
+                pp.hero_name = snap.npc_name
+                pp.team = snap.team
+                break
+
+        agg = combat_agg.players.get(player_id)
+        if agg is not None:
+            pp.damage = agg.damage
+            pp.damage_taken = agg.damage_taken
+            pp.healing = agg.healing
+            pp.ability_uses = agg.ability_uses
+            pp.item_uses = agg.item_uses
+            pp.gold_reasons = agg.gold_reasons
+            pp.xp_reasons = agg.xp_reasons
+            pp.kills_log = agg.kills_log
+            pp.purchase_log = _dedup_purchase_log(
+                agg.purchase_log,
+                player_ext.first_snapshot_tick.get(player_id),
+                player_ext._sample_interval,
+            )
+            pp.runes_log = agg.runes_log
+            pp.buyback_log = agg.buyback_log
+            pp.stuns_dealt = agg.stuns_dealt
+
+        kda = player_ext.scoreboard.get(player_id)
+        if kda is not None:
+            pp.kills, pp.deaths, pp.assists = kda
+
+        # Lane position heatmap (7d) — post-process existing snapshots
+        lane_pos: defaultdict[str, int] = defaultdict(int)
+        for snap in player_ext.snapshots:
+            if snap.player_id != player_id or snap.x is None or snap.y is None:
+                continue
+            lane_pos[f"{int(snap.x) // _LANE_GRID}_{int(snap.y) // _LANE_GRID}"] += 1
+        pp.lane_pos = lane_pos
+
+    # Extract player names from CDOTA_PlayerResource entity.
+    # Two field path variants: newer replays use m_vecPlayerData.{slot}.m_iszPlayerName,
+    # older replays use m_iszPlayerNames.{slot}.
+    # Reference: refs/manta/manta_test.go line ~703
+    if parser.entity_manager is not None:
+        pr = parser.entity_manager.find_by_class_name("CDOTA_PlayerResource")
+        if pr is not None:
+            for player_id in range(10):
+                slot = f"{player_id:04d}"
+                name, ok = pr.get_string(f"m_vecPlayerData.{slot}.m_iszPlayerName")
+                if not ok or not name:
+                    name, ok = pr.get_string(f"m_iszPlayerNames.{slot}")
+                if ok and name:
+                    match.players[player_id].player_name = name
+
+    # Attach ward logs per player
+    for ward in match.wards:
+        if 0 <= ward.player_id < 10:
+            pp = match.players[ward.player_id]
+            if ward.ward_type == "observer":
+                pp.obs_log.append(ward)
+            else:
+                pp.sen_log.append(ward)
+
+    # Compute radiant_gold_adv / radiant_xp_adv per game-minute boundary.
+    # Use total_earned fields (monotonically increasing) rather than spendable gold.
+    # Compute the minimum series length so all 10 active players contribute to every bucket.
+    # Reference: refs/parser/src/main/java/opendota/CreateParsedDataBlob.java processAllPlayers()
+    active_players = [
+        pp for pp in match.players if pp.total_earned_gold_t_min and pp.total_earned_xp_t_min
+    ]
+    if active_players:
+        n_minutes = min(
+            min(len(pp.total_earned_gold_t_min), len(pp.total_earned_xp_t_min))
+            for pp in active_players
+        )
+        gold_adv = [0] * n_minutes
+        xp_adv = [0] * n_minutes
+        for pp in active_players:
+            sign = 1 if pp.team == 2 else -1  # 2=Radiant, 3=Dire
+            for i in range(n_minutes):
+                gold_adv[i] += sign * pp.total_earned_gold_t_min[i]
+                xp_adv[i] += sign * (
+                    pp.total_earned_xp_t_min[i] if i < len(pp.total_earned_xp_t_min) else 0
+                )
+        match.radiant_gold_adv = gold_adv
+        match.radiant_xp_adv = xp_adv
+
+    # Detect teamfights (Phase 9)
+    hero_to_slot = {pp.hero_name: pp.player_id for pp in match.players if pp.hero_name}
+    player_snaps: dict[int, Any] = {
+        pid: [s for s in player_ext.snapshots if s.player_id == pid] for pid in range(10)
+    }
+    match.teamfights = detect_teamfights(
+        all_entries,
+        hero_to_slot=hero_to_slot,
+        player_snapshots=player_snaps,
+    )
+
+    return match

--- a/src/gem/models.py
+++ b/src/gem/models.py
@@ -8,6 +8,7 @@ Reference: refs/parser/src/main/java/opendota/CreateParsedDataBlob.java
 
 from __future__ import annotations
 
+from collections import defaultdict
 from dataclasses import dataclass, field
 
 from gem.combatlog import CombatLogEntry
@@ -121,12 +122,20 @@ class ParsedPlayer:
     purchase_log: list[CombatLogEntry] = field(default_factory=list)
     runes_log: list[CombatLogEntry] = field(default_factory=list)
     buyback_log: list[CombatLogEntry] = field(default_factory=list)
-    lane_pos: dict[str, int] = field(default_factory=dict)
+    lane_pos: defaultdict[str, int] = field(default_factory=lambda: defaultdict(int))
     position_log: list[tuple[int, float, float]] = field(default_factory=list)
     stuns_dealt: float = 0.0
     kills: int = 0
     deaths: int = 0
     assists: int = 0
+
+    def __repr__(self) -> str:
+        hero = self.hero_name.removeprefix("npc_dota_hero_") if self.hero_name else "unknown"
+        team = "Radiant" if self.team == 2 else "Dire" if self.team == 3 else f"team={self.team}"
+        return (
+            f"ParsedPlayer(slot={self.player_id}, hero={hero}, team={team}, "
+            f"kda={self.kills}/{self.deaths}/{self.assists})"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -177,3 +186,15 @@ class ParsedMatch:
     courier_snapshots: list[CourierSnapshot] = field(default_factory=list)
     draft: list[DraftEvent] = field(default_factory=list)
     teamfights: list[Teamfight] = field(default_factory=list)
+
+    def __repr__(self) -> str:
+        winner = "Radiant" if self.radiant_win else "Dire" if self.radiant_win is False else "?"
+        duration_min = (
+            round(max(pp.times[-1] for pp in self.players if pp.times) / 30 / 60)
+            if any(pp.times for pp in self.players)
+            else 0
+        )
+        return (
+            f"ParsedMatch(match_id={self.match_id}, winner={winner}, "
+            f"duration=~{duration_min}min, players={len(self.players)})"
+        )

--- a/src/gem/parser.py
+++ b/src/gem/parser.py
@@ -177,8 +177,8 @@ class ReplayParser:
         self.leagueid: int = 0
         self.radiant_win: bool | None = None
         self.game_start_tick: int | None = None
-        self._game_start_callbacks: list = []
-        self._game_end_callbacks: list = []
+        self._game_start_callbacks: list[Callable[[int], None]] = []
+        self._game_end_callbacks: list[Callable[[int], None]] = []
         self._game_ended: bool = False
 
     # ------------------------------------------------------------------
@@ -462,8 +462,8 @@ class ReplayParser:
                 self.combat_log.process_rune_pickup(
                     chat_event.playerid_1, chat_event.value, tick=self.tick
                 )
-            for cb in self._chat_event_callbacks:
-                cb(chat_event, self.tick)
+            for chat_cb in self._chat_event_callbacks:
+                chat_cb(chat_event, self.tick)
 
         elif type_id == _DOTA_UM_CHAT_MESSAGE:
             self._emit_chat_message(payload)

--- a/src/gem/reader.py
+++ b/src/gem/reader.py
@@ -434,6 +434,51 @@ class BitReader:
     # State inspection
     # ------------------------------------------------------------------
 
+    def peek_bits(self, n: int) -> int:
+        """Read n bits without advancing the position.
+
+        Refills the internal bit buffer exactly as read_bits does, so the
+        reader is left in a state where a subsequent skip_bits(n) or
+        read_bits(n) will consume the same bits.
+
+        Args:
+            n: Number of bits to peek (0 ≤ n ≤ 32).
+
+        Returns:
+            int: The unsigned integer value of the next n bits.
+
+        Raises:
+            BufferError: If fewer than n bits remain.
+        """
+        while n > self._bit_count:
+            remaining = self._size - self._pos
+            if remaining >= 4:
+                self._bit_val |= (
+                    struct.unpack_from("<I", self._buf, self._pos)[0] << self._bit_count
+                )
+                self._pos += 4
+                self._bit_count += 32
+            elif remaining > 0:
+                self._bit_val |= self._next_byte() << self._bit_count
+                self._bit_count += 8
+            else:
+                raise BufferError(
+                    f"insufficient buffer: need {n} bits at pos {self._pos}, size {self._size}"
+                )
+        return self._bit_val & ((1 << n) - 1)
+
+    def skip_bits(self, n: int) -> None:
+        """Discard n bits that have already been loaded into the bit buffer.
+
+        Must only be called after a peek_bits(n) that has already refilled
+        the buffer.  Does not refill — callers must ensure n ≤ _bit_count.
+
+        Args:
+            n: Number of bits to skip.
+        """
+        self._bit_val >>= n
+        self._bit_count -= n
+
     def rem_bits(self) -> int:
         """Return the number of unread bits remaining in the buffer.
 

--- a/tests/test_combat_aggregator.py
+++ b/tests/test_combat_aggregator.py
@@ -1,0 +1,175 @@
+"""Tests for gem.combat_aggregator.
+
+Covers _ParsedPlayerAgg structure and _CombatAggregator routing/accumulation.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import fields
+from unittest.mock import MagicMock
+
+from gem.combat_aggregator import _CombatAggregator, _ParsedPlayerAgg
+
+# ---------------------------------------------------------------------------
+# _ParsedPlayerAgg
+# ---------------------------------------------------------------------------
+
+
+class TestParsedPlayerAgg:
+    def test_counter_fields_are_defaultdict(self):
+        agg = _ParsedPlayerAgg()
+        for attr in (
+            "damage",
+            "damage_taken",
+            "healing",
+            "ability_uses",
+            "item_uses",
+            "gold_reasons",
+            "xp_reasons",
+        ):
+            assert isinstance(getattr(agg, attr), defaultdict), f"{attr} should be defaultdict"
+
+    def test_missing_key_returns_zero(self):
+        agg = _ParsedPlayerAgg()
+        assert agg.damage["unknown_hero"] == 0
+
+    def test_increment_without_prior_set(self):
+        agg = _ParsedPlayerAgg()
+        agg.ability_uses["spell"] += 1
+        agg.ability_uses["spell"] += 1
+        assert agg.ability_uses["spell"] == 2
+
+    def test_log_fields_are_lists(self):
+        agg = _ParsedPlayerAgg()
+        for attr in ("kills_log", "purchase_log", "runes_log", "buyback_log"):
+            assert isinstance(getattr(agg, attr), list), f"{attr} should be list"
+
+    def test_stuns_dealt_starts_zero(self):
+        assert _ParsedPlayerAgg().stuns_dealt == 0.0
+
+    def test_is_dataclass_with_slots(self):
+        assert hasattr(_ParsedPlayerAgg, "__slots__")
+        assert len(fields(_ParsedPlayerAgg)) > 0
+
+    def test_independent_instances_do_not_share_state(self):
+        a, b = _ParsedPlayerAgg(), _ParsedPlayerAgg()
+        a.damage["hero"] += 999
+        assert b.damage["hero"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _CombatAggregator
+# ---------------------------------------------------------------------------
+
+
+def _make_agg(player_id_raw: int = 0) -> tuple[_CombatAggregator, MagicMock]:
+    """Return a _CombatAggregator wired to a single fake hero entity."""
+    player_ext = MagicMock()
+    hero_entity = MagicMock()
+    hero_entity.get_int32.return_value = (player_id_raw, True)
+    player_ext._heroes_by_npc = {"npc_dota_hero_axe": hero_entity}
+    return _CombatAggregator(player_ext), hero_entity
+
+
+def _entry(**kwargs) -> MagicMock:
+    defaults = {
+        "log_type": "DAMAGE",
+        "attacker_name": "npc_dota_hero_axe",
+        "target_name": "npc_dota_hero_mirana",
+        "attacker_is_hero": True,
+        "target_is_hero": False,
+        "inflictor_name": "",
+        "value": 100,
+        "gold_reason": 0,
+        "xp_reason": 0,
+        "stun_duration": 0.0,
+    }
+    defaults.update(kwargs)
+    return MagicMock(**defaults)
+
+
+class TestCombatAggregatorDamage:
+    def test_damage_accumulates(self):
+        agg, _ = _make_agg(0)
+        agg.on_entry(_entry(value=200))
+        agg.on_entry(_entry(value=150))
+        assert agg.players[0].damage["npc_dota_hero_mirana"] == 350
+
+    def test_first_entry_no_keyerror(self):
+        agg, _ = _make_agg(0)
+        agg.on_entry(_entry(value=999))  # must not raise
+        assert agg.players[0].damage["npc_dota_hero_mirana"] == 999
+
+    def test_damage_taken_on_target(self):
+        player_ext = MagicMock()
+        # attacker = axe (pid 0), target = mirana (pid 1)
+        axe_entity = MagicMock()
+        axe_entity.get_int32.return_value = (0, True)
+        mirana_entity = MagicMock()
+        mirana_entity.get_int32.return_value = (2, True)  # slot 1
+        player_ext._heroes_by_npc = {
+            "npc_dota_hero_axe": axe_entity,
+            "npc_dota_hero_mirana": mirana_entity,
+        }
+        agg = _CombatAggregator(player_ext)
+        e = _entry(attacker_is_hero=True, target_is_hero=True, value=100)
+        agg.on_entry(e)
+        assert agg.players[1].damage_taken["npc_dota_hero_axe"] == 100
+
+
+class TestCombatAggregatorAbilityItem:
+    def test_ability_uses_accumulate(self):
+        agg, _ = _make_agg(0)
+        for _ in range(3):
+            agg.on_entry(_entry(log_type="ABILITY", inflictor_name="axe_berserkers_call"))
+        assert agg.players[0].ability_uses["axe_berserkers_call"] == 3
+
+    def test_item_uses_accumulate(self):
+        agg, _ = _make_agg(0)
+        agg.on_entry(_entry(log_type="ITEM", inflictor_name="item_blink"))
+        agg.on_entry(_entry(log_type="ITEM", inflictor_name="item_blink"))
+        assert agg.players[0].item_uses["item_blink"] == 2
+
+
+class TestCombatAggregatorGoldXP:
+    def test_gold_reasons_accumulate(self):
+        agg, _ = _make_agg(0)
+        e = _entry(
+            log_type="GOLD",
+            attacker_is_hero=False,
+            target_is_hero=False,
+            target_name="npc_dota_hero_axe",
+            gold_reason=6,
+            value=50,
+        )
+        agg.on_entry(e)
+        agg.on_entry(e)
+        assert agg.players[0].gold_reasons["6"] == 100
+
+    def test_xp_reasons_accumulate(self):
+        agg, _ = _make_agg(0)
+        e = _entry(
+            log_type="XP",
+            attacker_is_hero=False,
+            target_is_hero=False,
+            target_name="npc_dota_hero_axe",
+            xp_reason=0,
+            value=200,
+        )
+        agg.on_entry(e)
+        assert agg.players[0].xp_reasons["0"] == 200
+
+
+class TestCombatAggregatorRunes:
+    def test_rune_pickup_goes_to_correct_slot(self):
+        agg, _ = _make_agg(0)
+        e = _entry(log_type="PICKUP_RUNE", attacker_is_hero=False, value=4)
+        agg.on_entry(e)
+        assert len(agg.players[4].runes_log) == 1
+
+    def test_rune_out_of_range_ignored(self):
+        agg, _ = _make_agg(0)
+        e = _entry(log_type="PICKUP_RUNE", attacker_is_hero=False, value=10)
+        agg.on_entry(e)
+        assert 10 not in agg.players

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -386,3 +386,28 @@ class TestLeagueName:
     def test_return_type_none_for_zero(self) -> None:
         result = C.league_name(0)
         assert result is None
+
+
+class TestConstantsReexport:
+    """gem.constants must be accessible as an attribute of the gem package."""
+
+    def test_accessible_as_gem_constants(self):
+        import gem
+
+        assert hasattr(gem, "constants")
+
+    def test_hero_display_callable(self):
+        import gem
+
+        assert callable(gem.constants.hero_display)
+
+    def test_hero_display_returns_nonempty_string(self):
+        import gem
+
+        result = gem.constants.hero_display("npc_dota_hero_axe")
+        assert isinstance(result, str) and result
+
+    def test_constants_in_all(self):
+        import gem
+
+        assert "constants" in gem.__all__

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -155,3 +155,37 @@ class TestEntityHandlers:
 
         assert len(received) == 1
         assert received[0][1].has(EntityOp.CREATED)
+
+
+# ---------------------------------------------------------------------------
+# ClassInfo — @dataclass(slots=True)
+# ---------------------------------------------------------------------------
+
+
+class TestClassInfo:
+    def test_is_dataclass(self):
+        from dataclasses import is_dataclass
+
+        from gem.entities import ClassInfo
+
+        assert is_dataclass(ClassInfo)
+
+    def test_has_slots(self):
+        from gem.entities import ClassInfo
+
+        assert hasattr(ClassInfo, "__slots__")
+
+    def test_construction(self):
+        from gem.entities import ClassInfo
+
+        ci = ClassInfo(class_id=42, name="CDOTA_Unit_Hero_Axe", serializer=None)
+        assert ci.class_id == 42
+        assert ci.name == "CDOTA_Unit_Hero_Axe"
+        assert ci.serializer is None
+
+    def test_field_names(self):
+        from dataclasses import fields
+
+        from gem.entities import ClassInfo
+
+        assert {f.name for f in fields(ClassInfo)} == {"class_id", "name", "serializer"}

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -593,3 +593,97 @@ class TestExtractorsIntegration:
                 assert len(ts.ticks) == len(ts.xp_t) == len(ts.lh_t)
                 break
         assert found
+
+
+# ---------------------------------------------------------------------------
+# _find_team helper
+# ---------------------------------------------------------------------------
+
+
+class TestFindTeam:
+    def test_radiant_tower(self):
+        from gem.extractors.objectives import _TOWER_TEAM, _find_team
+
+        assert _find_team("npc_dota_goodguys_tower1", _TOWER_TEAM) == 2
+
+    def test_dire_tower(self):
+        from gem.extractors.objectives import _TOWER_TEAM, _find_team
+
+        assert _find_team("npc_dota_badguys_tower3", _TOWER_TEAM) == 3
+
+    def test_unknown_returns_zero(self):
+        from gem.extractors.objectives import _TOWER_TEAM, _find_team
+
+        assert _find_team("npc_dota_roshan", _TOWER_TEAM) == 0
+
+    def test_radiant_barracks(self):
+        from gem.extractors.objectives import _BARRACKS_TEAM, _find_team
+
+        assert _find_team("npc_dota_goodguys_melee_rax_top", _BARRACKS_TEAM) == 2
+
+    def test_dire_barracks(self):
+        from gem.extractors.objectives import _BARRACKS_TEAM, _find_team
+
+        assert _find_team("npc_dota_badguys_range_rax_bot", _BARRACKS_TEAM) == 3
+
+
+# ---------------------------------------------------------------------------
+# _AEGIS_EVENT_TYPE dispatch and _on_chat_event
+# ---------------------------------------------------------------------------
+
+
+class TestAegisEventType:
+    def test_all_three_types_mapped(self):
+        from gem.extractors.objectives import (
+            _AEGIS_EVENT_TYPE,
+            _CHAT_MSG_AEGIS,
+            _CHAT_MSG_AEGIS_STOLEN,
+            _CHAT_MSG_DENIED_AEGIS,
+        )
+
+        assert _AEGIS_EVENT_TYPE[_CHAT_MSG_AEGIS] == "pickup"
+        assert _AEGIS_EVENT_TYPE[_CHAT_MSG_AEGIS_STOLEN] == "stolen"
+        assert _AEGIS_EVENT_TYPE[_CHAT_MSG_DENIED_AEGIS] == "denied"
+
+    def test_unknown_type_not_present(self):
+        from gem.extractors.objectives import _AEGIS_EVENT_TYPE
+
+        assert _AEGIS_EVENT_TYPE.get(9999) is None
+
+    def test_on_chat_event_pickup(self):
+        from unittest.mock import MagicMock
+
+        from gem.extractors.objectives import _CHAT_MSG_AEGIS, ObjectivesExtractor
+
+        ext = ObjectivesExtractor()
+        msg = MagicMock(type=_CHAT_MSG_AEGIS, playerid_1=3)
+        ext._on_chat_event(msg, tick=1000)
+        assert ext.aegis_events[0].event_type == "pickup"
+        assert ext.aegis_events[0].player_id == 3
+
+    def test_on_chat_event_stolen(self):
+        from unittest.mock import MagicMock
+
+        from gem.extractors.objectives import _CHAT_MSG_AEGIS_STOLEN, ObjectivesExtractor
+
+        ext = ObjectivesExtractor()
+        ext._on_chat_event(MagicMock(type=_CHAT_MSG_AEGIS_STOLEN, playerid_1=7), tick=2000)
+        assert ext.aegis_events[0].event_type == "stolen"
+
+    def test_on_chat_event_denied(self):
+        from unittest.mock import MagicMock
+
+        from gem.extractors.objectives import _CHAT_MSG_DENIED_AEGIS, ObjectivesExtractor
+
+        ext = ObjectivesExtractor()
+        ext._on_chat_event(MagicMock(type=_CHAT_MSG_DENIED_AEGIS, playerid_1=5), tick=3000)
+        assert ext.aegis_events[0].event_type == "denied"
+
+    def test_on_chat_event_ignores_unknown(self):
+        from unittest.mock import MagicMock
+
+        from gem.extractors.objectives import ObjectivesExtractor
+
+        ext = ObjectivesExtractor()
+        ext._on_chat_event(MagicMock(type=9999), tick=500)
+        assert ext.aegis_events == []

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,68 @@
+"""Tests for gem.models — ParsedPlayer and ParsedMatch dataclasses."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from gem.models import ParsedMatch, ParsedPlayer
+
+
+class TestParsedPlayerLanePos:
+    def test_lane_pos_is_defaultdict(self):
+        assert isinstance(ParsedPlayer(player_id=0).lane_pos, defaultdict)
+
+    def test_missing_key_returns_zero(self):
+        assert ParsedPlayer(player_id=0).lane_pos["100_200"] == 0
+
+    def test_accumulates(self):
+        pp = ParsedPlayer(player_id=0)
+        pp.lane_pos["50_60"] += 1
+        pp.lane_pos["50_60"] += 1
+        assert pp.lane_pos["50_60"] == 2
+
+    def test_independent_players(self):
+        p1, p2 = ParsedPlayer(player_id=0), ParsedPlayer(player_id=1)
+        p1.lane_pos["10_20"] += 5
+        assert p2.lane_pos["10_20"] == 0
+
+
+class TestParsedPlayerRepr:
+    def test_slot_hero_team_kda(self):
+        pp = ParsedPlayer(
+            player_id=3,
+            hero_name="npc_dota_hero_axe",
+            team=2,
+            kills=5,
+            deaths=2,
+            assists=8,
+        )
+        r = repr(pp)
+        assert "slot=3" in r
+        assert "axe" in r
+        assert "Radiant" in r
+        assert "5/2/8" in r
+
+    def test_dire_team(self):
+        assert "Dire" in repr(ParsedPlayer(player_id=7, team=3))
+
+    def test_unknown_team(self):
+        assert "team=0" in repr(ParsedPlayer(player_id=0, team=0))
+
+    def test_no_hero_shows_unknown(self):
+        assert "unknown" in repr(ParsedPlayer(player_id=0))
+
+
+class TestParsedMatchRepr:
+    def test_radiant_win(self):
+        r = repr(ParsedMatch(match_id=12345, radiant_win=True))
+        assert "12345" in r
+        assert "Radiant" in r
+
+    def test_dire_win(self):
+        assert "Dire" in repr(ParsedMatch(match_id=99, radiant_win=False))
+
+    def test_unknown_winner(self):
+        assert "?" in repr(ParsedMatch(match_id=0, radiant_win=None))
+
+    def test_player_count(self):
+        assert "players=10" in repr(ParsedMatch())

--- a/tests/test_players_extractor.py
+++ b/tests/test_players_extractor.py
@@ -695,3 +695,24 @@ class TestRefreshTeamSlots:
         ext._refresh_team_slots()
         assert ext._player_team_slot[0] == 2
         assert ext._player_team_slot[1] == 0
+
+
+# ---------------------------------------------------------------------------
+# _HERO_CLASS_PREFIX constant
+# ---------------------------------------------------------------------------
+
+
+class TestHeroClassPrefix:
+    def test_value(self):
+        from gem.extractors.players import _HERO_CLASS_PREFIX
+
+        assert _HERO_CLASS_PREFIX == "CDOTA_Unit_Hero_"
+
+    def test_literal_not_duplicated_in_source(self):
+        import inspect
+
+        import gem.extractors.players as pm
+
+        src = inspect.getsource(pm)
+        # The raw string literal should appear at most once (the definition line)
+        assert src.count('"CDOTA_Unit_Hero_"') <= 1

--- a/tests/test_wards_extractor.py
+++ b/tests/test_wards_extractor.py
@@ -523,3 +523,26 @@ class TestMakeEvent:
         ev = ext._make_event(wp, coord=None, spawn=spawn)
         assert ev.expires_tick is None
         assert ev.killed_tick is None
+
+
+# ---------------------------------------------------------------------------
+# Ward lifespan named constants
+# ---------------------------------------------------------------------------
+
+
+class TestWardLifespanConstants:
+    def test_values(self):
+        from gem.extractors.wards import (
+            _EXPIRY_TOLERANCE_TICKS,
+            _OBSERVER_LIFESPAN_TICKS,
+            _SENTRY_LIFESPAN_TICKS,
+        )
+
+        assert _OBSERVER_LIFESPAN_TICKS == 720
+        assert _SENTRY_LIFESPAN_TICKS == 360
+        assert _EXPIRY_TOLERANCE_TICKS == 30
+
+    def test_observer_longer_than_sentry(self):
+        from gem.extractors.wards import _OBSERVER_LIFESPAN_TICKS, _SENTRY_LIFESPAN_TICKS
+
+        assert _OBSERVER_LIFESPAN_TICKS > _SENTRY_LIFESPAN_TICKS


### PR DESCRIPTION
- Replace all dict.get(k, 0) + v counter patterns with defaultdict(int) + += in _ParsedPlayerAgg, _CombatAggregator, and match_builder.py lane heatmap
- Convert _ParsedPlayerAgg and ClassInfo from manual __slots__/__init__ to @dataclass(slots=True)
- Extract magic numbers to named constants: _OBSERVER_LIFESPAN_TICKS, _SENTRY_LIFESPAN_TICKS, _EXPIRY_TOLERANCE_TICKS in wards.py; _HERO_CLASS_PREFIX in players.py
- Replace _tower_team/_barracks_team duplicate functions with single _find_team(name, mapping) helper; replace aegis if/elif chain with _AEGIS_EVENT_TYPE dispatch dict
- Parametrize all bare list/dict type hints (match_builder.py, teamfights.py, parser.py)
- Add __repr__ to ParsedMatch and ParsedPlayer for better REPL/notebook experience
- Re-export gem.constants from package __init__ so gem.constants.hero_display() works without a separate import