### PR TITLE
Add schema/ README and tidy the nested-package facades

### DIFF
--- a/src/gem/schema/README.md
+++ b/src/gem/schema/README.md
@@ -1,0 +1,188 @@
+# gem.schema
+
+`gem.schema` is the part of the parser that turns a replay's **send-table
+schema** into concrete **field decoders**, and then uses those decoders to read
+**entity field values** out of bit-packed entity-update streams.
+
+If `gem.binary` answers *"where does the next chunk of bytes/bits begin and
+end?"*, `gem.schema` answers *"given these bits and this entity's class, what
+does each field decode to, and where does it live in the entity's state tree?"*
+
+This package sits directly above `gem.binary` (it consumes `BitReader`) and
+directly below `gem.state` (which owns entity lifecycle and string tables and
+*calls into* this package to apply updates). `gem.schema` does not import
+`gem.state` — the dependency only flows one way.
+
+## Mental Model
+
+Entity decoding is a **two-stage process**:
+
+```text
+Stage 1 — build the schema (once, at replay start)
+  CDemoSendTables  (a protobuf message)
+    -> parse_send_tables()
+         -> a tree of Serializer -> Field objects,
+            each Field with a decoder function chosen ONCE here
+
+Stage 2 — decode entity updates (many times, every packet)
+  bit-packed entity delta
+    -> read_field_paths()   : which fields changed (Huffman-coded paths)
+    -> read_fields()        : walk each path into the Serializer tree,
+                              call that field's decoder, write the value
+                              into the entity's FieldState tree
+```
+
+The key idea: **a field's decoder is resolved exactly once**, when the send
+tables are parsed (Stage 1). At decode time (Stage 2) the parser never re-asks
+"what type is this field?" — it already has the decoder attached to the `Field`.
+This is why the package is split the way it is: schema-building and value-
+decoding are separate concerns that happen at different times.
+
+## The Four Areas
+
+| Area | Module(s) | Role |
+|---|---|---|
+| **Send tables** | `sendtable/` | Parse `CDemoSendTables` → a `Serializer`/`Field` tree. Assign each field its decoder and field *model* (simple / fixed-array / variable-table / …). |
+| **Field paths** | `field_path/` | Decode the Huffman-coded operation stream that says *which* fields in an entity changed, mutating a `FieldPath` cursor. |
+| **Field decoders** | `field_decoder/` | The catalog of value decoders (bool, string, varint, quantized float, vectors, angles…) plus the dispatch tables that map a field's declared type to the right one. |
+| **Reading + state** | `field_reader.py`, `field_state.py` | `read_fields()` ties it together: walk each decoded field path into the serializer tree, run the field's decoder, and store the result in a `FieldState` tree. |
+
+### `sendtable/`
+
+- `models.py` — `FieldType`, `Field`, `Serializer`, and the `FIELD_MODEL_*`
+  constants. A field's *model* (SIMPLE, FIXED_ARRAY, FIXED_TABLE,
+  VARIABLE_ARRAY, VARIABLE_TABLE) determines how its field path is interpreted
+  during decode — e.g. a variable-table field path addresses into a dynamically
+  sized collection.
+- `parser.py` — `parse_send_tables()`: builds the serializer tree from the
+  protobuf, resolving each field's decoder via `field_decoder`.
+- `patches.py` — build-specific corrections to field metadata, applied when a
+  particular game build encodes a field differently than its declared type
+  implies.
+
+### `field_path/`
+
+Field paths are how an entity update says "field 3, then sub-field 0, then
+element 12 changed" without spelling out names. They are Huffman-coded for
+compactness.
+
+- `models.py` — `FieldPath`, a small mutable cursor (a list of indices plus a
+  position) that operations push/pop/increment.
+- `operations.py` — the table of ~40 field-path operations (the canonical
+  `FIELD_PATH_OPS`); each operation mutates a `FieldPath`.
+- `huffman.py` — the Huffman tree / flat decode table that maps bits → which
+  operation to apply. Built once at import time.
+- `path_sequence.py` — `read_field_paths()`: the loop that reads operations
+  until the path stream terminates, yielding the list of changed paths.
+
+### `field_decoder/`
+
+- `scalar_codecs.py` — individual value decoders (boolean, string, signed/
+  unsigned varints, coord/noscale/simulation-time floats, …).
+- `composite_codecs.py` — factories for vector and angle decoders.
+- `quantized_float.py` — `QuantizedFloatDecoder`, the bit-count/flag-driven
+  decoder for Valve's quantized floats.
+- `type_resolver.py` — the dispatch tables (`find_decoder`,
+  `find_decoder_by_base_type`) that pick a decoder from a field's declared type
+  or name.
+- `contracts.py` — the typing protocols (`FieldDecoder`, and the `_FieldLike` /
+  `_FieldTypeLike` structural protocols). This is a thin module on purpose: it
+  exists so the dispatch tables and codecs can share types without an import
+  cycle.
+
+### `field_reader.py` and `field_state.py`
+
+- `field_reader.py` — `read_fields()`: the bridge between a decoded list of
+  field paths and the actual values. For each path it walks the serializer tree
+  (recursing into nested tables), finds the field, calls its decoder against the
+  `BitReader`, and writes the value into the entity's `FieldState`.
+- `field_state.py` — `FieldState`, the nested **mutable** value tree that mirrors
+  manta's structure. It grows lazily (a sparse tree) because most entities only
+  touch a handful of their fields per update.
+
+## Public Surface vs Internal Helpers
+
+Each nested package exposes a **facade** `__init__.py`: callers import from
+`gem.schema.sendtable`, `gem.schema.field_path`, and `gem.schema.field_decoder`
+(or the top-level `gem.schema`), never from the implementation submodules.
+
+`__all__` in each facade lists only the **stable public surface**. Several
+underscore-prefixed names are *also* re-exported (e.g. `_parse_field_type`,
+`_FIELD_PATCHES`, the `_*_factory` decoder factories, `_QFF_*` flag constants,
+the `_FIELD_*` dispatch tables). These are **shared internals** — used by sibling
+modules and by tests — and are importable by name, but they are deliberately
+kept out of `__all__` so they do not appear as public API. The redundant
+`import X as X` aliases on those lines mark them as intentional re-exports.
+
+So when reading a facade: **names without a leading underscore are the contract;
+underscore-prefixed re-exports are wiring.**
+
+## What This Package Does Not Do
+
+`gem.schema` deliberately does not:
+
+- read the outer `.dem` stream or unpack inner packet streams (that is
+  `gem.binary`)
+- own entity creation/update/delete, serial numbers, or handles (that is
+  `gem.state.entities`)
+- maintain string tables, including the `instancebaseline` table that seeds new
+  entities' default field values (that is `gem.state.string_table`)
+- interpret what a field *means* in Dota terms — a decoded `m_iHealth` is just an
+  integer here; attaching meaning is the job of `extractors` and `analysis`
+- decode game events or the combat log (`gem.state.game_events`, `gem.combat`)
+
+Keeping this boundary sharp localizes bugs. If field *values* come out wrong
+(off by a quantization step, wrong sign, wrong vector length), the bug is almost
+always in `field_decoder` or a `sendtable` patch. If the *wrong field* is being
+written, look at `field_path` or `field_reader`'s tree walk.
+
+## Common Pitfalls
+
+### Confusing the two stages
+
+A decoder is chosen at **schema-build** time, not decode time. If a field decodes
+incorrectly for one game build, the fix usually belongs in `sendtable/patches.py`
+(correct the field's metadata so the right decoder is selected), not in the
+decode loop.
+
+### Field models drive field-path interpretation
+
+The same field-path operation means different things depending on the field's
+*model*. A `VARIABLE_TABLE` field grows on demand; a `FIXED_ARRAY` does not.
+Misclassifying a field's model makes its paths address the wrong slot — which
+shows up as values landing in the wrong field, not as a decode error.
+
+### `FieldState` is sparse and mutable
+
+`FieldState` is not a fully-populated dict of every field. It is a lazily grown
+tree; a field that was never sent simply is not present. Code reading entity
+state must tolerate missing fields rather than assume a dense structure.
+
+### Quantized floats need their flags
+
+`QuantizedFloatDecoder` depends on bit count, low/high bounds, and the `_QFF_*`
+encode flags from the field definition. A quantized float read without its flags
+(e.g. treated as a plain float) produces plausible-but-wrong values — the kind of
+bug that passes a smoke test but corrupts positions/health curves.
+
+## When To Add Code Here
+
+Add code to `gem.schema` when the change is about **how a replay's schema maps to
+decoders, or how field values/paths are read**.
+
+Good fits:
+
+- a missing or corrected value decoder (a new Source 2 float/int encoding)
+- a `sendtable` patch for a build that encodes a field differently
+- a field-path operation or Huffman-table correction
+- a fix to how `read_fields` walks nested tables
+
+Poor fits:
+
+- interpreting a decoded field as a Dota concept (gold, position, hero) →
+  `extractors` / `analysis`
+- entity lifecycle, baselines, or string tables → `gem.state`
+- outer/inner stream framing or bit primitives → `gem.binary`
+
+When in doubt, keep `gem.schema` about **schema → decoders → values**, and let
+`gem.state` decide *which entity* a value belongs to and *when* it changes.

--- a/src/gem/schema/field_decoder/__init__.py
+++ b/src/gem/schema/field_decoder/__init__.py
@@ -2,16 +2,32 @@
 
 Implementation modules use domain-specific names to avoid confusion with
 ``binary.reader`` and ``schema.field_reader``. Callers should continue to import
-from ``gem.schema.field_decoder``.
+from ``gem.schema.field_decoder``. ``__all__`` lists the stable public surface:
+the named scalar/composite decoders, the ``find_decoder`` lookups, and the
+``FieldDecoder``/``QuantizedFloatDecoder`` types. The underscore-prefixed names
+re-exported below (decoder factories, quantized-float flag constants, the
+dispatch tables, and the ``_FieldLike``/``_FieldTypeLike`` protocols) are
+internal helpers shared with sibling modules and tests — importable by name, but
+not part of the public contract.
 """
 
-from gem.schema.field_decoder.composite_codecs import _qangle_factory, _vector_normal_decoder
-from gem.schema.field_decoder.contracts import FieldDecoder, _FieldLike, _FieldTypeLike
+# Underscore-prefixed names use redundant ``as`` aliases to mark them as
+# deliberate re-exports (shared internals, not public API) without listing them
+# in ``__all__``.
+from gem.schema.field_decoder.composite_codecs import (
+    _qangle_factory as _qangle_factory,
+    _vector_normal_decoder as _vector_normal_decoder,
+)
+from gem.schema.field_decoder.contracts import (
+    FieldDecoder,
+    _FieldLike as _FieldLike,
+    _FieldTypeLike as _FieldTypeLike,
+)
 from gem.schema.field_decoder.quantized_float import (
-    _QFF_ENCODE_INTEGERS,
-    _QFF_ENCODE_ZERO,
-    _QFF_ROUNDDOWN,
-    _QFF_ROUNDUP,
+    _QFF_ENCODE_INTEGERS as _QFF_ENCODE_INTEGERS,
+    _QFF_ENCODE_ZERO as _QFF_ENCODE_ZERO,
+    _QFF_ROUNDDOWN as _QFF_ROUNDDOWN,
+    _QFF_ROUNDUP as _QFF_ROUNDUP,
     QuantizedFloatDecoder,
 )
 from gem.schema.field_decoder.scalar_codecs import (
@@ -29,14 +45,14 @@ from gem.schema.field_decoder.scalar_codecs import (
     unsigned_decoder,
 )
 from gem.schema.field_decoder.type_resolver import (
-    _FIELD_NAME_DECODERS,
-    _FIELD_TYPE_DECODERS,
-    _FIELD_TYPE_FACTORIES,
-    _float_factory,
-    _quantized_factory,
-    _unsigned64_factory,
-    _unsigned_factory,
-    _vector_factory,
+    _FIELD_NAME_DECODERS as _FIELD_NAME_DECODERS,
+    _FIELD_TYPE_DECODERS as _FIELD_TYPE_DECODERS,
+    _FIELD_TYPE_FACTORIES as _FIELD_TYPE_FACTORIES,
+    _float_factory as _float_factory,
+    _quantized_factory as _quantized_factory,
+    _unsigned64_factory as _unsigned64_factory,
+    _unsigned_factory as _unsigned_factory,
+    _vector_factory as _vector_factory,
     find_decoder,
     find_decoder_by_base_type,
 )
@@ -44,22 +60,6 @@ from gem.schema.field_decoder.type_resolver import (
 __all__ = [
     "FieldDecoder",
     "QuantizedFloatDecoder",
-    "_FIELD_NAME_DECODERS",
-    "_FIELD_TYPE_DECODERS",
-    "_FIELD_TYPE_FACTORIES",
-    "_FieldLike",
-    "_FieldTypeLike",
-    "_QFF_ENCODE_INTEGERS",
-    "_QFF_ENCODE_ZERO",
-    "_QFF_ROUNDDOWN",
-    "_QFF_ROUNDUP",
-    "_float_factory",
-    "_qangle_factory",
-    "_quantized_factory",
-    "_unsigned64_factory",
-    "_unsigned_factory",
-    "_vector_factory",
-    "_vector_normal_decoder",
     "boolean_decoder",
     "component_decoder",
     "default_decoder",

--- a/src/gem/schema/field_path/__init__.py
+++ b/src/gem/schema/field_path/__init__.py
@@ -2,9 +2,17 @@
 
 The implementation is split into models, operations, Huffman, and sequence
 modules, but callers should continue to import from ``gem.schema.field_path``.
+``__all__`` lists the stable public surface. The underscore-prefixed names
+re-exported below (``_HUFF_DECODE_TABLE``, ``_HUFF_TABLE_BITS``) are internal
+Huffman-table details shared with tests — importable by name, but not part of
+the public contract.
 """
 
-from gem.schema.field_path.huffman import _HUFF_DECODE_TABLE, _HUFF_TABLE_BITS, HUFF_TREE
+from gem.schema.field_path.huffman import (
+    _HUFF_DECODE_TABLE as _HUFF_DECODE_TABLE,
+    _HUFF_TABLE_BITS as _HUFF_TABLE_BITS,
+    HUFF_TREE,
+)
 from gem.schema.field_path.models import FieldPath
 from gem.schema.field_path.operations import FIELD_PATH_OPS, FieldPathOp
 from gem.schema.field_path.path_sequence import read_field_paths
@@ -14,7 +22,5 @@ __all__ = [
     "FieldPath",
     "FieldPathOp",
     "HUFF_TREE",
-    "_HUFF_DECODE_TABLE",
-    "_HUFF_TABLE_BITS",
     "read_field_paths",
 ]

--- a/src/gem/schema/sendtable/__init__.py
+++ b/src/gem/schema/sendtable/__init__.py
@@ -1,8 +1,11 @@
 """Public send-table schema API.
 
 The implementation is split into parser, model, and patch modules, but callers
-should continue to import from ``gem.schema.sendtable``. This module re-exports
-the stable symbols used by parser, entity state, tests, and documentation.
+should continue to import from ``gem.schema.sendtable``. ``__all__`` lists the
+stable public surface. The underscore-prefixed names re-exported below
+(``_parse_field_type``, ``_FIELD_PATCHES``, ``_FieldPatch``) are internal
+helpers shared with sibling modules and tests — importable by name, but not part
+of the public contract.
 """
 
 from gem.schema.sendtable.models import (
@@ -14,10 +17,13 @@ from gem.schema.sendtable.models import (
     Field,
     FieldType,
     Serializer,
-    _parse_field_type,
+    _parse_field_type as _parse_field_type,
 )
 from gem.schema.sendtable.parser import parse_send_tables
-from gem.schema.sendtable.patches import _FIELD_PATCHES, _FieldPatch
+from gem.schema.sendtable.patches import (
+    _FIELD_PATCHES as _FIELD_PATCHES,
+    _FieldPatch as _FieldPatch,
+)
 
 __all__ = [
     "FIELD_MODEL_FIXED_ARRAY",
@@ -28,8 +34,5 @@ __all__ = [
     "Field",
     "FieldType",
     "Serializer",
-    "_FIELD_PATCHES",
-    "_FieldPatch",
-    "_parse_field_type",
     "parse_send_tables",
 ]


### PR DESCRIPTION
## Summary

Two related changes to `gem.schema` — the parser's most complex subpackage:

1. **A `schema/README.md`** modeled on the existing `binary/README.md`.
2. **Tidied the three nested-package facades** so their `__all__` lists stop advertising internal helpers as public API.

## Why

`schema/` was flagged in a package-wide organization audit as the #1 README candidate: it has the steepest learning curve (entity reconstruction from send-table schemas), the deepest nesting (3 nested packages a reader must navigate), and the thinnest top-level doc. The audit also found that the nested facades' `__all__` lists advertised ~25 underscore-prefixed internal symbols as public — contradicting the whole point of a facade and making it impossible to tell the 5-ish symbols that matter from the wiring.

## The README

Follows the `binary/README.md` structure: purpose → mental model → the four areas → key concepts → **what it does NOT do** → common pitfalls → **when to add code here**. The centerpiece is the **two-stage model**:

```
Stage 1 (once):  CDemoSendTables → parse_send_tables() → Serializer/Field tree,
                 each Field's decoder resolved ONCE here
Stage 2 (per packet): read_field_paths() → read_fields() → decode values into FieldState
```

Every claim (class names, function names, the 5 `FIELD_MODEL_*` constants, the one-way `schema`→`state` dependency, the 40 field-path ops) was verified against the code.

## The facade cleanup

Each nested `__init__.py` (`sendtable`, `field_path`, `field_decoder`) listed underscore-prefixed internals in `__all__`. The fix:

- **Trim `__all__`** to the genuine public surface (names without a leading underscore).
- **Keep the underscore names re-exported** — sibling modules and tests import them *by name* (e.g. `from gem.schema.sendtable import _parse_field_type`), which works regardless of `__all__` membership.
- Mark those re-export lines with redundant `import X as X` aliases (PEP 484 convention) so ruff recognizes them as deliberate, not dead imports.

**Why this is safe:** `__all__` only governs `import *` and "what's advertised as public" — and there are **zero** `from gem.schema.* import *` wildcard imports anywhere. Direct named imports are unaffected. Verified empirically before touching anything.

Result — facades now advertise only the public surface:
| Facade | `__all__` before | after |
|---|---|---|
| `sendtable` | 12 (3 private) | 9 |
| `field_path` | 7 (2 private) | 5 |
| `field_decoder` | 32 (18 private) | 16 |

## Verification

- `uv run ruff check` / `ruff format` → clean ✅
- `uv run mypy src/gem/` → Success, 82 files ✅
- underscore symbols still import by name (the tests' pattern) ✅
- `uv run pytest -q` → **1544 passed**, 3 skipped ✅
- `uv run pytest tests/test_extractors.py -m integration` → **7 passed** (real-replay schema decode path) ✅

## Notes

- The nested folder structure is **kept** — these were deliberate `Refactor X into schema subpackage` splits of former monoliths, external callers only use the package facade, and it's the same pattern as the recent `reports/sections/` split. The audit's "nesting is confusing" finding was really about the leaky `__all__`, which this fixes.
- Docs-only-plus-`__all__`-trim: no runtime code paths change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)