### PR TITLE
parser: surface partial-parse state instead of silently truncating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gem's output against the real OpenDota match API field by field. `examples/quickstart.py`
   gains a short teaser of these fields and a pointer to the full showcase.
 
+### Changed
+- `ReplayParser.parse()` now logs a swallowed stream-end exception at `WARNING`
+  instead of `DEBUG`, and records it on the parser as `ReplayParser.parse_error`
+  (the exception) and `ReplayParser.truncated_at_tick` (the last tick reached);
+  both stay `None` on a clean parse. The broad catch is intentional
+  (truncated/partial replays legitimately raise on the final corrupt block, and
+  parsing continues with whatever was read), but a genuine mid-stream
+  decoder/extractor bug is indistinguishable from an expected truncated tail — at
+  `DEBUG` it was invisible at the default log level, so silent partial output
+  could look complete. Consumers can now inspect these attributes to detect a
+  partial parse programmatically. No behavior change beyond log visibility and
+  the new attributes.
+
 ### Fixed
 - `PlayerExtractor._read_inventory` read only the legacy
   `m_pEntity.m_nameStringableIndex`; modern replays expose item names via

--- a/src/gem/parser.py
+++ b/src/gem/parser.py
@@ -212,6 +212,15 @@ class ReplayParser:
         # OpenDota-style match duration in seconds: the horn-anchored combat-log
         # time at GAME_STATE==6 (ancient destroyed). None until that state is seen.
         self.duration_s: int | None = None
+        # Set when the stream loop terminates on an exception rather than running
+        # to completion. ``parse_error`` is the exception, ``truncated_at_tick``
+        # the last tick reached. Both stay None on a clean parse. This is the
+        # programmatic counterpart to the WARNING logged in ``parse()``: an
+        # expected truncated-tail and a genuine mid-stream bug are
+        # indistinguishable here, so consumers can inspect these to tell whether a
+        # ``ParsedMatch`` is complete instead of trusting silent partial output.
+        self.parse_error: Exception | None = None
+        self.truncated_at_tick: int | None = None
         self._game_start_callbacks: list[Callable[[int], None]] = []
         self._game_end_callbacks: list[Callable[[int], None]] = []
         self._game_ended: bool = False
@@ -401,8 +410,14 @@ class ReplayParser:
         except Exception as exc:
             # Truncated files raise on the final corrupt snappy block — that is
             # expected for partial replays, so parsing continues with whatever was
-            # read. Log at debug level so genuine corruption stays diagnosable.
-            logger.debug("Replay stream ended early at tick %d: %r", self.tick, exc)
+            # read. Log at warning level: a genuine mid-stream decoder/extractor
+            # bug is indistinguishable here from an expected truncated tail, so
+            # surface it rather than letting silent partial output look complete.
+            # Record it on the parser too, so consumers can detect a partial
+            # parse programmatically instead of scraping logs.
+            self.parse_error = exc
+            self.truncated_at_tick = self.tick
+            logger.warning("Replay stream ended early at tick %d: %r", self.tick, exc)
 
         # Read match metadata from CDOTAGamerulesProxy entity if DEM_FileInfo
         # didn't populate them (e.g. truncated replays or early stop).

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -20,6 +20,7 @@ Reference: manta/parser.go, manta/demo_packet.go
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import gem.parser as parser_module
@@ -208,6 +209,14 @@ class TestReplayParserInit:
         p = ReplayParser(b"")
         assert p.game_time_s is None
 
+    def test_parse_error_starts_none(self):
+        p = ReplayParser(b"")
+        assert p.parse_error is None
+
+    def test_truncated_at_tick_starts_none(self):
+        p = ReplayParser(b"")
+        assert p.truncated_at_tick is None
+
     def test_entity_manager_starts_none(self):
         p = ReplayParser(b"")
         assert p.entity_manager is None
@@ -229,6 +238,44 @@ class TestReplayParserInit:
     def test_game_ended_false(self):
         p = ReplayParser(b"")
         assert p._game_ended is False
+
+
+# ---------------------------------------------------------------------------
+# ReplayParser partial-parse / truncation reporting
+# ---------------------------------------------------------------------------
+
+
+class TestReplayParserPartialParse:
+    def test_missing_magic_is_recorded_not_raised(self, caplog):
+        # The magic-header check runs inside parse()'s swallowed try-block, so an
+        # unparseable file (here: empty input, which fails magic validation) is
+        # reported via the attributes rather than propagating a ValueError.
+        p = ReplayParser(b"")
+
+        with caplog.at_level(logging.WARNING, logger="gem.parser"):
+            p.parse()  # must not raise
+
+        assert isinstance(p.parse_error, ValueError)
+        assert p.truncated_at_tick == 0
+
+    def test_stream_exception_is_recorded_not_raised(self, caplog):
+        # Valid Source 2 magic + the 8-byte metadata skip, then a single outer
+        # message whose payload decodes to a bogus CDemoPacket. The stream
+        # constructs (magic passes) and then raises mid-iteration, which parse()
+        # must swallow — recording the failure on the parser instead of
+        # propagating, and logging at WARNING so it is visible by default.
+        buf = b"PBDEMS2\x00" + (b"\x00" * 8) + b"\x07\x00\xff\xff\xff\xff\x0f\x41"
+        p = ReplayParser(buf)
+
+        with caplog.at_level(logging.WARNING, logger="gem.parser"):
+            p.parse()  # must not raise
+
+        assert p.parse_error is not None
+        assert p.truncated_at_tick == 0
+        assert any(
+            "stream ended early" in r.message and r.levelno == logging.WARNING
+            for r in caplog.records
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `ReplayParser.parse()` now logs a swallowed stream-end exception at `WARNING` instead of `DEBUG`, and records it on the parser as `parse_error` (the exception) and `truncated_at_tick` (the last tick reached). Both stay `None` on a clean parse.
- Adds regression tests: init-state `None` defaults plus behavioral coverage that a bad-magic and a mid-stream decode error are recorded (not raised) and logged at `WARNING`.
- No behavior change beyond log visibility and the new attributes.

## Rationale

- The broad `except` is intentional — truncated/partial replays legitimately raise on the final corrupt snappy block, so parsing continues with whatever was read (graceful degradation is a real requirement, and the bulk path already surfaces errors via `ParseResult.error`).
- But a genuine mid-stream decoder/extractor bug is **indistinguishable** from an expected truncated tail. At `DEBUG` the swallowed exception was below the default log level, so silent partial output could look complete — the worst failure mode for a DS/ML parser.
- This is the smallest change that closes that gap: surface the failure (WARNING) and make a partial parse detectable programmatically, without the heavier `TruncatedStreamError` / `strict=` machinery (intentionally deferred as YAGNI).
- Addresses finding #1 from the code-quality review tracked in #106.

## Testing

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src`
- [x] `uv run pytest tests/ -m "not integration"` (1655 passed, 3 skipped; `tests/test_parser.py` 73 → 77)
- [ ] Docs build, if docs changed (no docs changed)

## Notes

- [x] Generated protobuf files under `src/gem/proto/` were not edited manually.
- [x] Large replay artifacts are not committed unless explicitly required for tests.
- [x] Secrets and local credentials are not included.

Refs #106.
