### PR TITLE
[codex] add icon cache checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,8 +460,8 @@ If you run a benchmark, please open an issue/PR with:
 - **Draft ID quirks** — replay pick/ban IDs can differ from static hero API IDs in some patches/formats (commonly transformed IDs). `gem` normalizes these, but edge cases may still appear.
 - **Purchase attribution in spectator/HLTV paths** — purchase events are not always directly hero-attributed in combat log data; reconstruction relies on entity state and may be incomplete in edge cases.
 - **Summon ownership edge cases** — most summoned-unit attribution is handled, but complex ownership cases can still produce occasional mismatches.
-- **Hero icons** — not bundled in the package. Run `python scripts/fetch_hero_icons.py` to download them locally before using the draft or teamfight report examples.
-- **Item icons** — not bundled in the package. Run `python scripts/fetch_item_icons.py` to download them locally before using reports that render item/rune icons.
+- **Hero icons** — not bundled in the package. Run `python scripts/fetch_hero_icons.py --check` to audit the local cache, or `python scripts/fetch_hero_icons.py` to download missing icons before using the draft or teamfight report examples.
+- **Item icons** — not bundled in the package. Run `python scripts/fetch_item_icons.py --check` to audit the local cache, or `python scripts/fetch_item_icons.py` to download missing non-recipe icons before using reports that render item/rune icons. Recipe icons are skipped by default; pass `--include-recipes` if you need them.
 
 ---
 

--- a/scripts/fetch_hero_icons.py
+++ b/scripts/fetch_hero_icons.py
@@ -12,6 +12,7 @@ where ``{short}`` is derived from the NPC name by stripping ``npc_dota_hero_``.
 Usage::
 
     python scripts/fetch_hero_icons.py           # skip already-downloaded
+    python scripts/fetch_hero_icons.py --check   # report missing icons
     python scripts/fetch_hero_icons.py --force   # re-download all
 """
 
@@ -23,6 +24,7 @@ import ssl
 import sys
 import time
 import urllib.request
+from collections.abc import Sequence
 from pathlib import Path
 
 _HEROES_JSON = Path(__file__).parent.parent / "src" / "gem" / "data" / "heroes.json"
@@ -46,9 +48,38 @@ def _short(npc_name: str) -> str:
     return npc_name.removeprefix("npc_dota_hero_")
 
 
-def fetch(force: bool = False) -> None:
-    _OUT_DIR.mkdir(parents=True, exist_ok=True)
-    heroes: dict = json.loads(_HEROES_JSON.read_text(encoding="utf-8"))
+def _hero_shorts(heroes_path: Path) -> tuple[str, ...]:
+    heroes: dict = json.loads(heroes_path.read_text(encoding="utf-8"))
+    return tuple(_short(npc_name) for npc_name in sorted(heroes))
+
+
+def missing_icon_shorts(
+    heroes_path: Path = _HEROES_JSON,
+    out_dir: Path = _OUT_DIR,
+) -> tuple[str, ...]:
+    return tuple(
+        short for short in _hero_shorts(heroes_path) if not (out_dir / f"{short}.png").exists()
+    )
+
+
+def check(heroes_path: Path = _HEROES_JSON, out_dir: Path = _OUT_DIR) -> int:
+    missing = missing_icon_shorts(heroes_path, out_dir)
+    if not missing:
+        print(f"All hero icons present in {out_dir}")
+        return 0
+
+    print(f"Missing {len(missing)} hero icon{'s' if len(missing) != 1 else ''} in {out_dir}:")
+    for short in missing:
+        print(f"  - {short}")
+    return 1
+
+
+def fetch(
+    force: bool = False,
+    heroes_path: Path = _HEROES_JSON,
+    out_dir: Path = _OUT_DIR,
+) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
 
     # macOS doesn't use system certs by default; disable verification for CDN
     ctx = ssl.create_default_context()
@@ -56,9 +87,8 @@ def fetch(force: bool = False) -> None:
     ctx.verify_mode = ssl.CERT_NONE
 
     ok = failed = skipped = 0
-    for npc_name in sorted(heroes):
-        short = _short(npc_name)
-        out_path = _OUT_DIR / f"{short}.png"
+    for short in _hero_shorts(heroes_path):
+        out_path = out_dir / f"{short}.png"
         if out_path.exists() and not force:
             skipped += 1
             continue
@@ -86,11 +116,25 @@ def fetch(force: bool = False) -> None:
             print(f"  FAIL {short}", file=sys.stderr)
             failed += 1
 
-    print(f"\nDone — {ok} downloaded, {skipped} skipped, {failed} failed → {_OUT_DIR}")
+    print(f"\nDone — {ok} downloaded, {skipped} skipped, {failed} failed -> {out_dir}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Download Dota 2 hero icons.")
+    parser.add_argument(
+        "--check", action="store_true", help="Report missing icons without downloading"
+    )
+    parser.add_argument("--force", action="store_true", help="Re-download existing files")
+    parser.add_argument("--heroes", type=Path, default=_HEROES_JSON, help="Path to heroes.json")
+    parser.add_argument("--out-dir", type=Path, default=_OUT_DIR, help="Icon output directory")
+    args = parser.parse_args(argv)
+
+    if args.check:
+        return check(args.heroes, args.out_dir)
+
+    fetch(force=args.force, heroes_path=args.heroes, out_dir=args.out_dir)
+    return 0
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Download Dota 2 hero icons.")
-    parser.add_argument("--force", action="store_true", help="Re-download existing files")
-    args = parser.parse_args()
-    fetch(force=args.force)
+    raise SystemExit(main())

--- a/scripts/fetch_item_icons.py
+++ b/scripts/fetch_item_icons.py
@@ -12,7 +12,8 @@ where ``{short}`` is derived from the item key by stripping ``item_``.
 Usage::
 
     python scripts/fetch_item_icons.py           # skip already-downloaded
-    python scripts/fetch_item_icons.py --force   # re-download all
+    python scripts/fetch_item_icons.py --check   # report missing icons
+    python scripts/fetch_item_icons.py --force   # re-download non-recipe icons
 """
 
 from __future__ import annotations
@@ -23,6 +24,7 @@ import ssl
 import sys
 import time
 import urllib.request
+from collections.abc import Sequence
 from pathlib import Path
 
 _ITEMS_JSON = Path(__file__).parent.parent / "src" / "gem" / "data" / "items.json"
@@ -34,18 +36,63 @@ def _short(item_key: str) -> str:
     return item_key.removeprefix("item_")
 
 
-def fetch(force: bool = False) -> None:
-    _OUT_DIR.mkdir(parents=True, exist_ok=True)
-    items: dict = json.loads(_ITEMS_JSON.read_text(encoding="utf-8"))
+def _item_shorts(items_path: Path, *, include_recipes: bool = False) -> tuple[str, ...]:
+    items: dict = json.loads(items_path.read_text(encoding="utf-8"))
+    shorts = []
+    for item_key in sorted(items):
+        short = _short(item_key)
+        if short.startswith("recipe_") and not include_recipes:
+            continue
+        shorts.append(short)
+    return tuple(shorts)
+
+
+def missing_icon_shorts(
+    items_path: Path = _ITEMS_JSON,
+    out_dir: Path = _OUT_DIR,
+    *,
+    include_recipes: bool = False,
+) -> tuple[str, ...]:
+    return tuple(
+        short
+        for short in _item_shorts(items_path, include_recipes=include_recipes)
+        if not (out_dir / f"{short}.png").exists()
+    )
+
+
+def check(
+    items_path: Path = _ITEMS_JSON,
+    out_dir: Path = _OUT_DIR,
+    *,
+    include_recipes: bool = False,
+) -> int:
+    missing = missing_icon_shorts(items_path, out_dir, include_recipes=include_recipes)
+    if not missing:
+        print(f"All item icons present in {out_dir}")
+        return 0
+
+    print(f"Missing {len(missing)} item icon{'s' if len(missing) != 1 else ''} in {out_dir}:")
+    for short in missing:
+        print(f"  - {short}")
+    return 1
+
+
+def fetch(
+    force: bool = False,
+    items_path: Path = _ITEMS_JSON,
+    out_dir: Path = _OUT_DIR,
+    *,
+    include_recipes: bool = False,
+) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
 
     ctx = ssl.create_default_context()
     ctx.check_hostname = False
     ctx.verify_mode = ssl.CERT_NONE
 
     ok = failed = skipped = 0
-    for item_key in sorted(items):
-        short = _short(item_key)
-        out_path = _OUT_DIR / f"{short}.png"
+    for short in _item_shorts(items_path, include_recipes=include_recipes):
+        out_path = out_dir / f"{short}.png"
         if out_path.exists() and not force:
             skipped += 1
             continue
@@ -63,11 +110,35 @@ def fetch(force: bool = False) -> None:
             print(f"  FAIL {short}  ({exc})", file=sys.stderr)
             failed += 1
 
-    print(f"\nDone — {ok} downloaded, {skipped} skipped, {failed} failed → {_OUT_DIR}")
+    print(f"\nDone — {ok} downloaded, {skipped} skipped, {failed} failed -> {out_dir}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Download Dota 2 item icons.")
+    parser.add_argument(
+        "--check", action="store_true", help="Report missing icons without downloading"
+    )
+    parser.add_argument("--force", action="store_true", help="Re-download existing files")
+    parser.add_argument(
+        "--include-recipes",
+        action="store_true",
+        help="Include recipe_* constants when checking or downloading icons",
+    )
+    parser.add_argument("--items", type=Path, default=_ITEMS_JSON, help="Path to items.json")
+    parser.add_argument("--out-dir", type=Path, default=_OUT_DIR, help="Icon output directory")
+    args = parser.parse_args(argv)
+
+    if args.check:
+        return check(args.items, args.out_dir, include_recipes=args.include_recipes)
+
+    fetch(
+        force=args.force,
+        items_path=args.items,
+        out_dir=args.out_dir,
+        include_recipes=args.include_recipes,
+    )
+    return 0
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Download Dota 2 item icons.")
-    parser.add_argument("--force", action="store_true", help="Re-download existing files")
-    args = parser.parse_args()
-    fetch(force=args.force)
+    raise SystemExit(main())

--- a/tests/test_fetch_icons.py
+++ b/tests/test_fetch_icons.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import fetch_hero_icons, fetch_item_icons
+
+
+def test_item_icon_check_ignores_recipe_items_by_default(tmp_path: Path) -> None:
+    items_path = tmp_path / "items.json"
+    items_path.write_text(
+        json.dumps(
+            {
+                "blink": {"id": 1, "dname": "Blink Dagger"},
+                "conjurers_catalyst": {"id": 1864, "dname": "Conjurer's Catalyst"},
+                "recipe_blink": {"id": 2, "dname": "Recipe: Blink Dagger"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    icon_dir = tmp_path / "item_icons"
+    icon_dir.mkdir()
+    (icon_dir / "blink.png").write_bytes(b"png")
+
+    assert fetch_item_icons.missing_icon_shorts(items_path, icon_dir) == ("conjurers_catalyst",)
+    assert fetch_item_icons.missing_icon_shorts(
+        items_path,
+        icon_dir,
+        include_recipes=True,
+    ) == (
+        "conjurers_catalyst",
+        "recipe_blink",
+    )
+
+
+def test_item_icon_check_returns_nonzero_for_missing_non_recipe_icons(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    items_path = tmp_path / "items.json"
+    items_path.write_text(
+        json.dumps(
+            {
+                "blink": {"id": 1, "dname": "Blink Dagger"},
+                "conjurers_catalyst": {"id": 1864, "dname": "Conjurer's Catalyst"},
+                "recipe_blink": {"id": 2, "dname": "Recipe: Blink Dagger"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    icon_dir = tmp_path / "item_icons"
+    icon_dir.mkdir()
+    (icon_dir / "blink.png").write_bytes(b"png")
+
+    status = fetch_item_icons.main(
+        ["--check", "--items", str(items_path), "--out-dir", str(icon_dir)]
+    )
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert "Missing 1 item icon" in captured.out
+    assert "conjurers_catalyst" in captured.out
+    assert "recipe_blink" not in captured.out
+
+
+def test_hero_icon_check_returns_zero_when_icons_are_complete(tmp_path: Path, capsys) -> None:
+    heroes_path = tmp_path / "heroes.json"
+    heroes_path.write_text(
+        json.dumps({"npc_dota_hero_axe": {"id": 2, "localized_name": "Axe"}}),
+        encoding="utf-8",
+    )
+    icon_dir = tmp_path / "hero_icons"
+    icon_dir.mkdir()
+    (icon_dir / "axe.png").write_bytes(b"png")
+
+    status = fetch_hero_icons.main(
+        ["--check", "--heroes", str(heroes_path), "--out-dir", str(icon_dir)]
+    )
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert "All hero icons present" in captured.out
+
+
+def test_hero_icon_check_reports_missing_icons(tmp_path: Path, capsys) -> None:
+    heroes_path = tmp_path / "heroes.json"
+    heroes_path.write_text(
+        json.dumps(
+            {
+                "npc_dota_hero_axe": {"id": 2, "localized_name": "Axe"},
+                "npc_dota_hero_largo": {"id": 155, "localized_name": "Largo"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    icon_dir = tmp_path / "hero_icons"
+    icon_dir.mkdir()
+    (icon_dir / "axe.png").write_bytes(b"png")
+
+    status = fetch_hero_icons.main(
+        ["--check", "--heroes", str(heroes_path), "--out-dir", str(icon_dir)]
+    )
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert "Missing 1 hero icon" in captured.out
+    assert "largo" in captured.out

--- a/uv.lock
+++ b/uv.lock
@@ -448,7 +448,7 @@ wheels = [
 
 [[package]]
 name = "gem-dota"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "ipykernel" },


### PR DESCRIPTION
## Summary

- Add `--check` mode to hero and item icon fetch scripts.
- Skip `recipe_*` item icons by default while keeping `--include-recipes` available.
- Add tests for icon cache audits and update README guidance.

## Rationale

- 7.41 added new item and enhancement constants, and the local ignored item icon cache could silently become stale.
- The parser package should continue excluding binary icon assets from the wheel while still giving report authors a reliable cache audit path.

## Testing

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src`
- [x] `uv run pytest tests/ -m "not integration"`
- [ ] Docs build, if docs changed

## Notes

- [x] Generated protobuf files under `src/gem/proto/dota2/` were not edited manually.
- [x] Large replay artifacts are not committed unless explicitly required for tests.
- [x] Secrets and local credentials are not included.
- Local ignored caches were refreshed after the tooling change: `fetch_item_icons.py --check` and `fetch_hero_icons.py --check` both report complete caches.