### PR TITLE
Polish README for production + reconcile develop with published 0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are best-effort offline estimates exact only after `enrich_with_api_rates` /
   `apply_api_rates` (see issue #68). `tower_damage` is now ~exact offline.
 
+## [0.2.8] - 2026-05-24
+
+### Added
+- OpenDota fixture refresh tooling via `scripts/fetch_opendota_fixture.py`, plus DreamLeague Season 29 fixture metadata for patch 7.41 validation.
+- Neutral item found event parsing, including model/dataframe outputs and constants-audit coverage for newly observed item IDs.
+- Neutral camp annotation audit tooling via `scripts/audit_camp_annotations.py`, which groups neutral deaths by camp zones and reports replay-derived evidence.
+- A regenerated 7.40 map fixture with 7.41 camp annotations, larger camp icons, type-colored rings, and a legend for camp tiers.
+- Pull request template checks for release hygiene and parser safety.
+
+### Changed
+- Updated bundled constants from current OpenDota/dotaconstants references for 7.41-era items and abilities.
+- Refreshed camp-zone annotations for confirmed 7.41 camp type swaps.
+- Hero and item icon fetch scripts now support cache checks so unchanged icon assets are not rewritten unnecessarily.
+- Source 2 combat log parsing now preserves neutral camp stack metadata and event locations when available.
+
+### Fixed
+- Nearby-gold attribution in the camp audit now ignores unscoped `GOLD` events whose attacker and target names are both absent, preventing inflated camp summaries.
+
 ## [0.2.7] - 2026-03-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,17 +21,27 @@
 🎞️ Generate HTML analysis reports with combat, vision, economy, draft, and movement views  
 🧰 Export analysis-ready outputs as structured models, DataFrames, JSON, and Parquet
 
+> [!NOTE]
+> **Project status.** The core parsing pipeline — binary reader, entity delta system, combat log (S1 + S2), string tables, extractors, and the `ParsedMatch` output model — is **stable** and validated against OpenDota outputs (see [Known limitations](#known-limitations) for the remaining parity residuals). Features marked *(experimental)* — vision estimation, farming-pattern analysis, and Roshan conversion — are best-effort reconstructions, not ground-truth telemetry, and their heuristics may change. Published to PyPI as **`gem-dota`** (import name `gem`).
+
 ---
 
 ## Why Gem?
 
-“Gem” is inspired by **Gem of True Sight** in Dota — something that reveals what is normally hidden. Replays are dense binary data; this library aims to surface that hidden information in a form people can actually work with.
+Named after the **Gem of True Sight** — it reveals what is normally hidden. Replays are dense binary blobs; `gem` surfaces that information as structured Python objects you can analyze directly.
 
-We built `gem` in **Python** because most people in data, ML, and AI workflows already live in Python ecosystems. Go/Java parsers are excellent, but they are often not the first language for this audience. The goal is to democratize replay parsing: make it approachable from scratch, easy to inspect, and simple to plug into notebooks, pandas, and ML pipelines.
+Three reasons it exists:
 
-There is also a practical high-MMR reason: once your MMR is around **8500+**, ranked games are typically **Immortal Draft**, and many matches become effectively private to public stats ecosystems. In those cases, services like OpenDota, Dotabuff, and STRATZ often cannot parse or expose the game through normal API flows, so the most reliable path for serious self-review is parsing your own replays (or replays shared by trusted friends/pro teammates).
+- **Python-native.** Data/ML/AI work lives in Python. The excellent Go/Java parsers aren't the first language for that audience — `gem` makes replay parsing approachable from a notebook and easy to plug into pandas and ML pipelines.
+- **Reach private/high-MMR games.** Around **8500+ MMR** (Immortal Draft), many matches are effectively invisible to OpenDota/Dotabuff/STRATZ public API flows. Parsing your own replays is the most reliable path for serious self-review.
+- **Data ownership & transparency.** API/GraphQL outputs are already-processed interpretations with information loss and hidden assumptions. `gem` is open source and inspectable end-to-end, so you can understand the data from first principles.
 
-Another core reason is data ownership and transparency. API/GraphQL outputs from sites like OpenDota and STRATZ are already processed interpretations, which can involve information loss and hidden assumptions. With `gem`, we want to help people understand replay parsing from first principles in a user-friendly, widely adopted language, with an implementation that is open source and inspectable end-to-end. Skadistats once open-sourced SMOKE years ago (Cython-based rather than pure Python), but it is no longer maintained; `gem` aims to help fill that gap for today’s Python/data community.
+<details>
+<summary>More context</summary>
+
+Skadistats once open-sourced SMOKE (Cython-based rather than pure Python), but it is no longer maintained; `gem` aims to fill that gap for today's Python/data community. The implementation is an independent Python reimplementation cross-checked against Manta (Go), Clarity (Java), and the OpenDota parser (Java) — see [Acknowledgements](#acknowledgements).
+
+</details>
 
 ---
 
@@ -273,15 +283,25 @@ In short: think of `ParsedMatch` as one container holding both **per-player summ
 
 ## Releases
 
+> Full per-release detail lives in [`CHANGELOG.md`](CHANGELOG.md) and the [GitHub Releases](https://github.com/whanyu1212/gem-dota/releases) page; the highlights below summarize recent versions.
+
+### [v0.2.8](https://github.com/whanyu1212/gem-dota/releases/tag/v0.2.8)
+
+- **Neutral item tracking** — `DOTA_UM_FoundNeutralItem` events are parsed into `NeutralItemFoundEvent` (player, item key, tier, enhancement/trinket fields), with model/DataFrame outputs and constants-audit coverage for newly observed item IDs.
+- **Neutral camp annotation tooling** — `scripts/audit_camp_annotations.py` groups neutral deaths into camp zones with replay-derived evidence; combat-log parsing now preserves neutral-camp stack metadata and event locations when available.
+- **7.41 data refresh** — bundled constants updated for 7.41-era items/abilities, camp-zone annotations refreshed for confirmed camp type swaps, and a regenerated 7.40 map fixture with 7.41 camp overlays.
+- **OpenDota fixture tooling** — `scripts/fetch_opendota_fixture.py` plus DreamLeague Season 29 fixture metadata for patch-7.41 validation.
+- **Icon-fetch caching** — hero/item icon scripts now skip unchanged assets.
+
+<details>
+<summary>Older releases</summary>
+
 ### [v0.2.7](https://github.com/whanyu1212/gem-dota/releases/tag/v0.2.7)
 
 - **Experimental farming-pattern analysis** — objective-aware camp-path context, larger interactive report view, and detailed documentation for the heuristic model and its limits.
 - **Roshan conversion analysis** — `gem.build_rosh_conversions(match)` plus a dedicated `Roshan Conversion` report tab to show how each Roshan translated into fights, objectives, and map pressure.
 - **Sampling and validation fixes** — player time-series sampling now stops at game end, hero movement sampling uses each player's canonical selected hero entity, and the OpenDota validator now supports broader replay-sampling workflows.
 - **Economy series split** — `ParsedPlayer.gold_t` is now current unspent gold only, with cumulative earned gold exposed separately via `ParsedPlayer.total_earned_gold_t`.
-
-<details>
-<summary>Older releases</summary>
 
 ### [v0.2.6](https://github.com/whanyu1212/gem-dota/releases/tag/v0.2.6)
 
@@ -386,6 +406,10 @@ In short: think of `ParsedMatch` as one container holding both **per-player summ
 | `constants.py` | Compatibility facade for older catalog imports |
 | `reports/` | Self-contained HTML report generation from `ParsedMatch` |
 | `extractors/` | Per-tick polling of entity state — players, lane, objectives, wards, courier, draft, teamfights |
+| `analysis/` | Post-parse helpers — spatial/combat/vision lookups plus experimental map-context and Roshan-conversion builders |
+| `replays/` | Bulk parsing (`parse_many`, parallel workers) and replay download/decompress from OpenDota/Valve CDN |
+
+> Each package carries its own `README.md` with a deeper mental model, mechanics, and pitfalls. Module-level architecture is documented in [`docs/architecture.md`](docs/architecture.md).
 
 ---
 
@@ -425,6 +449,26 @@ Topics covered: DEM binary format, Protocol Buffers, varint encoding, the entity
 
 ---
 
+## Contributing
+
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow and PR checklist. The repo is managed with [`uv`](https://docs.astral.sh/uv/) and enforces lint, format, and type checks via pre-commit.
+
+```bash
+uv sync --group dev          # install project + dev dependencies
+
+uv run pytest                # fast suite (skips slow/integration markers)
+uv run pytest -m integration # replay-backed integration tests (needs fixtures)
+
+uv run ruff check src/ tests/    # lint
+uv run ruff format src/ tests/   # format
+uv run mypy src/gem/             # type-check
+```
+
+> [!TIP]
+> Parser-logic changes should be verified against the reference parsers in `refs/` (Manta → Clarity → OpenDota) and ship with a focused regression test. See `CONTRIBUTING.md` and [CLAUDE.md](CLAUDE.md) for the parser-safety conventions.
+
+---
+
 ## AI-Assisted Development
 
 If you use AI coding tools, see [CLAUDE.md](CLAUDE.md) and [AGENTS.md](AGENTS.md) for project context, architecture, and coding conventions.
@@ -433,29 +477,13 @@ Use AI as acceleration, not substitution: take ownership of what you submit. Und
 
 ---
 
-## Performance & benchmarking (cross-language)
+## Performance
 
-Replay parsers in **Go** and **Java** are often faster in raw throughput, while `gem` prioritizes **Python-native ergonomics** for data/ML/AI workflows. Our goal is to be fast enough for research/production analysis while remaining easy to inspect, extend, and integrate with pandas/notebooks.
+`gem` is a pure-Python parser. The reference parsers in **Go** ([Manta](https://github.com/dotabuff/manta)) and **Java** ([Clarity](https://github.com/skadistats/clarity)) are faster in raw throughput — that is the expected trade-off. `gem` instead optimizes for **Python-native ergonomics**: parse a replay and work with the result directly in pandas/notebooks/ML pipelines, with an implementation you can read end-to-end. It is built to be fast enough for research and batch analysis (bulk parsing runs across multiple processes via `gem.parse_many`), not to win raw throughput benchmarks.
 
-To keep comparisons fair, benchmark parsers with the same:
-- replay set (size + patch range),
-- extracted outputs (same scope),
-- hardware/CPU and OS,
-- warmup policy and run count.
+Parse cost scales with extraction scope: full per-tick state extraction is much heavier than event-only parsing, and HTML report generation (chart/asset rendering) is heavier still than plain parse/JSON export. For large jobs, prefer `parse_many*` with multiple workers and export to Parquet.
 
-> Benchmark results vary heavily by extraction scope (event-only vs full per-tick state), so we recommend reporting both **replays/sec** and **time per replay** with replay sizes.
-
-| Parser | Language | Scope | Throughput (replays/sec) | Notes |
-|---|---|---|---:|---|
-| gem | Python | Full extraction | TBD | Focused on analytics-first workflows |
-| Manta (reference) | Go | TBD | TBD | High-throughput backend-oriented parser |
-| Clarity (reference) | Java | TBD | TBD | Mature JVM parser ecosystem |
-
-If you run a benchmark, please open an issue/PR with:
-- hardware specs,
-- command/config used,
-- replay sample list,
-- median/p95 numbers.
+> Published cross-language benchmark numbers are intentionally omitted until they can be produced fairly — same replay set, same extraction scope, same hardware, with warmup and run counts reported. If you run a comparison, please open an issue/PR with hardware specs, the command/config used, the replay sample list, and median/p95 numbers (both **replays/sec** and **time per replay** with replay sizes).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gem-dota"
-version = "0.2.7"
+version = "0.2.8"
 description = "Dota 2 Source 2 replay parser for data science and ML workflows"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/gem/replays/README.md
+++ b/src/gem/replays/README.md
@@ -1,0 +1,61 @@
+# gem.replays
+
+`gem.replays` is the *bulk + acquisition* layer. It does not parse the binary
+format itself — it sits on top of `gem.parse()` and answers two operational
+questions the core parser leaves open:
+
+1. **Where does a replay come from?** (`fetch.py`) — download and decompress a
+   `.dem` from the OpenDota / Valve CDN given a match ID, and optionally enrich a
+   parsed match with Game-Coordinator scalars from the OpenDota API.
+2. **How do I parse many at once?** (`batch.py`) — run `gem.parse()` across a
+   directory of replays using a process pool, returning per-replay results or one
+   concatenated set of DataFrames.
+
+Everything here is exposed through the public API (`gem.fetch_replay`,
+`gem.parse_many`, …); most callers never import `gem.replays` directly.
+
+## Mental Model
+
+```text
+fetch_replay(match_id)  ──►  match.dem  ──►  gem.parse(path)  ──►  ParsedMatch
+                                                  ▲
+parse_many([paths]) ──── ProcessPoolExecutor ─────┘   (one worker per replay)
+```
+
+- **`fetch.py`** is I/O over the network: resolve the replay URL, stream-download
+  the bz2 blob, decompress to `.dem`. `enrich_with_api_rates` / `apply_api_rates`
+  are a separate opt-in step that overlays OpenDota's published
+  `hero_damage`/`tower_damage`/`gpm`/`xpm` scalars onto a `ParsedMatch` (these are
+  GC values the replay alone cannot reproduce exactly — see issue #68 and the
+  repo `Known limitations`).
+- **`batch.py`** is CPU parallelism: each replay is parsed in its own process
+  (`_parse_one`), so a failed replay yields a `ParseResult` with the exception
+  rather than aborting the whole run. `parse_many_to_dataframe` /
+  `parse_many_to_parquet` add the concat/export step on top.
+
+## What this layer does NOT do
+
+- It does **not** decode the binary format — that is `binary` → `schema` →
+  `state` → `parser`. `replays` only orchestrates calls to the finished
+  `gem.parse()`.
+- It does **not** require network access for `batch.py`. Only `fetch.py` reaches
+  the network; bulk parsing of local files is fully offline.
+- `apply_api_rates` does **not** change replay-derived fields — it only overlays
+  GC scalars, and it is opt-in. Plain `gem.parse()` never calls the network.
+
+## Pitfalls
+
+- **Parquet needs an engine.** `parse_many_to_parquet` requires `pyarrow`
+  (recommended) or `fastparquet` in the environment.
+- **Process-pool pickling.** Workers parse in separate processes, so results are
+  pickled back; keep custom post-processing out of the worker path.
+- **API enrichment is rate-limited and best-effort.** `fetch_opendota_match`
+  hits the public OpenDota API; for private/high-MMR matches it may return
+  nothing, which is exactly the case `gem` exists to handle offline.
+
+## When to add code here
+
+Add to `replays/` when the work is about **acquiring** replays or **scaling**
+parsing across many of them — not when it is about *how* a single replay is
+decoded (that belongs in the core pipeline) or *what* is extracted from one
+(that belongs in `extractors` / `analysis`).

--- a/uv.lock
+++ b/uv.lock
@@ -448,7 +448,7 @@ wheels = [
 
 [[package]]
 name = "gem-dota"
-version = "0.2.7"
+version = "0.2.8"
 source = { editable = "." }
 dependencies = [
     { name = "ipykernel" },


### PR DESCRIPTION
## Summary

Production-readiness pass on the main README, plus a release-hygiene fix: `develop` was silently behind its own published release.

### Release reconciliation
`0.2.8` is already published (PyPI + `v0.2.8` tag), but the release branch was never back-merged into `develop` — so `develop`'s `pyproject.toml` still said `0.2.7` and its CHANGELOG had no `[0.2.8]` entry.

- Bump `pyproject.toml` `0.2.7 → 0.2.8` (`gem.__version__` now reports `0.2.8`, matching PyPI).
- Add the `[0.2.8]` CHANGELOG entry (neutral items, camp-annotation tooling, 7.41 data refresh) sourced from the `v0.2.8` tag. The `[Unreleased]` block stays as genuine post-0.2.8 develop work (damage-source attribution).

### README touch-ups
- **Project status** note up top — stable core pipeline (validated vs OpenDota) vs `(experimental)` flags called out explicitly.
- **Tightened "Why Gem?"** from three dense paragraphs to a crisp three-bullet value prop + a collapsible "More context".
- **Releases** — added v0.2.8 highlights, collapsed v0.2.7 into older releases, and pointed to `CHANGELOG.md` / GitHub Releases as the source of truth (so the README stops drifting as a second changelog).
- **Performance** — replaced the all-`TBD` cross-language benchmark table (TBD numbers read as unfinished) with honest positioning: Python-native ergonomics over raw throughput, plus the fair-comparison methodology for anyone who runs a real benchmark.
- **Contributing** section — `uv sync` + the verify-a-build commands (`pytest` / `ruff` / `mypy`) so the quality bar is visible.
- **Components table** — added the `analysis/` and `replays/` packages (both were missing) and linked to the per-package READMEs + `docs/architecture.md`.

### Also
- Added the missing `src/gem/replays/README.md` so the "each package carries its own README" claim actually holds — `replays/` was the only package without one (modeled on the established package-README structure).

## Verification
- `gem.__version__` → `0.2.8` (matches PyPI).
- `<details>` tags balanced, internal anchors resolve, all referenced files exist (CONTRIBUTING.md, CHANGELOG.md, docs/architecture.md, per-package READMEs).
- ruff + mypy clean (pre-commit); **1571 fast tests pass**.

## Notes
- Confirmed the README's buyback formula `floor(200 + net_worth / 13)` matches the implemented code (`reports/sections/economy.py`: `200 + nw // 13`) — no change needed.
- Left `CLAUDE.md`'s deferred-work `/12` approximation note alone (speculative future-work note, not a user-facing claim — out of scope for a README PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)