### PR TITLE
Fix day/night cycle: 10-minute cycle, night at 5:00

### DIFF
--- a/docs/experimental/estimate-vision.md
+++ b/docs/experimental/estimate-vision.md
@@ -83,31 +83,31 @@ Current constants in `src/gem/analysis/vision.py`:
 day hero vision   = 1800
 night hero vision = 800
 ward vision       = 1600
-full cycle        = 15 minutes
-night starts      = 7:30 into the cycle
+full cycle        = 10 minutes
+night starts      = 5:00 into the cycle
 tick rate         = 30 ticks/sec
 ```
 
 Derived tick constants:
 
 ```text
-DAY_NIGHT_CYCLE_TICKS = 15 * 60 * 30 = 27000
-NIGHT_START_TICKS     = 7 * 60 * 30 + 15 * 30 = 13950
+DAY_NIGHT_CYCLE_TICKS = 10 * 60 * 30 = 18000
+NIGHT_START_TICKS     = 5 * 60 * 30  = 9000
 ```
 
 The function converts absolute replay tick into game-relative tick:
 
 ```text
 game_ticks = max(tick - game_start_tick, 0)
-phase      = game_ticks % 27000
-daytime    = phase < 13950
+phase      = game_ticks % 18000
+daytime    = phase < 9000
 ```
 
 Interpretation:
 
-- before `7:30`, it is day
-- after `7:30`, it is night
-- after `15:00`, the cycle repeats
+- before `5:00`, it is day
+- at/after `5:00`, it is night
+- at `10:00`, the cycle repeats
 
 This yields the hero vision radius for the rest of the check.
 

--- a/src/gem/analysis/README.md
+++ b/src/gem/analysis/README.md
@@ -115,13 +115,13 @@ These are O(log N) or single-pass helpers over a sorted/parallel fact list.
 `vision.py` is the package's honest fuzzy area. Its docstrings repeatedly state
 that the results are heuristics with no terrain/high-ground modelling.
 
-- `is_daytime(game_start_tick, tick)` computes the Dota day/night phase: a full
-  cycle is 15 minutes (`_DAY_NIGHT_CYCLE_TICKS = 27000`), with night starting at
-  `_NIGHT_START_TICKS = 13050` (the expression `7 * 60 * 30 + 15 * 30`; the
-  inline code comment labels this "7:30 into the cycle = 13950", but the literal
-  it sums to is 13050, i.e. 7:15 — the comment is stale). `_is_daytime` is a
-  backwards-compatible alias for the same function (kept because the dev branch
-  exported the underscored name).
+- `is_daytime(game_start_tick, tick)` computes the Dota day/night phase. The
+  cycle is 10 minutes (`_DAY_NIGHT_CYCLE_TICKS = 18000`): day from 0:00, night
+  from 5:00 (`_NIGHT_START_TICKS = 9000`), repeating. Tick 0 is daytime; the
+  first night begins at tick 9000.
+  (Reference: [Liquipedia — Time of Day](https://liquipedia.net/dota2/Time_of_Day).)
+  `_is_daytime` is a backwards-compatible alias for the same function (kept
+  because the dev branch exported the underscored name).
 - `estimate_vision(match, team, tick, x, y)` returns a distance-sorted list of
   `VisionSource` dataclasses (`kind` ∈ `"hero" | "ward" | "modifier"`) for every
   allied unit that *could* see `(x, y)`. Hero radius is day/night-adjusted

--- a/src/gem/analysis/vision.py
+++ b/src/gem/analysis/vision.py
@@ -20,10 +20,11 @@ _NIGHT_VISION: int = 800
 # Observer ward vision radius (constant, no items change it)
 _WARD_VISION: int = 1600
 
-# Day/night cycle constants (ticks at 30 ticks/sec)
-# Day starts at game time 0:00, each full cycle is 15 minutes (7:30 day + 7:30 night)
-_DAY_NIGHT_CYCLE_TICKS: int = 15 * 60 * 30  # 27000 ticks
-_NIGHT_START_TICKS: int = 7 * 60 * 30 + 15 * 30  # 7:30 into cycle = 13950 ticks
+# Day/night cycle constants (ticks at 30 ticks/sec).
+# Dota's cycle is 10 minutes: day from 0:00, night from 5:00, repeating.
+# Reference: https://liquipedia.net/dota2/Time_of_Day
+_DAY_NIGHT_CYCLE_TICKS: int = 10 * 60 * 30  # 18000 ticks (10:00)
+_NIGHT_START_TICKS: int = 5 * 60 * 30  # 9000 ticks (night starts at 5:00)
 
 
 @dataclass
@@ -55,8 +56,10 @@ class VisionSource:
 def is_daytime(game_start_tick: int | None, tick: int) -> bool:
     """Return True if it is daytime at the given absolute tick.
 
-    Dota 2 day/night cycle: day starts at game time 0:00.  Each half-cycle
-    is 7 minutes 30 seconds (13500 ticks).  The cycle repeats every 15 minutes.
+    Dota 2 day/night cycle: day starts at game time 0:00, night begins at 5:00,
+    and the cycle repeats every 10 minutes (5 min day + 5 min night). Tick 0 is
+    daytime; the first night begins at tick 9000 (5:00).
+    Reference: https://liquipedia.net/dota2/Time_of_Day
 
     Args:
         game_start_tick: Absolute tick when the game clock started, or ``None``.

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -16,10 +16,11 @@ _DAY_VISION = 1800
 _NIGHT_VISION = 800
 _WARD_VISION = 1600
 
-# game_start_tick=0 → tick 0 = game time 0:00 (daytime)
-# Night starts at 7:30 = 13500 ticks into a cycle
-_NIGHT_TICK = 14000  # well into night (13500+ ticks from game start)
-_DAY_TICK = 5000  # well into day (< 13500 ticks from game start)
+# game_start_tick=0 → tick 0 = game time 0:00 (daytime).
+# Dota's cycle is 10 min: day 0:00–5:00, night 5:00–10:00, repeating.
+# Night starts at 5:00 = 9000 ticks into a cycle.
+_NIGHT_TICK = 11000  # well into night (5:00–10:00 → 9000–18000 ticks)
+_DAY_TICK = 5000  # well into day (< 9000 ticks from game start)
 
 
 def _player(team: int, position_log: list[tuple[int, float, float]]) -> MagicMock:
@@ -92,32 +93,47 @@ def _match(
 
 
 class TestIsDaytime:
+    # Dota's cycle is 10 min (18000 ticks): day 0:00–5:00, night 5:00–10:00.
+    # Night starts at 5:00 = 9000 ticks. Reference:
+    # https://liquipedia.net/dota2/Time_of_Day
+
     def test_game_start_is_daytime(self) -> None:
         assert is_daytime(0, 0) is True
 
     def test_early_game_is_daytime(self) -> None:
-        assert is_daytime(0, 5000) is True
+        assert is_daytime(0, 5000) is True  # 2:46, day
 
-    def test_after_7m30s_is_night(self) -> None:
-        # Night starts at 13500 ticks after game start
-        assert is_daytime(0, 14000) is False
+    def test_tick_just_before_night_is_day(self) -> None:
+        # 8999 ticks = 4:59.96 — last tick of the first day.
+        assert is_daytime(0, 8999) is True
 
-    def test_second_cycle_day(self) -> None:
-        # Second day: 27000 ticks into game (one full cycle)
-        assert is_daytime(0, 27000) is True
+    def test_night_starts_exactly_at_5min(self) -> None:
+        # 9000 ticks = 5:00 — the first night tick (boundary is night).
+        assert is_daytime(0, 9000) is False
 
-    def test_second_cycle_night(self) -> None:
-        # Second night: 27000 + 14000 = 41000
-        assert is_daytime(0, 41000) is False
+    def test_well_into_first_night(self) -> None:
+        assert is_daytime(0, 11000) is False  # 6:06, night
+
+    def test_day_returns_exactly_at_10min(self) -> None:
+        # 18000 ticks = 10:00 — one full cycle, back to day.
+        assert is_daytime(0, 18000) is True
+
+    def test_second_night_starts_at_15min(self) -> None:
+        # 27000 ticks = 15:00 — start of the second night (was day under the
+        # old, buggy 15-minute cycle).
+        assert is_daytime(0, 27000) is False
+
+    def test_third_day_at_20min(self) -> None:
+        assert is_daytime(0, 36000) is True  # 20:00, day again
 
     def test_game_start_tick_offset(self) -> None:
-        # If game started at tick 1000, game time 0 = tick 1000
+        # If game started at tick 1000, game time 0 = tick 1000.
         assert is_daytime(1000, 1000) is True
-        assert is_daytime(1000, 1000 + 14000) is False
+        assert is_daytime(1000, 1000 + 9000) is False  # 5:00 → night
 
     def test_none_game_start_treated_as_zero(self) -> None:
         assert is_daytime(None, 5000) is True
-        assert is_daytime(None, 14000) is False
+        assert is_daytime(None, 11000) is False
 
     def test_underscore_alias_preserved(self) -> None:
         # `_is_daytime` is a backwards-compat alias for the renamed public


### PR DESCRIPTION
## Summary

`is_daytime()` (and the `estimate_vision` / `ward_vision_impact` helpers that depend on it) used the **wrong day/night cycle**. This corrects it.

**Dota's actual cycle** (verified against [Liquipedia](https://liquipedia.net/dota2/Time_of_Day) and the [Dota 2 Wiki](https://dota2.fandom.com/wiki/Time_of_Day)): a **10-minute cycle** — 5 min day, 5 min night — with the game starting in day at 0:00 and the **first night beginning at 5:00**, repeating (day returns at 10:00, second night at 15:00, …).

## The bug

The constants encoded a **15-minute cycle with night at ~7:15**, and were internally self-contradictory — three different wrong values for one boundary:

```python
# before
_DAY_NIGHT_CYCLE_TICKS = 15 * 60 * 30          # 27000  (should be 18000)
_NIGHT_START_TICKS     = 7 * 60 * 30 + 15 * 30 # 13050  (7:15)
# ...with a comment saying "= 13950 ticks" and a docstring saying "7:30"
```

Effect: `is_daytime()` reported **day during real night** (5:00–7:15) and **desynced entirely** after the first cycle (every subsequent boundary was off). So `estimate_vision()` used the day hero radius (1800) when it should have used the night radius (800), and vice-versa, for affected ticks.

## The fix

```python
# after
_DAY_NIGHT_CYCLE_TICKS = 10 * 60 * 30  # 18000 (10:00)
_NIGHT_START_TICKS     = 5 * 60 * 30   # 9000  (night starts at 5:00)
```

Plus the docstring, the `analysis/` README, and `docs/experimental/estimate-vision.md` — all three reproduced the wrong figures and are now corrected.

## Tests

The **old tests asserted the buggy behavior** and had to be rewritten, not just extended — e.g. `is_daytime(0, 27000)` was asserted `True`, but 15:00 is the start of the second night, now correctly `False`. New tests pin the exact boundaries:

| tick | clock | phase | expected |
|---|---|---|---|
| 8999 | 4:59 | day | `True` |
| 9000 | 5:00 | **night boundary** | `False` |
| 18000 | 10:00 | day returns | `True` |
| 27000 | 15:00 | second night | `False` |
| 36000 | 20:00 | day | `True` |

## Verification

- `uv run ruff check` / `ruff format` / `uv run mypy src/gem/` → clean ✅
- `uv run pytest -q` → **1547 passed**, 3 skipped (3 new boundary tests) ✅
- Cycle numbers cross-checked against two authoritative sources (Liquipedia + Dota 2 Wiki).

## Context

This was flagged while documenting `analysis/vision.py` in #79 — the README honestly noted the discrepancy rather than papering over it, and this PR resolves it as a focused, test-backed behavioral fix (kept separate from the docs PR by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)