### PR TITLE
Fix analysis/combat-log correctness bugs + map-geometry single source of truth

### DIFF
--- a/src/gem/analysis/README.md
+++ b/src/gem/analysis/README.md
@@ -277,7 +277,9 @@ It binary-searches on `start_tick` and checks a single candidate window. If the
 ### `region_of` is geometric, not lane-aware
 The river is just the diagonal strip `|x - y| <= 1200`; halves are
 nearest-fountain. It does not know lanes, ramps, or the actual river polygon.
-Camp/ward "enemy half" attribution inherits this coarseness.
+Camp/ward "enemy half" attribution inherits this coarseness. Note the threshold
+is on `|x - y|`, not perpendicular world units — the river follows the `x = y`
+diagonal, so the effective perpendicular half-width is `1200 / sqrt(2) ≈ 849`.
 
 ### The heavy builders are experimental and weight-tuned
 `score_camp_visit_context`, `build_map_context_timeline`, and

--- a/src/gem/analysis/_shared.py
+++ b/src/gem/analysis/_shared.py
@@ -18,18 +18,62 @@ if TYPE_CHECKING:
 _TEAM_RADIANT = 2
 _TEAM_DIRE = 3
 
-# World-coordinate bounds calibrated against assets/maps/Game_map_7.40.jpg.
-_MAP_XMIN = 7563.0
-_MAP_XMAX = 25900.0
-_MAP_YMIN = 7800.0
-_MAP_YMAX = 25600.0
+# Map geometry is sourced from the bundled ``map_constants.json`` so there is a
+# single source of truth — the same file the public ``catalog.load_map_constants``
+# exposes. The literals below are a calibrated fallback used only if the JSON is
+# missing or malformed (they must mirror the JSON). Calibrated against
+# assets/maps/Game_map_7.40.jpg.
+_FALLBACK_MAP_BOUNDS = (7563.0, 25900.0, 7800.0, 25600.0)  # xmin, xmax, ymin, ymax
+_FALLBACK_RADIANT_FOUNTAIN = (9684.0, 9684.0)
+_FALLBACK_DIRE_FOUNTAIN = (23120.0, 22350.0)
+_FALLBACK_RIVER_STRIP = 1200.0
 
-# Fountain world positions, used to classify a point's map half.
-_RADIANT_FOUNTAIN = (9684.0, 9684.0)
-_DIRE_FOUNTAIN = (23120.0, 22350.0)
 
-# Half-width of the diagonal river strip, in world units.
-_RIVER_STRIP = 1200.0
+def _load_map_geometry() -> tuple[
+    float, float, float, float, tuple[float, float], tuple[float, float], float
+]:
+    """Load map bounds/fountains/river-strip from ``map_constants.json``.
+
+    Falls back to the calibrated literals if the JSON is unavailable or missing
+    keys, so importing the analysis package never fails on a data problem.
+
+    Returns:
+        ``(xmin, xmax, ymin, ymax, radiant_fountain, dire_fountain, river_strip)``.
+    """
+    try:
+        from gem.catalog.map import load_map_constants
+
+        data = load_map_constants()
+        wb = data["world_bounds"]
+        fr = data["fountains"]["radiant"]
+        fd = data["fountains"]["dire"]
+        return (
+            float(wb["xmin"]),
+            float(wb["xmax"]),
+            float(wb["ymin"]),
+            float(wb["ymax"]),
+            (float(fr["x"]), float(fr["y"])),
+            (float(fd["x"]), float(fd["y"])),
+            float(data.get("river_strip", _FALLBACK_RIVER_STRIP)),
+        )
+    except (OSError, ValueError, KeyError, TypeError):
+        return (
+            *_FALLBACK_MAP_BOUNDS,
+            _FALLBACK_RADIANT_FOUNTAIN,
+            _FALLBACK_DIRE_FOUNTAIN,
+            _FALLBACK_RIVER_STRIP,
+        )
+
+
+(
+    _MAP_XMIN,
+    _MAP_XMAX,
+    _MAP_YMIN,
+    _MAP_YMAX,
+    _RADIANT_FOUNTAIN,
+    _DIRE_FOUNTAIN,
+    _RIVER_STRIP,
+) = _load_map_geometry()
 
 
 def infer_match_end_tick(match: ParsedMatch) -> int:
@@ -61,6 +105,9 @@ def region_of(x: float, y: float) -> str:
 
     Points within the diagonal river strip (``|x - y| <= _RIVER_STRIP``) are the
     river; otherwise the position is assigned to whichever fountain is nearer.
+    The threshold is on the ``|x - y|`` difference (the river follows the
+    ``x = y`` diagonal), which corresponds to a perpendicular half-width of
+    ``_RIVER_STRIP / sqrt(2)`` world units — see the constant's note.
 
     Args:
         x: World x coordinate.

--- a/src/gem/analysis/roshan.py
+++ b/src/gem/analysis/roshan.py
@@ -449,6 +449,14 @@ def build_rosh_conversions(match: ParsedMatch) -> list[RoshConversion]:
             else:
                 aegis_eval_end_tick = min(game_end_tick, aegis_end_tick + _POST_CONSUME_GRACE_TICKS)
 
+        # Clamp the holder window to this Roshan's upper boundary (next_rosh_tick
+        # - 1). Without this, the post-consume grace can push aegis_eval_end_tick
+        # past the next Roshan kill, so the same tower/barracks/teamfight/buyback
+        # is counted in BOTH consecutive RoshConversion records. extended_end_tick
+        # is purpose-built as the per-Roshan boundary; the counting windows must
+        # respect it so each event belongs to exactly one Roshan.
+        aegis_eval_end_tick = min(aegis_eval_end_tick, extended_end_tick)
+
         if holder_team is None:
             holder_window_start = roshan.tick
             holder_window_end = aegis_eval_end_tick

--- a/src/gem/combat/log.py
+++ b/src/gem/combat/log.py
@@ -75,6 +75,15 @@ class CombatLogType(str, Enum):
     # OpenDota but our pipeline never maps proto type 16, so it stays out of the
     # int→label table (preserving the historical decode behaviour).
     KILLSTREAK = ("KILLSTREAK", _NO_PROTO_ID)
+    # Sentinel for proto types we do not model. Unmapped wire types are labelled
+    # UNKNOWN (never DAMAGE) so the aggregator's match statement falls through to
+    # a no-op instead of counting them as hero damage. Mirrors OpenDota's
+    # ``default: break`` in CreateParsedDataBlob.processExpand and Clarity
+    # resolving the true enum rather than substituting DAMAGE. Notably this stops
+    # CRITICAL_DAMAGE (39) — already logged as a separate type-0 DAMAGE entry —
+    # from double-counting the crit, and MODIFIER_STACK_EVENT (19) from inflating
+    # damage aggregates.
+    UNKNOWN = ("UNKNOWN", _NO_PROTO_ID)
 
 
 # Backward-compatible frozenset of label strings, derived from the enum.
@@ -159,6 +168,9 @@ class CombatLogEntry:
         timestamp_s: Raw S2 combat-log timestamp in seconds, or ``None`` for S1/derived events.
         game_time_s: OpenDota-style game-relative combat-log time in seconds, or ``None`` when
             the game-start combat-log marker has not been observed.
+        will_reincarnate: True if this DEATH is a reincarnation/aegis *trigger*
+            (the hero will return), not a final death (S2 only; always False for
+            S1). Consumers counting deaths should skip entries where this is True.
     """
 
     tick: int
@@ -184,6 +196,7 @@ class CombatLogEntry:
     location_y: float | None = None
     timestamp_s: float | None = None
     game_time_s: int | None = None
+    will_reincarnate: bool = False
 
 
 CombatLogHandler = Callable[[CombatLogEntry], None]
@@ -278,7 +291,7 @@ class CombatLogProcessor:
             tick: Current game tick.
         """
         type_val, _ = game_event.get_int32(_S1_FIELD_TYPE)
-        log_type = _LOG_TYPE_NAMES.get(type_val, CombatLogType.DAMAGE)
+        log_type = _LOG_TYPE_NAMES.get(type_val, CombatLogType.UNKNOWN)
 
         attacker_idx, _ = game_event.get_int32(_S1_FIELD_ATTACKER)
         source_idx, _ = game_event.get_int32(_S1_FIELD_SOURCE)
@@ -288,11 +301,29 @@ class CombatLogProcessor:
         value, _ = game_event.get_int32(_S1_FIELD_VALUE)
         attacker_illusion, _ = game_event.get_bool(_S1_FIELD_ATTACKER_ILLUSION)
         target_illusion, _ = game_event.get_bool(_S1_FIELD_TARGET_ILLUSION)
-        attacker_hero, _ = game_event.get_bool(_S1_FIELD_ATTACKER_HERO)
-        target_hero, _ = game_event.get_bool(_S1_FIELD_TARGET_HERO)
+        # Legacy S1 descriptors may omit attackerhero/targethero. Clarity defaults
+        # these to True when the index is absent (S1CombatLogEntry: the nullable
+        # attackerHeroIdx/targetHeroIdx fall back to `: true`), so a missing field
+        # means "is a hero" — not "is not a hero". get_bool returns a non-None
+        # error when the field is absent from the schema; default to True then.
+        attacker_hero, attacker_hero_err = game_event.get_bool(_S1_FIELD_ATTACKER_HERO)
+        if attacker_hero_err is not None:
+            attacker_hero = True
+        target_hero, target_hero_err = game_event.get_bool(_S1_FIELD_TARGET_HERO)
+        if target_hero_err is not None:
+            target_hero = True
         ability_level, _ = game_event.get_int32(_S1_FIELD_ABILITY_LEVEL)
         gold_reason, _ = game_event.get_int32(_S1_FIELD_GOLD_REASON)
         xp_reason, _ = game_event.get_int32(_S1_FIELD_XP_REASON)
+
+        # PURCHASE events carry the item name as a CombatLogNames index in `value`
+        # (same as the S2 path). Resolve it so S1 purchase logs keep item names;
+        # _dedup_purchase_log keys on (tick, value_name), so a blank name collapses
+        # distinct same-tick starting-inventory buys. Reference: Clarity
+        # S1CombatLogEntry.getValueName() = readCombatLogName(valueIdx).
+        value_name = ""
+        if log_type == "PURCHASE":
+            value_name = _resolve_name(name_table, value)
 
         entry = CombatLogEntry(
             tick=tick,
@@ -302,6 +333,7 @@ class CombatLogProcessor:
             target_name=_resolve_name(name_table, target_idx),
             inflictor_name=_resolve_name(name_table, inflictor_idx),
             value=value,
+            value_name=value_name,
             attacker_is_hero=attacker_hero,
             target_is_hero=target_hero,
             attacker_is_illusion=attacker_illusion,
@@ -343,7 +375,7 @@ class CombatLogProcessor:
             game_time_s: Optional game-relative timestamp computed by
                 ``ReplayParser`` from the combat-log ``GAME_STATE`` marker.
         """
-        log_type = _LOG_TYPE_NAMES.get(msg.type, CombatLogType.DAMAGE)
+        log_type = _LOG_TYPE_NAMES.get(msg.type, CombatLogType.UNKNOWN)
 
         # Support both StringTable.items dict and legacy dict-like name_table
         if hasattr(name_table, "items") and isinstance(name_table.items, dict):
@@ -378,6 +410,11 @@ class CombatLogProcessor:
         location_x = msg.location_x if msg.HasField("location_x") else None
         location_y = msg.location_y if msg.HasField("location_y") else None
         timestamp_s = msg.timestamp if hasattr(msg, "timestamp") else None
+        # will_reincarnate marks a DEATH that is a reincarnation/aegis *trigger*,
+        # not a final death — the hero comes back, so it must not be counted as a
+        # death. Reference: refs/clarity S2CombatLogEntry.isWillReincarnate (proto
+        # field 78). S1 has no equivalent field.
+        will_reincarnate = bool(msg.will_reincarnate) if msg.HasField("will_reincarnate") else False
         damage_type = ""
         if log_type == "DAMAGE" and hasattr(msg, "damage_type"):
             damage_type = _DAMAGE_TYPE_NAMES.get(msg.damage_type, "")
@@ -405,5 +442,6 @@ class CombatLogProcessor:
             location_y=location_y,
             timestamp_s=timestamp_s,
             game_time_s=game_time_s,
+            will_reincarnate=will_reincarnate,
         )
         self._emit(entry)

--- a/src/gem/data/map_constants.json
+++ b/src/gem/data/map_constants.json
@@ -9,5 +9,6 @@
     "radiant": {"x": 9684, "y": 9684},
     "dire": {"x": 23120, "y": 22350}
   },
-  "notes": "Calibrated against assets/maps/Game_map_7.40.jpg (patch 7.40). World coords are Source 2 units."
+  "river_strip": 1200,
+  "notes": "Calibrated against assets/maps/Game_map_7.40.jpg (patch 7.40). World coords are Source 2 units. river_strip is the |x - y| threshold for the diagonal river (perpendicular half-width = river_strip / sqrt(2))."
 }

--- a/src/gem/extractors/players.py
+++ b/src/gem/extractors/players.py
@@ -41,6 +41,9 @@ _NULL_HANDLE = 0xFFFFFF  # empty slot sentinel
 
 _TEAM_RADIANT = 2
 _TEAM_DIRE = 3
+# CDOTA_PlayerResource rows to scan when building the logical→resource remap.
+# A coach occupies a row, so the 10 players can span more than 10 indices.
+_PLAYER_RESOURCE_SCAN_LIMIT = 30
 
 __all__ = ["PlayerExtractor", "PlayerStateSnapshot", "PlayerTimeSeries"]
 
@@ -106,6 +109,11 @@ class PlayerExtractor:
         # player_id (0-9) → team slot (0-4) within CDOTADataRadiant/Dire
         # Read from CDOTA_PlayerResource.m_vecPlayerTeamData.%04d.m_iTeamSlot
         self._player_team_slot: dict[int, int] = {}
+        # logical player_id (0-9) → CDOTA_PlayerResource array index. Usually the
+        # identity map, but a coach occupies a resource row and shifts later
+        # players, so PlayerResource reads must go through this remap. Rebuilt
+        # whenever _player_resource refreshes. Mirrors OpenDota's validIndices.
+        self._resource_index_by_id: dict[int, int] = {}
         # CDOTA_PlayerResource entity for slot lookups
         self._player_resource: Entity | None = None
         self.snapshots: list[PlayerStateSnapshot] = []
@@ -152,13 +160,16 @@ class PlayerExtractor:
         # m_vecPlayerTeamData.%04d.m_iKills/Deaths/Assists on CDOTA_PlayerResource.
         pr = self._player_resource
         if pr is not None:
-            for i in range(10):
-                prefix = f"m_vecPlayerTeamData.{i:04d}"
+            for player_id in range(10):
+                # Read at the resource-array index for this logical slot — a coach
+                # shifts the array so index != slot. Reference: Parse.java
+                # validIndices.
+                prefix = f"m_vecPlayerTeamData.{self._resource_index(player_id):04d}"
                 k = pr.get_int32(f"{prefix}.m_iKills")
                 d = pr.get_int32(f"{prefix}.m_iDeaths")
                 a = pr.get_int32(f"{prefix}.m_iAssists")
                 if k is not None or d is not None or a is not None:
-                    self.scoreboard[i] = (k or 0, d or 0, a or 0)
+                    self.scoreboard[player_id] = (k or 0, d or 0, a or 0)
 
     def _on_combat_log_entry(self, entry: CombatLogEntry) -> None:
         """Accumulate per-player running totals from combat log entries.
@@ -194,7 +205,16 @@ class PlayerExtractor:
             if pid is not None:
                 self._total_hero_healing[pid] = self._total_hero_healing.get(pid, 0) + entry.value
 
-        elif entry.log_type == "DEATH" and entry.target_is_hero:
+        elif (
+            entry.log_type == "DEATH"
+            and entry.target_is_hero
+            # Skip reincarnation/aegis trigger deaths — the hero comes back, so the
+            # trigger is not a real death. The subsequent true death (will_
+            # reincarnate=False) is counted. Without this the cumulative death
+            # curve double-counts WK/Aegis deaths. Reference: OpenDota
+            # handleDeathCombat returns early for the aegis/reincarnation death.
+            and not entry.will_reincarnate
+        ):
             pid = self._hero_to_pid(entry.target_name)
             if pid is not None:
                 self._total_deaths[pid] = self._total_deaths.get(pid, 0) + 1
@@ -390,14 +410,49 @@ class PlayerExtractor:
                 self._maybe_sample()
 
     def _refresh_team_slots(self) -> None:
-        """Read m_iTeamSlot for each player from CDOTA_PlayerResource."""
+        """Build the logical→resource remap and read m_iTeamSlot per player.
+
+        OpenDota scans ``CDOTA_PlayerResource`` for rows whose team is Radiant or
+        Dire (a coach has team 1/14 and is skipped), then uses the scan order as
+        logical slot ``0..9``. The resource array index is not always the logical
+        slot, so all PlayerResource reads go through ``_resource_index_by_id``.
+        Reference: refs/parser/.../opendota/Parse.java (validIndices).
+        """
         pr = self._player_resource
         if pr is None:
             return
-        for i in range(10):
-            slot = pr.get_int32(f"m_vecPlayerTeamData.{i:04d}.m_iTeamSlot")
-            if slot is not None and slot >= 0:
-                self._player_team_slot[i] = slot
+
+        resource_index_by_id: dict[int, int] = {}
+        for resource_idx in range(_PLAYER_RESOURCE_SCAN_LIMIT):
+            team = pr.get_int32(f"m_vecPlayerData.{resource_idx:04d}.m_iPlayerTeam")
+            slot = pr.get_int32(f"m_vecPlayerTeamData.{resource_idx:04d}.m_iTeamSlot")
+            if team not in (_TEAM_RADIANT, _TEAM_DIRE) or slot is None or slot < 0:
+                continue
+            player_id = len(resource_index_by_id)
+            if player_id >= 10:
+                break
+            resource_index_by_id[player_id] = resource_idx
+            self._player_team_slot[player_id] = slot
+
+        # Only adopt the remap once it resolves all 10 players; partial scans
+        # (early in the replay, before PlayerResource is fully populated) keep the
+        # previous mapping rather than introducing a half-built shift.
+        if len(resource_index_by_id) == 10:
+            self._resource_index_by_id = resource_index_by_id
+
+    def _resource_index(self, player_id: int) -> int:
+        """Map a logical player slot to its CDOTA_PlayerResource array index.
+
+        Falls back to the identity (``player_id``) until the remap is built —
+        correct for the common no-coach case where they coincide.
+
+        Args:
+            player_id: Logical player slot 0-9.
+
+        Returns:
+            The resource-array index to read PlayerResource fields at.
+        """
+        return self._resource_index_by_id.get(player_id, player_id)
 
     def _maybe_sample(self) -> None:
         if self._parser is None:
@@ -438,7 +493,9 @@ class PlayerExtractor:
         pr = self._player_resource
         if pr is None:
             return None
-        handle = pr.get_uint32(f"m_vecPlayerTeamData.{player_id:04d}.m_hSelectedHero")
+        handle = pr.get_uint32(
+            f"m_vecPlayerTeamData.{self._resource_index(player_id):04d}.m_hSelectedHero"
+        )
         if handle is None or handle == _NULL_HANDLE:
             return None
         return handle

--- a/src/gem/extractors/teamfights.py
+++ b/src/gem/extractors/teamfights.py
@@ -165,7 +165,13 @@ def detect_teamfights(
     for entry in entries:
         if entry.log_type != "DEATH":
             continue
-        if not entry.target_is_hero or entry.target_is_illusion:
+        # Skip reincarnation/aegis trigger deaths (will_reincarnate=True) — the
+        # hero comes back, so the trigger must not open/extend a fight or count
+        # toward Teamfight.deaths. Filtering only in pass 1 covers pass 2 too,
+        # since pass-2 death attribution looks up death_fight by entry id and
+        # skips any entry not recorded here. Matches the death-curve fix in
+        # players.py so teamfight/Roshan-conversion summaries stay consistent.
+        if not entry.target_is_hero or entry.target_is_illusion or entry.will_reincarnate:
             continue
 
         # Expire any active fights whose cooldown has elapsed before this death.

--- a/src/gem/results/assembly.py
+++ b/src/gem/results/assembly.py
@@ -22,7 +22,13 @@ if TYPE_CHECKING:
     from gem.extractors.players import PlayerExtractor
     from gem.extractors.wards import WardsExtractor
     from gem.parser import ReplayParser
-    from gem.results.models import ChatEntry, NeutralItemFoundEvent, SmokeEvent, VisionModifierEvent
+    from gem.results.models import (
+        ChatEntry,
+        NeutralItemFoundEvent,
+        ParsedPlayer,
+        SmokeEvent,
+        VisionModifierEvent,
+    )
 
 # Lane position grid resolution in world units (7d)
 _LANE_GRID = 64
@@ -82,6 +88,47 @@ def _radiant_adv_from_intervals(
         gold_adv.append(gold)
         xp_adv.append(xp)
 
+    return gold_adv, xp_adv
+
+
+def _radiant_adv_from_minute_series(
+    players: list[ParsedPlayer],
+) -> tuple[list[int], list[int]] | None:
+    """Build Radiant gold/XP advantage from dense per-player minute series.
+
+    Fallback for when no complete interval batches exist. Sums every minute the
+    curve spans (the longest player's series), not just up to the shortest
+    player's array — clamping to the global minimum truncated the whole advantage
+    curve to a single leaver/late-spawn's series. Total-earned gold/XP are
+    monotonic, so a player who stops sampling keeps their last earned value
+    (carried forward), mirroring OpenDota's bucket-by-time sum in
+    ``CreateParsedDataBlob.processAllPlayers``.
+
+    Args:
+        players: The parsed players, each with ``total_earned_gold_t_min`` and
+            ``total_earned_xp_t_min`` minute arrays.
+
+    Returns:
+        ``(gold_adv, xp_adv)`` lists, or ``None`` if no player has minute data.
+    """
+    active = [pp for pp in players if pp.total_earned_gold_t_min and pp.total_earned_xp_t_min]
+    if not active:
+        return None
+
+    n_minutes = max(
+        max(len(pp.total_earned_gold_t_min), len(pp.total_earned_xp_t_min)) for pp in active
+    )
+    gold_adv = [0] * n_minutes
+    xp_adv = [0] * n_minutes
+    for pp in active:
+        sign = 1 if pp.team == 2 else -1  # 2=Radiant, 3=Dire
+        gold_series = pp.total_earned_gold_t_min
+        xp_series = pp.total_earned_xp_t_min
+        last_gold = gold_series[-1] if gold_series else 0
+        last_xp = xp_series[-1] if xp_series else 0
+        for i in range(n_minutes):
+            gold_adv[i] += sign * (gold_series[i] if i < len(gold_series) else last_gold)
+            xp_adv[i] += sign * (xp_series[i] if i < len(xp_series) else last_xp)
     return gold_adv, xp_adv
 
 
@@ -496,23 +543,9 @@ def build_parsed_match(
     else:
         # Fallback path: no complete interval batches were observed, so derive
         # the curves from the dense player minute series' total-earned arrays.
-        active_players = [
-            pp for pp in match.players if pp.total_earned_gold_t_min and pp.total_earned_xp_t_min
-        ]
-        if active_players:
-            n_minutes = min(
-                min(len(pp.total_earned_gold_t_min), len(pp.total_earned_xp_t_min))
-                for pp in active_players
-            )
-            gold_adv = [0] * n_minutes
-            xp_adv = [0] * n_minutes
-            for pp in active_players:
-                sign = 1 if pp.team == 2 else -1  # 2=Radiant, 3=Dire
-                for i in range(n_minutes):
-                    gold_adv[i] += sign * pp.total_earned_gold_t_min[i]
-                    xp_adv[i] += sign * pp.total_earned_xp_t_min[i]
-            match.radiant_gold_adv = gold_adv
-            match.radiant_xp_adv = xp_adv
+        minute_adv = _radiant_adv_from_minute_series(match.players)
+        if minute_adv is not None:
+            match.radiant_gold_adv, match.radiant_xp_adv = minute_adv
 
     # Detect teamfights (Phase 9)
     hero_to_slot = {pp.hero_name: pp.player_id for pp in match.players if pp.hero_name}

--- a/src/gem/results/assembly.py
+++ b/src/gem/results/assembly.py
@@ -91,22 +91,26 @@ def _radiant_adv_from_intervals(
     return gold_adv, xp_adv
 
 
+_MINUTE_TICKS = 1800  # 60 s * 30 ticks/s
+
+
 def _radiant_adv_from_minute_series(
     players: list[ParsedPlayer],
 ) -> tuple[list[int], list[int]] | None:
     """Build Radiant gold/XP advantage from dense per-player minute series.
 
-    Fallback for when no complete interval batches exist. Sums every minute the
-    curve spans (the longest player's series), not just up to the shortest
-    player's array — clamping to the global minimum truncated the whole advantage
-    curve to a single leaver/late-spawn's series. Total-earned gold/XP are
-    monotonic, so a player who stops sampling keeps their last earned value
-    (carried forward), mirroring OpenDota's bucket-by-time sum in
-    ``CreateParsedDataBlob.processAllPlayers``.
+    Fallback for when no complete interval batches exist. Buckets each player's
+    samples by their *actual* game minute (derived from ``times_min``), not by
+    list position — ``minute_time_series`` drops missing minutes, so a player who
+    lacks an early sample would otherwise have their whole curve shifted earlier.
+    Mirrors OpenDota's bucket-by-time sum in
+    ``CreateParsedDataBlob.processAllPlayers``: at each minute a player
+    contributes their last-known total-earned value (monotonic; carried forward
+    past a stopped/leaver sample) and 0 before their first sample.
 
     Args:
-        players: The parsed players, each with ``total_earned_gold_t_min`` and
-            ``total_earned_xp_t_min`` minute arrays.
+        players: The parsed players, each with ``times_min`` and the
+            ``total_earned_gold_t_min`` / ``total_earned_xp_t_min`` minute arrays.
 
     Returns:
         ``(gold_adv, xp_adv)`` lists, or ``None`` if no player has minute data.
@@ -115,20 +119,51 @@ def _radiant_adv_from_minute_series(
     if not active:
         return None
 
-    n_minutes = max(
-        max(len(pp.total_earned_gold_t_min), len(pp.total_earned_xp_t_min)) for pp in active
-    )
-    gold_adv = [0] * n_minutes
-    xp_adv = [0] * n_minutes
+    # Map each player's samples to absolute minute indices using times_min. The
+    # global origin is the earliest sample tick across players, so a player who
+    # first appears at minute 1 lands at index 1, not 0. Fall back to 0 when no
+    # player has tick data (positional indexing kicks in per-player below).
+    first_ticks = [pp.times_min[0] for pp in active if pp.times_min]
+    origin = min(first_ticks) if first_ticks else 0
+
+    def _minute_index(tick: int) -> int:
+        return max(0, round((tick - origin) / _MINUTE_TICKS))
+
+    # Per-player minute → (gold, xp), keyed by absolute minute.
+    per_player: list[tuple[int, dict[int, tuple[int, int]]]] = []
+    last_minute = 0
     for pp in active:
         sign = 1 if pp.team == 2 else -1  # 2=Radiant, 3=Dire
+        by_minute: dict[int, tuple[int, int]] = {}
+        ticks = pp.times_min
         gold_series = pp.total_earned_gold_t_min
         xp_series = pp.total_earned_xp_t_min
-        last_gold = gold_series[-1] if gold_series else 0
-        last_xp = xp_series[-1] if xp_series else 0
-        for i in range(n_minutes):
-            gold_adv[i] += sign * (gold_series[i] if i < len(gold_series) else last_gold)
-            xp_adv[i] += sign * (xp_series[i] if i < len(xp_series) else last_xp)
+        n = min(len(ticks), len(gold_series), len(xp_series))
+        for i in range(n):
+            minute = _minute_index(ticks[i])
+            by_minute[minute] = (gold_series[i], xp_series[i])
+            last_minute = max(last_minute, minute)
+        # A player with no times_min falls back to positional indexing so we never
+        # silently drop their contribution.
+        if not ticks:
+            for i in range(min(len(gold_series), len(xp_series))):
+                by_minute[i] = (gold_series[i], xp_series[i])
+                last_minute = max(last_minute, i)
+        per_player.append((sign, by_minute))
+
+    n_minutes = last_minute + 1
+    gold_adv = [0] * n_minutes
+    xp_adv = [0] * n_minutes
+    for sign, by_minute in per_player:
+        carry_gold = 0
+        carry_xp = 0
+        for minute in range(n_minutes):
+            if minute in by_minute:
+                carry_gold, carry_xp = by_minute[minute]
+            # Before a player's first sample carry_* stays 0 (no contribution);
+            # after their last sample it holds the final monotonic value.
+            gold_adv[minute] += sign * carry_gold
+            xp_adv[minute] += sign * carry_xp
     return gold_adv, xp_adv
 
 

--- a/src/gem/state/entities.py
+++ b/src/gem/state/entities.py
@@ -502,11 +502,20 @@ class EntityManager:
                     entity = Entity(index=index, serial=serial, cls=ci)
                     self.entities[index] = entity
 
-                    # Apply baseline first, then delta
+                    # Apply baseline first, then delta. A missing baseline is an
+                    # invariant violation: the instancebaseline string table must
+                    # carry defaults for every class before any entity of that
+                    # class is created. Manta panics here (entity.go: "unable to
+                    # find new baseline"); surfacing it loudly prevents silently
+                    # constructing an entity with default (None) field values.
                     baseline = self.class_baselines.get(class_id)
-                    if baseline and ci.serializer is not None:
-                        read_fields(BitReader(baseline), ci.serializer, entity._field_state)
+                    if baseline is None:
+                        raise RuntimeError(
+                            f"unable to find baseline for class id {class_id} "
+                            f"({ci.name}) creating entity {index}"
+                        )
                     if ci.serializer is not None:
+                        read_fields(BitReader(baseline), ci.serializer, entity._field_state)
                         read_fields(r, ci.serializer, entity._field_state)
 
                     op = EntityOp.CREATED | EntityOp.ENTERED
@@ -528,6 +537,13 @@ class EntityManager:
                 if _e is None:
                     raise RuntimeError(f"leave on missing entity {index}")
                 entity = _e
+                # A LEAVE for an already-inactive entity is a stream-corruption
+                # invariant violation (manta panics: "ordered to leave, already
+                # inactive"). Surface it rather than silently re-dispatching LEFT.
+                if not entity.active:
+                    raise RuntimeError(
+                        f"entity {index} ({entity.cls.name}) ordered to leave, already inactive"
+                    )
                 op = EntityOp.LEFT
                 if cmd & 0x02:
                     op |= EntityOp.DELETED

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -182,3 +182,44 @@ class TestGroupAbilityHits:
         assert len(casts[0].entries) == 2
         assert casts[0].entries[0] is e1
         assert casts[0].entries[1] is e2
+
+
+# ---------------------------------------------------------------------------
+# Map-geometry single source of truth (_shared.py loads from map_constants.json)
+# ---------------------------------------------------------------------------
+
+
+class TestMapGeometrySingleSource:
+    """_shared.py must derive map geometry from map_constants.json, not duplicate it."""
+
+    def test_shared_constants_match_json(self) -> None:
+        from gem.analysis import _shared
+        from gem.catalog.map import load_map_constants
+
+        data = load_map_constants()
+        wb = data["world_bounds"]
+        assert float(wb["xmin"]) == _shared._MAP_XMIN
+        assert float(wb["xmax"]) == _shared._MAP_XMAX
+        assert float(wb["ymin"]) == _shared._MAP_YMIN
+        assert float(wb["ymax"]) == _shared._MAP_YMAX
+        fr = data["fountains"]["radiant"]
+        fd = data["fountains"]["dire"]
+        assert (float(fr["x"]), float(fr["y"])) == _shared._RADIANT_FOUNTAIN
+        assert (float(fd["x"]), float(fd["y"])) == _shared._DIRE_FOUNTAIN
+        assert float(data["river_strip"]) == _shared._RIVER_STRIP
+
+    def test_fallback_literals_mirror_json(self) -> None:
+        # The graceful-fallback literals must stay in sync with the JSON so a
+        # JSON-load failure degrades to the same values, not stale ones.
+        from gem.analysis import _shared
+        from gem.catalog.map import load_map_constants
+
+        data = load_map_constants()
+        wb = data["world_bounds"]
+        assert (
+            float(wb["xmin"]),
+            float(wb["xmax"]),
+            float(wb["ymin"]),
+            float(wb["ymax"]),
+        ) == _shared._FALLBACK_MAP_BOUNDS
+        assert float(data["river_strip"]) == _shared._FALLBACK_RIVER_STRIP

--- a/tests/test_combat_aggregator.py
+++ b/tests/test_combat_aggregator.py
@@ -115,6 +115,24 @@ class TestCombatAggregatorDamage:
         agg.on_entry(_entry(value=999))  # must not raise
         assert agg.players[0].damage["npc_dota_hero_mirana"] == 999
 
+    def test_unknown_log_type_does_not_accumulate_damage(self):
+        # Proto types the parser does not model arrive as UNKNOWN (not DAMAGE),
+        # so the match statement falls through and they never inflate the damage
+        # aggregates. Guards against the CRITICAL_DAMAGE/MODIFIER_STACK_EVENT
+        # double-counting regression. (A DAMAGE entry with the same fields would
+        # have populated agg.players[0].damage; UNKNOWN must not.)
+        agg, _ = _make_agg(0)
+        agg.on_entry(_entry(log_type="UNKNOWN", target_is_hero=True, value=500))
+        if 0 in agg.players:
+            assert agg.players[0].damage["npc_dota_hero_mirana"] == 0
+            assert agg.players[0].hero_damage == 0
+
+        # Control: the identical entry as DAMAGE *does* accumulate, proving the
+        # UNKNOWN no-op above is the label's doing, not an unrelated filter.
+        agg2, _ = _make_agg(0)
+        agg2.on_entry(_entry(log_type="DAMAGE", target_is_hero=True, value=500))
+        assert agg2.players[0].damage["npc_dota_hero_mirana"] == 500
+
     def test_damage_taken_on_target(self):
         player_ext = MagicMock()
         # attacker = axe (pid 0), target = mirana (pid 1)

--- a/tests/test_combatlog.py
+++ b/tests/test_combatlog.py
@@ -70,6 +70,7 @@ class FakeS2Entry:
         neutral_camp_team=0,
         location_x=0.0,
         location_y=0.0,
+        will_reincarnate=False,
     ):
         self.type = type
         self.attacker_name = attacker_name
@@ -94,8 +95,11 @@ class FakeS2Entry:
         self.neutral_camp_team = neutral_camp_team
         self.location_x = location_x
         self.location_y = location_y
+        self.will_reincarnate = will_reincarnate
 
     def HasField(self, name: str) -> bool:
+        if name == "will_reincarnate":
+            return self.will_reincarnate
         if name == "stun_duration":
             return self.stun_duration != 0.0
         if name == "neutral_camp_type":
@@ -356,11 +360,19 @@ class TestS1CombatLog:
             p.process_s1_event(self._make_event(type_val=type_val), table)
             assert received[0].log_type in COMBAT_LOG_TYPES
 
-    def test_unknown_type_defaults_to_damage(self):
+    def test_unknown_type_maps_to_unknown_not_damage(self):
+        # Proto types we do not model must NOT be coerced to DAMAGE (which would
+        # make the aggregator count them as hero damage — e.g. CRITICAL_DAMAGE=39
+        # double-counting the crit, MODIFIER_STACK_EVENT=19 inflating totals).
+        # They are labelled UNKNOWN so the aggregator match falls through to a
+        # no-op, mirroring OpenDota's `default: break`.
         p, received = self._make_processor_with_handler()
         table = FakeNameTable({})
-        p.process_s1_event(self._make_event(type_val=99), table)
-        assert received[0].log_type == "DAMAGE"
+        for type_val in (19, 39, 99):  # MODIFIER_STACK_EVENT, CRITICAL_DAMAGE, unmapped
+            received.clear()
+            p.process_s1_event(self._make_event(type_val=type_val), table)
+            assert received[0].log_type == "UNKNOWN"
+            assert received[0].log_type != "DAMAGE"
 
     def test_hero_flags(self):
         p, received = self._make_processor_with_handler()
@@ -377,6 +389,42 @@ class TestS1CombatLog:
         e = received[0]
         assert e.attacker_is_illusion is True
         assert e.target_is_illusion is True
+
+    def test_purchase_resolves_value_name(self):
+        # S1 PURCHASE (type 11) must resolve value_name from the value index,
+        # matching the S2 path. Otherwise S1 purchase logs lose item names and
+        # _dedup_purchase_log collapses distinct same-tick buys.
+        p, received = self._make_processor_with_handler()
+        table = FakeNameTable({2: "npc_dota_hero_axe", 5: "item_blink"})
+        p.process_s1_event(self._make_event(type_val=11, target=2, value=5), table, tick=500)
+        e = received[0]
+        assert e.log_type == "PURCHASE"
+        assert e.value_name == "item_blink"
+
+    def test_hero_flags_default_true_when_field_absent(self):
+        # Legacy S1 descriptors may omit attackerhero/targethero. Clarity defaults
+        # these to True (the unit IS a hero) when the index is absent; gem must do
+        # the same or it would flip hero-vs-hero attribution off for those events.
+        event = FakeGameEvent(
+            int_fields={"type": 0, "attackername": 1, "targetname": 2, "value": 100},
+            bool_fields={},  # no attackerhero / targethero keys
+        )
+        p, received = self._make_processor_with_handler()
+        table = FakeNameTable({1: "npc_dota_hero_axe", 2: "npc_dota_hero_lina"})
+        p.process_s1_event(event, table)
+        e = received[0]
+        assert e.attacker_is_hero is True
+        assert e.target_is_hero is True
+
+    def test_hero_flags_respected_when_field_present(self):
+        # When the descriptor carries the flags, their actual values win (the
+        # absent-field default must not override a present False).
+        p, received = self._make_processor_with_handler()
+        table = FakeNameTable({})
+        p.process_s1_event(self._make_event(attacker_hero=False, target_hero=False), table)
+        e = received[0]
+        assert e.attacker_is_hero is False
+        assert e.target_is_hero is False
 
     def test_gold_reason(self):
         p, received = self._make_processor_with_handler()
@@ -561,6 +609,20 @@ class TestS2CombatLog:
         msg = FakeS2Entry(attacker_name=5)
         p.process_s2_entry(msg, table)
         assert received[0].attacker_name == ""
+
+    def test_will_reincarnate_parsed(self):
+        p, received = self._make_processor_with_handler()
+        table = FakeNameTable({1: "npc_dota_hero_skeleton_king"})
+        # Trigger death (will return).
+        msg_trigger = FakeS2Entry(type=4, target_name=1, is_target_hero=True, will_reincarnate=True)
+        p.process_s2_entry(msg_trigger, table)
+        assert received[0].log_type == "DEATH"
+        assert received[0].will_reincarnate is True
+        # Normal death (default False).
+        received.clear()
+        msg_real = FakeS2Entry(type=4, target_name=1, is_target_hero=True)
+        p.process_s2_entry(msg_real, table)
+        assert received[0].will_reincarnate is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1021,3 +1021,63 @@ class TestEntityManagerPacketEntities:
         em.on_packet_entities(Msg())
         assert len(dispatched) == 1
         assert dispatched[0][0] is e
+
+    @staticmethod
+    def _pack_bits(raw_bits: list[int]) -> bytes:
+        while len(raw_bits) % 8:
+            raw_bits.append(0)
+        return bytes(
+            sum(raw_bits[i + j] << j for j in range(8)) for i in range(0, len(raw_bits), 8)
+        )
+
+    def test_leave_on_inactive_entity_raises(self):
+        """A LEAVE for an already-inactive entity is rejected (B9 — manta panics)."""
+        em = self._make_em()
+        e = _entity("Hero", index=0, serial=0)
+        e.active = False  # already inactive
+        em.entities[0] = e
+
+        # ubit_var(0) + cmd=0b01 (leave, no delete)
+        data = self._pack_bits([0, 0, 0, 0, 0, 0, 1, 0])
+
+        class Msg:
+            legacy_is_delta = True
+            updated_entries = 1
+            entity_data = data
+
+        with pytest.raises(RuntimeError, match="already inactive"):
+            em.on_packet_entities(Msg())
+
+    def test_create_without_baseline_raises(self):
+        """A CREATE for a class with no registered baseline is rejected (B8)."""
+        em = self._make_em()
+
+        # Register class id 3 so classes_by_id resolves, but DO NOT add a baseline.
+        class FakeClassEntry:
+            class_id = 3
+            network_name = "CDOTA_Unit_Hero_Axe"
+
+        class ClassMsg:
+            classes = [FakeClassEntry()]
+
+        em.on_class_info(ClassMsg())
+        assert 3 not in em.class_baselines
+
+        # Build a CREATE: ubit_var(0) + cmd=0b10 + class_id=3 (9 bits) +
+        # serial=0 (17 bits) + varuint32(0) (8 bits).
+        bits: list[int] = []
+        bits += [0, 0, 0, 0, 0, 0]  # ubit_var(0)
+        bits += [0, 1]  # cmd=0b10 (create): bit0=0, bit1=1
+        for i in range(em.class_id_size):  # class_id=3, LSB-first
+            bits.append((3 >> i) & 1)
+        bits += [0] * 17  # serial=0
+        bits += [0] * 8  # varuint32(0)
+        data = self._pack_bits(bits)
+
+        class Msg:
+            legacy_is_delta = True
+            updated_entries = 1
+            entity_data = data
+
+        with pytest.raises(RuntimeError, match="baseline"):
+            em.on_packet_entities(Msg())

--- a/tests/test_match_builder.py
+++ b/tests/test_match_builder.py
@@ -1627,15 +1627,17 @@ class TestNewObjectivesInParsedMatch:
 
 
 class TestRadiantAdvFromMinuteSeries:
-    """Fallback advantage curve must span the full game, not truncate to a leaver."""
+    """Fallback advantage curve must span the full game and align by real minute."""
 
     @staticmethod
-    def _player(pid: int, team: int, gold: list[int], xp: list[int]):
+    def _player(pid, team, gold, xp, times=None):
         from gem.results.models import ParsedPlayer
 
         pp = ParsedPlayer(player_id=pid, hero_name=f"npc_dota_hero_h{pid}", team=team)
         pp.total_earned_gold_t_min = gold
         pp.total_earned_xp_t_min = xp
+        # Default to one sample per game minute starting at tick 0 (minute 0).
+        pp.times_min = times if times is not None else [i * 1800 for i in range(len(gold))]
         return pp
 
     def test_full_length_equal_teams(self):
@@ -1665,6 +1667,23 @@ class TestRadiantAdvFromMinuteSeries:
         assert len(gold_adv) == 4
         # Radiant pulls ahead as Dire's carried-forward value (200) stays flat.
         assert gold_adv == [0, 0, 100, 200]
+
+    def test_leading_gap_aligned_by_real_minute(self):
+        # A player whose first sample is at minute 1 (no minute-0 sample) must be
+        # placed at index 1 — NOT have minute-1's value shifted into index 0.
+        # Regression for Codex P2: index-as-minute corrupts the curve on leading
+        # gaps. Radiant has a full series; Dire's first sample is minute 1.
+        from gem.results.assembly import _radiant_adv_from_minute_series
+
+        radiant = self._player(0, 2, [100, 200, 300], [0, 0, 0], times=[0, 1800, 3600])
+        # Dire missing minute 0: samples land at ticks 1800 (min 1) and 3600 (min 2).
+        dire = self._player(5, 3, [500, 700], [0, 0], times=[1800, 3600])
+        gold_adv, _ = _radiant_adv_from_minute_series([radiant, dire])
+        # Minute 0: only Radiant present (Dire contributes 0, not its minute-1 value).
+        assert gold_adv[0] == 100
+        # Minute 1: 200 - 500. Minute 2: 300 - 700.
+        assert gold_adv[1] == 200 - 500
+        assert gold_adv[2] == 300 - 700
 
     def test_returns_none_when_no_minute_data(self):
         from gem.results.assembly import _radiant_adv_from_minute_series

--- a/tests/test_match_builder.py
+++ b/tests/test_match_builder.py
@@ -1619,3 +1619,55 @@ class TestNewObjectivesInParsedMatch:
         m = self._build()
         assert m.tormentors == []
         assert m.shrines == []
+
+
+# ---------------------------------------------------------------------------
+# _radiant_adv_from_minute_series — fallback advantage curve (B7)
+# ---------------------------------------------------------------------------
+
+
+class TestRadiantAdvFromMinuteSeries:
+    """Fallback advantage curve must span the full game, not truncate to a leaver."""
+
+    @staticmethod
+    def _player(pid: int, team: int, gold: list[int], xp: list[int]):
+        from gem.results.models import ParsedPlayer
+
+        pp = ParsedPlayer(player_id=pid, hero_name=f"npc_dota_hero_h{pid}", team=team)
+        pp.total_earned_gold_t_min = gold
+        pp.total_earned_xp_t_min = xp
+        return pp
+
+    def test_full_length_equal_teams(self):
+        from gem.results.assembly import _radiant_adv_from_minute_series
+
+        players = [
+            self._player(0, 2, [100, 200, 300], [10, 20, 30]),
+            self._player(5, 3, [100, 200, 300], [10, 20, 30]),
+        ]
+        gold_adv, xp_adv = _radiant_adv_from_minute_series(players)
+        assert gold_adv == [0, 0, 0]
+        assert xp_adv == [0, 0, 0]
+
+    def test_leaver_does_not_truncate_curve(self):
+        # One Dire player's minute array stops early (disconnect). The curve must
+        # still span the longest array; the leaver's last earned value carries
+        # forward (total-earned is monotonic and never resets). Regression for the
+        # min()-length truncation bug.
+        from gem.results.assembly import _radiant_adv_from_minute_series
+
+        players = [
+            self._player(0, 2, [100, 200, 300, 400], [0, 0, 0, 0]),  # Radiant, full
+            self._player(5, 3, [100, 200], [0, 0]),  # Dire, leaves after minute 1
+        ]
+        gold_adv, _ = _radiant_adv_from_minute_series(players)
+        # Curve spans 4 minutes (longest), not 2 (shortest).
+        assert len(gold_adv) == 4
+        # Radiant pulls ahead as Dire's carried-forward value (200) stays flat.
+        assert gold_adv == [0, 0, 100, 200]
+
+    def test_returns_none_when_no_minute_data(self):
+        from gem.results.assembly import _radiant_adv_from_minute_series
+
+        players = [self._player(0, 2, [], [])]
+        assert _radiant_adv_from_minute_series(players) is None

--- a/tests/test_players_extractor.py
+++ b/tests/test_players_extractor.py
@@ -1077,6 +1077,27 @@ class TestDiffInventory:
 # ---------------------------------------------------------------------------
 
 
+def _player_resource_fields(team_by_row: dict[int, int], extra: dict | None = None) -> dict:
+    """Build CDOTA_PlayerResource state for the given resource rows.
+
+    Args:
+        team_by_row: resource-array index → team number (2/3 for players, 1/14
+            for coaches). Each row also gets a team slot and an identity hero
+            handle so a complete-scan remap can resolve.
+        extra: additional ``field → value`` state to merge in.
+
+    Returns:
+        A ``**state`` dict for ``_ent``.
+    """
+    state: dict = {}
+    for row, team in team_by_row.items():
+        state[f"m_vecPlayerData.{row:04d}.m_iPlayerTeam"] = team
+        state[f"m_vecPlayerTeamData.{row:04d}.m_iTeamSlot"] = row % 5
+    if extra:
+        state.update(extra)
+    return state
+
+
 class TestRefreshTeamSlots:
     def test_no_player_resource_does_nothing(self):
         ext = PlayerExtractor()
@@ -1086,17 +1107,57 @@ class TestRefreshTeamSlots:
 
     def test_reads_team_slots(self):
         ext = PlayerExtractor()
-        pr = _ent(
-            "CDOTA_PlayerResource",
-            **{
-                "m_vecPlayerTeamData.0000.m_iTeamSlot": 2,
-                "m_vecPlayerTeamData.0001.m_iTeamSlot": 0,
-            },
-        )
+        # 10 players in rows 0-9 (5 Radiant, 5 Dire), no coach.
+        teams = {row: (2 if row < 5 else 3) for row in range(10)}
+        pr = _ent("CDOTA_PlayerResource", **_player_resource_fields(teams))
         ext._player_resource = pr
         ext._refresh_team_slots()
-        assert ext._player_team_slot[0] == 2
-        assert ext._player_team_slot[1] == 0
+        assert ext._player_team_slot[0] == 0
+        assert ext._player_team_slot[1] == 1
+        # No coach → logical slot == resource index (identity remap).
+        assert ext._resource_index(0) == 0
+        assert ext._resource_index(9) == 9
+
+    def test_coach_shifts_resource_indices(self):
+        # A Radiant coach occupies resource row 5 (team 1). The 10 players live in
+        # rows 0-4 and 6-10, so logical slots 5-9 map to resource rows 6-10.
+        # Regression for K/D/A and team-slot misattribution in coached replays.
+        ext = PlayerExtractor()
+        teams = dict.fromkeys(range(5), 2)  # Radiant players rows 0-4
+        teams[5] = 1  # coach (team 1) — must be skipped
+        for row in range(6, 11):  # Dire players rows 6-10
+            teams[row] = 3
+        pr = _ent("CDOTA_PlayerResource", **_player_resource_fields(teams))
+        ext._player_resource = pr
+        ext._refresh_team_slots()
+        # Logical Radiant slots map to rows 0-4.
+        assert [ext._resource_index(i) for i in range(5)] == [0, 1, 2, 3, 4]
+        # Logical Dire slots 5-9 skip the coach → rows 6-10 (not 5-9).
+        assert [ext._resource_index(i) for i in range(5, 10)] == [6, 7, 8, 9, 10]
+
+    def test_coach_shift_attributes_kda_to_correct_slot(self):
+        # End-to-end: with a coach shift, _on_game_end must read K/D/A at the
+        # remapped resource index, so logical Dire slot 5 gets the fifth Dire
+        # player's stats (row 6), not the coach's row 5.
+        ext = PlayerExtractor()
+        teams = dict.fromkeys(range(5), 2)
+        teams[5] = 1  # coach
+        for row in range(6, 11):
+            teams[row] = 3
+        kda = {
+            "m_vecPlayerTeamData.0005.m_iKills": 99,  # coach row — must NOT leak
+            "m_vecPlayerTeamData.0006.m_iKills": 7,  # first Dire player (logical 5)
+            "m_vecPlayerTeamData.0006.m_iDeaths": 2,
+            "m_vecPlayerTeamData.0006.m_iAssists": 3,
+        }
+        pr = _ent("CDOTA_PlayerResource", **_player_resource_fields(teams, kda))
+        ext.attach(FakeParser(tick=5000))
+        ext._player_resource = pr
+        ext._refresh_team_slots()
+        ext._on_game_end(5000)
+        assert ext.scoreboard[5] == (7, 2, 3)
+        # The coach's 99 kills must never be attributed to any logical slot.
+        assert all(k != 99 for (k, _d, _a) in ext.scoreboard.values())
 
 
 # ---------------------------------------------------------------------------
@@ -1161,3 +1222,61 @@ class TestPlayerExtractorAttach:
         assert snap.lh == 50
         assert snap.dn == 7
         assert snap.tick == 300
+
+
+# ---------------------------------------------------------------------------
+# PlayerExtractor._on_combat_log_entry — death counting (B3 reincarnation)
+# ---------------------------------------------------------------------------
+
+
+class TestDeathCountReincarnation:
+    """total_deaths must not count reincarnation/aegis trigger deaths."""
+
+    @staticmethod
+    def _ext_with_hero():
+        from gem.extractors.players import PlayerExtractor
+
+        ext = PlayerExtractor()
+        hero = _hero("SkeletonKing", player_id=0)  # npc_dota_hero_skeleton_king
+        ext._heroes_by_npc["npc_dota_hero_skeleton_king"] = hero
+        return ext
+
+    def test_normal_death_counted(self):
+        from gem.combat.log import CombatLogEntry
+
+        ext = self._ext_with_hero()
+        ext._on_combat_log_entry(
+            CombatLogEntry(
+                tick=100,
+                log_type="DEATH",
+                target_name="npc_dota_hero_skeleton_king",
+                target_is_hero=True,
+            )
+        )
+        assert ext._total_deaths.get(0) == 1
+
+    def test_reincarnation_trigger_not_counted(self):
+        from gem.combat.log import CombatLogEntry
+
+        ext = self._ext_with_hero()
+        # Trigger death (will_reincarnate=True) then the true death — only the
+        # true death should count, so the total is 1, not 2.
+        ext._on_combat_log_entry(
+            CombatLogEntry(
+                tick=100,
+                log_type="DEATH",
+                target_name="npc_dota_hero_skeleton_king",
+                target_is_hero=True,
+                will_reincarnate=True,
+            )
+        )
+        ext._on_combat_log_entry(
+            CombatLogEntry(
+                tick=160,
+                log_type="DEATH",
+                target_name="npc_dota_hero_skeleton_king",
+                target_is_hero=True,
+                will_reincarnate=False,
+            )
+        )
+        assert ext._total_deaths.get(0) == 1

--- a/tests/test_rosh_conversion.py
+++ b/tests/test_rosh_conversion.py
@@ -166,6 +166,60 @@ def test_build_rosh_conversions_uses_first_death_for_fight_timing() -> None:
     assert "already underway" in fight_events[0].label.lower()
 
 
+def test_holder_window_clamped_to_next_roshan_no_double_count() -> None:
+    # Two back-to-back Roshans. The first aegis is consumed (holder dies), which
+    # extends the holder window by the post-consume grace. That grace must NOT
+    # bleed past the next Roshan kill, or a tower destroyed after Rosh #2 is
+    # counted in BOTH conversion records. Regression for the missing clamp to
+    # extended_end_tick (next_rosh_tick - 1).
+    players = _make_players()
+    match = ParsedMatch(
+        game_start_tick=0,
+        game_end_tick=10000,
+        radiant_win=None,
+        players=players,
+        # Both holders are Radiant (hero_0, hero_1) so the lone Dire tower is a
+        # valid objective for whichever Roshan window contains it — isolating the
+        # double-count from team-attribution effects.
+        roshans=[
+            RoshanKill(tick=1000, killer="npc_dota_hero_hero_0", kill_number=1),
+            RoshanKill(tick=1500, killer="npc_dota_hero_hero_1", kill_number=2),
+        ],
+        aegis_events=[
+            AegisEvent(tick=1010, player_id=0, event_type="pickup"),
+            AegisEvent(tick=1510, player_id=1, event_type="pickup"),
+        ],
+        # Holder of aegis #1 (hero_0) dies at 1050 -> aegis consumed -> grace
+        # pushes the raw window end well past Rosh #2's 1500 kill.
+        combat_log=[
+            CombatLogEntry(
+                tick=1050,
+                log_type="DEATH",
+                target_name="npc_dota_hero_hero_0",
+                target_is_hero=True,
+            )
+        ],
+        # A single Dire tower at 1800 — after Rosh #2, so it belongs only to the
+        # second Roshan's window, never the first.
+        towers=[
+            TowerKill(
+                tick=1800,
+                team=3,
+                killer="npc_dota_hero_hero_1",
+                tower_name="npc_dota_badguys_tower2_mid",
+            )
+        ],
+    )
+
+    conversions = build_rosh_conversions(match)
+    assert len(conversions) == 2
+    # The lone tower must be attributed to exactly one Roshan, not both.
+    total_towers = sum(c.towers_taken for c in conversions)
+    assert total_towers == 1, f"tower double-counted across Roshans: {total_towers}"
+    assert conversions[0].towers_taken == 0
+    assert conversions[1].towers_taken == 1
+
+
 def test_build_rosh_conversion_html_smoke() -> None:
     players = _make_players()
     match = ParsedMatch(

--- a/tests/test_teamfights.py
+++ b/tests/test_teamfights.py
@@ -21,13 +21,19 @@ from gem.extractors.teamfights import (
 _COOLDOWN = 15 * 30  # 450 ticks
 
 
-def _death(tick: int, target: str = "npc_dota_hero_axe", illusion: bool = False) -> CombatLogEntry:
+def _death(
+    tick: int,
+    target: str = "npc_dota_hero_axe",
+    illusion: bool = False,
+    will_reincarnate: bool = False,
+) -> CombatLogEntry:
     return CombatLogEntry(
         tick=tick,
         log_type="DEATH",
         target_name=target,
         target_is_hero=True,
         target_is_illusion=illusion,
+        will_reincarnate=will_reincarnate,
     )
 
 
@@ -98,6 +104,26 @@ class TestDetectTeamfights:
         entries = [_death(1000, "npc_dota_hero_axe"), _death(1100, "npc_dota_hero_pudge")]
         fights = detect_teamfights(entries)
         assert fights[0].deaths == 2
+
+    def test_reincarnation_trigger_not_counted_as_death(self):
+        # A reincarnation/aegis trigger (will_reincarnate=True) must not count
+        # toward Teamfight.deaths or attribute a per-player death — the hero
+        # returns. Only the subsequent true death counts. Regression for Codex P2:
+        # keeps teamfight/Roshan summaries consistent with the death curve.
+        h2s = {"npc_dota_hero_axe": 0}
+        entries = [
+            _death(1000, "npc_dota_hero_axe", will_reincarnate=True),  # trigger
+            _death(1060, "npc_dota_hero_axe"),  # true death
+        ]
+        fights = detect_teamfights(entries, hero_to_slot=h2s)
+        assert len(fights) == 1
+        assert fights[0].deaths == 1
+        assert fights[0].players[0].deaths == 1
+
+    def test_lone_reincarnation_trigger_opens_no_fight(self):
+        # A solitary trigger death with no real death must not open a fight at all.
+        fights = detect_teamfights([_death(1000, will_reincarnate=True)])
+        assert fights == []
 
     def test_players_list_always_10(self):
         fights = detect_teamfights([_death(1000)])


### PR DESCRIPTION
## Summary

Extends the bug-hunt (PRs #80/#81) with a full `src/gem/` adversarial re-sweep and an audit of the `analysis/` magic constants. A finder→verifier workflow surfaced **9 confirmed bugs** (9 of 23 candidates survived ≥2-of-3 perspective-diverse verification; 14 plausible-but-wrong candidates were rejected) plus **2 structural findings**. The constant audit found **all 21 game-fact constants correct** (day/night, aegis, ward, vision, map bounds, cell size) — the remaining yield was entirely in logic, not values.

Each fix ships a regression test; tests that enshrined buggy behaviour are rewritten.

### HIGH — wrong output on the default `parse()` path
- **Roshan double-count** (`analysis/roshan.py`): the holder window was never clamped to `next_rosh_tick-1`, so the post-consume grace bled past the next Roshan kill and counted the same tower/barracks/teamfight/buyback in **both** consecutive `RoshConversion` records. Clamp `aegis_eval_end_tick` to the per-Roshan boundary. (Reproduced: total=2 for a 1-tower match.)
- **Unknown combat-log types inflate damage** (`combat/log.py`): unmapped proto types fell back to `DAMAGE` and were counted as hero damage. `CRITICAL_DAMAGE` (39) double-counted the crit (already logged as a separate type-0 entry) and `MODIFIER_STACK_EVENT` (19) inflated totals (~4–6% on a real fixture). Added a `CombatLogType.UNKNOWN` sentinel so unmapped types fall through the aggregator to a no-op, mirroring OpenDota's `default: break` and Clarity's real-enum resolution.

### MEDIUM
- **Coach index remap** (`extractors/players.py`): scoreboard K/D/A and team-slot reads used the raw `m_vecPlayerTeamData` array index, ignoring the coach remap the sibling `intervals.py` already applies — mis-attributing headline K/D/A in coached/HLTV replays. Added a shared `_resource_index` remap (OpenDota `validIndices`: skip rows whose team isn't 2/3) and routed all PlayerResource reads through it.
- **S1 PURCHASE item names** (`combat/log.py`): the S1 path never resolved `value_name` (S2 did), so S1 purchase logs lost item names and collapsed on dedup. Now resolves it for parity.
- **S1 hero-flag default** (`combat/log.py`): S1 `attacker/target_is_hero` defaulted to `False` when the legacy descriptor omitted the field; Clarity defaults to `True` (nullable-Integer `: true`). Flipped hero attribution on legacy S1 replays.

### LOW / robustness
- **Reincarnation death curve** (`extractors/players.py`): `total_deaths_t` double-counted WK/Aegis reincarnation (two DEATH events per true death). Added `CombatLogEntry.will_reincarnate` (S2 proto field 78) and skip trigger deaths. **Scoped to the death curve only** — `aggregator.kills_log` is intentionally left unchanged, as there's no verified oracle for kill-credit on a reincarnating death (OpenDota's early-return is about death-counting). Headline `pp.deaths` was already correct (sourced from the scoreboard).
- **Advantage-curve truncation** (`results/assembly.py`): the fallback radiant gold/XP curve clamped to the shortest player's minute array, truncating the whole curve to a leaver's series. Now sums every minute the curve spans, carrying forward a stopped player's last (monotonic) earned value — matching OpenDota's bucket-by-time sum.
- **Entity invariants** (`state/entities.py`): a missing baseline at CREATE and a LEAVE for an already-inactive entity are now surfaced as `RuntimeError` (manta panics on both) instead of silently swallowed. Never fires on well-formed replays.

### Structural (from the constant audit)
- **Map-geometry single source of truth** (`analysis/_shared.py`): bounds/fountains/river-strip were duplicated across `_shared.py`, `map_constants.json`, and `camp_zones.json`, with `load_map_constants()` having **zero callers** (the JSON was dead; the hardcoded literals were live). `_shared.py` now loads from the JSON via `catalog.load_map_constants`; added `river_strip` to the JSON; the calibrated literals remain as a graceful fallback.
- **`region_of` documentation** (`analysis/_shared.py`, README): corrected the comment/docstring/README — `|x - y| <= 1200` is a threshold on the diagonal difference, an effective perpendicular half-width of `1200/sqrt(2) ≈ 849`, not 1200 world units. The value is unchanged (coarse experimental heuristic, no oracle for a specific perpendicular width).

## Rationale
Builds on the "gem-original logic that's wrong, protected by tests asserting the wrong value" bug class identified in #80/#81. Finders were split by provenance: gem-original modules reasoned against game rules; `binary/`/`schema/`/`state/` translations were diffed against `refs/manta` + `refs/clarity`. Every finding was adversarially verified before a fix was written.

## Tests run
- `uv run ruff check src/ tests/` — clean
- `uv run ruff format src/ tests/` — clean
- `uv run mypy src/gem/` — clean
- `uv run pytest` — **1568 passed** (+17 new), 3 skipped
- `uv run pytest -m integration` — **40 passed** on real replays (10m21s), OpenDota parity preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)