### PR TITLE
Narrow exception handling and add error context

### DIFF
--- a/src/gem/catalog/items.py
+++ b/src/gem/catalog/items.py
@@ -32,7 +32,11 @@ def item_display(internal: str) -> str:
     """
     key = internal.removeprefix("item_")
     item = ITEMS.get(key)
-    return str(item["dname"]) if item else internal
+    # Fall back to the raw name if the catalog row lacks a display name, rather
+    # than raising KeyError on malformed data (abilities.py does the same).
+    if item is None:
+        return internal
+    return str(item.get("dname", internal))
 
 
 def item_key_by_id(item_id: int) -> str | None:

--- a/src/gem/parser.py
+++ b/src/gem/parser.py
@@ -37,6 +37,7 @@ Reference: manta/parser.go, manta/demo_packet.go, manta/game_event.go
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from pathlib import Path
 
@@ -79,6 +80,8 @@ from gem.schema.sendtable import parse_send_tables
 from gem.state.entities import Entity, EntityManager, EntityOp
 from gem.state.game_events import GameEventHandler, GameEventManager
 from gem.state.string_table import StringTables, handle_create, handle_update
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Outer EDemoCommands IDs (stripped of DEM_IsCompressed = 0x40)
@@ -390,9 +393,11 @@ class ReplayParser:
                     if self._stop_at_tick is not None and tick > self._stop_at_tick:
                         break
                     self._dispatch_outer(msg_type, data)
-        except Exception:
-            # Truncated files raise on final corrupt snappy block — that's OK
-            pass
+        except Exception as exc:
+            # Truncated files raise on the final corrupt snappy block — that is
+            # expected for partial replays, so parsing continues with whatever was
+            # read. Log at debug level so genuine corruption stays diagnosable.
+            logger.debug("Replay stream ended early at tick %d: %r", self.tick, exc)
 
         # Read match metadata from CDOTAGamerulesProxy entity if DEM_FileInfo
         # didn't populate them (e.g. truncated replays or early stop).

--- a/src/gem/replays/fetch.py
+++ b/src/gem/replays/fetch.py
@@ -41,13 +41,19 @@ def fetch_replay_url(match_id: int) -> str:
         The ``replay_url`` string from the OpenDota API response.
 
     Raises:
-        ValueError: If OpenDota returns no replay URL for the match.
+        ValueError: If OpenDota returns no replay URL or a non-JSON response.
         urllib.error.URLError: If the API request fails.
     """
     url = f"{OPENDOTA_API}/{match_id}"
     req = urllib.request.Request(url, headers={"User-Agent": "gem/1.0"})
     with urllib.request.urlopen(req, context=_SSL_CONTEXT, timeout=20) as resp:
-        data = json.loads(resp.read())
+        raw = resp.read()
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"OpenDota returned a non-JSON response for match {match_id} ({url})"
+        ) from exc
 
     replay_url = data.get("replay_url")
     if not replay_url:
@@ -78,7 +84,8 @@ def download_and_decompress(match_id: int, replay_url: str, out_dir: Path | str 
     bz2_path = out_dir / f"{match_id}.dem.bz2"
 
     req = urllib.request.Request(replay_url, headers={"User-Agent": "Mozilla/5.0"})
-    with urllib.request.urlopen(req, context=_SSL_CONTEXT) as resp:
+    # Larger timeout than the JSON API calls: a full replay is 100-300 MB.
+    with urllib.request.urlopen(req, context=_SSL_CONTEXT, timeout=120) as resp:
         bz2_path.write_bytes(resp.read())
 
     dem_path.write_bytes(bz2.decompress(bz2_path.read_bytes()))
@@ -172,12 +179,19 @@ def fetch_opendota_match(match_id: int) -> dict:
         The decoded OpenDota match JSON object.
 
     Raises:
+        ValueError: If OpenDota returns a non-JSON response.
         urllib.error.URLError: If the API request fails.
     """
     url = f"{OPENDOTA_API}/{match_id}"
     req = urllib.request.Request(url, headers={"User-Agent": "gem/1.0"})
     with urllib.request.urlopen(req, context=_SSL_CONTEXT, timeout=20) as resp:
-        return json.loads(resp.read())
+        raw = resp.read()
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"OpenDota returned a non-JSON response for match {match_id} ({url})"
+        ) from exc
 
 
 def enrich_with_api_rates(match: ParsedMatch, match_id: int) -> ParsedMatch:

--- a/src/gem/reports/_sections.py
+++ b/src/gem/reports/_sections.py
@@ -2862,7 +2862,10 @@ def _load_camp_zones() -> dict:
         camps = obj.get("camps", [])
         if isinstance(camps, list):
             return obj
-    except Exception:
+    except (OSError, ValueError):
+        # Bundled-asset load failure (missing file / malformed JSON): the camp
+        # overlay is optional, so fall back to an empty set rather than failing
+        # the whole report. (json.JSONDecodeError is a ValueError subclass.)
         pass
     return {"camps": []}
 

--- a/src/gem/reports/builder.py
+++ b/src/gem/reports/builder.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import base64
 import html
 import json
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -59,6 +60,8 @@ from gem.reports.assets import (
     load_map_base64,
 )
 from gem.results.models import ParsedMatch
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -152,7 +155,8 @@ def _build_movement_tab(match: ParsedMatch, map_b64: str | None) -> str:
         import plotly.graph_objects as go  # noqa: F401
 
         from gem.reports._movement import build_figure
-    except Exception:
+    except ImportError:
+        # Plotly (and its transitive deps) are optional; omit the Movement tab.
         return ""
 
     try:
@@ -208,6 +212,9 @@ def _build_movement_tab(match: ParsedMatch, map_b64: str | None) -> str:
             f"</div></div>"
         )
     except Exception:
+        # Rendering can fail many ways (temp I/O, base64, plotly internals);
+        # degrade gracefully by omitting the tab, but log for diagnosis.
+        logger.debug("Movement tab rendering failed; omitting it", exc_info=True)
         return ""
 
 

--- a/tests/test_apply_api_rates.py
+++ b/tests/test_apply_api_rates.py
@@ -7,6 +7,12 @@ plus this function.
 
 from __future__ import annotations
 
+import contextlib
+import io
+
+import pytest
+
+from gem.replays import fetch
 from gem.replays.fetch import _opendota_slot_to_player_id, apply_api_rates
 from gem.results.models import ParsedMatch
 
@@ -20,6 +26,18 @@ def test_slot_to_player_id_maps_radiant_and_dire():
     assert _opendota_slot_to_player_id(4) == 4
     assert _opendota_slot_to_player_id(128) == 5
     assert _opendota_slot_to_player_id(132) == 9
+
+
+def test_fetch_opendota_match_raises_value_error_on_non_json(monkeypatch):
+    # A non-JSON response (e.g. an HTML error/rate-limit page) should surface a
+    # ValueError naming the match, not a bare JSONDecodeError.
+    @contextlib.contextmanager
+    def fake_urlopen(*_args, **_kwargs):
+        yield io.BytesIO(b"<html>rate limited</html>")
+
+    monkeypatch.setattr(fetch.urllib.request, "urlopen", fake_urlopen)
+    with pytest.raises(ValueError, match="non-JSON response for match 123"):
+        fetch.fetch_opendota_match(123)
 
 
 def test_applies_rates_and_derives_totals():

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -33,6 +33,20 @@ def test_catalog_resolves_internal_hero_suffixes() -> None:
     assert catalog.hero_npc_name("nevermore") == "npc_dota_hero_nevermore"
 
 
+def test_item_display_unknown_falls_back_to_raw_name() -> None:
+    # Unknown items return the raw string rather than raising.
+    assert catalog.item_display("item_not_a_real_item") == "item_not_a_real_item"
+    assert catalog.item_display("totally_unknown") == "totally_unknown"
+
+
+def test_item_display_missing_dname_falls_back(monkeypatch) -> None:
+    # A catalog row without a "dname" key must not raise KeyError.
+    from gem.catalog import items as items_mod
+
+    monkeypatch.setitem(items_mod.ITEMS, "_malformed", {"id": 99999})
+    assert catalog.item_display("item__malformed") == "item__malformed"
+
+
 def test_catalog_loads_core_json_resources() -> None:
     heroes = catalog.load_data_json("heroes.json")
     assert heroes["npc_dota_hero_axe"]["localized_name"] == "Axe"


### PR DESCRIPTION
## Summary

Phase 5 of the code-quality audit: targeted exception-handling narrowing and error-context hardening. **Behavior-preserving** — graceful degradation is unchanged; only error *context* and *visibility* improve.

- **`fetch.py`** — both `json.loads` calls now raise a `ValueError` naming the match + URL when OpenDota returns a non-JSON body (e.g. an HTML rate-limit page) instead of a bare `JSONDecodeError`; `download_and_decompress` gained `timeout=120` (the only `urlopen` without one — larger than the 20s JSON calls since a replay is 100–300 MB).
- **`catalog/items.py`** — `item_display` falls back to `item.get("dname", raw)` so a malformed catalog row no longer raises `KeyError` (matches `abilities.py`).
- **`parser.py`** — kept the truncated-tail catch (expected for partial replays) but it now logs at debug via a module logger, so genuine corruption is diagnosable.
- **`reports/builder.py`** — narrowed the optional-plotly import guard to `ImportError`; kept the figure-render catch broad but added a debug log (`exc_info`) before degrading to no Movement tab.
- **`reports/_sections.py`** — narrowed the camp-zone load guard from `except Exception` to `(OSError, ValueError)`.

`batch.py`'s worker catch was left as-is — it already returns the full exception object via `ParseResult.error`, preserving complete context (better than the audit's `repr(exc)` suggestion).

## Rationale

The audit flagged several broad `except Exception` blocks. Where the masked failure is a clear, expected condition (optional deps, bundled-asset load, truncated-replay tail) I narrowed to the specific exception type or kept the broad catch but added debug logging so failures stay diagnosable. Network JSON parsing now fails with actionable context. None of this changes control flow or output.

## Testing

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src`
- [x] `uv run pytest tests/ -m "not integration"` (1534 passed, 3 skipped; +3 new)
- [x] `uv run pytest -m integration` (40 passed)
- [ ] Docs build, if docs changed (no docs changed)

## Notes

- [x] Generated protobuf files under `src/gem/proto/` were not edited manually.
- [x] Large replay artifacts are not committed unless explicitly required for tests.
- [x] Secrets and local credentials are not included.

This completes the low/medium-risk items from the audit. Remaining (deliberately deferred): the larger `reports/_sections.py` decomposition and the `CombatLogEntry` enum migration — both higher-risk, tightly coupled to output, and best done as separate individually-tested efforts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
