### PR TITLE
extractors: share PlayerResource scan + team-data paths (#106 finding #4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   could look complete. Consumers can now inspect these attributes to detect a
   partial parse programmatically. No behavior change beyond log visibility and
   the new attributes.
+- **Internal:** the duplicated `CDOTA_PlayerResource` scan and team-data field
+  paths shared by `PlayerExtractor` and `IntervalExtractor` are consolidated into
+  `gem.extractors._snapshots` (`scan_player_resource`, `team_data_prefix`,
+  `team_data_field`, and the `TEAM_RADIANT`/`TEAM_DIRE`/`PLAYER_RESOURCE_SCAN_LIMIT`
+  constants). No output change — the OpenDota parity validator and full suite are
+  unchanged — but the two extractors no longer keep divergent copies of the scan
+  loop and field strings. The intentionally-different `m_vecDataTeam` *reading*
+  logic (the interval extractor's two-frame history) is left separate.
 
 ### Fixed
 - `PlayerExtractor._read_inventory` read only the legacy

--- a/src/gem/extractors/_snapshots.py
+++ b/src/gem/extractors/_snapshots.py
@@ -22,6 +22,14 @@ if TYPE_CHECKING:
 _CELL_SIZE = 128  # Source 2 world units per grid cell
 _HERO_CLASS_PREFIX = "CDOTA_Unit_Hero_"
 
+# Dota team ids on ``CDOTA_PlayerResource.m_vecPlayerData.*.m_iPlayerTeam``.
+# Spectators/coaches use other ids (1/14) and are skipped by the scan.
+TEAM_RADIANT = 2
+TEAM_DIRE = 3
+# CDOTA_PlayerResource rows to scan when building the logical→resource remap.
+# A coach occupies a row, so the 10 players can span more than 10 indices.
+PLAYER_RESOURCE_SCAN_LIMIT = 30
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -86,6 +94,103 @@ def _player_id_from_entity(entity: Entity | None, *, allow_owner: bool = False) 
         if val is not None and val >= 0:
             return val // 2
     return None
+
+
+@dataclass(frozen=True)
+class PlayerResourceScan:
+    """Logical-slot mappings derived from one ``CDOTA_PlayerResource`` scan.
+
+    OpenDota scans PlayerResource for rows whose team is Radiant or Dire (a coach
+    has team 1/14 and is skipped), then uses the scan order as the logical player
+    slot ``0..9``. The resource-array index is not always the logical slot, so the
+    indirection is kept explicit. ``resolved`` is ``True`` only when all 10 players
+    were found, letting callers decide whether to adopt a partial early-game scan.
+
+    Attributes:
+        index_by_id: Logical slot ``0..9`` → ``m_vecPlayerData`` array index.
+        team_by_id: Logical slot → team id (``TEAM_RADIANT``/``TEAM_DIRE``).
+        team_slot_by_id: Logical slot → ``m_iTeamSlot`` (the ``m_vecDataTeam`` index).
+        resolved: ``True`` iff all 10 player slots were resolved.
+    """
+
+    index_by_id: dict[int, int]
+    team_by_id: dict[int, int]
+    team_slot_by_id: dict[int, int]
+    resolved: bool
+
+
+def scan_player_resource(player_resource: Entity) -> PlayerResourceScan:
+    """Scan ``CDOTA_PlayerResource`` for the logical player→resource mappings.
+
+    Walks the first ``PLAYER_RESOURCE_SCAN_LIMIT`` rows, skipping any whose team is
+    not Radiant/Dire or whose team slot is missing/negative (coaches, empty rows),
+    and assigns the surviving rows logical slots ``0..9`` in scan order.
+
+    Reference: refs/parser/src/main/java/opendota/Parse.java (validIndices).
+
+    Args:
+        player_resource: The live ``CDOTA_PlayerResource`` entity.
+
+    Returns:
+        A :class:`PlayerResourceScan` with the three slot maps and a ``resolved``
+        flag (``True`` once all 10 players are mapped).
+    """
+    index_by_id: dict[int, int] = {}
+    team_by_id: dict[int, int] = {}
+    team_slot_by_id: dict[int, int] = {}
+
+    for resource_idx in range(PLAYER_RESOURCE_SCAN_LIMIT):
+        team = player_resource.get_int32(f"m_vecPlayerData.{resource_idx:04d}.m_iPlayerTeam")
+        team_slot = player_resource.get_int32(f"m_vecPlayerTeamData.{resource_idx:04d}.m_iTeamSlot")
+        if team not in (TEAM_RADIANT, TEAM_DIRE) or team_slot is None or team_slot < 0:
+            continue
+        player_id = len(index_by_id)
+        if player_id >= 10:
+            break
+        index_by_id[player_id] = resource_idx
+        team_by_id[player_id] = team
+        team_slot_by_id[player_id] = team_slot
+
+    return PlayerResourceScan(
+        index_by_id=index_by_id,
+        team_by_id=team_by_id,
+        team_slot_by_id=team_slot_by_id,
+        resolved=len(index_by_id) == 10,
+    )
+
+
+def team_data_prefix(team_slot: int) -> str:
+    """Build the ``m_vecDataTeam`` entry prefix for a team slot.
+
+    The ``CDOTA_DataRadiant``/``CDOTA_DataDire`` entities expose per-player data
+    under ``m_vecDataTeam.{slot:04d}.*``. Callers that read several fields off the
+    same slot keep this prefix and append field names; callers reading a single
+    field can use :func:`team_data_field` instead.
+
+    Args:
+        team_slot: The ``m_iTeamSlot`` index into ``m_vecDataTeam``.
+
+    Returns:
+        The entry prefix, e.g. ``"m_vecDataTeam.0003"``.
+    """
+    return f"m_vecDataTeam.{team_slot:04d}"
+
+
+def team_data_field(team_slot: int, field_name: str) -> str:
+    """Build a ``m_vecDataTeam`` field path for a team slot.
+
+    The ``CDOTA_DataRadiant``/``CDOTA_DataDire`` entities expose per-player
+    counters (``m_iTotalEarnedGold``, ``m_iTotalEarnedXP``, ``m_iLastHitCount``,
+    ``m_iDenyCount``, ``m_iNetWorth``) under ``m_vecDataTeam.{slot}``.
+
+    Args:
+        team_slot: The ``m_iTeamSlot`` index into ``m_vecDataTeam``.
+        field_name: The counter field, e.g. ``"m_iTotalEarnedGold"``.
+
+    Returns:
+        The dotted field path, e.g. ``"m_vecDataTeam.0003.m_iTotalEarnedGold"``.
+    """
+    return f"{team_data_prefix(team_slot)}.{field_name}"
 
 
 def _snapshot_hero(entity: Entity, tick: int) -> PlayerStateSnapshot | None:

--- a/src/gem/extractors/intervals.py
+++ b/src/gem/extractors/intervals.py
@@ -24,15 +24,19 @@ import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from gem.extractors._snapshots import _HERO_CLASS_PREFIX, _player_id_from_entity
+from gem.extractors._snapshots import (
+    _HERO_CLASS_PREFIX,
+    TEAM_DIRE,
+    TEAM_RADIANT,
+    _player_id_from_entity,
+    scan_player_resource,
+    team_data_prefix,
+)
 from gem.state.entities import Entity, EntityOp
 
 if TYPE_CHECKING:
     from gem.parser import ReplayParser
 
-_TEAM_RADIANT = 2
-_TEAM_DIRE = 3
-_PLAYER_RESOURCE_SCAN_LIMIT = 30
 _TICKS_PER_SECOND = 30
 _FINAL_INTERVAL_GRACE_TICKS = 15 * _TICKS_PER_SECOND
 
@@ -248,7 +252,7 @@ class IntervalExtractor:
             else:
                 self._data_radiant = entity
                 self._record_team_data(entity, self._cur_data_radiant, self._prev_data_radiant)
-                self._record_team_counters(entity, _TEAM_RADIANT)
+                self._record_team_counters(entity, TEAM_RADIANT)
                 self._maybe_emit()
             return
 
@@ -258,7 +262,7 @@ class IntervalExtractor:
             else:
                 self._data_dire = entity
                 self._record_team_data(entity, self._cur_data_dire, self._prev_data_dire)
-                self._record_team_counters(entity, _TEAM_DIRE)
+                self._record_team_counters(entity, TEAM_DIRE)
                 self._maybe_emit()
             return
 
@@ -283,25 +287,13 @@ class IntervalExtractor:
         if pr is None:
             return
 
-        player_index_by_id: dict[int, int] = {}
-        player_team: dict[int, int] = {}
-        player_team_slot: dict[int, int] = {}
-
-        for resource_idx in range(_PLAYER_RESOURCE_SCAN_LIMIT):
-            team = pr.get_int32(f"m_vecPlayerData.{resource_idx:04d}.m_iPlayerTeam")
-            team_slot = pr.get_int32(f"m_vecPlayerTeamData.{resource_idx:04d}.m_iTeamSlot")
-            if team not in (_TEAM_RADIANT, _TEAM_DIRE) or team_slot is None or team_slot < 0:
-                continue
-            player_id = len(player_index_by_id)
-            if player_id >= 10:
-                break
-            player_index_by_id[player_id] = resource_idx
-            player_team[player_id] = team
-            player_team_slot[player_id] = team_slot
-
-        self._player_index_by_id = player_index_by_id
-        self._player_team = player_team
-        self._player_team_slot = player_team_slot
+        # Unlike PlayerExtractor, the interval extractor adopts the scan
+        # unconditionally (including partial early-game scans) — its consumers
+        # already guard on a fully-populated mapping before emitting.
+        scan = scan_player_resource(pr)
+        self._player_index_by_id = scan.index_by_id
+        self._player_team = scan.team_by_id
+        self._player_team_slot = scan.team_slot_by_id
 
     def _maybe_emit(self) -> None:
         if self._parser is None or self._ended:
@@ -309,9 +301,9 @@ class IntervalExtractor:
         if self._player_resource is None or not self._player_index_by_id:
             return
         teams = set(self._player_team.values())
-        if _TEAM_RADIANT in teams and self._data_radiant is None:
+        if TEAM_RADIANT in teams and self._data_radiant is None:
             return
-        if _TEAM_DIRE in teams and self._data_dire is None:
+        if TEAM_DIRE in teams and self._data_dire is None:
             return
 
         game_time_s = self._clock()
@@ -405,7 +397,7 @@ class IntervalExtractor:
             team_slot = self._player_team_slot.get(player_id)
             if team_slot is None:
                 continue
-            player_slot = team_slot if team == _TEAM_RADIANT else 128 + team_slot
+            player_slot = team_slot if team == TEAM_RADIANT else 128 + team_slot
             self.snapshots.append(
                 IntervalSnapshot(
                     tick=tick,
@@ -436,11 +428,11 @@ class IntervalExtractor:
             team_slot = self._player_team_slot.get(player_id)
             if team_slot is None:
                 return False
-            data_entity = self._data_radiant if team == _TEAM_RADIANT else self._data_dire
+            data_entity = self._data_radiant if team == TEAM_RADIANT else self._data_dire
             if data_entity is None:
                 return False
 
-            prefix = f"m_vecDataTeam.{team_slot:04d}"
+            prefix = team_data_prefix(team_slot)
             for field_name in (
                 "m_iTotalEarnedGold",
                 "m_iTotalEarnedXP",
@@ -476,7 +468,7 @@ class IntervalExtractor:
             existing = cur.get(team_slot)
             if existing is not None and existing[0] != tick:
                 prev[team_slot] = existing
-            prefix = f"m_vecDataTeam.{team_slot:04d}"
+            prefix = team_data_prefix(team_slot)
             cur[team_slot] = (
                 tick,
                 (
@@ -498,10 +490,10 @@ class IntervalExtractor:
 
         Args:
             entity: The just-updated ``CDOTA_DataRadiant``/``CDOTA_DataDire``.
-            team: ``_TEAM_RADIANT`` or ``_TEAM_DIRE``.
+            team: ``TEAM_RADIANT`` or ``TEAM_DIRE``.
         """
         for team_slot in range(5):
-            prefix = f"m_vecDataTeam.{team_slot:04d}"
+            prefix = team_data_prefix(team_slot)
             counters = self._team_counters.setdefault((team, team_slot), {})
             for attr, field_name in _TEAM_COUNTER_FIELDS.items():
                 value = entity.get_int32(f"{prefix}.{field_name}")
@@ -576,7 +568,7 @@ class IntervalExtractor:
         the values agree anyway.
 
         Args:
-            team: ``_TEAM_RADIANT`` or ``_TEAM_DIRE``.
+            team: ``TEAM_RADIANT`` or ``TEAM_DIRE``.
             team_slot: The player's team slot, 0-4.
             data_entity: The live data entity for the team (fallback source).
             emit_tick: The tick of the boundary emit.
@@ -584,15 +576,15 @@ class IntervalExtractor:
         Returns:
             ``(gold, xp, lh, dn, net_worth)`` for the boundary frame.
         """
-        cur = self._cur_data_radiant if team == _TEAM_RADIANT else self._cur_data_dire
-        prev = self._prev_data_radiant if team == _TEAM_RADIANT else self._prev_data_dire
+        cur = self._cur_data_radiant if team == TEAM_RADIANT else self._cur_data_dire
+        prev = self._prev_data_radiant if team == TEAM_RADIANT else self._prev_data_dire
         cur_frame = cur.get(team_slot)
         if cur_frame is not None and cur_frame[0] < emit_tick:
             return cur_frame[1]
         prev_frame = prev.get(team_slot)
         if prev_frame is not None and prev_frame[0] < emit_tick:
             return prev_frame[1]
-        prefix = f"m_vecDataTeam.{team_slot:04d}"
+        prefix = team_data_prefix(team_slot)
         return (
             _int_or_zero(data_entity.get_int32(f"{prefix}.m_iTotalEarnedGold")),
             _int_or_zero(data_entity.get_int32(f"{prefix}.m_iTotalEarnedXP")),
@@ -610,12 +602,12 @@ class IntervalExtractor:
             team_slot = self._player_team_slot.get(player_id)
             if team_slot is None:
                 continue
-            data_entity = self._data_radiant if team == _TEAM_RADIANT else self._data_dire
+            data_entity = self._data_radiant if team == TEAM_RADIANT else self._data_dire
             if data_entity is None:
                 continue
 
             gold, xp, lh, dn, net_worth = self._team_data_values(team, team_slot, data_entity, tick)
-            player_slot = team_slot if team == _TEAM_RADIANT else 128 + team_slot
+            player_slot = team_slot if team == TEAM_RADIANT else 128 + team_slot
             self.snapshots.append(
                 IntervalSnapshot(
                     tick=tick,

--- a/src/gem/extractors/players.py
+++ b/src/gem/extractors/players.py
@@ -14,11 +14,14 @@ from typing import TYPE_CHECKING
 from gem.combat.log import CombatLogEntry, CombatLogType
 from gem.extractors._snapshots import (
     _HERO_CLASS_PREFIX,
+    TEAM_RADIANT,
     PlayerStateSnapshot,
     PlayerTimeSeries,
     _player_id_from_entity,
     _pos,
     _snapshot_hero,
+    scan_player_resource,
+    team_data_field,
 )
 from gem.state.entities import Entity, EntityOp
 
@@ -34,16 +37,6 @@ if TYPE_CHECKING:
 _ITEM_SLOTS = 17  # total slots to scan (0-16)
 _ABILITY_SLOTS = 32  # m_hAbilities.0000-0031 per hero entity
 _NULL_HANDLE = 0xFFFFFF  # empty slot sentinel
-
-# ---------------------------------------------------------------------------
-# Constants
-# ---------------------------------------------------------------------------
-
-_TEAM_RADIANT = 2
-_TEAM_DIRE = 3
-# CDOTA_PlayerResource rows to scan when building the logical→resource remap.
-# A coach occupies a row, so the 10 players can span more than 10 indices.
-_PLAYER_RESOURCE_SCAN_LIMIT = 30
 
 __all__ = ["PlayerExtractor", "PlayerStateSnapshot", "PlayerTimeSeries"]
 
@@ -422,23 +415,15 @@ class PlayerExtractor:
         if pr is None:
             return
 
-        resource_index_by_id: dict[int, int] = {}
-        for resource_idx in range(_PLAYER_RESOURCE_SCAN_LIMIT):
-            team = pr.get_int32(f"m_vecPlayerData.{resource_idx:04d}.m_iPlayerTeam")
-            slot = pr.get_int32(f"m_vecPlayerTeamData.{resource_idx:04d}.m_iTeamSlot")
-            if team not in (_TEAM_RADIANT, _TEAM_DIRE) or slot is None or slot < 0:
-                continue
-            player_id = len(resource_index_by_id)
-            if player_id >= 10:
-                break
-            resource_index_by_id[player_id] = resource_idx
-            self._player_team_slot[player_id] = slot
+        scan = scan_player_resource(pr)
+        # Keep team slots current even on a partial scan (matches prior behaviour).
+        self._player_team_slot.update(scan.team_slot_by_id)
 
         # Only adopt the remap once it resolves all 10 players; partial scans
         # (early in the replay, before PlayerResource is fully populated) keep the
         # previous mapping rather than introducing a half-built shift.
-        if len(resource_index_by_id) == 10:
-            self._resource_index_by_id = resource_index_by_id
+        if scan.resolved:
+            self._resource_index_by_id = scan.index_by_id
 
     def _resource_index(self, player_id: int) -> int:
         """Map a logical player slot to its CDOTA_PlayerResource array index.
@@ -570,24 +555,23 @@ class PlayerExtractor:
             #
             # Reference: refs/parser/Parse.java — getEntityProperty(dataTeam,
             #   "m_vecDataTeam.%i.m_iTotalEarnedGold/XP", teamSlot)
-            data_entity = self._data_radiant if snap.team == _TEAM_RADIANT else self._data_dire
+            data_entity = self._data_radiant if snap.team == TEAM_RADIANT else self._data_dire
             if data_entity is not None:
                 # Prefer authoritative team slot; fall back to pid % 5
                 team_slot = self._player_team_slot.get(snap.player_id, snap.player_id % 5)
-                prefix = f"m_vecDataTeam.{team_slot:04d}"
-                nw = data_entity.get_int32(f"{prefix}.m_iNetWorth")
+                nw = data_entity.get_int32(team_data_field(team_slot, "m_iNetWorth"))
                 if nw is not None and nw > 0:
                     snap.net_worth = nw
-                teg = data_entity.get_int32(f"{prefix}.m_iTotalEarnedGold")
+                teg = data_entity.get_int32(team_data_field(team_slot, "m_iTotalEarnedGold"))
                 if teg is not None and teg > 0:
                     snap.total_earned_gold = teg
-                tex = data_entity.get_int32(f"{prefix}.m_iTotalEarnedXP")
+                tex = data_entity.get_int32(team_data_field(team_slot, "m_iTotalEarnedXP"))
                 if tex is not None and tex > 0:
                     snap.total_earned_xp = tex
-                lh = data_entity.get_int32(f"{prefix}.m_iLastHitCount")
+                lh = data_entity.get_int32(team_data_field(team_slot, "m_iLastHitCount"))
                 if lh is not None and lh > 0:
                     snap.lh = lh
-                dn = data_entity.get_int32(f"{prefix}.m_iDenyCount")
+                dn = data_entity.get_int32(team_data_field(team_slot, "m_iDenyCount"))
                 if dn is not None and dn > 0:
                     snap.dn = dn
             # Overlay authoritative hero level from CDOTA_PlayerResource

--- a/tests/test_players_extractor.py
+++ b/tests/test_players_extractor.py
@@ -8,7 +8,14 @@ All tests use fake entities and a fake parser — no real .dem files.
 
 from __future__ import annotations
 
-from gem.extractors._snapshots import _player_id_from_entity
+from gem.extractors._snapshots import (
+    TEAM_DIRE,
+    TEAM_RADIANT,
+    _player_id_from_entity,
+    scan_player_resource,
+    team_data_field,
+    team_data_prefix,
+)
 from gem.extractors.players import (
     PlayerExtractor,
     PlayerStateSnapshot,
@@ -102,6 +109,77 @@ class TestPlayerIdFromEntity:
         # m_nPlayerID == -1 (unset sentinel) should fall through to m_iPlayerID.
         e = _ent(m_nPlayerID=-1, m_iPlayerID=10)
         assert _player_id_from_entity(e) == 5
+
+
+def _player_resource(rows: list[tuple[int, int | None]]) -> Entity:
+    """Build a CDOTA_PlayerResource entity from (team, team_slot) rows.
+
+    Each tuple occupies a sequential resource-array index; a team_slot of None
+    omits the m_iTeamSlot field for that row (simulating an unpopulated entry).
+    """
+    state: dict[str, int] = {}
+    for idx, (team, slot) in enumerate(rows):
+        state[f"m_vecPlayerData.{idx:04d}.m_iPlayerTeam"] = team
+        if slot is not None:
+            state[f"m_vecPlayerTeamData.{idx:04d}.m_iTeamSlot"] = slot
+    return _ent("CDOTA_PlayerResource", **state)
+
+
+class TestScanPlayerResource:
+    """The shared CDOTA_PlayerResource scan (formerly duplicated in
+    PlayerExtractor._refresh_team_slots and IntervalExtractor._refresh_player_mappings).
+    """
+
+    def test_no_coach_is_identity_map(self):
+        rows = [(TEAM_RADIANT, i) for i in range(5)] + [(TEAM_DIRE, i) for i in range(5)]
+        scan = scan_player_resource(_player_resource(rows))
+        assert scan.resolved is True
+        assert scan.index_by_id == {i: i for i in range(10)}
+        assert scan.team_by_id[0] == TEAM_RADIANT
+        assert scan.team_by_id[9] == TEAM_DIRE
+
+    def test_coach_row_is_skipped_and_shifts_indices(self):
+        # A coach (team 1) at resource index 0 shifts the 10 players to indices 1..10.
+        rows = [(1, 0)] + [(TEAM_RADIANT, i) for i in range(5)] + [(TEAM_DIRE, i) for i in range(5)]
+        scan = scan_player_resource(_player_resource(rows))
+        assert scan.resolved is True
+        # Logical slot 0 maps to resource index 1 (past the coach).
+        assert scan.index_by_id[0] == 1
+        assert scan.team_by_id[0] == TEAM_RADIANT
+        assert scan.team_slot_by_id[0] == 0
+
+    def test_partial_scan_is_unresolved(self):
+        scan = scan_player_resource(_player_resource([(TEAM_RADIANT, i) for i in range(4)]))
+        assert scan.resolved is False
+        assert len(scan.index_by_id) == 4
+
+    def test_missing_team_slot_row_is_skipped(self):
+        # A row with no m_iTeamSlot is not a valid player and must be skipped.
+        rows = [(TEAM_RADIANT, None)] + [(TEAM_RADIANT, i) for i in range(5)]
+        scan = scan_player_resource(_player_resource(rows))
+        # 5 valid players (the None-slot row dropped), so it never resolves to 10.
+        assert len(scan.index_by_id) == 5
+        assert scan.index_by_id[0] == 1
+
+    def test_caps_at_ten_players(self):
+        # More than 10 valid rows: only the first 10 are mapped.
+        rows = [(TEAM_RADIANT, i) for i in range(12)]
+        scan = scan_player_resource(_player_resource(rows))
+        assert len(scan.index_by_id) == 10
+        assert scan.resolved is True
+
+
+class TestTeamDataPathHelpers:
+    """The m_vecDataTeam path builders that single-source the field strings."""
+
+    def test_team_data_prefix_pads_slot(self):
+        assert team_data_prefix(3) == "m_vecDataTeam.0003"
+
+    def test_team_data_field_appends_field(self):
+        assert team_data_field(3, "m_iTotalEarnedGold") == "m_vecDataTeam.0003.m_iTotalEarnedGold"
+
+    def test_field_builds_on_prefix(self):
+        assert team_data_field(7, "m_iNetWorth") == f"{team_data_prefix(7)}.m_iNetWorth"
 
 
 class FakeCombatLog:


### PR DESCRIPTION
## Summary

- Consolidates the duplicated `CDOTA_PlayerResource` scan and `m_vecDataTeam` field-path strings shared by `PlayerExtractor` and `IntervalExtractor` into the already-shared `gem.extractors._snapshots`.
- New shared API: `scan_player_resource(pr) -> PlayerResourceScan`, `team_data_prefix`, `team_data_field`, and the `TEAM_RADIANT`/`TEAM_DIRE`/`PLAYER_RESOURCE_SCAN_LIMIT` constants.
- Adds unit coverage for the scan (coach-row skipping, partial scan, 10-player cap) that neither extractor had before.
- Addresses finding **#4** from the code-quality review tracked in #106.

## Rationale

- Both extractors kept a **byte-identical** PlayerResource scan loop and their own copies of the team-data field strings/constants. A field-name or guard fix in one and not the other would silently desync them on the same gold/xp/lh/dn data — a live drift risk since both files are under active OpenDota-parity churn.
- The fix extracts the **drift-prone strings and scan loop** (the thing that breaks parity if it diverges), not the reading logic.
- **Deliberately NOT merged:** the `m_vecDataTeam` *reading* logic. `PlayerExtractor` overlays raw values with `>0` guards; `IntervalExtractor` wraps every read in `_int_or_zero` and builds two-frame history tuples for the OpenDota pre-crossing nudge. Those are intentionally different and stay separate (the review flagged this explicitly).
- Each caller keeps its own adopt policy via the scan's `resolved` flag: `PlayerExtractor` adopts the remap only on a full 10-player scan; `IntervalExtractor` adopts partial scans (its consumers guard before emitting). Both prior behaviours are preserved exactly.

## Testing

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src`
- [x] `uv run pytest tests/ -m "not integration"` (1663 passed, 3 skipped; +8 new tests)
- [x] `uv run python scripts/validate_opendota.py` — **216 passed, 0 field failures, 0 errors**; advantage curves exact (final values to the unit, max curve err 0.16%/0.18%). This is the behaviour-preserving proof.
- [ ] Docs build, if docs changed (no docs changed)

## Notes

- [x] Generated protobuf files under `src/gem/proto/` were not edited manually.
- [x] Large replay artifacts are not committed unless explicitly required for tests.
- [x] Secrets and local credentials are not included.

Refs #106 (finding #4).
