### PR TITLE
refactor: split entities.py and players.py into focused modules

### DIFF
--- a/src/gem/entities.py
+++ b/src/gem/entities.py
@@ -19,12 +19,13 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from gem.field_path import FieldPath, read_field_paths
+from gem.field_path import FieldPath
+from gem.field_reader import read_fields
+from gem.field_state import FieldState
 from gem.reader import BitReader
 from gem.sendtable import (
     FIELD_MODEL_FIXED_ARRAY,
     FIELD_MODEL_FIXED_TABLE,
-    FIELD_MODEL_SIMPLE,
     FIELD_MODEL_VARIABLE_ARRAY,
     FIELD_MODEL_VARIABLE_TABLE,
     Field,
@@ -71,130 +72,6 @@ class EntityOp(enum.IntFlag):
             True if the flag is set.
         """
         return bool(self & other)
-
-
-# ---------------------------------------------------------------------------
-# FieldState — nested list tree mirroring manta/field_state.go
-# ---------------------------------------------------------------------------
-
-
-class FieldState:
-    """Nested mutable tree that stores decoded field values.
-
-    The tree mirrors ``manta/field_state.go``: each node is a list of
-    ``Any``, where a slot may hold a leaf value or a child ``FieldState``.
-    Paths from ``read_field_paths`` index into this tree.
-    """
-
-    __slots__ = ("_state",)
-
-    def __init__(self) -> None:
-        self._state: list[Any] = [None] * 8
-
-    def _ensure(self, idx: int) -> None:
-        if len(self._state) < idx + 2:
-            new_len = max(idx + 2, len(self._state) * 2)
-            self._state.extend([None] * (new_len - len(self._state)))
-
-    def get(self, fp: FieldPath) -> Any:
-        """Read the value at the given field path.
-
-        Args:
-            fp: A FieldPath produced by read_field_paths.
-
-        Returns:
-            The stored value, or None if the slot is empty/missing.
-        """
-        node: FieldState = self
-        for i in range(fp.last + 1):
-            z = fp.path[i]
-            if len(node._state) < z + 2:
-                return None
-            if i == fp.last:
-                return node._state[z]
-            child = node._state[z]
-            if not isinstance(child, FieldState):
-                return None
-            node = child
-        return None
-
-    def set(self, fp: FieldPath, value: Any) -> None:
-        """Write a value at the given field path, growing the tree as needed.
-
-        Args:
-            fp: A FieldPath produced by read_field_paths.
-            value: The decoded value to store.
-        """
-        node: FieldState = self
-        for i in range(fp.last + 1):
-            z = fp.path[i]
-            node._ensure(z)
-            if i == fp.last:
-                if not isinstance(node._state[z], FieldState):
-                    node._state[z] = value
-                return
-            child = node._state[z]
-            if not isinstance(child, FieldState):
-                child = FieldState()
-                node._state[z] = child
-            node = child
-
-
-# ---------------------------------------------------------------------------
-# Decoder dispatch — mirrors manta/field.go getDecoderForFieldPath
-# ---------------------------------------------------------------------------
-
-
-def _get_decoder(serializer: Serializer, fp: FieldPath, pos: int) -> Any:
-    f: Field = serializer.fields[fp.path[pos]]
-    return _get_decoder_for_field(f, fp, pos + 1)
-
-
-def _get_decoder_for_field(f: Field, fp: FieldPath, pos: int) -> Any:
-    model = f.model
-
-    if model in (FIELD_MODEL_SIMPLE, FIELD_MODEL_FIXED_ARRAY):
-        return f.decoder
-
-    if model == FIELD_MODEL_FIXED_TABLE:
-        if fp.last == pos - 1:
-            return f.base_decoder
-        assert f.serializer is not None
-        return _get_decoder(f.serializer, fp, pos)
-
-    if model == FIELD_MODEL_VARIABLE_ARRAY:
-        if fp.last == pos:
-            return f.child_decoder
-        return f.base_decoder
-
-    if model == FIELD_MODEL_VARIABLE_TABLE:
-        if fp.last >= pos + 1:
-            assert f.serializer is not None
-            return _get_decoder(f.serializer, fp, pos + 1)
-        return f.base_decoder
-
-    return f.decoder
-
-
-# ---------------------------------------------------------------------------
-# read_fields — mirrors manta/field_reader.go
-# ---------------------------------------------------------------------------
-
-
-def read_fields(r: BitReader, serializer: Serializer, state: FieldState) -> None:
-    """Read all field-path/value pairs from *r* into *state*.
-
-    Args:
-        r: BitReader positioned at the start of the entity delta.
-        serializer: The Serializer schema for this entity class.
-        state: The FieldState tree to update.
-    """
-    fps = read_field_paths(r)
-    for fp in fps:
-        decoder = _get_decoder(serializer, fp, 0)
-        if decoder is not None:
-            value = decoder(r)
-            state.set(fp, value)
 
 
 # ---------------------------------------------------------------------------

--- a/src/gem/extractors/_snapshots.py
+++ b/src/gem/extractors/_snapshots.py
@@ -1,0 +1,191 @@
+"""Player state snapshot and time-series dataclasses for the player extractor.
+
+Contains the data models and helper functions for sampling hero entity state.
+These are implementation details of the ``extractors`` package; consumers should
+import ``PlayerStateSnapshot`` and ``PlayerTimeSeries`` from
+``gem.extractors.players`` or ``gem.extractors``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from gem.entities import Entity
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_CELL_SIZE = 128  # Source 2 world units per grid cell
+_HERO_CLASS_PREFIX = "CDOTA_Unit_Hero_"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _pos(entity: Entity) -> tuple[float, float] | None:
+    """Return world (x, y) from cell+vec encoding on the entity.
+
+    Args:
+        entity: The entity to read coordinates from.
+
+    Returns:
+        ``(x, y)`` world coordinates, or ``None`` if any field is missing.
+    """
+    cell_x, ok_cx = entity.get_uint32("CBodyComponent.m_cellX")
+    cell_y, ok_cy = entity.get_uint32("CBodyComponent.m_cellY")
+    vec_x, ok_vx = entity.get_float32("CBodyComponent.m_vecX")
+    vec_y, ok_vy = entity.get_float32("CBodyComponent.m_vecY")
+    if not (ok_cx and ok_cy and ok_vx and ok_vy):
+        return None
+    return (cell_x * _CELL_SIZE + vec_x, cell_y * _CELL_SIZE + vec_y)
+
+
+def _snapshot_hero(entity: Entity, tick: int) -> PlayerStateSnapshot | None:
+    """Build a ``PlayerStateSnapshot`` from a hero entity.
+
+    Args:
+        entity: A ``CDOTA_Unit_Hero_*`` entity.
+        tick: Current game tick.
+
+    Returns:
+        A snapshot, or ``None`` if the player ID could not be resolved.
+    """
+    # m_nPlayerID (post-7.31) or m_iPlayerID (pre-7.31) — raw value is doubled;
+    # divide by 2 to get player slot 0-9. Reference: opendota/Parse.java getPlayerSlotFromEntity()
+    player_id, ok = entity.get_int32("m_nPlayerID")
+    if not ok:
+        player_id, ok = entity.get_int32("m_iPlayerID")
+    if not ok or player_id < 0:
+        return None
+    player_id //= 2
+
+    team, _ = entity.get_int32("m_iTeamNum")
+    level, _ = entity.get_int32("m_nCurrentLevel")
+    xp, _ = entity.get_int32("m_iCurrentXP")
+    hp, _ = entity.get_int32("m_iHealth")
+    max_hp, _ = entity.get_int32("m_iMaxHealth")
+    mana, _ = entity.get_float32("m_flMana")
+    max_mana, _ = entity.get_float32("m_flMaxMana")
+    lh, _ = entity.get_int32("m_iLastHitCount")
+    dn, _ = entity.get_int32("m_iDenies")
+
+    pos = _pos(entity)
+
+    # Convert entity class name to the canonical NPC name (camelCase → snake_case).
+    # "CDOTA_Unit_Hero_TemplarAssassin" → "npc_dota_hero_templar_assassin"
+    # "CDOTA_Unit_Hero_Nyx_Assassin"   → "npc_dota_hero_nyx_assassin" (already underscored)
+    # This matches dotaconstants keys and the combat log string table.
+    # Reference: refs/parser/Parse.java combatLogName2
+    _ending = entity.get_class_name()[len(_HERO_CLASS_PREFIX) :].replace("_", "")
+    _npc_name = "npc_dota_hero" + re.sub(r"([A-Z])", r"_\1", _ending).lower()
+    return PlayerStateSnapshot(
+        tick=tick,
+        player_id=player_id,
+        npc_name=_npc_name,
+        team=team,
+        level=level,
+        xp=xp,
+        gold=0,  # spendable gold — set by extractor from CDOTAPlayerController
+        total_earned_gold=0,  # cumulative — set by extractor from m_iTotalEarnedGold
+        net_worth=0,
+        lh=lh,
+        dn=dn,
+        hp=hp,
+        max_hp=max_hp,
+        mana=mana,
+        max_mana=max_mana,
+        x=pos[0] if pos else None,
+        y=pos[1] if pos else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PlayerStateSnapshot:
+    """A single per-player state sample taken at one tick.
+
+    Attributes:
+        tick: Game tick of this sample.
+        player_id: Player slot (0-9).
+        npc_name: Hero NPC name, e.g. ``"npc_dota_hero_axe"``.
+        team: Team number (2=Radiant, 3=Dire).
+        level: Hero level (1-30).
+        xp: Cumulative XP total.
+        gold: Spendable gold from ``CDOTAPlayerController``, or 0 if not read.
+        net_worth: Net worth from ``CDOTAPlayerController``, or 0 if not read.
+        total_earned_gold: Cumulative gold earned (``m_iTotalEarnedGold``), or 0 if not read.
+        total_earned_xp: Cumulative XP earned (``m_iTotalEarnedXP``), or 0 if not read.
+        lh: Last-hit count.
+        dn: Deny count.
+        hp: Current hit points.
+        max_hp: Maximum hit points.
+        mana: Current mana.
+        max_mana: Maximum mana.
+        x: World x coordinate, or ``None`` if unavailable.
+        y: World y coordinate, or ``None`` if unavailable.
+        ability_levels: Ability name → level mapping for learned abilities.
+    """
+
+    tick: int
+    player_id: int
+    npc_name: str
+    team: int
+    level: int
+    xp: int
+    gold: int
+    net_worth: int
+    lh: int
+    dn: int
+    hp: int
+    max_hp: int
+    mana: float
+    max_mana: float
+    x: float | None
+    y: float | None
+    total_earned_gold: int = 0
+    total_earned_xp: int = 0
+    ability_levels: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class PlayerTimeSeries:
+    """Time-series data for one player, aggregated from snapshots.
+
+    Attributes:
+        player_id: Player slot (0-9).
+        ticks: Tick values for each sample.
+        gold_t: Spendable gold at each sample tick.
+        total_earned_gold_t: Cumulative total earned gold at each sample tick.
+        total_earned_xp_t: Cumulative total earned XP at each sample tick.
+        net_worth_t: Net worth at each sample tick.
+        lh_t: Last-hit count at each sample tick.
+        dn_t: Deny count at each sample tick.
+        xp_t: Cumulative XP at each sample tick.
+        hp_t: Current hit points at each sample tick.
+        mana_t: Current mana at each sample tick.
+        x_t: World x coordinate at each sample tick (``None`` if unavailable).
+        y_t: World y coordinate at each sample tick (``None`` if unavailable).
+    """
+
+    player_id: int
+    ticks: list[int] = field(default_factory=list)
+    gold_t: list[int] = field(default_factory=list)
+    total_earned_gold_t: list[int] = field(default_factory=list)
+    total_earned_xp_t: list[int] = field(default_factory=list)
+    net_worth_t: list[int] = field(default_factory=list)
+    lh_t: list[int] = field(default_factory=list)
+    dn_t: list[int] = field(default_factory=list)
+    xp_t: list[int] = field(default_factory=list)
+    hp_t: list[int] = field(default_factory=list)
+    mana_t: list[float] = field(default_factory=list)
+    x_t: list[float | None] = field(default_factory=list)
+    y_t: list[float | None] = field(default_factory=list)

--- a/src/gem/extractors/players.py
+++ b/src/gem/extractors/players.py
@@ -9,10 +9,16 @@ Reference: examples/extraction_demo.py, refs/parser/src/main/java/opendota/Parse
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from gem.entities import Entity, EntityOp
+from gem.extractors._snapshots import (
+    _HERO_CLASS_PREFIX,
+    PlayerStateSnapshot,
+    PlayerTimeSeries,
+    _pos,
+    _snapshot_hero,
+)
 
 if TYPE_CHECKING:
     from gem.parser import ReplayParser
@@ -31,180 +37,10 @@ _NULL_HANDLE = 0xFFFFFF  # empty slot sentinel
 # Constants
 # ---------------------------------------------------------------------------
 
-_CELL_SIZE = 128  # Source 2 world units per grid cell
 _TEAM_RADIANT = 2
 _TEAM_DIRE = 3
-_HERO_CLASS_PREFIX = "CDOTA_Unit_Hero_"
 
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _pos(entity: Entity) -> tuple[float, float] | None:
-    """Return world (x, y) from cell+vec encoding on the entity.
-
-    Args:
-        entity: The entity to read coordinates from.
-
-    Returns:
-        ``(x, y)`` world coordinates, or ``None`` if any field is missing.
-    """
-    cell_x, ok_cx = entity.get_uint32("CBodyComponent.m_cellX")
-    cell_y, ok_cy = entity.get_uint32("CBodyComponent.m_cellY")
-    vec_x, ok_vx = entity.get_float32("CBodyComponent.m_vecX")
-    vec_y, ok_vy = entity.get_float32("CBodyComponent.m_vecY")
-    if not (ok_cx and ok_cy and ok_vx and ok_vy):
-        return None
-    return (cell_x * _CELL_SIZE + vec_x, cell_y * _CELL_SIZE + vec_y)
-
-
-def _snapshot_hero(entity: Entity, tick: int) -> PlayerStateSnapshot | None:
-    """Build a ``PlayerStateSnapshot`` from a hero entity.
-
-    Args:
-        entity: A ``CDOTA_Unit_Hero_*`` entity.
-        tick: Current game tick.
-
-    Returns:
-        A snapshot, or ``None`` if the player ID could not be resolved.
-    """
-    # m_nPlayerID (post-7.31) or m_iPlayerID (pre-7.31) — raw value is doubled;
-    # divide by 2 to get player slot 0-9. Reference: opendota/Parse.java getPlayerSlotFromEntity()
-    player_id, ok = entity.get_int32("m_nPlayerID")
-    if not ok:
-        player_id, ok = entity.get_int32("m_iPlayerID")
-    if not ok or player_id < 0:
-        return None
-    player_id //= 2
-
-    team, _ = entity.get_int32("m_iTeamNum")
-    level, _ = entity.get_int32("m_nCurrentLevel")
-    xp, _ = entity.get_int32("m_iCurrentXP")
-    hp, _ = entity.get_int32("m_iHealth")
-    max_hp, _ = entity.get_int32("m_iMaxHealth")
-    mana, _ = entity.get_float32("m_flMana")
-    max_mana, _ = entity.get_float32("m_flMaxMana")
-    lh, _ = entity.get_int32("m_iLastHitCount")
-    dn, _ = entity.get_int32("m_iDenies")
-
-    pos = _pos(entity)
-
-    # Convert entity class name to the canonical NPC name (camelCase → snake_case).
-    # "CDOTA_Unit_Hero_TemplarAssassin" → "npc_dota_hero_templar_assassin"
-    # "CDOTA_Unit_Hero_Nyx_Assassin"   → "npc_dota_hero_nyx_assassin" (already underscored)
-    # This matches dotaconstants keys and the combat log string table.
-    # Reference: refs/parser/Parse.java combatLogName2
-    _ending = entity.get_class_name()[len(_HERO_CLASS_PREFIX) :].replace("_", "")
-    _npc_name = "npc_dota_hero" + re.sub(r"([A-Z])", r"_\1", _ending).lower()
-    return PlayerStateSnapshot(
-        tick=tick,
-        player_id=player_id,
-        npc_name=_npc_name,
-        team=team,
-        level=level,
-        xp=xp,
-        gold=0,  # spendable gold — set by extractor from CDOTAPlayerController
-        total_earned_gold=0,  # cumulative — set by extractor from m_iTotalEarnedGold
-        net_worth=0,
-        lh=lh,
-        dn=dn,
-        hp=hp,
-        max_hp=max_hp,
-        mana=mana,
-        max_mana=max_mana,
-        x=pos[0] if pos else None,
-        y=pos[1] if pos else None,
-    )
-
-
-# ---------------------------------------------------------------------------
-# Data classes
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class PlayerStateSnapshot:
-    """A single per-player state sample taken at one tick.
-
-    Attributes:
-        tick: Game tick of this sample.
-        player_id: Player slot (0-9).
-        npc_name: Hero NPC name, e.g. ``"npc_dota_hero_axe"``.
-        team: Team number (2=Radiant, 3=Dire).
-        level: Hero level (1-30).
-        xp: Cumulative XP total.
-        gold: Spendable gold from ``CDOTAPlayerController``, or 0 if not read.
-        net_worth: Net worth from ``CDOTAPlayerController``, or 0 if not read.
-        total_earned_gold: Cumulative gold earned (``m_iTotalEarnedGold``), or 0 if not read.
-        total_earned_xp: Cumulative XP earned (``m_iTotalEarnedXP``), or 0 if not read.
-        lh: Last-hit count.
-        dn: Deny count.
-        hp: Current hit points.
-        max_hp: Maximum hit points.
-        mana: Current mana.
-        max_mana: Maximum mana.
-        x: World x coordinate, or ``None`` if unavailable.
-        y: World y coordinate, or ``None`` if unavailable.
-        ability_levels: Ability name → level mapping for learned abilities.
-    """
-
-    tick: int
-    player_id: int
-    npc_name: str
-    team: int
-    level: int
-    xp: int
-    gold: int
-    net_worth: int
-    lh: int
-    dn: int
-    hp: int
-    max_hp: int
-    mana: float
-    max_mana: float
-    x: float | None
-    y: float | None
-    total_earned_gold: int = 0
-    total_earned_xp: int = 0
-    ability_levels: dict[str, int] = field(default_factory=dict)
-
-
-@dataclass
-class PlayerTimeSeries:
-    """Time-series data for one player, aggregated from snapshots.
-
-    Attributes:
-        player_id: Player slot (0-9).
-        ticks: Tick values for each sample.
-        gold_t: Spendable gold at each sample tick.
-        total_earned_gold_t: Cumulative total earned gold at each sample tick.
-        total_earned_xp_t: Cumulative total earned XP at each sample tick.
-        net_worth_t: Net worth at each sample tick.
-        lh_t: Last-hit count at each sample tick.
-        dn_t: Deny count at each sample tick.
-        xp_t: Cumulative XP at each sample tick.
-        hp_t: Current hit points at each sample tick.
-        mana_t: Current mana at each sample tick.
-        x_t: World x coordinate at each sample tick (``None`` if unavailable).
-        y_t: World y coordinate at each sample tick (``None`` if unavailable).
-    """
-
-    player_id: int
-    ticks: list[int] = field(default_factory=list)
-    gold_t: list[int] = field(default_factory=list)
-    total_earned_gold_t: list[int] = field(default_factory=list)
-    total_earned_xp_t: list[int] = field(default_factory=list)
-    net_worth_t: list[int] = field(default_factory=list)
-    lh_t: list[int] = field(default_factory=list)
-    dn_t: list[int] = field(default_factory=list)
-    xp_t: list[int] = field(default_factory=list)
-    hp_t: list[int] = field(default_factory=list)
-    mana_t: list[float] = field(default_factory=list)
-    x_t: list[float | None] = field(default_factory=list)
-    y_t: list[float | None] = field(default_factory=list)
-
+__all__ = ["PlayerExtractor", "PlayerStateSnapshot", "PlayerTimeSeries"]
 
 # ---------------------------------------------------------------------------
 # Extractor

--- a/src/gem/field_reader.py
+++ b/src/gem/field_reader.py
@@ -1,0 +1,69 @@
+"""Field decoder dispatch and entity field reading.
+
+Mirrors ``manta/field_reader.go`` and the decoder-lookup logic in
+``manta/field.go`` (getDecoderForFieldPath).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from gem.field_path import FieldPath, read_field_paths
+from gem.field_state import FieldState
+from gem.reader import BitReader
+from gem.sendtable import (
+    FIELD_MODEL_FIXED_ARRAY,
+    FIELD_MODEL_FIXED_TABLE,
+    FIELD_MODEL_SIMPLE,
+    FIELD_MODEL_VARIABLE_ARRAY,
+    FIELD_MODEL_VARIABLE_TABLE,
+    Field,
+    Serializer,
+)
+
+
+def _get_decoder(serializer: Serializer, fp: FieldPath, pos: int) -> Any:
+    f: Field = serializer.fields[fp.path[pos]]
+    return _get_decoder_for_field(f, fp, pos + 1)
+
+
+def _get_decoder_for_field(f: Field, fp: FieldPath, pos: int) -> Any:
+    model = f.model
+
+    if model in (FIELD_MODEL_SIMPLE, FIELD_MODEL_FIXED_ARRAY):
+        return f.decoder
+
+    if model == FIELD_MODEL_FIXED_TABLE:
+        if fp.last == pos - 1:
+            return f.base_decoder
+        assert f.serializer is not None
+        return _get_decoder(f.serializer, fp, pos)
+
+    if model == FIELD_MODEL_VARIABLE_ARRAY:
+        if fp.last == pos:
+            return f.child_decoder
+        return f.base_decoder
+
+    if model == FIELD_MODEL_VARIABLE_TABLE:
+        if fp.last >= pos + 1:
+            assert f.serializer is not None
+            return _get_decoder(f.serializer, fp, pos + 1)
+        return f.base_decoder
+
+    return f.decoder
+
+
+def read_fields(r: BitReader, serializer: Serializer, state: FieldState) -> None:
+    """Read all field-path/value pairs from *r* into *state*.
+
+    Args:
+        r: BitReader positioned at the start of the entity delta.
+        serializer: The Serializer schema for this entity class.
+        state: The FieldState tree to update.
+    """
+    fps = read_field_paths(r)
+    for fp in fps:
+        decoder = _get_decoder(serializer, fp, 0)
+        if decoder is not None:
+            value = decoder(r)
+            state.set(fp, value)

--- a/src/gem/field_state.py
+++ b/src/gem/field_state.py
@@ -1,0 +1,72 @@
+"""Nested mutable field-value tree for entity state storage.
+
+Mirrors ``manta/field_state.go``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from gem.field_path import FieldPath
+
+
+class FieldState:
+    """Nested mutable tree that stores decoded field values.
+
+    The tree mirrors ``manta/field_state.go``: each node is a list of
+    ``Any``, where a slot may hold a leaf value or a child ``FieldState``.
+    Paths from ``read_field_paths`` index into this tree.
+    """
+
+    __slots__ = ("_state",)
+
+    def __init__(self) -> None:
+        self._state: list[Any] = [None] * 8
+
+    def _ensure(self, idx: int) -> None:
+        if len(self._state) < idx + 2:
+            new_len = max(idx + 2, len(self._state) * 2)
+            self._state.extend([None] * (new_len - len(self._state)))
+
+    def get(self, fp: FieldPath) -> Any:
+        """Read the value at the given field path.
+
+        Args:
+            fp: A FieldPath produced by read_field_paths.
+
+        Returns:
+            The stored value, or None if the slot is empty/missing.
+        """
+        node: FieldState = self
+        for i in range(fp.last + 1):
+            z = fp.path[i]
+            if len(node._state) < z + 2:
+                return None
+            if i == fp.last:
+                return node._state[z]
+            child = node._state[z]
+            if not isinstance(child, FieldState):
+                return None
+            node = child
+        return None
+
+    def set(self, fp: FieldPath, value: Any) -> None:
+        """Write a value at the given field path, growing the tree as needed.
+
+        Args:
+            fp: A FieldPath produced by read_field_paths.
+            value: The decoded value to store.
+        """
+        node: FieldState = self
+        for i in range(fp.last + 1):
+            z = fp.path[i]
+            node._ensure(z)
+            if i == fp.last:
+                if not isinstance(node._state[z], FieldState):
+                    node._state[z] = value
+                return
+            child = node._state[z]
+            if not isinstance(child, FieldState):
+                child = FieldState()
+                node._state[z] = child
+            node = child


### PR DESCRIPTION
  **Pure reorganisation — no logic changes, no behaviour changes.**

- `src/gem/field_state.py` — `FieldState` extracted from `entities.py`
- `src/gem/field_reader.py` — `_get_decoder`, `_get_decoder_for_field`, `read_fields` extracted from`entities.py`
- `src/gem/extractors/_snapshots.py` — `PlayerStateSnapshot`, `PlayerTimeSeries`, `_pos`, `_snapshot_hero` extracted from `extractors/players.py`

Each source file now has a single responsibility:

- `entities.py` — entity lifecycle and typed getters only
- `extractors/players.py` — `PlayerExtractor` orchestrator only