### PR TITLE
release: 0.4.1 (purchase parity + partial-parse state + reconcile develop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   logic (the interval extractor's two-frame history) is left separate.
 
 ### Fixed
+- OpenDota purchase parity (issue #95): per-player `purchase`, `purchase_time`,
+  and `first_purchase_time` now match the OpenDota match API exactly (verified
+  10/10 players on fixture 8855188139). Four corrections: (1) `purchase_time` now
+  **sums** every buy time for an item — OpenDota's behaviour — instead of keeping
+  only the last buy; (2) starting-inventory synthesis scans only slots 0-7 (main
+  inventory + backpack 6-7, mirroring OpenDota's `getHeroInventory`) instead of
+  0-16, so stash items are no longer miscounted as starting purchases; (3) removed
+  the gem-original starting-window purchase dedup that under-counted multi-copy
+  starting consumables (e.g. 2× `faerie_fire` counted as 1); (4) `purchase_log`
+  now excludes recipes (matching OpenDota — recipes remain in the `purchase`
+  count map). The earlier "needs a synthetic-inventory subsystem rewrite" note on
+  this issue was based on a misreading of the OpenDota reference (it emits
+  assembled items, not component+recipe — same as gem). Backed by a new
+  fixture-backed integration test (`tests/test_purchase_parity_integration.py`).
 - `PlayerExtractor._read_inventory` read only the legacy
   `m_pEntity.m_nameStringableIndex`; modern replays expose item names via
   `m_pEntity.m_nameStringTableIndex`, so inventory reads silently returned empty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-24
+
+Follow-up to the 0.4.0 OpenDota-parity release: brings the purchase aggregates
+to exact parity, surfaces partial-parse state, and an internal extractor
+consolidation. The supported top-level API is unchanged; the one behaviour
+change is corrected purchase output (now exact vs OpenDota).
+
+### Changed
+- `ReplayParser.parse()` now logs a swallowed stream-end exception at `WARNING`
+  instead of `DEBUG`, and records it on the parser as `ReplayParser.parse_error`
+  (the exception) and `ReplayParser.truncated_at_tick` (the last tick reached);
+  both stay `None` on a clean parse. The broad catch is intentional
+  (truncated/partial replays legitimately raise on the final corrupt block, and
+  parsing continues with whatever was read), but a genuine mid-stream
+  decoder/extractor bug is indistinguishable from an expected truncated tail — at
+  `DEBUG` it was invisible at the default log level, so silent partial output
+  could look complete. Consumers can now inspect these attributes to detect a
+  partial parse programmatically. No behavior change beyond log visibility and
+  the new attributes.
+- **Internal:** the duplicated `CDOTA_PlayerResource` scan and team-data field
+  paths shared by `PlayerExtractor` and `IntervalExtractor` are consolidated into
+  `gem.extractors._snapshots` (`scan_player_resource`, `team_data_prefix`,
+  `team_data_field`, and the `TEAM_RADIANT`/`TEAM_DIRE`/`PLAYER_RESOURCE_SCAN_LIMIT`
+  constants). No output change — the OpenDota parity validator and full suite are
+  unchanged — but the two extractors no longer keep divergent copies of the scan
+  loop and field strings. The intentionally-different `m_vecDataTeam` *reading*
+  logic (the interval extractor's two-frame history) is left separate.
+
+### Fixed
+- OpenDota purchase parity (issue #95): per-player `purchase`, `purchase_time`,
+  and `first_purchase_time` now match the OpenDota match API exactly (verified
+  10/10 players on fixture 8855188139). Four corrections: (1) `purchase_time` now
+  **sums** every buy time for an item — OpenDota's behaviour — instead of keeping
+  only the last buy; (2) starting-inventory synthesis scans only slots 0-7 (main
+  inventory + backpack 6-7, mirroring OpenDota's `getHeroInventory`) instead of
+  0-16, so stash items are no longer miscounted as starting purchases; (3) removed
+  the gem-original starting-window purchase dedup that under-counted multi-copy
+  starting consumables (e.g. 2× `faerie_fire` counted as 1); (4) `purchase_log`
+  now excludes recipes (matching OpenDota — recipes remain in the `purchase`
+  count map). The earlier "needs a synthetic-inventory subsystem rewrite" note on
+  this issue was based on a misreading of the OpenDota reference (it emits
+  assembled items, not component+recipe — same as gem). Backed by a new
+  fixture-backed integration test (`tests/test_purchase_parity_integration.py`).
+
+### Note
+- OpenDota's per-player `purchase` / `purchase_time` / `first_purchase_time`
+  maps now match the OpenDota match API exactly (see Fixed; verified 10/10
+  players on a validation fixture). The only residual is that pre-horn (negative)
+  buy timestamps for starting items can differ from OpenDota by ±1s — boundary
+  quantization on negative times only; counts and positive-time buys are exact.
+
 ## [0.4.0] - 2026-06-23
 
 OpenDota match-API parity release. `gem.parse()` now reproduces most of
@@ -81,42 +132,7 @@ is additive.
   gem's output against the real OpenDota match API field by field. `examples/quickstart.py`
   gains a short teaser of these fields and a pointer to the full showcase.
 
-### Changed
-- `ReplayParser.parse()` now logs a swallowed stream-end exception at `WARNING`
-  instead of `DEBUG`, and records it on the parser as `ReplayParser.parse_error`
-  (the exception) and `ReplayParser.truncated_at_tick` (the last tick reached);
-  both stay `None` on a clean parse. The broad catch is intentional
-  (truncated/partial replays legitimately raise on the final corrupt block, and
-  parsing continues with whatever was read), but a genuine mid-stream
-  decoder/extractor bug is indistinguishable from an expected truncated tail — at
-  `DEBUG` it was invisible at the default log level, so silent partial output
-  could look complete. Consumers can now inspect these attributes to detect a
-  partial parse programmatically. No behavior change beyond log visibility and
-  the new attributes.
-- **Internal:** the duplicated `CDOTA_PlayerResource` scan and team-data field
-  paths shared by `PlayerExtractor` and `IntervalExtractor` are consolidated into
-  `gem.extractors._snapshots` (`scan_player_resource`, `team_data_prefix`,
-  `team_data_field`, and the `TEAM_RADIANT`/`TEAM_DIRE`/`PLAYER_RESOURCE_SCAN_LIMIT`
-  constants). No output change — the OpenDota parity validator and full suite are
-  unchanged — but the two extractors no longer keep divergent copies of the scan
-  loop and field strings. The intentionally-different `m_vecDataTeam` *reading*
-  logic (the interval extractor's two-frame history) is left separate.
-
 ### Fixed
-- OpenDota purchase parity (issue #95): per-player `purchase`, `purchase_time`,
-  and `first_purchase_time` now match the OpenDota match API exactly (verified
-  10/10 players on fixture 8855188139). Four corrections: (1) `purchase_time` now
-  **sums** every buy time for an item — OpenDota's behaviour — instead of keeping
-  only the last buy; (2) starting-inventory synthesis scans only slots 0-7 (main
-  inventory + backpack 6-7, mirroring OpenDota's `getHeroInventory`) instead of
-  0-16, so stash items are no longer miscounted as starting purchases; (3) removed
-  the gem-original starting-window purchase dedup that under-counted multi-copy
-  starting consumables (e.g. 2× `faerie_fire` counted as 1); (4) `purchase_log`
-  now excludes recipes (matching OpenDota — recipes remain in the `purchase`
-  count map). The earlier "needs a synthetic-inventory subsystem rewrite" note on
-  this issue was based on a misreading of the OpenDota reference (it emits
-  assembled items, not component+recipe — same as gem). Backed by a new
-  fixture-backed integration test (`tests/test_purchase_parity_integration.py`).
 - `PlayerExtractor._read_inventory` read only the legacy
   `m_pEntity.m_nameStringableIndex`; modern replays expose item names via
   `m_pEntity.m_nameStringTableIndex`, so inventory reads silently returned empty
@@ -141,11 +157,6 @@ is additive.
   (Beastmaster boars/hawk, Brewmaster split units) under-count: gem resolves a
   summon to its owner by a single live name→entity lookup, which can't attribute
   each kill from an army of same-named units. Tracked as a follow-up.
-- OpenDota's per-player `purchase` / `purchase_time` / `first_purchase_time`
-  maps now match the OpenDota match API exactly (see Fixed; verified 10/10
-  players on a validation fixture). The only residual is that pre-horn (negative)
-  buy timestamps for starting items can differ from OpenDota by ±1s — boundary
-  quantization on negative times only; counts and positive-time buys are exact.
 - `ParsedMatch.pre_game_duration` is declared but currently always `0`: deriving
   it needs the `GAME_IN_PROGRESS` state-transition timestamp the parser does not
   yet expose (`m_flGameStartTime` is the clock anchor, not the pre-game span).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   could look complete. Consumers can now inspect these attributes to detect a
   partial parse programmatically. No behavior change beyond log visibility and
   the new attributes.
+- **Internal:** the duplicated `CDOTA_PlayerResource` scan and team-data field
+  paths shared by `PlayerExtractor` and `IntervalExtractor` are consolidated into
+  `gem.extractors._snapshots` (`scan_player_resource`, `team_data_prefix`,
+  `team_data_field`, and the `TEAM_RADIANT`/`TEAM_DIRE`/`PLAYER_RESOURCE_SCAN_LIMIT`
+  constants). No output change — the OpenDota parity validator and full suite are
+  unchanged — but the two extractors no longer keep divergent copies of the scan
+  loop and field strings. The intentionally-different `m_vecDataTeam` *reading*
+  logic (the interval extractor's two-frame history) is left separate.
 
 ### Fixed
 - `PlayerExtractor._read_inventory` read only the legacy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,11 +129,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   summon to its owner by a single live name→entity lookup, which can't attribute
   each kill from an army of same-named units. Tracked as a follow-up.
 - OpenDota's per-player `purchase` / `purchase_time` / `first_purchase_time`
-  maps are now reproduced (see Added), derived from `purchase_log` with
-  OpenDota's recipe handling. The underlying `purchase_log` still reconstructs
-  *starting* items as assembled-item events at a synthetic tick, so the earliest
-  buy times for starting items reflect that synthetic tick rather than each
-  component's true purchase time.
+  maps now match the OpenDota match API exactly (see Fixed; verified 10/10
+  players on a validation fixture). The only residual is that pre-horn (negative)
+  buy timestamps for starting items can differ from OpenDota by ±1s — boundary
+  quantization on negative times only; counts and positive-time buys are exact.
 - `ParsedMatch.pre_game_duration` is declared but currently always `0`: deriving
   it needs the `GAME_IN_PROGRESS` state-transition timestamp the parser does not
   yet expose (`m_flGameStartTime` is the clock anchor, not the pre-game span).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gem's output against the real OpenDota match API field by field. `examples/quickstart.py`
   gains a short teaser of these fields and a pointer to the full showcase.
 
+### Changed
+- `ReplayParser.parse()` now logs a swallowed stream-end exception at `WARNING`
+  instead of `DEBUG`, and records it on the parser as `ReplayParser.parse_error`
+  (the exception) and `ReplayParser.truncated_at_tick` (the last tick reached);
+  both stay `None` on a clean parse. The broad catch is intentional
+  (truncated/partial replays legitimately raise on the final corrupt block, and
+  parsing continues with whatever was read), but a genuine mid-stream
+  decoder/extractor bug is indistinguishable from an expected truncated tail — at
+  `DEBUG` it was invisible at the default log level, so silent partial output
+  could look complete. Consumers can now inspect these attributes to detect a
+  partial parse programmatically. No behavior change beyond log visibility and
+  the new attributes.
+
 ### Fixed
 - `PlayerExtractor._read_inventory` read only the legacy
   `m_pEntity.m_nameStringableIndex`; modern replays expose item names via

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gem-dota"
-version = "0.4.0"
+version = "0.4.1"
 description = "Dota 2 Source 2 replay parser for data science and ML workflows"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/gem/combat/__init__.py
+++ b/src/gem/combat/__init__.py
@@ -1,6 +1,6 @@
 """Combat log ingestion and aggregation primitives."""
 
-from gem.combat.aggregator import _CombatAggregator, _dedup_purchase_log, _ParsedPlayerAgg
+from gem.combat.aggregator import _CombatAggregator, _ParsedPlayerAgg
 from gem.combat.log import (
     COMBAT_LOG_TYPES,
     CombatLogEntry,
@@ -17,5 +17,4 @@ __all__ = [
     "CombatLogType",
     "_CombatAggregator",
     "_ParsedPlayerAgg",
-    "_dedup_purchase_log",
 ]

--- a/src/gem/combat/aggregator.py
+++ b/src/gem/combat/aggregator.py
@@ -136,48 +136,6 @@ class _ParsedPlayerAgg:
 
 
 # ---------------------------------------------------------------------------
-# Purchase log deduplication
-# ---------------------------------------------------------------------------
-
-
-def _dedup_purchase_log(
-    entries: list[CombatLogEntry],
-    first_snap_tick: int | None,
-    sample_interval: int,
-) -> list[CombatLogEntry]:
-    """Deduplicate purchase log entries within the starting inventory window.
-
-    The inventory snapshot and the combat log stream may both emit PURCHASE
-    entries for the same item within the first sample window.  Outside that
-    window, duplicate item purchases are legitimate (e.g. buying two separate
-    Branches) and are kept as-is.
-
-    Args:
-        entries: Raw purchase log entries (unsorted).
-        first_snap_tick: Tick of the player's first inventory snapshot, or
-            ``None`` if no snapshot was taken.
-        sample_interval: Width of the starting-item window in ticks.
-
-    Returns:
-        Deduplicated list sorted by tick.
-    """
-    if first_snap_tick is None:
-        return sorted(entries, key=lambda e: e.tick)
-
-    cutoff = first_snap_tick + sample_interval
-    seen: set[tuple] = set()
-    result = []
-    for entry in sorted(entries, key=lambda e: e.tick):
-        if entry.tick <= cutoff:
-            key = (entry.tick, entry.value_name)
-            if key in seen:
-                continue
-            seen.add(key)
-        result.append(entry)
-    return result
-
-
-# ---------------------------------------------------------------------------
 # Aggregator
 # ---------------------------------------------------------------------------
 

--- a/src/gem/combat/log.py
+++ b/src/gem/combat/log.py
@@ -342,8 +342,8 @@ class CombatLogProcessor:
 
         # PURCHASE events carry the item name as a CombatLogNames index in `value`
         # (same as the S2 path). Resolve it so S1 purchase logs keep item names;
-        # _dedup_purchase_log keys on (tick, value_name), so a blank name collapses
-        # distinct same-tick starting-inventory buys. Reference: Clarity
+        # value_name is the purchase-count key, so a blank name would mis-key the
+        # per-item purchase aggregates. Reference: Clarity
         # S1CombatLogEntry.getValueName() = readCombatLogName(valueIdx).
         value_name = ""
         if log_type == "PURCHASE":

--- a/src/gem/extractors/_snapshots.py
+++ b/src/gem/extractors/_snapshots.py
@@ -22,6 +22,14 @@ if TYPE_CHECKING:
 _CELL_SIZE = 128  # Source 2 world units per grid cell
 _HERO_CLASS_PREFIX = "CDOTA_Unit_Hero_"
 
+# Dota team ids on ``CDOTA_PlayerResource.m_vecPlayerData.*.m_iPlayerTeam``.
+# Spectators/coaches use other ids (1/14) and are skipped by the scan.
+TEAM_RADIANT = 2
+TEAM_DIRE = 3
+# CDOTA_PlayerResource rows to scan when building the logical→resource remap.
+# A coach occupies a row, so the 10 players can span more than 10 indices.
+PLAYER_RESOURCE_SCAN_LIMIT = 30
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -86,6 +94,103 @@ def _player_id_from_entity(entity: Entity | None, *, allow_owner: bool = False) 
         if val is not None and val >= 0:
             return val // 2
     return None
+
+
+@dataclass(frozen=True)
+class PlayerResourceScan:
+    """Logical-slot mappings derived from one ``CDOTA_PlayerResource`` scan.
+
+    OpenDota scans PlayerResource for rows whose team is Radiant or Dire (a coach
+    has team 1/14 and is skipped), then uses the scan order as the logical player
+    slot ``0..9``. The resource-array index is not always the logical slot, so the
+    indirection is kept explicit. ``resolved`` is ``True`` only when all 10 players
+    were found, letting callers decide whether to adopt a partial early-game scan.
+
+    Attributes:
+        index_by_id: Logical slot ``0..9`` → ``m_vecPlayerData`` array index.
+        team_by_id: Logical slot → team id (``TEAM_RADIANT``/``TEAM_DIRE``).
+        team_slot_by_id: Logical slot → ``m_iTeamSlot`` (the ``m_vecDataTeam`` index).
+        resolved: ``True`` iff all 10 player slots were resolved.
+    """
+
+    index_by_id: dict[int, int]
+    team_by_id: dict[int, int]
+    team_slot_by_id: dict[int, int]
+    resolved: bool
+
+
+def scan_player_resource(player_resource: Entity) -> PlayerResourceScan:
+    """Scan ``CDOTA_PlayerResource`` for the logical player→resource mappings.
+
+    Walks the first ``PLAYER_RESOURCE_SCAN_LIMIT`` rows, skipping any whose team is
+    not Radiant/Dire or whose team slot is missing/negative (coaches, empty rows),
+    and assigns the surviving rows logical slots ``0..9`` in scan order.
+
+    Reference: refs/parser/src/main/java/opendota/Parse.java (validIndices).
+
+    Args:
+        player_resource: The live ``CDOTA_PlayerResource`` entity.
+
+    Returns:
+        A :class:`PlayerResourceScan` with the three slot maps and a ``resolved``
+        flag (``True`` once all 10 players are mapped).
+    """
+    index_by_id: dict[int, int] = {}
+    team_by_id: dict[int, int] = {}
+    team_slot_by_id: dict[int, int] = {}
+
+    for resource_idx in range(PLAYER_RESOURCE_SCAN_LIMIT):
+        team = player_resource.get_int32(f"m_vecPlayerData.{resource_idx:04d}.m_iPlayerTeam")
+        team_slot = player_resource.get_int32(f"m_vecPlayerTeamData.{resource_idx:04d}.m_iTeamSlot")
+        if team not in (TEAM_RADIANT, TEAM_DIRE) or team_slot is None or team_slot < 0:
+            continue
+        player_id = len(index_by_id)
+        if player_id >= 10:
+            break
+        index_by_id[player_id] = resource_idx
+        team_by_id[player_id] = team
+        team_slot_by_id[player_id] = team_slot
+
+    return PlayerResourceScan(
+        index_by_id=index_by_id,
+        team_by_id=team_by_id,
+        team_slot_by_id=team_slot_by_id,
+        resolved=len(index_by_id) == 10,
+    )
+
+
+def team_data_prefix(team_slot: int) -> str:
+    """Build the ``m_vecDataTeam`` entry prefix for a team slot.
+
+    The ``CDOTA_DataRadiant``/``CDOTA_DataDire`` entities expose per-player data
+    under ``m_vecDataTeam.{slot:04d}.*``. Callers that read several fields off the
+    same slot keep this prefix and append field names; callers reading a single
+    field can use :func:`team_data_field` instead.
+
+    Args:
+        team_slot: The ``m_iTeamSlot`` index into ``m_vecDataTeam``.
+
+    Returns:
+        The entry prefix, e.g. ``"m_vecDataTeam.0003"``.
+    """
+    return f"m_vecDataTeam.{team_slot:04d}"
+
+
+def team_data_field(team_slot: int, field_name: str) -> str:
+    """Build a ``m_vecDataTeam`` field path for a team slot.
+
+    The ``CDOTA_DataRadiant``/``CDOTA_DataDire`` entities expose per-player
+    counters (``m_iTotalEarnedGold``, ``m_iTotalEarnedXP``, ``m_iLastHitCount``,
+    ``m_iDenyCount``, ``m_iNetWorth``) under ``m_vecDataTeam.{slot}``.
+
+    Args:
+        team_slot: The ``m_iTeamSlot`` index into ``m_vecDataTeam``.
+        field_name: The counter field, e.g. ``"m_iTotalEarnedGold"``.
+
+    Returns:
+        The dotted field path, e.g. ``"m_vecDataTeam.0003.m_iTotalEarnedGold"``.
+    """
+    return f"{team_data_prefix(team_slot)}.{field_name}"
 
 
 def _snapshot_hero(entity: Entity, tick: int) -> PlayerStateSnapshot | None:

--- a/src/gem/extractors/intervals.py
+++ b/src/gem/extractors/intervals.py
@@ -24,15 +24,19 @@ import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from gem.extractors._snapshots import _HERO_CLASS_PREFIX, _player_id_from_entity
+from gem.extractors._snapshots import (
+    _HERO_CLASS_PREFIX,
+    TEAM_DIRE,
+    TEAM_RADIANT,
+    _player_id_from_entity,
+    scan_player_resource,
+    team_data_prefix,
+)
 from gem.state.entities import Entity, EntityOp
 
 if TYPE_CHECKING:
     from gem.parser import ReplayParser
 
-_TEAM_RADIANT = 2
-_TEAM_DIRE = 3
-_PLAYER_RESOURCE_SCAN_LIMIT = 30
 _TICKS_PER_SECOND = 30
 _FINAL_INTERVAL_GRACE_TICKS = 15 * _TICKS_PER_SECOND
 
@@ -248,7 +252,7 @@ class IntervalExtractor:
             else:
                 self._data_radiant = entity
                 self._record_team_data(entity, self._cur_data_radiant, self._prev_data_radiant)
-                self._record_team_counters(entity, _TEAM_RADIANT)
+                self._record_team_counters(entity, TEAM_RADIANT)
                 self._maybe_emit()
             return
 
@@ -258,7 +262,7 @@ class IntervalExtractor:
             else:
                 self._data_dire = entity
                 self._record_team_data(entity, self._cur_data_dire, self._prev_data_dire)
-                self._record_team_counters(entity, _TEAM_DIRE)
+                self._record_team_counters(entity, TEAM_DIRE)
                 self._maybe_emit()
             return
 
@@ -283,25 +287,13 @@ class IntervalExtractor:
         if pr is None:
             return
 
-        player_index_by_id: dict[int, int] = {}
-        player_team: dict[int, int] = {}
-        player_team_slot: dict[int, int] = {}
-
-        for resource_idx in range(_PLAYER_RESOURCE_SCAN_LIMIT):
-            team = pr.get_int32(f"m_vecPlayerData.{resource_idx:04d}.m_iPlayerTeam")
-            team_slot = pr.get_int32(f"m_vecPlayerTeamData.{resource_idx:04d}.m_iTeamSlot")
-            if team not in (_TEAM_RADIANT, _TEAM_DIRE) or team_slot is None or team_slot < 0:
-                continue
-            player_id = len(player_index_by_id)
-            if player_id >= 10:
-                break
-            player_index_by_id[player_id] = resource_idx
-            player_team[player_id] = team
-            player_team_slot[player_id] = team_slot
-
-        self._player_index_by_id = player_index_by_id
-        self._player_team = player_team
-        self._player_team_slot = player_team_slot
+        # Unlike PlayerExtractor, the interval extractor adopts the scan
+        # unconditionally (including partial early-game scans) — its consumers
+        # already guard on a fully-populated mapping before emitting.
+        scan = scan_player_resource(pr)
+        self._player_index_by_id = scan.index_by_id
+        self._player_team = scan.team_by_id
+        self._player_team_slot = scan.team_slot_by_id
 
     def _maybe_emit(self) -> None:
         if self._parser is None or self._ended:
@@ -309,9 +301,9 @@ class IntervalExtractor:
         if self._player_resource is None or not self._player_index_by_id:
             return
         teams = set(self._player_team.values())
-        if _TEAM_RADIANT in teams and self._data_radiant is None:
+        if TEAM_RADIANT in teams and self._data_radiant is None:
             return
-        if _TEAM_DIRE in teams and self._data_dire is None:
+        if TEAM_DIRE in teams and self._data_dire is None:
             return
 
         game_time_s = self._clock()
@@ -405,7 +397,7 @@ class IntervalExtractor:
             team_slot = self._player_team_slot.get(player_id)
             if team_slot is None:
                 continue
-            player_slot = team_slot if team == _TEAM_RADIANT else 128 + team_slot
+            player_slot = team_slot if team == TEAM_RADIANT else 128 + team_slot
             self.snapshots.append(
                 IntervalSnapshot(
                     tick=tick,
@@ -436,11 +428,11 @@ class IntervalExtractor:
             team_slot = self._player_team_slot.get(player_id)
             if team_slot is None:
                 return False
-            data_entity = self._data_radiant if team == _TEAM_RADIANT else self._data_dire
+            data_entity = self._data_radiant if team == TEAM_RADIANT else self._data_dire
             if data_entity is None:
                 return False
 
-            prefix = f"m_vecDataTeam.{team_slot:04d}"
+            prefix = team_data_prefix(team_slot)
             for field_name in (
                 "m_iTotalEarnedGold",
                 "m_iTotalEarnedXP",
@@ -476,7 +468,7 @@ class IntervalExtractor:
             existing = cur.get(team_slot)
             if existing is not None and existing[0] != tick:
                 prev[team_slot] = existing
-            prefix = f"m_vecDataTeam.{team_slot:04d}"
+            prefix = team_data_prefix(team_slot)
             cur[team_slot] = (
                 tick,
                 (
@@ -498,10 +490,10 @@ class IntervalExtractor:
 
         Args:
             entity: The just-updated ``CDOTA_DataRadiant``/``CDOTA_DataDire``.
-            team: ``_TEAM_RADIANT`` or ``_TEAM_DIRE``.
+            team: ``TEAM_RADIANT`` or ``TEAM_DIRE``.
         """
         for team_slot in range(5):
-            prefix = f"m_vecDataTeam.{team_slot:04d}"
+            prefix = team_data_prefix(team_slot)
             counters = self._team_counters.setdefault((team, team_slot), {})
             for attr, field_name in _TEAM_COUNTER_FIELDS.items():
                 value = entity.get_int32(f"{prefix}.{field_name}")
@@ -576,7 +568,7 @@ class IntervalExtractor:
         the values agree anyway.
 
         Args:
-            team: ``_TEAM_RADIANT`` or ``_TEAM_DIRE``.
+            team: ``TEAM_RADIANT`` or ``TEAM_DIRE``.
             team_slot: The player's team slot, 0-4.
             data_entity: The live data entity for the team (fallback source).
             emit_tick: The tick of the boundary emit.
@@ -584,15 +576,15 @@ class IntervalExtractor:
         Returns:
             ``(gold, xp, lh, dn, net_worth)`` for the boundary frame.
         """
-        cur = self._cur_data_radiant if team == _TEAM_RADIANT else self._cur_data_dire
-        prev = self._prev_data_radiant if team == _TEAM_RADIANT else self._prev_data_dire
+        cur = self._cur_data_radiant if team == TEAM_RADIANT else self._cur_data_dire
+        prev = self._prev_data_radiant if team == TEAM_RADIANT else self._prev_data_dire
         cur_frame = cur.get(team_slot)
         if cur_frame is not None and cur_frame[0] < emit_tick:
             return cur_frame[1]
         prev_frame = prev.get(team_slot)
         if prev_frame is not None and prev_frame[0] < emit_tick:
             return prev_frame[1]
-        prefix = f"m_vecDataTeam.{team_slot:04d}"
+        prefix = team_data_prefix(team_slot)
         return (
             _int_or_zero(data_entity.get_int32(f"{prefix}.m_iTotalEarnedGold")),
             _int_or_zero(data_entity.get_int32(f"{prefix}.m_iTotalEarnedXP")),
@@ -610,12 +602,12 @@ class IntervalExtractor:
             team_slot = self._player_team_slot.get(player_id)
             if team_slot is None:
                 continue
-            data_entity = self._data_radiant if team == _TEAM_RADIANT else self._data_dire
+            data_entity = self._data_radiant if team == TEAM_RADIANT else self._data_dire
             if data_entity is None:
                 continue
 
             gold, xp, lh, dn, net_worth = self._team_data_values(team, team_slot, data_entity, tick)
-            player_slot = team_slot if team == _TEAM_RADIANT else 128 + team_slot
+            player_slot = team_slot if team == TEAM_RADIANT else 128 + team_slot
             self.snapshots.append(
                 IntervalSnapshot(
                     tick=tick,

--- a/src/gem/extractors/players.py
+++ b/src/gem/extractors/players.py
@@ -14,11 +14,14 @@ from typing import TYPE_CHECKING
 from gem.combat.log import CombatLogEntry, CombatLogType
 from gem.extractors._snapshots import (
     _HERO_CLASS_PREFIX,
+    TEAM_RADIANT,
     PlayerStateSnapshot,
     PlayerTimeSeries,
     _player_id_from_entity,
     _pos,
     _snapshot_hero,
+    scan_player_resource,
+    team_data_field,
 )
 from gem.state.entities import Entity, EntityOp
 
@@ -34,16 +37,6 @@ if TYPE_CHECKING:
 _ITEM_SLOTS = 17  # total slots to scan (0-16)
 _ABILITY_SLOTS = 32  # m_hAbilities.0000-0031 per hero entity
 _NULL_HANDLE = 0xFFFFFF  # empty slot sentinel
-
-# ---------------------------------------------------------------------------
-# Constants
-# ---------------------------------------------------------------------------
-
-_TEAM_RADIANT = 2
-_TEAM_DIRE = 3
-# CDOTA_PlayerResource rows to scan when building the logical→resource remap.
-# A coach occupies a row, so the 10 players can span more than 10 indices.
-_PLAYER_RESOURCE_SCAN_LIMIT = 30
 
 __all__ = ["PlayerExtractor", "PlayerStateSnapshot", "PlayerTimeSeries"]
 
@@ -422,23 +415,15 @@ class PlayerExtractor:
         if pr is None:
             return
 
-        resource_index_by_id: dict[int, int] = {}
-        for resource_idx in range(_PLAYER_RESOURCE_SCAN_LIMIT):
-            team = pr.get_int32(f"m_vecPlayerData.{resource_idx:04d}.m_iPlayerTeam")
-            slot = pr.get_int32(f"m_vecPlayerTeamData.{resource_idx:04d}.m_iTeamSlot")
-            if team not in (_TEAM_RADIANT, _TEAM_DIRE) or slot is None or slot < 0:
-                continue
-            player_id = len(resource_index_by_id)
-            if player_id >= 10:
-                break
-            resource_index_by_id[player_id] = resource_idx
-            self._player_team_slot[player_id] = slot
+        scan = scan_player_resource(pr)
+        # Keep team slots current even on a partial scan (matches prior behaviour).
+        self._player_team_slot.update(scan.team_slot_by_id)
 
         # Only adopt the remap once it resolves all 10 players; partial scans
         # (early in the replay, before PlayerResource is fully populated) keep the
         # previous mapping rather than introducing a half-built shift.
-        if len(resource_index_by_id) == 10:
-            self._resource_index_by_id = resource_index_by_id
+        if scan.resolved:
+            self._resource_index_by_id = scan.index_by_id
 
     def _resource_index(self, player_id: int) -> int:
         """Map a logical player slot to its CDOTA_PlayerResource array index.
@@ -570,24 +555,23 @@ class PlayerExtractor:
             #
             # Reference: refs/parser/Parse.java — getEntityProperty(dataTeam,
             #   "m_vecDataTeam.%i.m_iTotalEarnedGold/XP", teamSlot)
-            data_entity = self._data_radiant if snap.team == _TEAM_RADIANT else self._data_dire
+            data_entity = self._data_radiant if snap.team == TEAM_RADIANT else self._data_dire
             if data_entity is not None:
                 # Prefer authoritative team slot; fall back to pid % 5
                 team_slot = self._player_team_slot.get(snap.player_id, snap.player_id % 5)
-                prefix = f"m_vecDataTeam.{team_slot:04d}"
-                nw = data_entity.get_int32(f"{prefix}.m_iNetWorth")
+                nw = data_entity.get_int32(team_data_field(team_slot, "m_iNetWorth"))
                 if nw is not None and nw > 0:
                     snap.net_worth = nw
-                teg = data_entity.get_int32(f"{prefix}.m_iTotalEarnedGold")
+                teg = data_entity.get_int32(team_data_field(team_slot, "m_iTotalEarnedGold"))
                 if teg is not None and teg > 0:
                     snap.total_earned_gold = teg
-                tex = data_entity.get_int32(f"{prefix}.m_iTotalEarnedXP")
+                tex = data_entity.get_int32(team_data_field(team_slot, "m_iTotalEarnedXP"))
                 if tex is not None and tex > 0:
                     snap.total_earned_xp = tex
-                lh = data_entity.get_int32(f"{prefix}.m_iLastHitCount")
+                lh = data_entity.get_int32(team_data_field(team_slot, "m_iLastHitCount"))
                 if lh is not None and lh > 0:
                     snap.lh = lh
-                dn = data_entity.get_int32(f"{prefix}.m_iDenyCount")
+                dn = data_entity.get_int32(team_data_field(team_slot, "m_iDenyCount"))
                 if dn is not None and dn > 0:
                     snap.dn = dn
             # Overlay authoritative hero level from CDOTA_PlayerResource

--- a/src/gem/extractors/players.py
+++ b/src/gem/extractors/players.py
@@ -34,7 +34,11 @@ if TYPE_CHECKING:
 
 # Slots 0-5 = main inventory, 6-8 = backpack, 9-16 = stash
 # Reference: refs/parser/src/main/java/opendota/Parse.java getHeroItem() comment
-_ITEM_SLOTS = 17  # total slots to scan (0-16)
+_ITEM_SLOTS = 17  # total slots to scan (0-16) for ongoing inventory snapshots
+# Starting-inventory synthesis scans only slots 0-7 (6 inventory + backpack 6-7),
+# matching OpenDota's getHeroInventory (`for i < 8`, Parse.java:818). Stash 9-16
+# and backpack slot 8 are NOT counted as starting purchases.
+_STARTING_ITEM_SLOTS = 8
 _ABILITY_SLOTS = 32  # m_hAbilities.0000-0031 per hero entity
 _NULL_HANDLE = 0xFFFFFF  # empty slot sentinel
 
@@ -722,7 +726,13 @@ class PlayerExtractor:
             # Reference: refs/parser/Parse.java isPlayerStartingItemsWritten pattern
             self._inventory_initialized.add(player_id)
             self.first_snapshot_tick[player_id] = tick
-            for item_name in current.values():
+            # Only slots 0-7 count as starting inventory (OpenDota getHeroInventory
+            # scans `i < 8`); stash 9-16 and backpack slot 8 are excluded so they
+            # are not miscounted as starting purchases. One entry per occupied slot
+            # preserves per-unit copies (e.g. 2x branches), which OpenDota keeps.
+            for slot, item_name in current.items():
+                if slot >= _STARTING_ITEM_SLOTS:
+                    continue
                 if item_name and not item_name.startswith("item_recipe"):
                     entry = CombatLogEntry(
                         tick=tick,

--- a/src/gem/parser.py
+++ b/src/gem/parser.py
@@ -212,6 +212,15 @@ class ReplayParser:
         # OpenDota-style match duration in seconds: the horn-anchored combat-log
         # time at GAME_STATE==6 (ancient destroyed). None until that state is seen.
         self.duration_s: int | None = None
+        # Set when the stream loop terminates on an exception rather than running
+        # to completion. ``parse_error`` is the exception, ``truncated_at_tick``
+        # the last tick reached. Both stay None on a clean parse. This is the
+        # programmatic counterpart to the WARNING logged in ``parse()``: an
+        # expected truncated-tail and a genuine mid-stream bug are
+        # indistinguishable here, so consumers can inspect these to tell whether a
+        # ``ParsedMatch`` is complete instead of trusting silent partial output.
+        self.parse_error: Exception | None = None
+        self.truncated_at_tick: int | None = None
         self._game_start_callbacks: list[Callable[[int], None]] = []
         self._game_end_callbacks: list[Callable[[int], None]] = []
         self._game_ended: bool = False
@@ -401,8 +410,14 @@ class ReplayParser:
         except Exception as exc:
             # Truncated files raise on the final corrupt snappy block — that is
             # expected for partial replays, so parsing continues with whatever was
-            # read. Log at debug level so genuine corruption stays diagnosable.
-            logger.debug("Replay stream ended early at tick %d: %r", self.tick, exc)
+            # read. Log at warning level: a genuine mid-stream decoder/extractor
+            # bug is indistinguishable here from an expected truncated tail, so
+            # surface it rather than letting silent partial output look complete.
+            # Record it on the parser too, so consumers can detect a partial
+            # parse programmatically instead of scraping logs.
+            self.parse_error = exc
+            self.truncated_at_tick = self.tick
+            logger.warning("Replay stream ended early at tick %d: %r", self.tick, exc)
 
         # Read match metadata from CDOTAGamerulesProxy entity if DEM_FileInfo
         # didn't populate them (e.g. truncated replays or early stop).

--- a/src/gem/results/assembly.py
+++ b/src/gem/results/assembly.py
@@ -131,7 +131,11 @@ def _build_purchase_aggregates(
         seconds = _entry_game_seconds(entry, game_start_tick)
         if key not in first_purchase_time:
             first_purchase_time[key] = seconds
-        purchase_time[key] = seconds  # last purchase wins
+        # OpenDota's purchase_time is the SUM of every purchase time for the item
+        # (a quirk of its additive map handler), not the latest buy. Match it for
+        # parity. first_purchase_time stays the earliest buy. Verified against
+        # fixture 8855188139: clarity=3696=sum([470,660,706,795,1065]).
+        purchase_time[key] = purchase_time.get(key, 0) + seconds
     return {
         "purchase": purchase,
         "purchase_time": purchase_time,
@@ -561,7 +565,6 @@ def build_parsed_match(
     Returns:
         Fully populated :class:`ParsedMatch`.
     """
-    from gem.combat.aggregator import _dedup_purchase_log
     from gem.extractors.teamfights import detect_opendota_teamfights, detect_teamfights
 
     # radiant_win resolution — three tiers in priority order:
@@ -710,13 +713,22 @@ def build_parsed_match(
             pp.gold_reasons = agg.gold_reasons
             pp.xp_reasons = agg.xp_reasons
             pp.kills_log = agg.kills_log
-            pp.purchase_log = _dedup_purchase_log(
-                agg.purchase_log,
-                player_ext.first_snapshot_tick.get(player_id),
-                player_ext._sample_interval,
-            )
-            # OpenDota purchase-timeline aggregates derived from the deduped log.
-            purchase_aggs = _build_purchase_aggregates(pp.purchase_log, game_start_tick)
+            # Chronological order, keeping every per-unit entry but EXCLUDING
+            # recipes — matching OpenDota's purchase_log (CreateParsedDataBlob
+            # filters key.startsWith("recipe_") out of the log while still counting
+            # recipes in the `purchase` map). OpenDota does NOT dedup starting items
+            # (its log genuinely lists e.g. 2x faerie_fire), so collapsing
+            # same-(tick, item) entries here under-counted starting consumables.
+            sorted_purchases = sorted(agg.purchase_log, key=lambda e: e.tick)
+            pp.purchase_log = [
+                entry
+                for entry in sorted_purchases
+                if not (opendota_translate(entry.value_name) or "").startswith("recipe_")
+            ]
+            # Aggregates are derived from the FULL log (with recipes): the `purchase`
+            # count map includes recipes, while purchase_time/first_purchase_time
+            # exclude them. _build_purchase_aggregates handles that split internally.
+            purchase_aggs = _build_purchase_aggregates(sorted_purchases, game_start_tick)
             pp.purchase = purchase_aggs["purchase"]
             pp.purchase_time = purchase_aggs["purchase_time"]
             pp.first_purchase_time = purchase_aggs["first_purchase_time"]

--- a/src/gem/results/models.py
+++ b/src/gem/results/models.py
@@ -230,7 +230,9 @@ class ParsedPlayer:
         gold_reasons: Gold received per reason code.
         xp_reasons: XP received per reason code.
         kills_log: Combat log DEATH entries where this player was the attacker.
-        purchase_log: PURCHASE combat log entries for this player.
+        purchase_log: Chronological PURCHASE combat log entries for this player,
+            excluding recipes (matching OpenDota's ``purchase_log``; recipes are
+            still counted in the ``purchase`` map).
         runes_log: ITEM combat log entries for rune pickups.
         buyback_log: BUYBACK combat log entries for this player.
         lane_pos: Dwell-tick counts keyed by ``"x_y"`` grid cell (64-unit resolution).

--- a/tests/test_combat_aggregator.py
+++ b/tests/test_combat_aggregator.py
@@ -1,7 +1,6 @@
 """Tests for gem.combat.aggregator.
 
-Covers _ParsedPlayerAgg structure, _CombatAggregator routing/accumulation,
-and _dedup_purchase_log deduplication logic.
+Covers _ParsedPlayerAgg structure and _CombatAggregator routing/accumulation.
 """
 
 from __future__ import annotations
@@ -10,8 +9,7 @@ from collections import defaultdict
 from dataclasses import fields
 from unittest.mock import MagicMock
 
-from gem.combat.aggregator import _CombatAggregator, _dedup_purchase_log, _ParsedPlayerAgg
-from gem.combat.log import CombatLogEntry
+from gem.combat.aggregator import _CombatAggregator, _ParsedPlayerAgg
 
 # ---------------------------------------------------------------------------
 # _ParsedPlayerAgg
@@ -460,75 +458,6 @@ class TestCombatAggregatorRunes:
         e = _entry(log_type="PICKUP_RUNE", attacker_is_hero=False, value=10)
         agg.on_entry(e)
         assert 10 not in agg.players
-
-
-# ---------------------------------------------------------------------------
-# _dedup_purchase_log
-# ---------------------------------------------------------------------------
-
-
-def _purchase(tick: int, item: str) -> CombatLogEntry:
-    return CombatLogEntry(tick=tick, log_type="PURCHASE", value_name=item)
-
-
-class TestDedupPurchaseLog:
-    def test_no_first_snap_returns_sorted(self):
-        entries = [_purchase(300, "item_branches"), _purchase(100, "item_tango")]
-        result = _dedup_purchase_log(entries, first_snap_tick=None, sample_interval=150)
-        assert [e.tick for e in result] == [100, 300]
-
-    def test_duplicate_within_window_removed(self):
-        # first_snap_tick=100, sample_interval=150 → cutoff=250
-        entries = [
-            _purchase(100, "item_branches"),
-            _purchase(100, "item_branches"),  # duplicate at same tick+item
-        ]
-        result = _dedup_purchase_log(entries, first_snap_tick=100, sample_interval=150)
-        assert len(result) == 1
-
-    def test_duplicate_outside_window_kept(self):
-        # cutoff = 100 + 150 = 250; tick 300 > 250 → both entries kept
-        entries = [
-            _purchase(100, "item_branches"),
-            _purchase(300, "item_branches"),  # same item but beyond cutoff
-        ]
-        result = _dedup_purchase_log(entries, first_snap_tick=100, sample_interval=150)
-        assert len(result) == 2
-
-    def test_different_items_at_same_tick_both_kept(self):
-        entries = [
-            _purchase(100, "item_tango"),
-            _purchase(100, "item_branches"),
-        ]
-        result = _dedup_purchase_log(entries, first_snap_tick=100, sample_interval=150)
-        assert len(result) == 2
-
-    def test_empty_list_returns_empty(self):
-        assert _dedup_purchase_log([], first_snap_tick=100, sample_interval=150) == []
-
-    def test_result_sorted_by_tick(self):
-        entries = [_purchase(500, "item_tango"), _purchase(200, "item_branches")]
-        result = _dedup_purchase_log(entries, first_snap_tick=100, sample_interval=150)
-        assert result[0].tick == 200
-        assert result[1].tick == 500
-
-    def test_cutoff_boundary_entry_is_deduplicated(self):
-        # Entry at exactly cutoff tick (100+150=250) is still inside window
-        entries = [
-            _purchase(250, "item_tango"),
-            _purchase(250, "item_tango"),
-        ]
-        result = _dedup_purchase_log(entries, first_snap_tick=100, sample_interval=150)
-        assert len(result) == 1
-
-    def test_entry_just_beyond_cutoff_is_kept(self):
-        # Entry at 251 > cutoff=250 → not deduplicated
-        entries = [
-            _purchase(250, "item_tango"),
-            _purchase(251, "item_tango"),
-        ]
-        result = _dedup_purchase_log(entries, first_snap_tick=100, sample_interval=150)
-        assert len(result) == 2
 
 
 class TestSummonKillAttribution:

--- a/tests/test_combatlog.py
+++ b/tests/test_combatlog.py
@@ -411,7 +411,7 @@ class TestS1CombatLog:
     def test_purchase_resolves_value_name(self):
         # S1 PURCHASE (type 11) must resolve value_name from the value index,
         # matching the S2 path. Otherwise S1 purchase logs lose item names and
-        # _dedup_purchase_log collapses distinct same-tick buys.
+        # the per-item purchase aggregates are mis-keyed.
         p, received = self._make_processor_with_handler()
         table = FakeNameTable({2: "npc_dota_hero_axe", 5: "item_blink"})
         p.process_s1_event(self._make_event(type_val=11, target=2, value=5), table, tick=500)

--- a/tests/test_match_builder.py
+++ b/tests/test_match_builder.py
@@ -1831,8 +1831,9 @@ class TestBuildPurchaseAggregates:
         # item_ prefix stripped; counts per item.
         assert aggs["purchase"] == {"blink": 1, "branches": 2}
 
-    def test_first_vs_last_purchase_time(self):
-        # belt bought at 100s and 300s -> first=100, last=300.
+    def test_first_purchase_time_and_purchase_time_sum(self):
+        # belt bought at 100s and 300s -> first_purchase_time=100 (earliest),
+        # purchase_time=400 (SUM of all buy times, matching OpenDota's quirk).
         aggs = self._build(
             [
                 _purchase("item_belt", tick=3000, game_time_s=100),
@@ -1840,7 +1841,19 @@ class TestBuildPurchaseAggregates:
             ]
         )
         assert aggs["first_purchase_time"]["belt"] == 100
-        assert aggs["purchase_time"]["belt"] == 300
+        assert aggs["purchase_time"]["belt"] == 400
+
+    def test_purchase_time_sums_multiple_buys(self):
+        # Three buys at 100/200/300 -> purchase_time=600, first_purchase_time=100.
+        aggs = self._build(
+            [
+                _purchase("item_clarity", tick=3000, game_time_s=100),
+                _purchase("item_clarity", tick=6000, game_time_s=200),
+                _purchase("item_clarity", tick=9000, game_time_s=300),
+            ]
+        )
+        assert aggs["first_purchase_time"]["clarity"] == 100
+        assert aggs["purchase_time"]["clarity"] == 600
 
     def test_recipes_counted_but_excluded_from_timing(self):
         # OpenDota: purchase count includes recipes; purchase_time/first exclude them.

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -20,6 +20,7 @@ Reference: manta/parser.go, manta/demo_packet.go
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import gem.parser as parser_module
@@ -208,6 +209,14 @@ class TestReplayParserInit:
         p = ReplayParser(b"")
         assert p.game_time_s is None
 
+    def test_parse_error_starts_none(self):
+        p = ReplayParser(b"")
+        assert p.parse_error is None
+
+    def test_truncated_at_tick_starts_none(self):
+        p = ReplayParser(b"")
+        assert p.truncated_at_tick is None
+
     def test_entity_manager_starts_none(self):
         p = ReplayParser(b"")
         assert p.entity_manager is None
@@ -229,6 +238,44 @@ class TestReplayParserInit:
     def test_game_ended_false(self):
         p = ReplayParser(b"")
         assert p._game_ended is False
+
+
+# ---------------------------------------------------------------------------
+# ReplayParser partial-parse / truncation reporting
+# ---------------------------------------------------------------------------
+
+
+class TestReplayParserPartialParse:
+    def test_missing_magic_is_recorded_not_raised(self, caplog):
+        # The magic-header check runs inside parse()'s swallowed try-block, so an
+        # unparseable file (here: empty input, which fails magic validation) is
+        # reported via the attributes rather than propagating a ValueError.
+        p = ReplayParser(b"")
+
+        with caplog.at_level(logging.WARNING, logger="gem.parser"):
+            p.parse()  # must not raise
+
+        assert isinstance(p.parse_error, ValueError)
+        assert p.truncated_at_tick == 0
+
+    def test_stream_exception_is_recorded_not_raised(self, caplog):
+        # Valid Source 2 magic + the 8-byte metadata skip, then a single outer
+        # message whose payload decodes to a bogus CDemoPacket. The stream
+        # constructs (magic passes) and then raises mid-iteration, which parse()
+        # must swallow — recording the failure on the parser instead of
+        # propagating, and logging at WARNING so it is visible by default.
+        buf = b"PBDEMS2\x00" + (b"\x00" * 8) + b"\x07\x00\xff\xff\xff\xff\x0f\x41"
+        p = ReplayParser(buf)
+
+        with caplog.at_level(logging.WARNING, logger="gem.parser"):
+            p.parse()  # must not raise
+
+        assert p.parse_error is not None
+        assert p.truncated_at_tick == 0
+        assert any(
+            "stream ended early" in r.message and r.levelno == logging.WARNING
+            for r in caplog.records
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_players_extractor.py
+++ b/tests/test_players_extractor.py
@@ -8,7 +8,14 @@ All tests use fake entities and a fake parser — no real .dem files.
 
 from __future__ import annotations
 
-from gem.extractors._snapshots import _player_id_from_entity
+from gem.extractors._snapshots import (
+    TEAM_DIRE,
+    TEAM_RADIANT,
+    _player_id_from_entity,
+    scan_player_resource,
+    team_data_field,
+    team_data_prefix,
+)
 from gem.extractors.players import (
     PlayerExtractor,
     PlayerStateSnapshot,
@@ -102,6 +109,77 @@ class TestPlayerIdFromEntity:
         # m_nPlayerID == -1 (unset sentinel) should fall through to m_iPlayerID.
         e = _ent(m_nPlayerID=-1, m_iPlayerID=10)
         assert _player_id_from_entity(e) == 5
+
+
+def _player_resource(rows: list[tuple[int, int | None]]) -> Entity:
+    """Build a CDOTA_PlayerResource entity from (team, team_slot) rows.
+
+    Each tuple occupies a sequential resource-array index; a team_slot of None
+    omits the m_iTeamSlot field for that row (simulating an unpopulated entry).
+    """
+    state: dict[str, int] = {}
+    for idx, (team, slot) in enumerate(rows):
+        state[f"m_vecPlayerData.{idx:04d}.m_iPlayerTeam"] = team
+        if slot is not None:
+            state[f"m_vecPlayerTeamData.{idx:04d}.m_iTeamSlot"] = slot
+    return _ent("CDOTA_PlayerResource", **state)
+
+
+class TestScanPlayerResource:
+    """The shared CDOTA_PlayerResource scan (formerly duplicated in
+    PlayerExtractor._refresh_team_slots and IntervalExtractor._refresh_player_mappings).
+    """
+
+    def test_no_coach_is_identity_map(self):
+        rows = [(TEAM_RADIANT, i) for i in range(5)] + [(TEAM_DIRE, i) for i in range(5)]
+        scan = scan_player_resource(_player_resource(rows))
+        assert scan.resolved is True
+        assert scan.index_by_id == {i: i for i in range(10)}
+        assert scan.team_by_id[0] == TEAM_RADIANT
+        assert scan.team_by_id[9] == TEAM_DIRE
+
+    def test_coach_row_is_skipped_and_shifts_indices(self):
+        # A coach (team 1) at resource index 0 shifts the 10 players to indices 1..10.
+        rows = [(1, 0)] + [(TEAM_RADIANT, i) for i in range(5)] + [(TEAM_DIRE, i) for i in range(5)]
+        scan = scan_player_resource(_player_resource(rows))
+        assert scan.resolved is True
+        # Logical slot 0 maps to resource index 1 (past the coach).
+        assert scan.index_by_id[0] == 1
+        assert scan.team_by_id[0] == TEAM_RADIANT
+        assert scan.team_slot_by_id[0] == 0
+
+    def test_partial_scan_is_unresolved(self):
+        scan = scan_player_resource(_player_resource([(TEAM_RADIANT, i) for i in range(4)]))
+        assert scan.resolved is False
+        assert len(scan.index_by_id) == 4
+
+    def test_missing_team_slot_row_is_skipped(self):
+        # A row with no m_iTeamSlot is not a valid player and must be skipped.
+        rows = [(TEAM_RADIANT, None)] + [(TEAM_RADIANT, i) for i in range(5)]
+        scan = scan_player_resource(_player_resource(rows))
+        # 5 valid players (the None-slot row dropped), so it never resolves to 10.
+        assert len(scan.index_by_id) == 5
+        assert scan.index_by_id[0] == 1
+
+    def test_caps_at_ten_players(self):
+        # More than 10 valid rows: only the first 10 are mapped.
+        rows = [(TEAM_RADIANT, i) for i in range(12)]
+        scan = scan_player_resource(_player_resource(rows))
+        assert len(scan.index_by_id) == 10
+        assert scan.resolved is True
+
+
+class TestTeamDataPathHelpers:
+    """The m_vecDataTeam path builders that single-source the field strings."""
+
+    def test_team_data_prefix_pads_slot(self):
+        assert team_data_prefix(3) == "m_vecDataTeam.0003"
+
+    def test_team_data_field_appends_field(self):
+        assert team_data_field(3, "m_iTotalEarnedGold") == "m_vecDataTeam.0003.m_iTotalEarnedGold"
+
+    def test_field_builds_on_prefix(self):
+        assert team_data_field(7, "m_iNetWorth") == f"{team_data_prefix(7)}.m_iNetWorth"
 
 
 class FakeCombatLog:

--- a/tests/test_purchase_parity_integration.py
+++ b/tests/test_purchase_parity_integration.py
@@ -1,0 +1,141 @@
+"""Integration test: per-player purchase aggregates match OpenDota.
+
+Parses one full OpenDota fixture and checks that each player's
+``ParsedPlayer.purchase`` (per-item count map), ``purchase_time`` (OpenDota's
+SUM-of-buy-times quirk), and ``first_purchase_time`` (earliest buy) match the
+OpenDota match API for the same hero.
+
+Regression guard for issue #95: gem previously deduped starting-inventory
+purchases (under-counting multi-copy consumables) and used last-purchase-wins
+for ``purchase_time``. After aligning to OpenDota — starting scan limited to
+slots 0-7, no dedup, ``purchase_time`` summed — these match exactly.
+
+Assertions avoid two known OpenDota quirks the values must NOT be pinned to:
+- pre-horn (negative) timestamps differ by ±1s (boundary quantization), so we
+  assert on positive-time items like ``black_king_bar`` instead.
+- ``first_purchase_time[tango]`` can skip a time-0 log entry on some players.
+
+Marked ``slow`` + ``integration`` — needs a real ``.dem`` plus its
+``.opendota.json``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import gem
+from gem.catalog.heroes import HEROES
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "opendota"
+_MATCH_ID = 8855188139
+
+_NAME_TO_HERO_ID = {name: meta["id"] for name, meta in HEROES.items()}
+
+# Per-hero expected purchase counts, verified against the OpenDota fixture.
+# Keyed by hero_id (slot-independent so the test is robust to draft order).
+_EXPECTED_COUNTS = {
+    11: {  # Shadow Fiend
+        "tango": 2,
+        "faerie_fire": 2,
+        "clarity": 5,
+        "tpscroll": 2,
+        "black_king_bar": 1,
+        "recipe_black_king_bar": 1,
+    },
+    120: {  # Pangolier
+        "tango": 2,
+        "faerie_fire": 1,
+        "clarity": 6,
+        "tpscroll": 6,
+        "branches": 4,
+        "ward_observer": 2,
+        "ward_sentry": 2,
+    },
+}
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+class TestPurchaseParityMatchesOpenDota:
+    @pytest.fixture(scope="class")
+    def paired(self):
+        """Parse the fixture once and pair each player with its OpenDota blob.
+
+        Returns:
+            Dict of ``hero_id -> (ParsedPlayer, opendota_player_dict)``.
+        """
+        dem = FIXTURES_DIR / f"{_MATCH_ID}.dem"
+        od_path = FIXTURES_DIR / f"{_MATCH_ID}.opendota.json"
+        if not dem.exists() or not od_path.exists():
+            pytest.skip(f"OpenDota fixture {_MATCH_ID} (.dem + .opendota.json) not available")
+
+        match = gem.parse(str(dem))
+        with open(od_path) as fh:
+            od = json.load(fh)
+        od_by_hero = {p["hero_id"]: p for p in od.get("players") or []}
+
+        pairs = {}
+        for player in match.players:
+            hero_id = _NAME_TO_HERO_ID.get(player.hero_name)
+            od_player = od_by_hero.get(hero_id)
+            if od_player is not None:
+                pairs[hero_id] = (player, od_player)
+        return pairs
+
+    def test_all_players_paired(self, paired):
+        assert len(paired) == 10
+
+    def test_purchase_counts_match_opendota(self, paired):
+        # Every per-item count must match across all 10 players — this is the
+        # core #95 parity fix (dedup removal + slot 0-7).
+        mismatches = []
+        for hero_id, (player, od_player) in paired.items():
+            od_counts = od_player.get("purchase") or {}
+            for item, count in od_counts.items():
+                if player.purchase.get(item, 0) != count:
+                    mismatches.append(
+                        f"hero {hero_id} {item}: gem={player.purchase.get(item, 0)} od={count}"
+                    )
+        assert not mismatches, f"purchase count divergence: {mismatches}"
+
+    def test_known_count_oracle(self, paired):
+        # Belt-and-braces explicit checks on hand-verified items.
+        for hero_id, expected in _EXPECTED_COUNTS.items():
+            player, _ = paired[hero_id]
+            for item, count in expected.items():
+                assert player.purchase.get(item, 0) == count, (
+                    f"hero {hero_id} purchase[{item}]={player.purchase.get(item, 0)}, expected {count}"
+                )
+
+    def test_purchase_time_is_sum(self, paired):
+        # purchase_time matches OpenDota's SUM-of-buy-times on positive-time items.
+        # Shadow Fiend (11): clarity sums to 3696, tpscroll to 1377; BKB single buy 1648.
+        sf, _ = paired[11]
+        assert sf.purchase_time["clarity"] == 3696
+        assert sf.purchase_time["tpscroll"] == 1377
+        assert sf.purchase_time["black_king_bar"] == 1648
+
+    def test_first_purchase_time_is_earliest(self, paired):
+        # first_purchase_time is the earliest buy. BKB is a clean positive-time
+        # single buy (avoids the pre-horn ±1 and tango time-0 quirks).
+        sf, _ = paired[11]
+        assert sf.first_purchase_time["black_king_bar"] == 1648
+        assert sf.first_purchase_time["clarity"] == 470
+
+    def test_recipes_counted_but_excluded_from_timing(self, paired):
+        # Recipes appear in the count map but never in the timing maps.
+        sf, _ = paired[11]
+        assert sf.purchase.get("recipe_black_king_bar") == 1
+        assert "recipe_black_king_bar" not in sf.purchase_time
+        assert "recipe_black_king_bar" not in sf.first_purchase_time
+
+    def test_purchase_log_has_no_recipes(self, paired):
+        # purchase_log (chronological) excludes recipe_ entries, like OpenDota.
+        for _, (player, _) in paired.items():
+            assert not any(
+                (e.value_name or "").removeprefix("item_").startswith("recipe_")
+                for e in player.purchase_log
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -448,7 +448,7 @@ wheels = [
 
 [[package]]
 name = "gem-dota"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "ipykernel" },


### PR DESCRIPTION
## Summary

Release **0.4.1** — a follow-up to the 0.4.0 OpenDota-parity release. Also reconciles `develop` with the 0.4.0 release state (the post-0.4.0 back-merge that was missed).

### New since 0.4.0
- **Fixed — OpenDota purchase parity (#109, closes #95):** `purchase` / `purchase_time` / `first_purchase_time` now match the OpenDota match API exactly (10/10 players verified). `purchase_time` sums per item; starting-inventory scan limited to slots 0-7; removed the gem-original dedup that under-counted consumables; `purchase_log` excludes recipes.
- **Changed — partial-parse visibility (#107):** `ReplayParser.parse()` records `parse_error` / `truncated_at_tick` and logs swallowed stream-end exceptions at `WARNING` (was `DEBUG`).
- **Changed — internal (#108):** consolidated the duplicated `CDOTA_PlayerResource` scan + team-data field paths into `gem.extractors._snapshots`. No output change.
- **Docs (#110):** corrected a stale purchase-parity note.

### Reconciliation
`develop` had drifted from the 0.4.0 release: `pyproject` still read `0.3.0` and the CHANGELOG had the 0.4.0 features under `[Unreleased]` with no dated `## [0.4.0]` section (0.4.0 was finalized on `main` but never back-merged). This branch merges `main` into `develop` (restoring the version + the dated `[0.4.0]` section) and carves the genuinely-new work into `## [0.4.1]`.

## Rationale

- **0.4.1 (not 0.5.0):** additive API (`parse_error`/`truncated_at_tick`) + a correctness fix toward the documented OpenDota-parity goal + an internal refactor. No breaking API changes. The one output change (purchase aggregates) is a fix *toward* parity, not a contract break.

## Testing

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src`
- [x] `uv run pytest tests/ -m "not integration"` — **1659 passed, 3 skipped**
- [x] `gem.__version__ == "0.4.1"`; `pyproject` + `uv.lock` consistent
- [ ] Docs build, if docs changed (CHANGELOG only)

## Notes

- [x] Generated protobuf files under `src/gem/proto/` were not edited manually.
- [x] Large replay artifacts are not committed.
- [x] Secrets and local credentials are not included.
- This PR targets `main` (release + tag + PyPI publish). The `[Unreleased]` section is intentionally empty post-cut.

Closes the 0.4.x follow-up tracked across #107 / #108 / #109 / #95.
