### PR TITLE
Add OpenDota-compatible teamfight output

### DIFF
--- a/scripts/validate_opendota.py
+++ b/scripts/validate_opendota.py
@@ -379,9 +379,6 @@ def _od_slot_to_gem_id(slot: int) -> int:
     return slot if slot < 128 else slot - 128 + 5
 
 
-_TEAMFIGHT_COOLDOWN_S = 15
-
-
 def _opendota_teamfights_from_combat_log(combat_log: list[Any]) -> list[dict[str, int]]:
     """Project gem combat log deaths into OpenDota-compatible teamfight windows.
 
@@ -390,42 +387,17 @@ def _opendota_teamfights_from_combat_log(combat_log: list[Any]) -> list[dict[str
     new hero death, then filters to windows with at least three deaths. This is
     intentionally separate from gem's richer spatial teamfight detector.
     """
-    fights: list[dict[str, int]] = []
-    current: dict[str, int] | None = None
+    from gem.extractors.teamfights import detect_opendota_teamfights
 
-    deaths = sorted(
-        (
-            entry
-            for entry in combat_log
-            if entry.log_type == "DEATH"
-            and entry.target_is_hero
-            and not entry.target_is_illusion
-            and entry.game_time_s is not None
-        ),
-        key=lambda entry: entry.game_time_s or 0,
-    )
-
-    for entry in deaths:
-        death_time_s = int(entry.game_time_s or 0)
-        if current is None or death_time_s - current["last_death"] >= _TEAMFIGHT_COOLDOWN_S:
-            if current is not None and current["deaths"] >= 3:
-                current["end"] = current["last_death"] + _TEAMFIGHT_COOLDOWN_S
-                fights.append(current)
-            current = {
-                "start": death_time_s - _TEAMFIGHT_COOLDOWN_S,
-                "end": 0,
-                "last_death": death_time_s,
-                "deaths": 0,
-            }
-
-        current["last_death"] = death_time_s
-        current["deaths"] += 1
-
-    if current is not None and current["deaths"] >= 3:
-        current["end"] = current["last_death"] + _TEAMFIGHT_COOLDOWN_S
-        fights.append(current)
-
-    return fights
+    return [
+        {
+            "start": fight.start,
+            "end": fight.end,
+            "last_death": fight.last_death,
+            "deaths": fight.deaths,
+        }
+        for fight in detect_opendota_teamfights(combat_log)
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/src/gem/api.py
+++ b/src/gem/api.py
@@ -89,6 +89,11 @@ from gem.analysis import (
 )
 from gem.catalog import hero_npc_name
 from gem.extractors.draft import resolve_pick_team
+from gem.extractors.teamfights import (
+    OpenDotaTeamfight,
+    OpenDotaTeamfightPlayer,
+    detect_opendota_teamfights,
+)
 from gem.replays.batch import (
     ParseResult,
     parse_many,
@@ -427,6 +432,8 @@ __all__ = [
     "parse_many_to_parquet",
     "ParsedMatch",
     "ParsedPlayer",
+    "OpenDotaTeamfight",
+    "OpenDotaTeamfightPlayer",
     "ChatEntry",
     "NeutralItemFoundEvent",
     "find_player",
@@ -443,6 +450,7 @@ __all__ = [
     "net_worth_at",
     "ward_vision_impact",
     "is_active_teamfight_participant",
+    "detect_opendota_teamfights",
     "format_npc_name",
     "MapContextBucket",
     "CampVisitContext",

--- a/src/gem/extractors/teamfights.py
+++ b/src/gem/extractors/teamfights.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     from gem.extractors.players import PlayerStateSnapshot
 
 # 15 seconds × 30 ticks/second  (reference uses 15s cooldown)
+_TEAMFIGHT_COOLDOWN_S: int = 15
 _COOLDOWN_TICKS: int = 15 * 30
 
 # Maximum world-unit distance between a death and an active fight's centroid
@@ -113,6 +114,48 @@ class Teamfight:
     centroid_y: float | None = None
     centroid_n: int = 0
     players: list[TeamfightPlayer] = field(default_factory=list)
+
+
+@dataclass
+class OpenDotaTeamfightPlayer:
+    """OpenDota-compatible per-player teamfight row.
+
+    This intentionally mirrors the OpenDota ``teamfights[].players[]`` schema.
+    It is a compatibility projection, separate from Gem's richer
+    ``TeamfightPlayer`` model.
+    """
+
+    deaths_pos: dict[str, dict[str, int]] = field(default_factory=dict)
+    ability_uses: dict[str, int] = field(default_factory=dict)
+    ability_targets: dict[str, int] = field(default_factory=dict)
+    item_uses: dict[str, int] = field(default_factory=dict)
+    killed: dict[str, int] = field(default_factory=dict)
+    deaths: int = 0
+    buybacks: int = 0
+    damage: int = 0
+    healing: int = 0
+    gold_delta: int = 0
+    xp_delta: int = 0
+    xp_start: int | None = None
+    xp_end: int | None = None
+
+
+@dataclass
+class OpenDotaTeamfight:
+    """OpenDota-compatible temporal teamfight window.
+
+    OpenDota opens a fight at ``first_death_time - 15``, extends it with hero
+    deaths that occur before the 15-second cooldown expires, then keeps only
+    windows with at least three hero deaths.
+    """
+
+    start: int
+    end: int
+    last_death: int
+    deaths: int
+    players: list[OpenDotaTeamfightPlayer] = field(
+        default_factory=lambda: [OpenDotaTeamfightPlayer() for _ in range(10)]
+    )
 
 
 def detect_teamfights(
@@ -371,6 +414,231 @@ def detect_teamfights(
                 fight.winner = "draw"
 
     return fights
+
+
+def detect_opendota_teamfights(
+    combat_log: list[CombatLogEntry],
+    hero_to_slot: dict[str, int] | None = None,
+    player_snapshots: dict[int, list[PlayerStateSnapshot]] | None = None,
+    *,
+    game_start_tick: int | None = None,
+    duration_s: int | None = None,
+) -> list[OpenDotaTeamfight]:
+    """Project combat log entries into OpenDota-compatible teamfight output.
+
+    This is intentionally separate from :func:`detect_teamfights`, which uses
+    Gem's spatial clustering and returns all skirmishes. The compatibility
+    output follows OpenDota's temporal-only death-window semantics and filters
+    to fights with at least three hero deaths.
+    """
+    h2s = hero_to_slot or {}
+    entries = sorted(
+        combat_log,
+        key=lambda e: (
+            _combat_time_s(e, game_start_tick=game_start_tick)
+            if _combat_time_s(e, game_start_tick=game_start_tick) is not None
+            else float("inf"),
+            e.tick,
+        ),
+    )
+
+    fights: list[OpenDotaTeamfight] = []
+    current: OpenDotaTeamfight | None = None
+
+    for entry in entries:
+        if not _is_counted_opendota_death(entry):
+            continue
+        death_time_s = _combat_time_s(entry, game_start_tick=game_start_tick)
+        if death_time_s is None:
+            continue
+
+        if current is None or death_time_s - current.last_death >= _TEAMFIGHT_COOLDOWN_S:
+            _append_closed_opendota_fight(fights, current, duration_s=duration_s)
+            current = OpenDotaTeamfight(
+                start=death_time_s - _TEAMFIGHT_COOLDOWN_S,
+                end=0,
+                last_death=death_time_s,
+                deaths=0,
+            )
+
+        current.last_death = death_time_s
+        current.deaths += 1
+
+    _append_closed_opendota_fight(fights, current, duration_s=duration_s)
+
+    if not fights:
+        return []
+
+    for fight in fights:
+        _populate_opendota_xp_bounds(
+            fight,
+            player_snapshots,
+            game_start_tick=game_start_tick,
+        )
+
+    for entry in entries:
+        event_time_s = _combat_time_s(entry, game_start_tick=game_start_tick)
+        if event_time_s is None:
+            continue
+        for fight in fights:
+            if event_time_s < fight.start or event_time_s > fight.end:
+                continue
+            _populate_opendota_teamfight_event(
+                fight,
+                entry,
+                h2s,
+                player_snapshots,
+            )
+
+    return fights
+
+
+def _append_closed_opendota_fight(
+    fights: list[OpenDotaTeamfight],
+    fight: OpenDotaTeamfight | None,
+    *,
+    duration_s: int | None,
+) -> None:
+    if fight is None or fight.deaths < 3:
+        return
+    end = fight.last_death + _TEAMFIGHT_COOLDOWN_S
+    if duration_s is not None and end > duration_s:
+        return
+    fight.end = end
+    fights.append(fight)
+
+
+def _combat_time_s(entry: CombatLogEntry, *, game_start_tick: int | None) -> int | None:
+    if entry.game_time_s is not None:
+        return int(entry.game_time_s)
+    if game_start_tick is None:
+        return None
+    return int(round((entry.tick - game_start_tick) / 30))
+
+
+def _is_counted_opendota_death(entry: CombatLogEntry) -> bool:
+    return (
+        entry.log_type == "DEATH"
+        and entry.target_is_hero
+        and not entry.target_is_illusion
+        and not entry.will_reincarnate
+    )
+
+
+def _populate_opendota_xp_bounds(
+    fight: OpenDotaTeamfight,
+    player_snapshots: dict[int, list[PlayerStateSnapshot]] | None,
+    *,
+    game_start_tick: int | None,
+) -> None:
+    if player_snapshots is None or game_start_tick is None:
+        return
+    start_tick = game_start_tick + fight.start * 30
+    end_tick = game_start_tick + fight.end * 30
+    for player_id, snaps in player_snapshots.items():
+        if player_id >= len(fight.players):
+            continue
+        xp_start = _nearest_xp(snaps, start_tick)
+        xp_end = _nearest_xp(snaps, end_tick)
+        if xp_start is not None:
+            fight.players[player_id].xp_start = xp_start
+        if xp_end is not None:
+            fight.players[player_id].xp_end = xp_end
+
+
+def _populate_opendota_teamfight_event(
+    fight: OpenDotaTeamfight,
+    entry: CombatLogEntry,
+    hero_to_slot: dict[str, int],
+    player_snapshots: dict[int, list[PlayerStateSnapshot]] | None,
+) -> None:
+    if entry.log_type == "DEATH":
+        _populate_opendota_death(fight, entry, hero_to_slot, player_snapshots)
+        return
+
+    if entry.log_type == "BUYBACK":
+        bslot = entry.value
+        if isinstance(bslot, int) and 0 <= bslot < len(fight.players):
+            fight.players[bslot].buybacks += 1
+        return
+
+    source_slot = _source_slot(entry, hero_to_slot)
+    target_slot = hero_to_slot.get(entry.target_name)
+
+    if entry.log_type == "DAMAGE":
+        if entry.target_is_hero and not entry.target_is_illusion and source_slot is not None:
+            fight.players[source_slot].damage += entry.value
+    elif entry.log_type == "HEAL":
+        if entry.target_is_hero and not entry.target_is_illusion and source_slot is not None:
+            fight.players[source_slot].healing += entry.value
+    elif entry.log_type == "GOLD":
+        if target_slot is not None:
+            fight.players[target_slot].gold_delta += entry.value
+    elif entry.log_type == "XP":
+        if target_slot is not None:
+            fight.players[target_slot].xp_delta += entry.value
+    elif entry.log_type == "ABILITY":
+        if source_slot is not None and entry.inflictor_name:
+            key = _opendota_translate(entry.inflictor_name)
+            if key is not None:
+                uses = fight.players[source_slot].ability_uses
+                uses[key] = uses.get(key, 0) + 1
+    elif entry.log_type == "ITEM" and source_slot is not None and entry.inflictor_name:
+        key = _opendota_translate(entry.inflictor_name)
+        if key is not None:
+            uses = fight.players[source_slot].item_uses
+            uses[key] = uses.get(key, 0) + 1
+
+
+def _populate_opendota_death(
+    fight: OpenDotaTeamfight,
+    entry: CombatLogEntry,
+    hero_to_slot: dict[str, int],
+    player_snapshots: dict[int, list[PlayerStateSnapshot]] | None,
+) -> None:
+    if not _is_counted_opendota_death(entry):
+        return
+
+    target_slot = hero_to_slot.get(entry.target_name)
+    source_name = entry.damage_source_name or entry.attacker_name
+    if source_name == entry.target_name:
+        return
+
+    source_slot = hero_to_slot.get(source_name)
+    if source_slot is not None and 0 <= source_slot < len(fight.players):
+        killed = fight.players[source_slot].killed
+        killed[entry.target_name] = killed.get(entry.target_name, 0) + 1
+
+    if target_slot is None or not 0 <= target_slot < len(fight.players):
+        return
+
+    target_player = fight.players[target_slot]
+    target_player.deaths += 1
+
+    if player_snapshots is None:
+        return
+    pos = _nearest_pos(player_snapshots.get(target_slot, []), entry.tick)
+    if pos is None:
+        return
+    x = str(round(pos[0]))
+    y = str(round(pos[1]))
+    y_counts = target_player.deaths_pos.setdefault(x, {})
+    y_counts[y] = y_counts.get(y, 0) + 1
+
+
+def _source_slot(entry: CombatLogEntry, hero_to_slot: dict[str, int]) -> int | None:
+    source_name = entry.damage_source_name or entry.attacker_name
+    if not source_name:
+        return None
+    return hero_to_slot.get(source_name)
+
+
+def _opendota_translate(name: str) -> str | None:
+    if name == "dota_unknown":
+        return None
+    if name.startswith("item_"):
+        return name[5:]
+    return name
 
 
 def _near_fight(

--- a/src/gem/extractors/teamfights.py
+++ b/src/gem/extractors/teamfights.py
@@ -601,13 +601,12 @@ def _populate_opendota_death(
 
     target_slot = hero_to_slot.get(entry.target_name)
     source_name = entry.damage_source_name or entry.attacker_name
-    if source_name == entry.target_name:
-        return
 
-    source_slot = hero_to_slot.get(source_name)
-    if source_slot is not None and 0 <= source_slot < len(fight.players):
-        killed = fight.players[source_slot].killed
-        killed[entry.target_name] = killed.get(entry.target_name, 0) + 1
+    if source_name and source_name != entry.target_name:
+        source_slot = hero_to_slot.get(source_name)
+        if source_slot is not None and 0 <= source_slot < len(fight.players):
+            killed = fight.players[source_slot].killed
+            killed[entry.target_name] = killed.get(entry.target_name, 0) + 1
 
     if target_slot is None or not 0 <= target_slot < len(fight.players):
         return

--- a/src/gem/results/assembly.py
+++ b/src/gem/results/assembly.py
@@ -279,7 +279,7 @@ def build_parsed_match(
         Fully populated :class:`ParsedMatch`.
     """
     from gem.combat.aggregator import _dedup_purchase_log
-    from gem.extractors.teamfights import detect_teamfights
+    from gem.extractors.teamfights import detect_opendota_teamfights, detect_teamfights
 
     # radiant_win resolution — three tiers in priority order:
     #   1. CDemoFileInfo.game_winner (set during parse, empty for HLTV replays)
@@ -618,6 +618,13 @@ def build_parsed_match(
         hero_to_slot=hero_to_slot,
         player_snapshots=player_snaps,
         slot_to_team=slot_to_team,
+    )
+    match.opendota_teamfights = detect_opendota_teamfights(
+        all_entries,
+        hero_to_slot=hero_to_slot,
+        player_snapshots=player_snaps,
+        game_start_tick=match.game_start_tick,
+        duration_s=match.duration or None,
     )
 
     # Build per-player ability level snapshots for ability_level_at_tick().

--- a/src/gem/results/dataframes.py
+++ b/src/gem/results/dataframes.py
@@ -300,6 +300,11 @@ def build_dataframes(match: ParsedMatch) -> dict[str, pd.DataFrame]:
         if match.teamfights
         else pd.DataFrame()
     )
+    opendota_teamfights_df = (
+        pd.DataFrame([asdict(tf) for tf in match.opendota_teamfights])
+        if match.opendota_teamfights
+        else pd.DataFrame()
+    )
     smoke_df = (
         pd.DataFrame([asdict(se) for se in match.smoke_events])
         if match.smoke_events
@@ -328,6 +333,7 @@ def build_dataframes(match: ParsedMatch) -> dict[str, pd.DataFrame]:
         "radiant_advantage": advantage_df,
         "draft": draft_df,
         "teamfights": teamfights_df,
+        "opendota_teamfights": opendota_teamfights_df,
         "smoke_events": smoke_df,
         "courier_snapshots": courier_df,
         "neutral_item_finds": neutral_item_finds_df,

--- a/src/gem/results/models.py
+++ b/src/gem/results/models.py
@@ -22,7 +22,7 @@ from gem.extractors.objectives import (
     TormentorKill,
     TowerKill,
 )
-from gem.extractors.teamfights import Teamfight
+from gem.extractors.teamfights import OpenDotaTeamfight, Teamfight
 from gem.extractors.wards import WardEvent
 
 
@@ -436,6 +436,9 @@ class ParsedMatch:
             approximate activating-hero position.
         draft: Hero pick and ban events from the draft phase.
         teamfights: All detected teamfight windows with per-player breakdowns.
+        opendota_teamfights: OpenDota-compatible temporal teamfight windows.
+            These use OpenDota's 15-second death-window grouping and 3+ death
+            filter, while ``teamfights`` keeps Gem's richer spatial detector.
         vision_modifiers: Vision-granting modifier events (Slardar Corrosive Haze,
             Bounty Hunter Track, Dust of Appearance, Gem of True Sight, etc.).
             Used by ``estimate_vision`` to detect reveals beyond geometry.
@@ -482,6 +485,7 @@ class ParsedMatch:
     smoke_events: list[SmokeEvent] = field(default_factory=list)
     draft: list[DraftEvent] = field(default_factory=list)
     teamfights: list[Teamfight] = field(default_factory=list)
+    opendota_teamfights: list[OpenDotaTeamfight] = field(default_factory=list)
     vision_modifiers: list[VisionModifierEvent] = field(default_factory=list)
 
     @property

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -100,6 +100,7 @@ class TestBuildDataframes:
         assert "radiant_advantage" in dfs
         assert "draft" in dfs
         assert "teamfights" in dfs
+        assert "opendota_teamfights" in dfs
         assert "smoke_events" in dfs
         assert "courier_snapshots" in dfs
         assert "neutral_item_finds" in dfs
@@ -109,6 +110,7 @@ class TestBuildDataframes:
         assert "player_buyback_log" in dfs
 
         assert dfs["neutral_item_finds"].empty
+        assert dfs["opendota_teamfights"].empty
 
     def test_neutral_item_finds_dataframe_includes_event_fields(self):
         neutral_event_cls = getattr(model_module, "NeutralItemFoundEvent", None)

--- a/tests/test_match_builder.py
+++ b/tests/test_match_builder.py
@@ -64,6 +64,7 @@ class _FakePlayerSnapshot:
     tick: int
     npc_name: str
     team: int
+    total_earned_xp: int = 0
     x: float | None = None
     y: float | None = None
     ability_levels: dict = field(default_factory=dict)
@@ -235,6 +236,83 @@ class TestBuildParsedMatchSmoke:
     def test_game_start_tick_propagated(self):
         m = self._build(game_start_tick=6000)
         assert m.game_start_tick == 6000
+
+    def test_opendota_teamfights_populated(self):
+        parser = _make_parser(game_start_tick=6000)
+        player_ext = _make_player_ext(
+            snapshots=[
+                _FakePlayerSnapshot(
+                    player_id=0,
+                    tick=9000,
+                    npc_name="npc_dota_hero_axe",
+                    team=2,
+                    x=10.0,
+                    y=20.0,
+                ),
+                _FakePlayerSnapshot(
+                    player_id=1,
+                    tick=9030,
+                    npc_name="npc_dota_hero_pudge",
+                    team=3,
+                    x=30.0,
+                    y=40.0,
+                ),
+                _FakePlayerSnapshot(
+                    player_id=2,
+                    tick=9060,
+                    npc_name="npc_dota_hero_lina",
+                    team=3,
+                    x=50.0,
+                    y=60.0,
+                ),
+            ]
+        )
+        entries = [
+            CombatLogEntry(
+                tick=9000,
+                game_time_s=100,
+                log_type="DEATH",
+                attacker_name="npc_dota_hero_axe",
+                target_name="npc_dota_hero_pudge",
+                target_is_hero=True,
+            ),
+            CombatLogEntry(
+                tick=9030,
+                game_time_s=101,
+                log_type="DEATH",
+                attacker_name="npc_dota_hero_axe",
+                target_name="npc_dota_hero_lina",
+                target_is_hero=True,
+            ),
+            CombatLogEntry(
+                tick=9060,
+                game_time_s=102,
+                log_type="DEATH",
+                attacker_name="npc_dota_hero_pudge",
+                target_name="npc_dota_hero_axe",
+                target_is_hero=True,
+            ),
+        ]
+
+        m = build_parsed_match(
+            parser,
+            player_ext,
+            _make_obj_ext(),
+            _make_ward_ext(),
+            _make_courier_ext(),
+            _make_draft_ext(),
+            _make_combat_agg(),
+            entries,
+            [],
+        )
+
+        assert len(m.opendota_teamfights) == 1
+        assert m.opendota_teamfights[0].start == 85
+        assert m.opendota_teamfights[0].end == 117
+        assert m.opendota_teamfights[0].players[0].killed == {
+            "npc_dota_hero_pudge": 1,
+            "npc_dota_hero_lina": 1,
+        }
 
     def test_has_ten_players(self):
         m = self._build()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 
 import gem
 import gem.api
+from gem.extractors.teamfights import OpenDotaTeamfight
 from gem.results.models import ParsedMatch, ParsedPlayer
 
 
@@ -42,6 +43,17 @@ class TestSerializationHelpers:
         decoded = json.loads(payload)
         assert decoded["match_id"] == 7
         assert "players" in decoded
+
+    def test_to_dict_includes_opendota_teamfights(self):
+        match = ParsedMatch(
+            match_id=7,
+            opendota_teamfights=[OpenDotaTeamfight(start=10, end=30, last_death=15, deaths=3)],
+        )
+
+        data = gem.to_dict(match)
+
+        assert data["opendota_teamfights"][0]["start"] == 10
+        assert data["opendota_teamfights"][0]["players"][0]["damage"] == 0
 
     def test_parse_to_json_uses_parse_result(self, monkeypatch):
         fake_match = ParsedMatch(match_id=999)

--- a/tests/test_teamfights.py
+++ b/tests/test_teamfights.py
@@ -398,6 +398,33 @@ class TestDetectOpenDotaTeamfights:
         assert fight.players[1].deaths_pos == {"123": {"568": 1}}
         assert fight.players[1].buybacks == 1
 
+    def test_self_kill_records_opendota_death_without_kill_credit(self):
+        h2s = {
+            "npc_dota_hero_axe": 0,
+            "npc_dota_hero_pudge": 1,
+            "npc_dota_hero_lina": 2,
+        }
+        snaps = _make_snaps("npc_dota_hero_axe", 0, 3000, 321.2, 654.8)
+        entries = [
+            CombatLogEntry(
+                tick=3000,
+                game_time_s=100,
+                log_type="DEATH",
+                attacker_name="npc_dota_hero_axe",
+                target_name="npc_dota_hero_axe",
+                target_is_hero=True,
+            ),
+            _death(3030, "npc_dota_hero_pudge", game_time_s=101),
+            _death(3060, "npc_dota_hero_lina", game_time_s=102),
+        ]
+
+        fight = detect_opendota_teamfights(entries, hero_to_slot=h2s, player_snapshots=snaps)[0]
+
+        assert fight.deaths == 3
+        assert fight.players[0].deaths == 1
+        assert fight.players[0].deaths_pos == {"321": {"655": 1}}
+        assert fight.players[0].killed == {}
+
 
 # ---------------------------------------------------------------------------
 # XP delta unit tests

--- a/tests/test_teamfights.py
+++ b/tests/test_teamfights.py
@@ -15,6 +15,7 @@ from gem.extractors.teamfights import (
     _nearest_pos,
     _nearest_xp,
     _update_centroid,
+    detect_opendota_teamfights,
     detect_teamfights,
 )
 
@@ -26,9 +27,11 @@ def _death(
     target: str = "npc_dota_hero_axe",
     illusion: bool = False,
     will_reincarnate: bool = False,
+    game_time_s: int | None = None,
 ) -> CombatLogEntry:
     return CombatLogEntry(
         tick=tick,
+        game_time_s=game_time_s,
         log_type="DEATH",
         target_name=target,
         target_is_hero=True,
@@ -260,6 +263,140 @@ class TestDetectTeamfights:
         entries = [_death(1000), item_entry]
         fights = detect_teamfights(entries, hero_to_slot=h2s)
         assert fights[0].players[0].item_uses.get("item_blink") == 1
+
+
+class TestDetectOpenDotaTeamfights:
+    def test_uses_combat_log_game_time_and_filters_short_windows(self):
+        fights = detect_opendota_teamfights(
+            [
+                _death(10_000, game_time_s=1033),
+                _death(10_030, target="npc_dota_hero_pudge", game_time_s=1038),
+                _death(10_060, target="npc_dota_hero_lina", game_time_s=1040),
+                _death(20_000, target="npc_dota_hero_crystal_maiden", game_time_s=1200),
+            ]
+        )
+
+        assert [(f.start, f.end, f.last_death, f.deaths) for f in fights] == [(1018, 1055, 1040, 3)]
+
+    def test_filters_illusions_and_reincarnation_triggers(self):
+        fights = detect_opendota_teamfights(
+            [
+                _death(100, game_time_s=100),
+                _death(110, target="npc_dota_hero_pudge", illusion=True, game_time_s=105),
+                _death(
+                    120,
+                    target="npc_dota_hero_lina",
+                    will_reincarnate=True,
+                    game_time_s=106,
+                ),
+                _death(200, target="npc_dota_hero_drow_ranger", game_time_s=200),
+                _death(210, target="npc_dota_hero_juggernaut", game_time_s=204),
+                _death(220, target="npc_dota_hero_sven", game_time_s=208),
+            ]
+        )
+
+        assert [(f.start, f.end, f.last_death, f.deaths) for f in fights] == [(185, 223, 208, 3)]
+
+    def test_temporal_output_does_not_spatially_split(self):
+        h2s = {"npc_dota_hero_axe": 0, "npc_dota_hero_pudge": 1, "npc_dota_hero_lina": 2}
+        snaps = {
+            **_make_snaps("npc_dota_hero_axe", 0, 3000, 0.0, 0.0),
+            **_make_snaps("npc_dota_hero_pudge", 1, 3030, 10_000.0, 10_000.0),
+            **_make_snaps("npc_dota_hero_lina", 2, 3060, -10_000.0, -10_000.0),
+        }
+
+        fights = detect_opendota_teamfights(
+            [
+                _death(3000, "npc_dota_hero_axe", game_time_s=100),
+                _death(3030, "npc_dota_hero_pudge", game_time_s=101),
+                _death(3060, "npc_dota_hero_lina", game_time_s=102),
+            ],
+            hero_to_slot=h2s,
+            player_snapshots=snaps,
+        )
+
+        assert len(fights) == 1
+        assert fights[0].deaths == 3
+
+    def test_populates_opendota_player_fields(self):
+        h2s = {"npc_dota_hero_axe": 0, "npc_dota_hero_pudge": 1}
+        snaps = _make_snaps("npc_dota_hero_pudge", 1, 3000, 123.4, 567.6)
+        entries = [
+            CombatLogEntry(
+                tick=3000,
+                game_time_s=100,
+                log_type="DEATH",
+                attacker_name="npc_dota_hero_axe",
+                target_name="npc_dota_hero_pudge",
+                target_is_hero=True,
+            ),
+            _death(3030, "npc_dota_hero_axe", game_time_s=101),
+            _death(3060, "npc_dota_hero_axe", game_time_s=102),
+            CombatLogEntry(
+                tick=3010,
+                game_time_s=101,
+                log_type="DAMAGE",
+                attacker_name="npc_dota_hero_axe",
+                target_name="npc_dota_hero_pudge",
+                attacker_is_hero=True,
+                target_is_hero=True,
+                value=250,
+            ),
+            CombatLogEntry(
+                tick=3011,
+                game_time_s=101,
+                log_type="HEAL",
+                attacker_name="npc_dota_hero_axe",
+                target_name="npc_dota_hero_pudge",
+                attacker_is_hero=True,
+                target_is_hero=True,
+                value=75,
+            ),
+            CombatLogEntry(
+                tick=3012,
+                game_time_s=101,
+                log_type="GOLD",
+                target_name="npc_dota_hero_axe",
+                value=200,
+            ),
+            CombatLogEntry(
+                tick=3013,
+                game_time_s=101,
+                log_type="XP",
+                target_name="npc_dota_hero_axe",
+                value=300,
+            ),
+            CombatLogEntry(
+                tick=3014,
+                game_time_s=101,
+                log_type="ABILITY",
+                attacker_name="npc_dota_hero_axe",
+                attacker_is_hero=True,
+                inflictor_name="axe_berserkers_call",
+            ),
+            CombatLogEntry(
+                tick=3015,
+                game_time_s=101,
+                log_type="ITEM",
+                attacker_name="npc_dota_hero_axe",
+                attacker_is_hero=True,
+                inflictor_name="item_blink",
+            ),
+            CombatLogEntry(tick=3016, game_time_s=101, log_type="BUYBACK", value=1),
+        ]
+
+        fight = detect_opendota_teamfights(entries, hero_to_slot=h2s, player_snapshots=snaps)[0]
+
+        assert fight.players[0].killed == {"npc_dota_hero_pudge": 1}
+        assert fight.players[0].damage == 250
+        assert fight.players[0].healing == 75
+        assert fight.players[0].gold_delta == 200
+        assert fight.players[0].xp_delta == 300
+        assert fight.players[0].ability_uses == {"axe_berserkers_call": 1}
+        assert fight.players[0].item_uses == {"blink": 1}
+        assert fight.players[1].deaths == 1
+        assert fight.players[1].deaths_pos == {"123": {"568": 1}}
+        assert fight.players[1].buybacks == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add OpenDota-compatible `OpenDotaTeamfight` / `OpenDotaTeamfightPlayer` models and a `detect_opendota_teamfights()` helper.
- Populate `ParsedMatch.opendota_teamfights` during normal parsing while keeping the existing spatial `teamfights` output unchanged.
- Expose the compatibility output through the public API, JSON serialization, DataFrame export, and the OpenDota validator.

## Validation

- `uv run ruff check src/gem/extractors/teamfights.py src/gem/results/models.py src/gem/results/assembly.py src/gem/results/dataframes.py src/gem/api.py scripts/validate_opendota.py tests/test_teamfights.py tests/test_validate_opendota.py tests/test_serialization.py tests/test_dataframes.py tests/test_match_builder.py`
- `uv run mypy src/gem/`
- `uv run pytest`
- `uv run python scripts/validate_opendota.py --match 8858445091 --fetch-missing --fetch-dir tmp/opendota-validation --mode full --json --out tmp/opendota-validation/8858445091.validation.after-opendota-teamfights.json`