### PR TITLE
Type CombatLogEntry.log_type as a CombatLogType enum

### DIFF
--- a/src/gem/combat/__init__.py
+++ b/src/gem/combat/__init__.py
@@ -1,13 +1,20 @@
 """Combat log ingestion and aggregation primitives."""
 
 from gem.combat.aggregator import _CombatAggregator, _dedup_purchase_log, _ParsedPlayerAgg
-from gem.combat.log import COMBAT_LOG_TYPES, CombatLogEntry, CombatLogHandler, CombatLogProcessor
+from gem.combat.log import (
+    COMBAT_LOG_TYPES,
+    CombatLogEntry,
+    CombatLogHandler,
+    CombatLogProcessor,
+    CombatLogType,
+)
 
 __all__ = [
     "COMBAT_LOG_TYPES",
     "CombatLogEntry",
     "CombatLogHandler",
     "CombatLogProcessor",
+    "CombatLogType",
     "_CombatAggregator",
     "_ParsedPlayerAgg",
     "_dedup_purchase_log",

--- a/src/gem/combat/aggregator.py
+++ b/src/gem/combat/aggregator.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from gem.combat.log import CombatLogType
 from gem.extractors._snapshots import _player_id_from_entity
 
 if TYPE_CHECKING:
@@ -291,7 +292,7 @@ class _CombatAggregator:
             self._agg(attacker_pid).stuns_dealt += entry.stun_duration
 
         match entry.log_type:
-            case "DAMAGE":
+            case CombatLogType.DAMAGE:
                 # Skip entries whose target is an ability/modifier name rather than
                 # a real unit (Valve logs some absorb/redirect interactions this
                 # way); OpenDota's per-target damage dict excludes them.
@@ -309,7 +310,7 @@ class _CombatAggregator:
                     self._agg(target_pid).damage_taken[source_unit] += entry.value
                     if entry.damage_type:
                         self._agg(target_pid).damage_taken_by_type[entry.damage_type] += entry.value
-            case "HEAL":
+            case CombatLogType.HEAL:
                 if source_pid is not None and _is_unit_target(entry.target_name):
                     heal_key = _illusion_key(entry.target_name, entry.target_is_illusion)
                     self._agg(source_pid).healing[heal_key] += entry.value
@@ -320,30 +321,30 @@ class _CombatAggregator:
                         and entry.target_name != source_unit
                     ):
                         self._agg(source_pid).hero_healing += entry.value
-            case "ABILITY":
+            case CombatLogType.ABILITY:
                 if attacker_pid is not None and entry.inflictor_name:
                     self._agg(attacker_pid).ability_uses[entry.inflictor_name] += 1
-            case "ITEM":
+            case CombatLogType.ITEM:
                 if attacker_pid is not None and entry.inflictor_name:
                     self._agg(attacker_pid).item_uses[entry.inflictor_name] += 1
-            case "GOLD":
+            case CombatLogType.GOLD:
                 if target_pid is not None:
                     self._agg(target_pid).gold_reasons[str(entry.gold_reason)] += entry.value
-            case "XP":
+            case CombatLogType.XP:
                 if target_pid is not None:
                     self._agg(target_pid).xp_reasons[str(entry.xp_reason)] += entry.value
-            case "DEATH":
+            case CombatLogType.DEATH:
                 if attacker_pid is not None:
                     self._agg(attacker_pid).kills_log.append(entry)
-            case "PURCHASE":
+            case CombatLogType.PURCHASE:
                 pid = attacker_pid if attacker_pid is not None else target_pid
                 if pid is not None:
                     self._agg(pid).purchase_log.append(entry)
-            case "PICKUP_RUNE":
+            case CombatLogType.PICKUP_RUNE:
                 # entry.value = player slot (from CDOTAUserMsg_ChatEvent.playerid_1)
                 pid = entry.value
                 if 0 <= pid < 10:
                     self._agg(pid).runes_log.append(entry)
-            case "BUYBACK":
+            case CombatLogType.BUYBACK:
                 # Populated via post-processing in match_builder after full name map is built.
                 pass

--- a/src/gem/combat/log.py
+++ b/src/gem/combat/log.py
@@ -15,48 +15,76 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any
 
 # ---------------------------------------------------------------------------
 # Combat log type constants
 # ---------------------------------------------------------------------------
 
-COMBAT_LOG_TYPES: frozenset[str] = frozenset(
-    [
-        "DAMAGE",
-        "HEAL",
-        "MODIFIER_ADD",
-        "MODIFIER_REMOVE",
-        "DEATH",
-        "ABILITY",
-        "ITEM",
-        "GOLD",
-        "XP",
-        "PURCHASE",
-        "BUYBACK",
-        "KILLSTREAK",
-        "NEUTRAL_CAMP_STACK",
-        "PICKUP_RUNE",
-    ]
-)
+# Sentinel proto_id for surfaced labels with no decoded wire type.
+_NO_PROTO_ID = -1
 
-# Mapping from DOTA_COMBATLOG_TYPES int → string label.
-# Reference: refs/manta/dota/dota_shared_enums.proto DOTA_COMBATLOG_TYPES
-# Note: type=7 (LOCATION) and type=9 (GAME_STATE) are not surfaced.
-_LOG_TYPE_NAMES: dict[int, str] = {
-    0: "DAMAGE",
-    1: "HEAL",
-    2: "MODIFIER_ADD",
-    3: "MODIFIER_REMOVE",
-    4: "DEATH",
-    5: "ABILITY",
-    6: "ITEM",
-    8: "GOLD",
-    10: "XP",
-    11: "PURCHASE",
-    12: "BUYBACK",
-    20: "NEUTRAL_CAMP_STACK",
-    21: "PICKUP_RUNE",
+
+class CombatLogType(str, Enum):
+    """The combat-log entry types this parser surfaces.
+
+    Subclasses ``(str, Enum)`` so members compare equal to their string label
+    (``CombatLogType.DAMAGE == "DAMAGE"``), work in ``in (...)`` membership
+    checks, and match ``case "DAMAGE":`` patterns — keeping the historical
+    string-based API backward compatible while adding type safety. (``StrEnum``
+    would be cleaner but is Python 3.11+; the project floor is 3.10.)
+
+    Each member also carries ``proto_id`` — the ``DOTA_COMBATLOG_TYPES`` integer
+    from the replay wire format — so the int→label mapping and the legacy
+    ``COMBAT_LOG_TYPES`` frozenset both derive from this single source of truth.
+    Members emitted only from derived paths (not decoded from a wire type) use
+    ``proto_id = _NO_PROTO_ID`` and are excluded from the int→label mapping.
+
+    Reference: refs/manta/dota/dota_shared_enums.proto ``DOTA_COMBATLOG_TYPES``.
+    Note: proto types 7 (LOCATION) and 9 (GAME_STATE) are intentionally not
+    surfaced.
+    """
+
+    # __str__ from Enum would render "CombatLogType.DAMAGE"; restore str's so
+    # str(member) == "DAMAGE" (f-strings already use str.__format__).
+    __str__ = str.__str__
+
+    proto_id: int
+
+    def __new__(cls, label: str, proto_id: int) -> CombatLogType:
+        member = str.__new__(cls, label)
+        member._value_ = label
+        member.proto_id = proto_id
+        return member
+
+    DAMAGE = ("DAMAGE", 0)
+    HEAL = ("HEAL", 1)
+    MODIFIER_ADD = ("MODIFIER_ADD", 2)
+    MODIFIER_REMOVE = ("MODIFIER_REMOVE", 3)
+    DEATH = ("DEATH", 4)
+    ABILITY = ("ABILITY", 5)
+    ITEM = ("ITEM", 6)
+    GOLD = ("GOLD", 8)
+    XP = ("XP", 10)
+    PURCHASE = ("PURCHASE", 11)
+    BUYBACK = ("BUYBACK", 12)
+    NEUTRAL_CAMP_STACK = ("NEUTRAL_CAMP_STACK", 20)
+    PICKUP_RUNE = ("PICKUP_RUNE", 21)
+    # Surfaced label without a wire type we decode: KILLSTREAK is reported by
+    # OpenDota but our pipeline never maps proto type 16, so it stays out of the
+    # int→label table (preserving the historical decode behaviour).
+    KILLSTREAK = ("KILLSTREAK", _NO_PROTO_ID)
+
+
+# Backward-compatible frozenset of label strings, derived from the enum.
+COMBAT_LOG_TYPES: frozenset[str] = frozenset(t.value for t in CombatLogType)
+
+# Mapping from DOTA_COMBATLOG_TYPES int → enum member, derived from the enum.
+# Excludes members with no decoded wire type; unmapped proto types fall back to
+# DAMAGE at the call site (preserving the original behaviour).
+_LOG_TYPE_NAMES: dict[int, CombatLogType] = {
+    t.proto_id: t for t in CombatLogType if t.proto_id != _NO_PROTO_ID
 }
 
 # Mapping from CMsgDOTACombatLogEntry.damage_type uint32 → normalized label.
@@ -99,7 +127,9 @@ class CombatLogEntry:
 
     Attributes:
         tick: Game tick at which the event occurred.
-        log_type: String label from COMBAT_LOG_TYPES.
+        log_type: The :class:`CombatLogType` for this entry. Compares equal to
+            its string label (e.g. ``log_type == "DAMAGE"``) for backward
+            compatibility.
         attacker_name: Name of the attacker unit/hero.
         damage_source_name: Name of the unit credited as the *source* of the
             damage/heal (``damage_source_name`` in the proto). For summon/spell
@@ -132,7 +162,7 @@ class CombatLogEntry:
     """
 
     tick: int
-    log_type: str
+    log_type: CombatLogType
     attacker_name: str = ""
     damage_source_name: str = ""
     target_name: str = ""
@@ -220,7 +250,7 @@ class CombatLogProcessor:
         """
         entry = CombatLogEntry(
             tick=tick,
-            log_type="PICKUP_RUNE",
+            log_type=CombatLogType.PICKUP_RUNE,
             value=player_slot,
             gold_reason=rune_type,
         )
@@ -248,7 +278,7 @@ class CombatLogProcessor:
             tick: Current game tick.
         """
         type_val, _ = game_event.get_int32(_S1_FIELD_TYPE)
-        log_type = _LOG_TYPE_NAMES.get(type_val, "DAMAGE")
+        log_type = _LOG_TYPE_NAMES.get(type_val, CombatLogType.DAMAGE)
 
         attacker_idx, _ = game_event.get_int32(_S1_FIELD_ATTACKER)
         source_idx, _ = game_event.get_int32(_S1_FIELD_SOURCE)
@@ -313,7 +343,7 @@ class CombatLogProcessor:
             game_time_s: Optional game-relative timestamp computed by
                 ``ReplayParser`` from the combat-log ``GAME_STATE`` marker.
         """
-        log_type = _LOG_TYPE_NAMES.get(msg.type, "DAMAGE")
+        log_type = _LOG_TYPE_NAMES.get(msg.type, CombatLogType.DAMAGE)
 
         # Support both StringTable.items dict and legacy dict-like name_table
         if hasattr(name_table, "items") and isinstance(name_table.items, dict):

--- a/src/gem/extractors/players.py
+++ b/src/gem/extractors/players.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
-from gem.combat.log import CombatLogEntry
+from gem.combat.log import CombatLogEntry, CombatLogType
 from gem.extractors._snapshots import (
     _HERO_CLASS_PREFIX,
     PlayerStateSnapshot,
@@ -667,7 +667,7 @@ class PlayerExtractor:
                 if item_name and not item_name.startswith("item_recipe"):
                     entry = CombatLogEntry(
                         tick=tick,
-                        log_type="PURCHASE",
+                        log_type=CombatLogType.PURCHASE,
                         target_name=npc_name,
                         value_name=item_name,
                     )

--- a/src/gem/results/dataframes.py
+++ b/src/gem/results/dataframes.py
@@ -6,7 +6,7 @@ suitable for tabular analysis.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -31,19 +31,22 @@ def build_dataframes(match: ParsedMatch) -> dict[str, pd.DataFrame]:
 
     import pandas as pd
 
-    def _plain_rows(items: list) -> list[dict]:
-        """``asdict`` each item, demoting Enum field values to their raw value.
+    def _plain_row(item: Any) -> dict:
+        """``asdict`` an item, demoting Enum field values to their raw value.
 
         Keeps DataFrame cells as primitives (e.g. ``"DAMAGE"`` rather than a
         ``CombatLogType`` member) so the exported schema stays backward
         compatible regardless of how internal fields are typed.
         """
-        rows = [asdict(it) for it in items]
-        for row in rows:
-            for key, value in row.items():
-                if isinstance(value, Enum):
-                    row[key] = value.value
-        return rows
+        row = asdict(item)
+        for key, value in row.items():
+            if isinstance(value, Enum):
+                row[key] = value.value
+        return row
+
+    def _plain_rows(items: list) -> list[dict]:
+        """``asdict`` each item with Enum field values demoted to primitives."""
+        return [_plain_row(it) for it in items]
 
     # --- players (per sample tick) ---
     player_rows: list[dict] = []
@@ -148,22 +151,22 @@ def build_dataframes(match: ParsedMatch) -> dict[str, pd.DataFrame]:
             )
 
         for entry in pp.kills_log:
-            row = asdict(entry)
+            row = _plain_row(entry)
             row["player_id"] = pp.player_id
             player_kills_rows.append(row)
 
         for entry in pp.purchase_log:
-            row = asdict(entry)
+            row = _plain_row(entry)
             row["player_id"] = pp.player_id
             player_purchase_rows.append(row)
 
         for entry in pp.runes_log:
-            row = asdict(entry)
+            row = _plain_row(entry)
             row["player_id"] = pp.player_id
             player_runes_rows.append(row)
 
         for entry in pp.buyback_log:
-            row = asdict(entry)
+            row = _plain_row(entry)
             row["player_id"] = pp.player_id
             player_buyback_rows.append(row)
 

--- a/src/gem/results/dataframes.py
+++ b/src/gem/results/dataframes.py
@@ -27,8 +27,23 @@ def build_dataframes(match: ParsedMatch) -> dict[str, pd.DataFrame]:
         ``objectives``, and ``chat``.
     """
     from dataclasses import asdict
+    from enum import Enum
 
     import pandas as pd
+
+    def _plain_rows(items: list) -> list[dict]:
+        """``asdict`` each item, demoting Enum field values to their raw value.
+
+        Keeps DataFrame cells as primitives (e.g. ``"DAMAGE"`` rather than a
+        ``CombatLogType`` member) so the exported schema stays backward
+        compatible regardless of how internal fields are typed.
+        """
+        rows = [asdict(it) for it in items]
+        for row in rows:
+            for key, value in row.items():
+                if isinstance(value, Enum):
+                    row[key] = value.value
+        return rows
 
     # --- players (per sample tick) ---
     player_rows: list[dict] = []
@@ -156,7 +171,7 @@ def build_dataframes(match: ParsedMatch) -> dict[str, pd.DataFrame]:
     players_min_df = pd.DataFrame(player_min_rows)
 
     # --- combat_log ---
-    combat_df = pd.DataFrame([asdict(e) for e in match.combat_log])
+    combat_df = pd.DataFrame(_plain_rows(match.combat_log))
 
     # --- wards ---
     wards_df = pd.DataFrame([asdict(w) for w in match.wards]) if match.wards else pd.DataFrame()

--- a/tests/test_combatlog.py
+++ b/tests/test_combatlog.py
@@ -4,9 +4,11 @@ Reference: clarity/CombatLog.java, odota/Parse.java
 """
 
 from gem.combat.log import (
+    _LOG_TYPE_NAMES,
     COMBAT_LOG_TYPES,
     CombatLogEntry,
     CombatLogProcessor,
+    CombatLogType,
     _resolve_name,
 )
 
@@ -139,6 +141,61 @@ class TestCombatLogTypes:
 
     def test_is_frozenset(self):
         assert isinstance(COMBAT_LOG_TYPES, frozenset)
+
+    def test_frozenset_derived_from_enum(self):
+        # The legacy frozenset is now derived from the enum — they must agree.
+        assert frozenset(t.value for t in CombatLogType) == COMBAT_LOG_TYPES
+
+
+# ---------------------------------------------------------------------------
+# CombatLogType — str-backed enum contract (3.10-compatible StrEnum)
+# ---------------------------------------------------------------------------
+
+
+class TestCombatLogTypeEnum:
+    """The enum must stay drop-in compatible with the historical string API."""
+
+    def test_member_equals_its_string_label(self):
+        assert CombatLogType.DAMAGE == "DAMAGE"
+        assert CombatLogType.PICKUP_RUNE == "PICKUP_RUNE"
+
+    def test_member_is_a_str_instance(self):
+        assert isinstance(CombatLogType.DAMAGE, str)
+
+    def test_str_renders_plain_label_not_qualified_name(self):
+        # (str, Enum) would render "CombatLogType.DAMAGE" without the __str__ fix.
+        assert str(CombatLogType.DAMAGE) == "DAMAGE"
+        assert f"{CombatLogType.DAMAGE}" == "DAMAGE"
+
+    def test_membership_in_string_tuple(self):
+        assert CombatLogType.DAMAGE in ("DAMAGE", "ABILITY", "ITEM")
+
+    def test_membership_in_frozenset(self):
+        assert CombatLogType.HEAL in COMBAT_LOG_TYPES
+
+    def test_match_case_matches_string_and_member(self):
+        def classify(lt: object) -> str:
+            match lt:
+                case "DAMAGE":
+                    return "damage"
+                case CombatLogType.HEAL:
+                    return "heal"
+                case _:
+                    return "other"
+
+        assert classify(CombatLogType.DAMAGE) == "damage"
+        assert classify(CombatLogType.HEAL) == "heal"
+
+    def test_proto_id_maps_only_decoded_wire_types(self):
+        # _LOG_TYPE_NAMES must mirror the historical hand-written int→label dict.
+        assert set(_LOG_TYPE_NAMES) == {0, 1, 2, 3, 4, 5, 6, 8, 10, 11, 12, 20, 21}
+        assert _LOG_TYPE_NAMES[0] is CombatLogType.DAMAGE
+
+    def test_killstreak_excluded_from_int_mapping(self):
+        # KILLSTREAK is a surfaced label with no decoded wire type (proto 16 is
+        # never mapped) — it stays out of the int→label table.
+        assert "KILLSTREAK" in COMBAT_LOG_TYPES
+        assert CombatLogType.KILLSTREAK.proto_id not in _LOG_TYPE_NAMES
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -47,19 +47,42 @@ class TestBuildDataframes:
         assert row["damage_taken_magical"] == 450
         assert row["damage_taken_pure"] == 20
 
-    def test_combat_log_dataframe_log_type_is_plain_str(self):
-        # log_type is a CombatLogType enum internally, but the exported
-        # DataFrame must hold plain str cells so the public schema is unchanged.
-        match = ParsedMatch(players=[ParsedPlayer(player_id=i) for i in range(10)])
+    def test_log_type_is_plain_str_in_every_log_bearing_table(self):
+        # log_type is a CombatLogType enum internally, but every exported table
+        # built from CombatLogEntry objects must hold plain str cells so the
+        # public DataFrame/Parquet schema is unchanged. This covers the
+        # top-level combat_log table AND the per-player log projections.
+        pp = ParsedPlayer(player_id=0)
+        pp.kills_log = [CombatLogEntry(tick=10, log_type=CombatLogType.DEATH)]
+        pp.purchase_log = [CombatLogEntry(tick=11, log_type=CombatLogType.PURCHASE)]
+        pp.runes_log = [CombatLogEntry(tick=12, log_type=CombatLogType.PICKUP_RUNE)]
+        pp.buyback_log = [CombatLogEntry(tick=13, log_type=CombatLogType.BUYBACK)]
+
+        match = ParsedMatch(players=[pp] + [ParsedPlayer(player_id=i) for i in range(1, 10)])
         match.combat_log = [
             CombatLogEntry(tick=10, log_type=CombatLogType.DAMAGE, value=100),
             CombatLogEntry(tick=20, log_type=CombatLogType.DEATH),
         ]
 
-        combat_df = build_dataframes(match)["combat_log"]
+        dfs = build_dataframes(match)
 
-        assert list(combat_df["log_type"]) == ["DAMAGE", "DEATH"]
-        assert all(type(v) is str for v in combat_df["log_type"])
+        log_tables = [
+            "combat_log",
+            "player_kills_log",
+            "player_purchase_log",
+            "player_runes_log",
+            "player_buyback_log",
+        ]
+        for name in log_tables:
+            df = dfs[name]
+            assert "log_type" in df.columns, name
+            assert all(type(v) is str for v in df["log_type"]), name
+
+        assert list(dfs["combat_log"]["log_type"]) == ["DAMAGE", "DEATH"]
+        assert list(dfs["player_kills_log"]["log_type"]) == ["DEATH"]
+        assert list(dfs["player_purchase_log"]["log_type"]) == ["PURCHASE"]
+        assert list(dfs["player_runes_log"]["log_type"]) == ["PICKUP_RUNE"]
+        assert list(dfs["player_buyback_log"]["log_type"]) == ["BUYBACK"]
 
     def test_build_dataframes_returns_extended_parity_keys(self):
         match = ParsedMatch()

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import gem.results.models as model_module
+from gem.combat.log import CombatLogEntry, CombatLogType
 from gem.extractors.objectives import AegisEvent, ShrineKill, TormentorKill
 from gem.results.dataframes import build_dataframes
 from gem.results.models import ParsedMatch, ParsedPlayer
@@ -45,6 +46,20 @@ class TestBuildDataframes:
         assert row["damage_taken_physical"] == 800
         assert row["damage_taken_magical"] == 450
         assert row["damage_taken_pure"] == 20
+
+    def test_combat_log_dataframe_log_type_is_plain_str(self):
+        # log_type is a CombatLogType enum internally, but the exported
+        # DataFrame must hold plain str cells so the public schema is unchanged.
+        match = ParsedMatch(players=[ParsedPlayer(player_id=i) for i in range(10)])
+        match.combat_log = [
+            CombatLogEntry(tick=10, log_type=CombatLogType.DAMAGE, value=100),
+            CombatLogEntry(tick=20, log_type=CombatLogType.DEATH),
+        ]
+
+        combat_df = build_dataframes(match)["combat_log"]
+
+        assert list(combat_df["log_type"]) == ["DAMAGE", "DEATH"]
+        assert all(type(v) is str for v in combat_df["log_type"])
 
     def test_build_dataframes_returns_extended_parity_keys(self):
         match = ParsedMatch()


### PR DESCRIPTION
## Summary

Replaces the magic-string `CombatLogEntry.log_type: str` with a type-safe
`CombatLogType` enum, gaining IDE autocomplete + typo protection while keeping
the historical string-based API and the public output schema **byte-identical**.

## Design

`CombatLogType(str, Enum)` — the 3.10-compatible `StrEnum` equivalent
(`enum.StrEnum` is 3.11+, project floor is `>=3.10`). Because members subclass
`str`, every existing usage keeps working untouched:

| Pattern | Still works? |
|---|---|
| `entry.log_type == "DAMAGE"` | ✅ (str equality) |
| `entry.log_type in ("DAMAGE", "ABILITY")` | ✅ |
| `case "DAMAGE":` | ✅ (matches the enum member) |
| `"DAMAGE" in COMBAT_LOG_TYPES` | ✅ (frozenset of strings) |
| `str(member)` / `f"{member}"` | ✅ → `"DAMAGE"` (via `__str__ = str.__str__`) |

~40 comparison sites across 9 modules need **zero changes**. mypy now enforces
a valid `CombatLogType` at every *construction* site — which caught a third
producer (`players.py:670`, the inventory-tracking PURCHASE path) that a grep
sweep would have missed. That's the silent-failure class this eliminates.

## DRY

The enum is the **single source of truth**. Previously each label string was
duplicated across the `COMBAT_LOG_TYPES` frozenset *and* the `_LOG_TYPE_NAMES`
int→label dict. Now both **derive** from the enum:

```python
COMBAT_LOG_TYPES = frozenset(t.value for t in CombatLogType)
_LOG_TYPE_NAMES  = {t.proto_id: t for t in CombatLogType if t.proto_id != _NO_PROTO_ID}
```

Each member carries its `DOTA_COMBATLOG_TYPES` `proto_id`. `KILLSTREAK` has no
wire type our pipeline decodes (proto 16 was never mapped), so it uses the
`_NO_PROTO_ID` sentinel and is excluded from the int→label table — preserving
the exact historical decode behaviour (the int-dict keys stay
`{0,1,2,3,4,5,6,8,10,11,12,20,21}`).

## Scope: `log_type` only

`gold_reason` / `xp_reason` are **`int` reason codes** (`gold_reason == 8` =
Wisdom rune), not a label space — they're already correctly typed and feed the
public `gold_reasons: dict[str, int]` output schema. Out of scope.

## Output schema preserved

`build_dataframes` gets a small generic helper that demotes any `Enum` field
value to its raw value when building the `combat_log` rows, so DataFrame cells
stay plain `str` — keeping the exported DataFrame/CSV/JSON schema unchanged.

## Verification

Golden byte-identity over a synthetic match exercising all 14 `log_type` values:
- combat_log DataFrame cells: `['str']` (not enum members) ✅
- CSV SHA256, JSON SHA256, full match `to_json` SHA256 — all **identical**
  before/after ✅

Commands run:
- `uv run ruff check` / `ruff format --check` → clean ✅
- `uv run mypy src/gem/` → Success, no issues in 82 files ✅
- `uv run pytest -q` → **1544 passed**, 3 skipped ✅
- `uv run pytest -m integration` → **40 passed** (real-replay parse through S1 +
  S2 combat-log producers, 11 min) ✅

## Tests added

- `TestCombatLogTypeEnum` — the full str-compat contract (`==`, `in`, `str()`,
  `match`/`case`, frozenset derivation, proto_id mapping, KILLSTREAK exclusion).
- `test_combat_log_dataframe_log_type_is_plain_str` — the DataFrame schema guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)