### PR TITLE
Add reports/, extractors/, analysis/ READMEs

### DIFF
--- a/src/gem/analysis/README.md
+++ b/src/gem/analysis/README.md
@@ -1,0 +1,314 @@
+# gem.analysis
+
+`gem.analysis` is the post-parse query layer of the replay parser. Every helper
+here takes a finished `ParsedMatch` (or one of its parts) and answers a question
+*about* a parsed game — "where was this hero at that tick?", "did the team have
+vision of the cliff?", "what did this Roshan convert into?" — without ever
+touching the binary stream, schema, or `ReplayParser`. It is the only package
+whose functions are designed to be called *after* parsing is complete, by a
+notebook, report, or downstream ML pipeline.
+
+The package divides into two halves:
+
+- **Cheap lookups** (`spatial.py`, `combat.py`, `abilities.py`, `formatting.py`)
+  — near-instant point queries over already-collected fact lists.
+- **Heavy, experimental builders** (`map_context.py`, `roshan.py`) — multi-pass
+  scans that synthesise new derived records (context buckets, Roshan-conversion
+  summaries) from many fact sources at once.
+
+A vision sub-area (`vision.py`) sits between the two and is explicitly an
+**approximation**, not a replay-accurate measurement.
+
+## Mental Model
+
+The whole package obeys one contract: **operate on `ParsedMatch` facts; never
+re-parse.**
+
+```text
+ReplayParser  ──parse──▶  ParsedMatch
+                            (players, wards, towers, barracks, roshans,
+                             tormentors, aegis_events, teamfights,
+                             combat_log, vision_modifiers, ...)
+                                   │
+                                   │  read-only
+                                   ▼
+                            gem.analysis
+                  ┌────────────────┴─────────────────┐
+                  │                                   │
+          cheap point lookups               heavy derived builders
+   position_at_tick / heroes_near /     build_map_context_timeline /
+   net_worth_at / teamfight_at_tick /   build_rosh_conversions
+   group_ability_hits / ability_                  │
+   level_at_tick / estimate_vision               ▼
+                  │                     new dataclasses
+                  ▼                     (MapContextBucket,
+          tuples / lists /              CampVisitContext,
+          small dataclasses             RoshConversion, ...)
+```
+
+Because the input is already a plain Python object graph, these helpers need no
+parser changes to extend. Adding a new question is just adding a new function
+that reads existing fields. That is the core reason this package exists
+separately from `extractors/`: extractors *collect* facts *during* a parse;
+analysis *interrogates* them afterwards.
+
+The public surface is re-exported from `analysis/__init__.py`; most of it is
+also surfaced at the top level of `gem` — `gem/__init__.py` does
+`from gem.api import *`, and `gem.api` re-exports the analysis helpers (e.g.
+`gem.position_at_tick`, `gem.build_rosh_conversions`).
+
+## Cheap Lookups
+
+These are O(log N) or single-pass helpers over a sorted/parallel fact list.
+
+### Spatial (`spatial.py`)
+
+- `position_at_tick(player, tick)` searches `player.position_log` (a list of
+  `(tick, x, y)` tuples sampled ~1/sec) with `bisect`, returning the `(x, y)` of
+  the nearest sample by tick distance, or `None` if the log is empty.
+- `heroes_near(match, tick, x, y, radius)` calls `position_at_tick` for every
+  player, keeps those within `radius` world units of `(x, y)`, and returns them
+  in **ascending distance order**. Heroes with no position sample are skipped.
+- `net_worth_at(player, tick)` does a *linear* `min()` scan over the parallel
+  `player.times` / `player.net_worth_t` arrays (sampled ~1/sec) and returns the
+  net worth at the nearest tick, or `0` if either array is empty.
+
+### Combat (`combat.py`)
+
+- `group_ability_hits(combat_log, window_ticks=5)` collapses the per-target
+  `DAMAGE` entries of a single multi-target cast (Ravage, RP, etc.) into one
+  `AbilityCast` dataclass. Only entries with a non-empty `inflictor_name` are
+  considered (raw right-clicks have an empty inflictor); entries from the same
+  `(attacker_name, inflictor_name)` pair within `window_ticks` of the cast's
+  **start tick** (`existing.tick`, which is fixed at the first hit and not
+  updated as more hits join) merge into the same cast. Default `5` (~1/6 s at
+  30 ticks/s) suits AoE spells; the docstring suggests `10`–`15` for channelled
+  abilities.
+- `teamfight_at_tick(match, tick)` binary-searches `match.teamfights` (assumed
+  non-overlapping and sorted by `start_tick`) and returns the `Teamfight` whose
+  `[start_tick, end_tick]` window contains `tick`, else `None`.
+- `is_active_teamfight_participant(player_stats)` returns `True` when a
+  per-fight stats object has any of `deaths`, `damage_dealt`, `damage_taken`, or
+  `healing` greater than 0 (read via `getattr(..., 0)`, so missing attributes
+  count as 0). This encodes the "direct hero-vs-hero combat" definition shared
+  with the HTML report.
+
+### Abilities (`abilities.py`)
+
+- `ability_level_at_tick(player, ability, tick)` reads
+  `player._ability_snapshots` — a list of `(tick, {ability_name: level})` tuples
+  built from per-minute snapshots — and returns the level from the latest
+  snapshot whose tick is `<= tick` (so it is "last known level at or before the
+  tick"). Returns `0` if snapshots are missing (the attribute is read with
+  `getattr(..., [])` for older parsed data) or the ability is not yet learned.
+  Ability names match the combat-log `inflictor_name` (e.g.
+  `"axe_berserkers_call"`).
+
+### Formatting (`formatting.py`)
+
+- `format_npc_name(name)` strips the `npc_dota_`, `goodguys_`, and `badguys_`
+  prefixes and turns underscores into spaces. It is for structures/neutrals; the
+  docstring directs heroes to `gem.constants.hero_display()` instead.
+
+## Vision — Explicit Approximations (`vision.py`)
+
+`vision.py` is the package's honest fuzzy area. Its docstrings repeatedly state
+that the results are heuristics with no terrain/high-ground modelling.
+
+- `is_daytime(game_start_tick, tick)` computes the Dota day/night phase: a full
+  cycle is 15 minutes (`_DAY_NIGHT_CYCLE_TICKS = 27000`), with night starting at
+  `_NIGHT_START_TICKS = 13050` (the expression `7 * 60 * 30 + 15 * 30`; the
+  inline code comment labels this "7:30 into the cycle = 13950", but the literal
+  it sums to is 13050, i.e. 7:15 — the comment is stale). `_is_daytime` is a
+  backwards-compatible alias for the same function (kept because the dev branch
+  exported the underscored name).
+- `estimate_vision(match, team, tick, x, y)` returns a distance-sorted list of
+  `VisionSource` dataclasses (`kind` ∈ `"hero" | "ward" | "modifier"`) for every
+  allied unit that *could* see `(x, y)`. Hero radius is day/night-adjusted
+  (`_DAY_VISION = 1800` / `_NIGHT_VISION = 800`); observer wards use a constant
+  `_WARD_VISION = 1600`; modifier reveals (from `match.vision_modifiers`, e.g.
+  Slardar Corrosive Haze, Track, Dust) report distance to the revealed hero with
+  `vision_radius = 0` and **no radius gate**. The docstring quotes ~85–90%
+  accuracy for the "was this initiation telegraphed or blind?" use case and lists
+  what it does *not* model (high ground, ability vision, summon/creep vision,
+  sentry true-sight).
+- `ward_vision_impact(ward, match)` counts *distinct* enemy heroes whose
+  `position_log` samples ever fell inside the ward's 1600-unit radius during its
+  alive window (squared-distance check against `_WARD_VISION_RADIUS_SQ`, one
+  sighting per hero). Returns `0` for non-observer wards or wards with no
+  coordinates. The docstring flags it as approximate: ~5 s sampling gaps, flat 2D
+  radius (no terrain), and day-vision radius always used.
+
+## Heavy Builders — Experimental (`map_context.py`, `roshan.py`)
+
+These are multi-pass scans that emit *new* derived dataclasses. They are the
+experimental, opinionated end of the package (scoring weights and thresholds are
+hand-tuned, not ground truth).
+
+### Map context (`map_context.py`)
+
+- `build_map_context_timeline(match, team, bucket_ticks=900, presence_window_ticks=2700)`
+  sweeps the game in fixed-width buckets (default 30 s) and, for each, emits a
+  `MapContextBucket` with tower-alive counts, T1-mid state, last Roshan/Tormentor
+  kill ticks, aegis-holder state, per-team observer counts, net-worth/XP
+  advantage, and decayed enemy presence per region. It maintains running
+  counters (`towers_alive`, `t1_mid_alive`, aegis bookkeeping) across buckets and
+  validates `team ∈ {2, 3}` and positive bucket/window sizes (raises
+  `ValueError`).
+- `score_camp_visit_context(*, team, camp_id, camp_type, neutral_kills, neutral_damage, xp_gain, bucket)`
+  turns a single camp visit plus its overlapping bucket into a `CampVisitContext`
+  with three `0–1` scores (`farm_safety_score`, `pressure_score`,
+  `expected_value_score`), a categorical `context_label` (one of six values like
+  `safe_home_farm` … `high_risk_invade`), and a list of explainability
+  `context_drivers`. All scoring is a hand-weighted linear blend clamped via
+  `_clamp01`.
+- `world_in_bounds(x, y)` is a simple bounds check against the calibrated map
+  rectangle.
+- Camp geometry comes from `gem.catalog.map.load_neutral_camp_centers()`, loaded
+  once into module-level `_CAMP_CENTERS`.
+
+### Roshan conversion (`roshan.py`)
+
+- `build_rosh_conversions(match)` returns one `RoshConversion` per entry in
+  `match.roshans`, answering "did this Roshan convert into fights / objectives /
+  map control / a closing sequence?" For each kill it associates the nearest
+  `AegisEvent` (within `_ASSOCIATION_WINDOW_TICKS = 30 s`), resolves the holder
+  team/hero, decides the aegis `fate` (`consumed` via a holder DEATH in the
+  combat log / `expired` / `denied` / `game_end` / `unknown`), then tallies
+  fights won/lost/drawn, towers, barracks, forced enemy buybacks, enemy-half
+  observer delta, and enemy-half farm-share shift across the advantage window. It
+  produces a 0–100 `conversion_score`, a `conversion_label`, an `aegis_outcome`,
+  human-readable `drivers`, and a sorted `timeline_events` list of
+  `RoshTimelineEvent`. Key windows: aegis duration `_AEGIS_DURATION_TICKS = 5 min`,
+  immediate-outcome `_IMMEDIATE_WINDOW_TICKS = 180 s`, post-consume grace
+  `_POST_CONSUME_GRACE_TICKS = 30 s` (all at 30 ticks/s).
+
+## Shared Internals (`_shared.py`)
+
+`_shared.py` holds map-geometry constants and the small lookups that were
+previously duplicated between `roshan.py`, `map_context.py`, and
+`reports/_sections.py`:
+
+- `_TEAM_RADIANT = 2`, `_TEAM_DIRE = 3` and the calibrated map bounds
+  (`_MAP_XMIN/XMAX/YMIN/YMAX`), fountain positions, and `_RIVER_STRIP`.
+- `region_of(x, y)` classifies a point as `"river"` (when `|x - y| <=
+  _RIVER_STRIP`) or, otherwise, the half of whichever fountain is nearer
+  (`"radiant_half"` / `"dire_half"`).
+- `nearest_series_value(times, values, tick)` is the `bisect`-based parallel-array
+  lookup used by `map_context.py` (the `spatial.py` and `roshan.py` helpers
+  inline their own near-identical scans rather than calling it).
+- `infer_match_end_tick(match)` returns `match.game_end_tick` when set, else the
+  latest tick observed across all players' `times` and `position_log`.
+
+## Data Flow Notes
+
+- Everything is read-only against `ParsedMatch`/`ParsedPlayer`. No function in
+  this package mutates the match or calls back into the parser.
+- The boundary with `extractors/` is **types only**: `combat.py` and `roshan.py`
+  import `Teamfight` / `AegisEvent` (and `combat.py`'s `CombatLogEntry`,
+  `roshan.py`/`map_context.py`'s `ParsedMatch`) under `if TYPE_CHECKING:`, so
+  there is no runtime dependency on the extractor or results packages. The one
+  real runtime import outside `analysis` is
+  `map_context.py` → `gem.catalog.map.load_neutral_camp_centers`.
+- `is_active_teamfight_participant` and `ward_vision_impact` deliberately accept
+  `object` / duck-typed args (read via `getattr`) so they work with any
+  stats/ward shape, not just the concrete extractor dataclass.
+
+## What This Package Does Not Do
+
+- **Read replay bytes / bits.** That is `binary` (`DemoStream`, `BitReader`).
+- **Build serializers or decode entity fields.** That is `schema`.
+- **Track string tables or entity lifecycle.** That is `state`.
+- **Ingest the combat log.** Producing `CombatLogEntry` objects (S1 + S2 paths)
+  is `combat`; this package only *reads* the finished `match.combat_log`.
+- **Collect facts during a parse.** Sampling player snapshots, ward placements,
+  teamfight windows, draft, objectives, etc. is `extractors`. Analysis only
+  imports extractor result *types* (under `TYPE_CHECKING`).
+- **Assemble `ParsedMatch` / export DataFrames/JSON/Parquet.** That is `results`
+  (`assembly.py`, `dataframes.py`, `models.py`).
+- **Render HTML reports.** That is `reports`; it *consumes* analysis output (and
+  shares `_shared.py` constants), but the rendering lives there.
+- **Resolve hero/item/ability/map names from IDs.** That is `catalog` (and the
+  `constants` facade). `map_context.py` calls into `catalog.map` for camp
+  centres; `format_npc_name` is only string munging, not a catalog lookup.
+
+If a value looks wrong here, the bug is usually upstream: a missing
+`position_log` sample, an empty `teamfights` list, or a mis-extracted ward — fix
+it in the extractor that produced the field, not in the lookup that reads it.
+
+## Common Pitfalls
+
+### `estimate_vision` / `ward_vision_impact` are approximations, not truth
+They do flat 2D radius checks with no high-ground, tree, or cliff modelling, and
+sample positions only every ~1–5 seconds. An empty `estimate_vision` result
+means "no *modelled* vision", not a guaranteed fog state. Do not treat their
+output as replay-accurate vision.
+
+### `modifier` vision sources have `vision_radius = 0` and no radius check
+In `estimate_vision`, a modifier-revealed enemy hero is *always* added as a
+source regardless of how far the query point is from that hero — the `distance`
+field is informational only. This is intentional (the modifier grants direct
+vision of the hero), not a missing radius gate.
+
+### `net_worth_at` scans linearly; `position_at_tick` bisects
+`net_worth_at` uses an O(N) `min()` over `player.times`, while `position_at_tick`
+and `teamfight_at_tick` use `bisect`. Don't assume all "at_tick" helpers share
+the same cost or that the arrays are interchangeable.
+
+### `ability_level_at_tick` reads a private attribute
+It depends on `player._ability_snapshots`. If that attribute is absent (older
+parsed data, or a hand-built `ParsedPlayer`), it silently returns `0` rather than
+raising. A constant `0` for a hero you know levelled the spell usually means the
+snapshots were never populated.
+
+### `group_ability_hits` ignores auto-attacks by design
+Entries with an empty `inflictor_name` (raw right-clicks) are dropped, and the
+merge key is `(attacker_name, inflictor_name)`. The window is measured from the
+cast's start tick (the first hit), not from the most recent hit, so a long
+sustained stream of hits from one `(attacker, ability)` pair will *not* keep
+extending the same cast indefinitely. Two genuinely separate casts of the same
+ability within `window_ticks` will merge; widen or narrow `window_ticks` per
+ability type (channelled spells need a larger window).
+
+### `teamfight_at_tick` assumes non-overlapping, sorted fights
+It binary-searches on `start_tick` and checks a single candidate window. If the
+`teamfights` list is unsorted or windows overlap, it can miss a containing fight.
+
+### `region_of` is geometric, not lane-aware
+The river is just the diagonal strip `|x - y| <= 1200`; halves are
+nearest-fountain. It does not know lanes, ramps, or the actual river polygon.
+Camp/ward "enemy half" attribution inherits this coarseness.
+
+### The heavy builders are experimental and weight-tuned
+`score_camp_visit_context`, `build_map_context_timeline`, and
+`build_rosh_conversions` encode hand-picked thresholds (e.g. `>= 3500` net-worth
+"winning_state", `0.10` farm-share delta, the 0–100 score weights). Treat their
+labels/scores as opinionated heuristics, not derived constants, and expect them
+to change between releases.
+
+## When To Add Code Here
+
+Add code to `gem.analysis` when the change answers a *new question about an
+already-parsed match* using fields that `ParsedMatch` already carries.
+
+Good fits:
+
+- a new point lookup over existing parallel arrays or fact lists (mirroring
+  `position_at_tick` / `net_worth_at`);
+- a new derived summary/scoring builder that scans existing facts (in the spirit
+  of `build_rosh_conversions`);
+- a refinement to a vision/region heuristic, clearly documented as an
+  approximation.
+
+Poor fits:
+
+- needing data that isn't on `ParsedMatch` yet — add a field in the relevant
+  **extractor** + `results` model first, then read it here;
+- anything that requires re-reading the replay, the schema, or live entity state
+  (that belongs in `binary`/`schema`/`state`/`extractors`);
+- name/ID resolution tables (belongs in `catalog`);
+- HTML/visual rendering (belongs in `reports`).
+
+Keep new helpers read-only, keep extractor result types behind `TYPE_CHECKING`,
+and push genuinely shared map constants into `_shared.py` rather than
+re-declaring them.

--- a/src/gem/extractors/README.md
+++ b/src/gem/extractors/README.md
@@ -1,0 +1,349 @@
+# gem.extractors
+
+`gem.extractors` is the *during-parse* observation layer. While the replay is
+streaming, each extractor attaches to a `ReplayParser`, registers callbacks, and
+accumulates structured records (per-player snapshots, objective kills, ward
+placements, draft picks/bans, courier state, per-minute interval curves). It
+answers "what happened, tick by tick, as the entity/combat-log state evolved" —
+a question the lower layers (`binary`, `schema`, `state`, `combat`) cannot
+answer because they only know how to *produce* events, not which of them to keep.
+
+This is distinct from `gem.analysis`, which runs *after* parsing on an already
+assembled `ParsedMatch`. Extractors need the live parser; analysis helpers do
+not.
+
+## Mental Model
+
+Every extractor follows the same three-phase contract: **attach → parse →
+read**.
+
+```text
+extractor = SomeExtractor()
+extractor.attach(parser)     # phase 1: register callbacks (before parse())
+parser.parse()               # phase 2: parser drives callbacks tick by tick
+results = extractor.results  # phase 3: read accumulated records (after parse())
+```
+
+During phase 2 the parser calls into each extractor through a small set of
+registration hooks it exposes (`parser.py`):
+
+```text
+ReplayParser
+  ├─ on_entity(cb)             → cb(entity, op)        entity create/update/delete
+  ├─ on_combat_log_entry(cb)   → cb(entry)             every CombatLogEntry
+  ├─ on_chat_event(cb)         → cb(msg, tick)         CDOTAUserMsg_ChatEvent
+  ├─ on_game_start(cb)         → cb(game_start_tick)
+  └─ on_game_end(cb)           → cb(tick)
+```
+
+An extractor's `attach()` wires itself to whichever subset it needs, stashes the
+`parser` reference (to read `parser.tick`, `parser.game_time_s`,
+`parser.combat_log_time_s`, `parser.entity_manager`, `parser.string_tables`),
+then does nothing further until the parser pushes data at it.
+
+```text
+                 attach()                  parse()                    read
+  Extractor  ───────────────►  ReplayParser  ───callbacks──►  Extractor  ──► records
+   (empty)      registers       (drives loop)    fire           (full)
+```
+
+The package splits into two tiers:
+
+- **Core extractors** (re-exported from `gem.extractors.__init__`):
+  `PlayerExtractor`, `ObjectivesExtractor`, `WardsExtractor`, `CourierExtractor`,
+  `DraftExtractor`, plus their record dataclasses.
+- **Internal helpers** (not in `__all__`): `IntervalExtractor` (intervals.py),
+  `detect_teamfights` (teamfights.py), `classify_lane` (lane.py), and the shared
+  `_snapshots.py` helpers. These are wired up by `gem.api.parse` and
+  `gem.results.assembly`, not imported by end users.
+
+## The attach → parse → read timing contract
+
+`attach(parser)` is the only setup step, and it must run **before**
+`parser.parse()` — callbacks registered after the stream starts miss earlier
+ticks. Inside `attach`, an extractor:
+
+1. saves `self._parser = parser` so it can read live parser state later;
+2. registers its callbacks (`parser.on_entity(self._on_entity)`, etc.).
+
+Results are only complete **after** `parse()` returns. Two extractors need an
+explicit post-parse finalize step, and `gem.api.parse` calls both
+(api.py:273-274):
+
+- `DraftExtractor.finalize()` — re-resolves *all* draft hero names through the
+  now fully-populated live `hero_id → npc_name` map, correcting picks that the
+  static fallback guessed wrong during the draft phase (see Pitfalls).
+- `WardsExtractor.finalize()` — back-fills placer NPC names for pre-game wards
+  whose owner resolved to a `CDOTAPlayerController` before a hero was assigned.
+
+`WardsExtractor.ward_events` and `ObjectivesExtractor.*_kills` are plain
+attributes populated incrementally; `PlayerExtractor.snapshots` likewise. The
+`time_series(player_id)` / `minute_time_series(player_id)` methods are *views*
+computed on demand from the accumulated snapshots, not separate buffers.
+
+## Core extractors
+
+### PlayerExtractor (players.py)
+
+The heaviest extractor. On every `on_entity` it tracks live references to the
+hero entities (`CDOTA_Unit_Hero_*`), player controllers
+(`CDOTAPlayerController`), team data entities
+(`CDOTADataRadiant`/`CDOTA_DataRadiant`, `CDOTADataDire`/`CDOTA_DataDire`), and
+`CDOTA_PlayerResource`. When `CDOTAGamerulesProxy` or a tracked entity updates,
+it calls `_maybe_sample()`, which gates on two cadences:
+
+- a **regular** interval gap (`sample_interval`, default 30 ticks ≈ 1 s), and
+- **minute boundaries** (`minute_snapshots=True` by default), aligned to the
+  game clock — `parser.game_time_s` when available, else every 1800 ticks from
+  game start.
+
+Each sample (`_sample`) builds a `PlayerStateSnapshot` per player from
+`_snapshot_hero`, then overlays the *authoritative* fields: current unspent gold
+and net worth from the controller (`m_iGold`, `m_iNetWorth`), and cumulative
+totals from the team data entity (`m_iTotalEarnedGold`, `m_iTotalEarnedXP`,
+`m_iNetWorth`, `m_iLastHitCount`, `m_iDenyCount`) addressed by
+`m_vecDataTeam.{team_slot:04d}.*`. This field-source distinction is critical:
+advantage curves must use the monotonic `m_iTotalEarnedGold`/`m_iTotalEarnedXP`,
+never the spendable `m_iGold` or the resets-on-level-up `m_iCurrentXP`.
+
+`PlayerExtractor` also subscribes to `on_combat_log_entry` to keep running,
+monotonic per-player totals (`_total_hero_damage`, `_total_hero_healing`,
+`_total_deaths`, `_total_stuns`) that it stamps into each snapshot, and on the
+first snapshot per player it emits synthetic `PURCHASE` combat-log entries for
+the starting inventory (`_diff_inventory`) by calling
+`parser.combat_log._emit`. At `on_game_end` it reads the authoritative
+kills/deaths/assists scoreboard from `CDOTA_PlayerResource`
+(`m_vecPlayerTeamData.{i:04d}.m_iKills/Deaths/Assists`).
+
+`hero_pos(npc_name)` exposes a live position lookup, resolving the canonical
+hero entity via the controller's `m_hAssignedHero` handle when possible.
+
+### ObjectivesExtractor (objectives.py)
+
+Listens to `on_combat_log_entry` for `DEATH` events and classifies the target
+NPC name into `TowerKill`, `RoshanKill`, `BarracksKill`, or `TormentorKill`
+(target `npc_dota_miniboss`). Tower/barracks ownership is resolved by NPC-name
+prefix (`npc_dota_goodguys_*` = Radiant, `npc_dota_badguys_*` = Dire). It also
+hooks `on_entity` to snapshot which Roshan drop item entities
+(`CDOTA_Item_Aegis`, `CDOTA_Item_Cheese`, `CDOTA_Item_RefresherOrb_Shard`,
+`CDOTA_Item_Roshans_Banner`) are alive at the kill tick, and `on_chat_event`
+for Aegis pickup/steal/denial (`AegisEvent`), Shrine kills (`ShrineKill`), and
+Tormentor player-slot attribution (patched onto the most recent `TormentorKill`).
+
+### WardsExtractor (wards.py)
+
+Uses `m_lifeState` *transitions* on ward entities (`CDOTA_NPC_Observer_Ward`,
+`CDOTA_NPC_Observer_Ward_TrueSight`) as the primary signal — the OpenDota
+approach. A transition to `m_lifeState == 0` (alive) is a placement: the entity
+already carries exact coordinates (`_pos`) and `m_hOwnerEntity`, so no
+coordinate-matching window is needed. A transition to `m_lifeState == 1` (dying)
+is a kill or natural expiry, disambiguated against per-target killer queues fed
+from combat-log `DEATH` events and lifespan tolerances
+(`_OBSERVER_LIFESPAN_TICKS`, `_SENTRY_LIFESPAN_TICKS`,
+`_EXPIRY_TOLERANCE_TICKS`). `finalize()` returns `ward_events`.
+
+### CourierExtractor (courier.py)
+
+Tracks `CDOTA_Unit_Courier*` entities and emits a `CourierSnapshot` (team,
+`m_iCourierState`, `m_bFlyingCourier`, position) at a fixed `sample_interval`
+(default 150 ticks ≈ 5 s).
+
+### DraftExtractor (draft.py)
+
+Polls `CDOTAGamerulesProxy` for `m_pGameRules.m_BannedHeroes.{i:04d}` (14 ban
+slots) and `m_pGameRules.m_SelectedHeroes.{i:04d}` (10 pick slots), emitting an
+idempotent `DraftEvent` per new `(is_pick, slot_index, hero_id)`. Hero-ID
+resolution is three-tier (`_resolve_name`): live map from hero entity class
+names, then `hero_id // 2` against bundled `heroes.json` (modern replays store
+`api_id * 2`), then a direct `heroes.json` lookup. `resolve_pick_team` is a
+module-level helper used at assembly time to pin a pick to the correct team via
+the player roster.
+
+## Internal extractors and helpers
+
+### IntervalExtractor (intervals.py) — INTERNAL
+
+The OpenDota-parity per-minute curve source. It is deliberately *not*
+re-exported from `gem.extractors`; `gem.api.parse` constructs it and
+`gem.results.assembly` consumes it. It exists separately from `PlayerExtractor`
+so the authoritative `gold_t`/`xp_t` advantage curves come from
+`CDOTA_DataRadiant`/`Dire` (via `m_vecDataTeam`) sampled exactly on game-clock
+interval boundaries, without overloading `PlayerExtractor`.
+
+Two subtle behaviours distinguish it from the dense player sampler:
+
+- **Clock axis** (`_clock`): it samples on `parser.combat_log_time_s` (the
+  combat-log timestamp axis anchored at the GAME_STATE==5 horn), falling back to
+  `parser.game_time_s` only before the horn timestamp is known. This avoids an
+  off-by-one final minute.
+- **Frame nudge** (`_team_data_values`): OpenDota reads the interval one entity
+  frame *before* gem's clock crossing, so `_emit` uses the latest team-data
+  frame with `observed_tick < emit_tick` rather than the live boundary-tick
+  value, removing a systematic +1. `_emit_final_boundary` is the one exception —
+  a terminal read at game end keeps the live value.
+
+It also carries terminal scalar counters (`team_counters`) read from the same
+`m_vecDataTeam` entry (camps/creeps stacked, wards placed, rune pickups, tower
+kills) and emits OpenDota's synthetic t=0 baseline.
+
+### teamfights.py — `detect_teamfights` (post-parse function)
+
+Not an extractor with `attach()` — a pure function called from
+`gem.results.assembly` on the finished combat log. It merges hero deaths within
+a 15-second cooldown (`_COOLDOWN_TICKS`), optionally splits concurrent fights by
+spatial centroid (`_FIGHT_RADIUS`) using `PlayerStateSnapshot` positions, then
+aggregates per-player stats into `Teamfight`/`TeamfightPlayer`. No
+minimum-death filter is applied.
+
+### lane.py — `classify_lane` (post-parse utility)
+
+A stateless function, no `Extractor` class. Given a player's `lane_pos` heatmap
+(64-unit grid cells) and team, it maps cells to coarse zones (`_cell_zone`),
+finds the dominant zone, and returns an OpenDota lane role
+(1=safe, 2=mid, 3=off, 4=jungle, 5=roaming, 0=unknown). Called from
+`gem.results.assembly`.
+
+### _snapshots.py — shared helpers
+
+Holds the dataclasses and helpers reused across extractors so each module need
+not re-derive them:
+
+- `PlayerStateSnapshot` / `PlayerTimeSeries` dataclasses (re-exported through
+  `players.py` and `gem.extractors`).
+- `_pos(entity)` — world `(x, y)` from `CBodyComponent.m_cellX/m_cellY` (×128)
+  plus `m_vecX/m_vecY`. Called directly by players, wards, courier, and
+  `_snapshot_hero`. (teamfights does not call `_pos`; it reads positions off the
+  already-built snapshot `.x`/`.y` via its own `_nearest_pos`.)
+- `_player_id_from_entity(entity, *, allow_owner=False)` — resolves an entity to
+  a player slot 0-9 by reading `m_nPlayerID`/`m_iPlayerID` and halving the
+  doubled raw value. `allow_owner` adds an `m_iPlayerOwnerID` fallback for
+  *owned units* (e.g. a ward's owner unit), but **must stay False for hero-name
+  lookups** so a hero-class illusion is not misattributed to the real hero.
+- `_snapshot_hero(entity, tick)` — builds a base `PlayerStateSnapshot` (gold and
+  cumulative fields left at 0 for the extractor to overlay).
+
+## What This Package Does Not Do
+
+- **It does not read bytes or bits.** Outer/inner stream framing and bit-level
+  decoding live in `gem.binary` (`DemoStream`, `BitReader`).
+- **It does not build serializers or decode entity field values.** The send-table
+  schema and field decoders are `gem.schema`; the entity lifecycle, `FieldState`
+  tree, and `EntityOp` come from `gem.state` (`entities.py`,
+  `string_table.py`). Extractors only *read* finished `Entity` objects via
+  `entity.get_int32`/`get_uint32`/`get_float32`/`get_bool`/`get_class_name`.
+- **It does not produce combat-log entries.** S1/S2 combat-log ingestion and
+  normalization are `gem.combat` (`log.py`, `aggregator.py`). Extractors consume
+  `CombatLogEntry` objects through `on_combat_log_entry`. (`PlayerExtractor`
+  does *emit* synthetic starting-inventory PURCHASE entries via
+  `parser.combat_log._emit`, but it does not parse the wire format.)
+- **It does not drive the parse loop or own the parser callbacks.** That is
+  `gem.parser.ReplayParser`. Extractors are passive subscribers.
+- **It does not map IDs to display names beyond hero-ID resolution.**
+  Hero/item/ability/XP lookups are `gem.catalog` (DraftExtractor imports
+  `HEROES` from it). Extractors store internal NPC/entity names, not localized
+  display strings.
+- **It does not assemble the final output model.** `ParsedMatch`/`ParsedPlayer`
+  construction is `gem.results` (`models.py`, `assembly.py`), which is where
+  `detect_teamfights` and `classify_lane` are actually invoked.
+- **It does not do post-parse analysis on `ParsedMatch`.** Position/net-worth
+  lookups, ability-hit grouping, vision geometry, map-context buckets, and Roshan
+  conversion records are `gem.analysis`. The boundary: if it needs the live
+  parser, it belongs here; if it needs only an assembled `ParsedMatch`, it
+  belongs in `gem.analysis`.
+- **It does not render reports.** That is `gem.reports`.
+
+## Common Pitfalls
+
+### Registering callbacks after `parse()` has started
+
+`attach(parser)` must be called before `parser.parse()`. Callbacks added late
+silently miss every earlier tick. There is no replay/rewind.
+
+### Reading results before the parse finishes (or before finalize)
+
+`time_series`, `minute_time_series`, `ward_events`, and `*_kills` are only
+complete after `parse()` returns. For `DraftExtractor` and `WardsExtractor` you
+must also call `finalize()` — `gem.api.parse` does this for you, but direct
+users of the extractors must not skip it. `DraftExtractor.finalize()`
+intentionally re-resolves **all** events, not just empty ones, because the
+direct-lookup fallback fires first during the draft and produces wrong heroes
+for doubled-ID picks.
+
+### Using the wrong gold/XP field
+
+`m_iGold` (controller) is spendable cash and drops on every purchase;
+`m_iCurrentXP` (hero) resets to 0 each level-up. For advantage curves use the
+monotonic `m_iTotalEarnedGold`/`m_iTotalEarnedXP` on
+`CDOTADataRadiant`/`CDOTADataDire` (`m_vecDataTeam.{slot}.*`). `PlayerExtractor`
+and `IntervalExtractor` both encode this; do not "simplify" by reading the hero
+or controller gold.
+
+### Passing `allow_owner=True` to a hero-name lookup
+
+`_player_id_from_entity(..., allow_owner=True)` is correct only for *owned
+units* (the ward's owner-unit path in `wards.py`). A hero-class illusion (Manta,
+Shadow Demon disruption) shares the real hero's class and may carry only
+`m_iPlayerOwnerID`; resolving it via the owner field misattributes the real
+hero's stats to the illusion's owner. Hero entities always carry
+`m_nPlayerID`/`m_iPlayerID`, so the default `allow_owner=False` is right for them.
+
+### Both NPC-name forms are registered on purpose
+
+Combat-log hero names are inconsistent: `templarassassin` vs
+`templar_assassin`. `players.py` and `draft.py` register *two* candidate NPC
+names per hero (a simple lowercase fold and a camelCase-split form) and overlay
+the canonical name from the `EntityNames` string table when available
+(`_sample` in players.py). Dropping either form breaks resolution for some
+heroes.
+
+### Treating `IntervalExtractor`, `detect_teamfights`, or `classify_lane` as public
+
+They are not in `gem.extractors.__all__`. `IntervalExtractor` is internal
+plumbing for OpenDota parity; `detect_teamfights` and `classify_lane` are
+post-parse functions invoked by `gem.results.assembly`, not attach-style
+extractors. Import them from their submodules only if you are extending the
+pipeline.
+
+### Recycled entity slots and `m_lifeState`
+
+Wards (and other entities) reuse index slots across a game. `WardsExtractor`
+keys live state by entity index and tracks the *previous* `m_lifeState` per
+index, detecting transitions rather than filtering on `EntityOp.CREATED`. A slot
+that emits `UPDATED` (not `CREATED`) still carries a valid placement; do not
+filter to `CREATED`-only.
+
+### Roshan drop entities are alive only between spawn and pickup
+
+`ObjectivesExtractor` snapshots `self._roshan_items` (items currently alive) at
+the `DEATH` tick. Items are created when Roshan spawns and deleted when picked
+up, so the alive set at kill time is exactly the drop list. It clears entries on
+`EntityOp.DELETED_LEFT`.
+
+## When To Add Code Here
+
+Add code to `gem.extractors` when the change is about **observing live
+entity/combat-log/chat state as the replay streams** and turning it into
+structured records.
+
+Good fits:
+
+- a new during-parse signal: a new objective, a new entity-state time series, a
+  new chat-event-derived record;
+- a new field overlay on `PlayerStateSnapshot` sourced from an entity read each
+  tick;
+- a new attach-style extractor following the `attach → callbacks → read`
+  contract, plus its record dataclass.
+
+Poor fits:
+
+- anything computed from a finished `ParsedMatch` with no live parser — put it in
+  `gem.analysis` (e.g. `position_at_tick`, vision estimation, Roshan
+  conversion);
+- new bit/byte decoding (`gem.binary`), entity-field decoding (`gem.schema` /
+  `gem.state`), or combat-log wire parsing (`gem.combat`);
+- ID→display-name tables (`gem.catalog`);
+- shaping the final output model or DataFrame/JSON export (`gem.results`);
+- HTML/report rendering (`gem.reports`).
+
+When adding shared snapshot dataclasses or helpers reused by more than one
+extractor, put them in `_snapshots.py` rather than duplicating per module.

--- a/src/gem/reports/README.md
+++ b/src/gem/reports/README.md
@@ -1,0 +1,311 @@
+# gem.reports
+
+`gem.reports` turns a fully parsed `ParsedMatch` into one self-contained,
+multi-tab HTML file you can open in a browser with no server, build step, or
+network access (icons and the map image are inlined as base64). It is the
+*presentation* layer: it asks "what does this match look like to a human?",
+whereas its neighbors (`extractors`, `analysis`, `results`) answer "what
+happened in this match?" and produce the structured data this package renders.
+
+This package is read-only with respect to the replay. It never touches `.dem`
+bytes, entities, or the combat log directly — it reads the
+`ParsedMatch`/`ParsedPlayer` dataclasses from `gem.results.models`, name/geometry
+lookups from `gem.catalog`, the post-parse helpers in `gem.analysis`, and
+(lazily, only inside `build_draft`) the `DraftEvent` / `resolve_pick_team`
+helpers from `gem.extractors.draft` to assign pick/ban teams — then emits HTML
+strings.
+
+## Mental Model
+
+A report is built as a tree of HTML strings that collapse into one document:
+
+```text
+ParsedMatch
+  -> build_html_report()                 (builder.py — the orchestrator)
+       -> configure assets, preload icons, set game-start tick
+       -> for each tab:
+            tab = (label, "\n".join of section build_*() outputs))
+              -> build_scoreboard(match)         -> "<div class='card'>...</div>"
+              -> build_gold_xp_chart(match)      -> "<div class='card'>...</div>"
+              -> build_wards(match, map_b64)      -> "<svg>...</svg> + <script>"
+              ...
+       -> drop tabs whose joined content is empty
+       -> wrap tabs in radio-driven .tab-bar / .tab-page markup
+       -> _deduplicate_data_uris(body)
+       -> wrap in <html><head>(REPORT_CSS + Chart.js CDN)</head><body>...</body>
+```
+
+Each **section builder** is a pure function `build_<name>(match, ...) -> str`.
+It receives the `ParsedMatch` (and sometimes `map_b64`), reads whatever fields
+it needs, and returns an HTML fragment — conventionally a `<div class="card">`
+wrapper, but a section may also emit `<svg>` minimaps and inline `<script>`
+blocks. If a section has no data to show it returns `""`; the builder filters
+those out so empty tabs disappear.
+
+The **builder** (`builder.py`) owns everything *between* sections: tab layout,
+the global `<head>`, the Chart.js CDN include, the JS that switches tabs and
+drives the teamfight filter sliders, the one-time map-image global, base64
+deduplication, and the optional Plotly Movement tab.
+
+## Section Builders And The `sections/` Package
+
+The section builders live in `gem/reports/sections/`, grouped by domain. Each
+module's docstring names its slice:
+
+| Module | `build_*` functions |
+|---|---|
+| `sections/match.py` | `build_header`, `build_scoreboard`, `build_objectives`, `build_rosh_conversion`, `build_draft`, `build_chat` |
+| `sections/economy.py` | `build_hero_timeseries_chart`, `build_gold_xp_chart`, `build_damage`, `build_purchases`, `build_buybacks`, `build_runes` |
+| `sections/combat.py` | `build_combat_timeseries_chart`, `build_kill_feed`, `build_teamfights` |
+| `sections/vision.py` | `build_wards`, `build_laning`, `build_farming` |
+| `sections/_shared.py` | helpers used by more than one section module (e.g. `_ward_enemies_seen`, Radiant/Dire color palettes) |
+
+`sections/__init__.py` re-exports all 18 `build_*` functions, so the package is
+the single import surface: `from gem.reports.sections import build_wards`.
+
+The grouping is by *what the section describes*, not by which tab it lands in.
+The Overview tab, for instance, is assembled in `builder.py` from
+`build_scoreboard` (match.py), `build_hero_timeseries_chart` (economy.py), and
+`build_gold_xp_chart` (economy.py). The tab/section mapping lives entirely in
+`build_html_report`'s `tabs` list (`builder.py:263`), not in the section
+modules.
+
+## The `_sections.py` Shim
+
+`_sections.py` used to be a single ~3,700-line module holding every builder. It
+is now a **backward-compatibility shim**: it imports the `build_*` functions
+from `gem.reports.sections` and re-exports them, so old imports like
+`from gem.reports._sections import build_rosh_conversion` keep working.
+`builder.py` still imports through this shim (`builder.py:34`).
+
+Prefer importing from `gem.reports.sections` in new code, but either import
+surface is complete: the shim's `__all__` (`_sections.py:35`) lists the same 18
+`build_*` functions as the canonical `sections/__init__.py` `__all__` — the two
+lists are identical.
+
+## How A `ParsedMatch` Becomes HTML
+
+`build_html_report(match, *, assets, options, map_b64)` in `builder.py` is the
+entry point. In order, it:
+
+1. Resolves `assets` (default `ReportAssets()`) and `options` (default
+   `ReportOptions()`), calls `configure_assets(assets)` to point the icon
+   loaders at the right directories and clear stale icon caches, and loads the
+   map image to base64 via `load_map_base64` unless a `map_b64` was passed.
+2. Calls `set_game_start_tick(match.game_start_tick or 0)` so the module-level
+   `fmt_tick` in `_formatting.py` renders game-relative `MM:SS` times.
+3. **Preloads icons** by name: canvas marker icons (`ward_observer`,
+   `ward_sentry`, `smoke_of_deceit`), every purchased item across all players'
+   `purchase_log` (via `value_name` with the `item_` prefix removed), and every
+   drafted hero portrait. These populate the global `ITEM_ICON_B64` /
+   `HERO_ICON_B64` caches in `assets.py` so section builders can look icons up by
+   short name without re-reading disk.
+4. Builds the header once (`build_header`, always visible above the tabs) and
+   assembles the `tabs` list, joining each tab's section outputs with `"\n"`
+   through `filter(None, ...)` so empty sections vanish.
+5. Appends the optional **Movement** tab (`_build_movement_tab`) when
+   `options.include_movement` is set and it returns non-empty.
+6. Drops any tab whose joined content is whitespace-only, then renders the
+   radio-input `.tab-bar` and `.tab-page` divs (first tab `checked`/`active`).
+7. Emits the tab-switching + teamfight-filter JS, the one-time map-image global
+   JS, runs `_deduplicate_data_uris` over the body, and wraps everything in the
+   final `<!DOCTYPE html>` document with `REPORT_CSS` inlined and the Chart.js
+   CDN `<script>` in `<head>`.
+
+`write_html_report(match, output_path, ...)` is the thin file-writing wrapper
+(creates parent dirs, writes UTF-8, returns the `Path`). `build_html(match,
+map_b64)` is a backward-compatible alias for the old example-helper name and
+just forwards to `build_html_report`.
+
+`__init__.py` exports the supported surface: `ReportAssets`, `ReportOptions`,
+`build_html`, `build_html_report`, `write_html_report`. The public package
+re-exports `gem.reports` so `gem.reports.build_html_report(match)` works
+(`api.py:68`); `examples/match_report.py` is a thin CLI wrapper over
+`write_html_report`.
+
+## Tabs Are JS-Driven, Not Pure CSS
+
+Tab switching is **JavaScript**, not a CSS `:checked` sibling selector. The CSS
+(`styles.py`) only defines `.tab-page { display: none }` and
+`.tab-page.active { display: block }`; the `tab_js` block in `builder.py`
+listens for radio `change` events and toggles the `.active` class on the
+matching `#page-tabN` div. The same handler resizes any visible Chart.js
+instances (charts mis-measure when laid out while `display:none`) and re-applies
+the teamfight slider filters (`tf-deaths` / `tf-participants` → show/hide
+`.tf-fight-card` elements by their `data-deaths` / `data-participants`). The
+slider/card markup those filters operate on is emitted by the teamfight section
+in `sections/combat.py`; only the filter *handler* lives in `builder.py`.
+
+## Assets: Base64 Icons And Map Images
+
+`assets.py` owns asset loading and the inline-icon caches:
+
+- `ReportAssets` is a frozen dataclass of three optional paths: `map_image`,
+  `hero_icon_dir`, `item_icon_dir`. `gem` does **not** ship map images or icon
+  caches in the wheel — callers point these at locally-fetched assets (see the
+  `scripts/fetch_*_icons.py` tooling).
+- Module-global dicts `ITEM_ICON_B64` and `HERO_ICON_B64` map short names to
+  `"data:image/png;base64,..."` URIs. `configure_assets` resets them on every
+  build so a second report with different asset dirs can't inherit stale icons.
+- `load_item_icons` / `load_hero_icons` read `<short>.png` files and fill the
+  caches; `item_icon_tag` / `hero_icon_src` render lookups (a missing hero icon
+  falls back to `HERO_PLACEHOLDER_B64`, an inline 1×1 grey PNG). `hero_short`
+  for the cell helpers comes from `_formatting.py` via `gem.catalog`.
+- `load_map_base64` returns the map image as a base64 string, or `None` when no
+  path is configured or the file is missing.
+
+### Base64 Deduplication
+
+Inlining icons can repeat the same multi-KB data URI dozens of times. Two
+mechanisms shrink that:
+
+- **Map image**: `build_html_report` emits the map exactly once as
+  `window._GEM_MAP_SRC` and the SVG minimaps reference it via
+  `<image class="gem-map-bg" href="">` placeholders, patched on
+  `DOMContentLoaded`. Sections never inline the map themselves (see
+  `vision.py` / `combat.py` `gem-map-bg` usage).
+- **Repeated icons**: `_deduplicate_data_uris` (`builder.py:89`) scans the
+  assembled body for `data:image/...;base64,...` URIs, and for any that appear
+  more than once, hoists each into a single `window._gem_icon_N` JS variable,
+  rewrites the `src=`/`href=` attributes to `data-gem-uri` sentinels, and adds a
+  `DOMContentLoaded` patch script. Single-use URIs are left inline.
+
+## The Optional Plotly Movement Tab
+
+`_movement.py` builds an animated hero-movement heatmap with Plotly, and
+`builder._build_movement_tab` embeds it. Plotly (and Pillow, used to thumbnail
+the map) are **optional** dependencies. The Movement tab is silently omitted
+when any of these hold:
+
+- `options.include_movement` is `False`,
+- no map image is available (`map_b64 is None`),
+- `import plotly` fails (`ImportError`),
+- rendering raises for any other reason (caught broadly, logged at `debug`).
+
+`_build_movement_tab` writes the decoded map to a temp file (Plotly's
+`build_figure` reads it as an image), embeds the figure with
+`include_plotlyjs="cdn"`, and injects a small JS shim to pause the animation at
+frame 0 so the tab opens static. `_movement.py` reads player `position_log`,
+`purchase_log`, `kills_log`, `combat_log`, gold/XP/LH series, and ability-level
+snapshots to build per-hero hover cards; world coordinates are mapped to `[0,1]`
+fractions via the `MAP_X/Y` bounds shared from `_formatting.py`.
+
+## Formatting And Styling Helpers
+
+- `_formatting.py` holds the shared constants and HTML helpers: `TICKS_PER_SEC`
+  (30), the `MAP_X/Y` world-coordinate bounds, team colors/names, rune and
+  game-mode label tables, `set_game_start_tick` / `fmt_tick` (game-relative
+  `MM:SS`), `e` (HTML escape), `team_badge`, and `hero_cell` (icon + name cell).
+  `fmt_tick` reads a module-global game-start tick set once per build.
+- `styles.py` is a single `REPORT_CSS` string (the dark GitHub-style theme,
+  card/table/tab/teamfight-card rules) inlined verbatim into `<head>`.
+
+## What This Package Does Not Do
+
+`gem.reports` only renders an already-parsed match. It deliberately does not:
+
+- **Parse replays or read `.dem` bytes** — that is `binary`, `schema`, `state`,
+  the top-level `parser.py`, and `combat`. (`reports` imports none of those
+  packages.)
+- **Extract per-tick state** (gold/XP/position time series, ward events,
+  teamfight windows, draft pick/ban events) — that is `extractors`, whose output
+  is baked into `ParsedMatch`/`ParsedPlayer`. (The one exception: `build_draft`
+  lazily imports `DraftEvent` / `resolve_pick_team` from `gem.extractors.draft`
+  to map already-parsed draft events to a team at render time; it does not
+  re-extract anything.)
+- **Compute analytical facts** — net worth at a tick, vision estimates,
+  ability-hit grouping, Roshan conversions, camp-context timelines, and
+  position-at-tick all come from `gem.analysis` (imported by the section
+  modules); reports just lay them out.
+- **Define the data model** — `ParsedMatch`, `ParsedPlayer`,
+  `VisionModifierEvent`, etc. live in `gem.results.models`. DataFrame/JSON/
+  Parquet export lives in `results`/`api`, not here.
+- **Resolve hero/item/ability names or load camp geometry** — those lookups
+  come from `gem.catalog` (`hero_display`, `item_display`, `ability_display`,
+  `load_camp_zones`, `league_name`).
+- **Ship assets** — no map images or icon caches are bundled; `ReportAssets`
+  points at locally-fetched files.
+
+If a number on the report is *wrong*, the bug is almost always upstream in
+`extractors` or `analysis`; this package's bugs look like broken layout,
+mis-escaped HTML, a missing icon, or a tab that should/shouldn't appear.
+
+## Common Pitfalls
+
+### Section builders are stateful through module globals
+
+`build_*` functions look pure but read three pieces of build-time global state:
+the `_GAME_START_TICK` in `_formatting.py` (set by `set_game_start_tick`) and
+the `ITEM_ICON_B64` / `HERO_ICON_B64` caches in `assets.py` (filled by
+`configure_assets` + the preloaders). Call a section builder outside
+`build_html_report` and you'll get unconfigured times (`fmt_tick` relative to
+tick 0) and missing icons (placeholder fallbacks). This is by design — the
+orchestrator sets that state up front — but it means the builders are not safe
+to call concurrently across matches.
+
+### Returning `""` is how a section opts out
+
+A section with no data must return an empty string, not an empty `<div>`. The
+builder's `filter(None, ...)` and the final
+`[(label, content) for ... if content.strip()]` both depend on this to hide
+empty sections and drop empty tabs. Returning a non-empty wrapper around no data
+will leave a stray empty card or tab.
+
+### Don't inline the map image inside a section
+
+SVG minimaps must use `<image class="gem-map-bg" href="">` and let the builder's
+one-time `window._GEM_MAP_SRC` patch fill the `href`. Inlining the base64 map
+directly in a section defeats the dedup and bloats the file by the map size per
+occurrence.
+
+### The Movement tab failing is not an error
+
+`_build_movement_tab` catches `ImportError` (no Plotly) and any rendering
+exception, logs at `debug`, and returns `""`. A report without a Movement tab is
+the expected outcome when Plotly/Pillow aren't installed or no map was provided
+— not a regression.
+
+### `build_html` is a legacy alias
+
+`build_html(match, map_b64)` exists only for older example code; it forwards to
+`build_html_report`. New callers should use `build_html_report` /
+`write_html_report` for the full keyword surface (`assets`, `options`).
+
+### Import from `sections`, not the `_sections` shim
+
+`_sections.py` works but is a thin compatibility layer over
+`gem.reports.sections`. Both expose the same complete `__all__` (18 `build_*`
+functions), but new code should import from `gem.reports.sections` so it depends
+on the canonical surface rather than the shim.
+
+## When To Add Code Here
+
+Add code to `gem.reports` when the change is about **how a parsed match is
+presented**.
+
+Good fits:
+
+- a new section builder (`build_<thing>(match, ...) -> str`) plus wiring it into
+  a tab in `build_html_report`'s `tabs` list and exporting it from
+  `sections/__init__.py`,
+- a new tab, layout, or CSS rule in `styles.py`,
+- a formatting/escaping/icon helper shared across sections (`_formatting.py`,
+  `assets.py`, or `sections/_shared.py`),
+- enriching the Movement hover cards or fixing a rendering edge case.
+
+To add a section: write `build_foo(match) -> str` in the domain-appropriate
+`sections/*.py` module (return `""` when empty), add it to that module's
+`__all__` and to `sections/__init__.py`, then add it to the right tab's joined
+list in `build_html_report`. Preload any icons it needs in the builder's preload
+block.
+
+Poor fits (belong upstream):
+
+- computing a new statistic or per-tick series — extend `extractors` or
+  `analysis` and surface it on `ParsedMatch`,
+- adding a field to the data model — that's `gem.results.models`,
+- name/geometry lookups — `gem.catalog`,
+- anything that needs to read the replay again — the parser pipeline.
+
+Keep this package presentation-focused: it should be possible to change every
+pixel of the report without touching a single line that parses a replay.

--- a/src/gem/reports/README.md
+++ b/src/gem/reports/README.md
@@ -1,11 +1,17 @@
 # gem.reports
 
-`gem.reports` turns a fully parsed `ParsedMatch` into one self-contained,
-multi-tab HTML file you can open in a browser with no server, build step, or
-network access (icons and the map image are inlined as base64). It is the
-*presentation* layer: it asks "what does this match look like to a human?",
-whereas its neighbors (`extractors`, `analysis`, `results`) answer "what
-happened in this match?" and produce the structured data this package renders.
+`gem.reports` turns a fully parsed `ParsedMatch` into one multi-tab HTML file
+you can open in a browser with no server or build step. All match *data* and
+images are self-contained — hero/item icons and the map are inlined as base64 —
+but the report is **not fully offline**: charts load Chart.js from a CDN
+(`builder.py:433`), and the optional Movement tab embeds Plotly via
+`include_plotlyjs="cdn"` (`builder.py:179`). In an air-gapped environment the
+HTML, tables, and SVG minimaps still render, but the Chart.js charts and the
+Plotly Movement tab will not (you'd need to vendor those libraries locally). It
+is the *presentation* layer: it asks "what does this match look like to a
+human?", whereas its neighbors (`extractors`, `analysis`, `results`) answer
+"what happened in this match?" and produce the structured data this package
+renders.
 
 This package is read-only with respect to the replay. It never touches `.dem`
 bytes, entities, or the combat log directly — it reads the
@@ -264,6 +270,16 @@ occurrence.
 exception, logs at `debug`, and returns `""`. A report without a Movement tab is
 the expected outcome when Plotly/Pillow aren't installed or no map was provided
 — not a regression.
+
+### Charts need a network connection (the report is not fully offline)
+
+Match data and images are inlined, but Chart.js (`builder.py:433`) and the
+Plotly Movement tab (`builder.py:179`, `include_plotlyjs="cdn"`) load from a CDN.
+Opening a report offline shows the tables, SVG minimaps, and layout fine but
+leaves the chart canvases and the Movement tab blank. To make a report truly
+self-contained, vendor those libraries (inline Chart.js into `<head>` and switch
+Plotly to `include_plotlyjs=True`) — this is not done by default to keep file
+size down.
 
 ### `build_html` is a legacy alias
 


### PR DESCRIPTION
## Summary

Completes the per-subpackage README set. Every subpackage with a non-trivial learning curve now has a README following the same template as `binary/`, `schema/`, and `state/`: **purpose → mental model → mechanics → what it does NOT do → common pitfalls → when to add code here.**

| README | Key stories captured |
|---|---|
| `reports/` | `builder.py` orchestrator → `sections/` domain modules; how a `ParsedMatch` becomes tabbed HTML; the `_sections.py` shim; JS-driven (not CSS) tab switching; base64 asset dedup; the optional Plotly Movement tab |
| `extractors/` | the **attach → parse → read** timing contract; core vs internal extractors (`IntervalExtractor` is internal-only); `detect_teamfights`/`classify_lane` are post-parse functions, *not* attach-style extractors; the `_snapshots` shared helpers; the during-parse vs post-parse boundary |
| `analysis/` | the post-parse "operate on `ParsedMatch` facts, never re-parse" contract; cheap lookups vs heavy **experimental** builders; vision helpers as **explicit approximations** (~85–90%, no terrain); the `TYPE_CHECKING`-only extractor-type boundary |

## How these were produced

Drafted and **adversarially fact-checked via a multi-agent workflow**: each subpackage flowed through a draft agent (read the code, write the README) and then an independent verify agent (re-grep every claim against the code, default to checking not trusting). The verify stage caught **10 real errors** the drafts would have shipped — e.g. a constant stated as `13950` that the code actually computes to `13050`, a fabricated claim that the `_sections` shim's `__all__` was missing a function, and `_pos` wrongly attributed to `teamfights.py`.

I then **independently re-verified the riskiest claims** myself: every `file:line` ref (`builder.py:263` tabs list, `:89` dedup, `api.py:273-274` finalize calls), the public-surface `__all__` lists, the slot counts (`_BAN_SLOTS=14`), and the timing constants (`_COOLDOWN_TICKS`, the four roshan windows, the vision radii). All accurate.

## Verification

- Docs-only — no code changed (pre-commit hooks correctly skipped).
- `uv run pytest -q` → **1544 passed**, 3 skipped ✅
- Every module/class/function/constant/line-ref claim checked against the code.

## One thing surfaced, deliberately NOT changed

Documenting `analysis/vision.py` surfaced a discrepancy at `vision.py:26`:
```python
_NIGHT_START_TICKS: int = 7 * 60 * 30 + 15 * 30  # 7:30 into cycle = 13950 ticks
```
The expression evaluates to **13050** (7:15), the comment says **13950**, and the surrounding block describes a **7:30** (13500) day/night split — three different values. This may be an off-by-15-seconds logic bug, not just a stale comment, so I left the code untouched and documented the true computed value in the README. Flagging it here for a separate decision (it's a behavioral question, out of scope for a docs PR).

## Backlog status

Every subpackage that warranted one now has a README: `binary/` (pre-existing), `schema/` (#76), `state/` (#77), and `reports/`/`extractors/`/`analysis/` (this PR). The audit's documentation goal is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)