### PR TITLE
Add report asset cache tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Report asset setup tooling: `python -m gem reports assets path/status/download/add-map`,
+  `ReportAssets.auto()`, and importable cache helpers so HTML report users can
+  populate local hero/item icon and map assets without shipping those assets in
+  the wheel. The downloader validates cached PNGs and falls back across current
+  and legacy Dota CDN icon paths.
 - `ParsedPlayer.final_items` — end-of-game inventory by slot index (0-5 main,
   6-8 backpack, 9-16 stash), keyed item name with the `item_` prefix. Read from
   the hero entity at the game-end tick; verified to match OpenDota's

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ uv sync --group dev
 ```
 
 > [!TIP]
-> Most users do not need to download hero/item icon assets. Icon fetching is only required for local report/example rendering that displays portraits or item/rune icons.
+> Most users do not need to download hero/item icon assets. Icon fetching is only required for local report/example rendering that displays portraits or item/rune icons; when you need it, run `python -m gem reports assets download --icons`.
 
 ---
 
@@ -163,6 +163,11 @@ python -m gem batch replays/ --format dataframe --output ./out
 
 # Show live progress and a timing breakdown
 python -m gem match.dem --progress --timings
+
+# Inspect or populate the HTML report asset cache
+python -m gem reports assets status
+python -m gem reports assets download --icons
+python -m gem reports assets add-map assets/maps/Game_map_7.40.jpg
 ```
 
 > [!TIP]
@@ -221,7 +226,8 @@ import gem
 from gem.reports import ReportAssets, write_html_report
 
 match = gem.parse("path/to/your_replay.dem")
-write_html_report(match, "report.html", assets=ReportAssets(map_image="assets/maps/Game_map_7.40.jpg"))
+assets = ReportAssets.auto(fallback_map="assets/maps/Game_map_7.40.jpg")
+write_html_report(match, "report.html", assets=assets)
 ```
 
 ```bash
@@ -511,8 +517,7 @@ Parse cost scales with extraction scope: full per-tick state extraction is much 
 - **Draft ID quirks** — replay pick/ban IDs can differ from static hero API IDs in some patches/formats (commonly transformed IDs). `gem` normalizes these, but edge cases may still appear.
 - **Purchase attribution in spectator/HLTV paths** — purchase events are not always directly hero-attributed in combat log data; reconstruction relies on entity state and may be incomplete in edge cases.
 - **Summon ownership edge cases** — most summoned-unit attribution is handled, but complex ownership cases can still produce occasional mismatches.
-- **Hero icons** — not bundled in the package. Run `python scripts/fetch_hero_icons.py --check` to audit the local cache, or `python scripts/fetch_hero_icons.py` to download missing icons before using the draft or teamfight report examples.
-- **Item icons** — not bundled in the package. Run `python scripts/fetch_item_icons.py --check` to audit the local cache, or `python scripts/fetch_item_icons.py` to download missing non-recipe icons before using reports that render item/rune icons. Recipe icons are skipped by default; pass `--include-recipes` if you need them.
+- **Report assets** — hero/item icons and map images are not bundled in the package. Run `python -m gem reports assets status` to audit the local cache, `python -m gem reports assets download --icons` to download missing non-recipe icons, and `python -m gem reports assets add-map assets/maps/Game_map_7.40.jpg` to copy a map image into the cache. Recipe icons are skipped by default; pass `--include-recipes` if you need them.
 
 ---
 

--- a/examples/match_report.py
+++ b/examples/match_report.py
@@ -14,13 +14,11 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 import gem
-from gem.reports import ReportAssets, write_html_report
+from gem.reports import ReportAssets, apply_opendota_player_names_from_path, write_html_report
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_DEM = REPO_ROOT / "tests" / "fixtures" / "opendota" / "8822520406.dem"
 DEFAULT_MAP = REPO_ROOT / "assets" / "maps" / "Game_map_7.40.jpg"
-DEFAULT_HERO_ICONS = REPO_ROOT / "src" / "gem" / "data" / "hero_icons"
-DEFAULT_ITEM_ICONS = REPO_ROOT / "src" / "gem" / "data" / "item_icons"
 
 
 def _existing(path: Path) -> Path | None:
@@ -44,6 +42,11 @@ def main() -> None:
         default=None,
         help="Path to map image for report overlays (default: assets/maps/Game_map_7.40.jpg)",
     )
+    parser.add_argument(
+        "--asset-dir",
+        default=None,
+        help="Report asset cache root (default: GEM_REPORT_ASSET_DIR or the user cache)",
+    )
     args = parser.parse_args()
 
     dem_path = Path(args.dem) if args.dem else DEFAULT_DEM
@@ -52,16 +55,27 @@ def main() -> None:
 
     print(f"Parsing {dem_path} ...")
     match = gem.parse(dem_path)
+    opendota_path = dem_path.with_suffix(".opendota.json")
+    if opendota_path.exists():
+        apply_opendota_player_names_from_path(match, opendota_path)
+        print(f"Player names loaded: {opendota_path}")
 
-    assets = ReportAssets(
-        map_image=_existing(map_path),
-        hero_icon_dir=_existing(DEFAULT_HERO_ICONS),
-        item_icon_dir=_existing(DEFAULT_ITEM_ICONS),
+    assets = ReportAssets.auto(
+        root=Path(args.asset_dir) if args.asset_dir else None,
+        fallback_map=map_path,
     )
+    if args.map:
+        assets = ReportAssets(
+            map_image=_existing(map_path),
+            hero_icon_dir=assets.hero_icon_dir,
+            item_icon_dir=assets.item_icon_dir,
+        )
     if assets.map_image:
         print(f"Map image loaded: {assets.map_image}")
     else:
         print(f"Map image not found at {map_path}; map-backed sections will render without it.")
+    if not assets.hero_icon_dir or not assets.item_icon_dir:
+        print("Icon cache is incomplete; run `python -m gem reports assets download --icons`.")
 
     written = write_html_report(match, output_path, assets=assets)
     print(f"Report written to: {written}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,8 @@ build-backend = "uv_build"
 
 [tool.uv.build-backend]
 module-name = "gem"
-# Icons are downloaded locally by fetch_hero_icons.py / fetch_item_icons.py
-# and must not be shipped in the published wheel.
+# Icons are downloaded locally by the report asset setup tooling and must not be
+# shipped in the published wheel.
 source-exclude = [
     ".DS_Store",
     "._*",

--- a/scripts/fetch_hero_icons.py
+++ b/scripts/fetch_hero_icons.py
@@ -19,29 +19,19 @@ Usage::
 from __future__ import annotations
 
 import argparse
-import json
-import ssl
 import sys
-import time
-import urllib.request
 from collections.abc import Sequence
 from pathlib import Path
 
-_HEROES_JSON = Path(__file__).parent.parent / "src" / "gem" / "data" / "heroes.json"
-_OUT_DIR = Path(__file__).parent.parent / "src" / "gem" / "data" / "hero_icons"
-_CDN_PRIMARY = "https://steamcdn-a.akamaihd.net/apps/dota2/images/heroes/{short}_icon.png"
-_CDN_FALLBACK = "https://cdn.dota2.com/apps/dota2/images/heroes/{short}_icon.png"
-_CDN_STRATZ = "https://cdn.stratz.com/images/dota2/heroes/{short}_icon.png"
-# Some heroes use a different short name on the CDN
-_CDN_OVERRIDES: dict[str, str] = {
-    "dawnbreaker": "dawnbreaker",
-    "kez": "kez",
-    "marci": "marci",
-    "muerta": "muerta",
-    "primal_beast": "primal_beast",
-    "ringmaster": "ringmaster",
-    "void_spirit": "void_spirit",
-}
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from gem.reports.asset_cache import (  # noqa: E402
+    HEROES_JSON as _HEROES_JSON,
+    SOURCE_HERO_ICON_DIR as _OUT_DIR,
+    download_hero_icons,
+    hero_icon_shorts,
+    missing_hero_icons,
+)
 
 
 def _short(npc_name: str) -> str:
@@ -49,17 +39,14 @@ def _short(npc_name: str) -> str:
 
 
 def _hero_shorts(heroes_path: Path) -> tuple[str, ...]:
-    heroes: dict = json.loads(heroes_path.read_text(encoding="utf-8"))
-    return tuple(_short(npc_name) for npc_name in sorted(heroes))
+    return hero_icon_shorts(heroes_path)
 
 
 def missing_icon_shorts(
     heroes_path: Path = _HEROES_JSON,
     out_dir: Path = _OUT_DIR,
 ) -> tuple[str, ...]:
-    return tuple(
-        short for short in _hero_shorts(heroes_path) if not (out_dir / f"{short}.png").exists()
-    )
+    return missing_hero_icons(heroes_path, out_dir)
 
 
 def check(heroes_path: Path = _HEROES_JSON, out_dir: Path = _OUT_DIR) -> int:
@@ -79,44 +66,17 @@ def fetch(
     heroes_path: Path = _HEROES_JSON,
     out_dir: Path = _OUT_DIR,
 ) -> None:
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    # macOS doesn't use system certs by default; disable verification for CDN
-    ctx = ssl.create_default_context()
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE
-
-    ok = failed = skipped = 0
-    for short in _hero_shorts(heroes_path):
-        out_path = out_dir / f"{short}.png"
-        if out_path.exists() and not force:
-            skipped += 1
-            continue
-
-        cdn_short = _CDN_OVERRIDES.get(short, short)
-        urls = [
-            _CDN_PRIMARY.format(short=cdn_short),
-            _CDN_FALLBACK.format(short=cdn_short),
-            _CDN_STRATZ.format(short=cdn_short),
-        ]
-        fetched = False
-        for url in urls:
-            try:
-                req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
-                with urllib.request.urlopen(req, timeout=10, context=ctx) as resp:
-                    out_path.write_bytes(resp.read())
-                print(f"  OK  {short}")
-                ok += 1
-                fetched = True
-                time.sleep(0.05)
-                break
-            except Exception:
-                continue
-        if not fetched:
-            print(f"  FAIL {short}", file=sys.stderr)
-            failed += 1
-
-    print(f"\nDone — {ok} downloaded, {skipped} skipped, {failed} failed -> {out_dir}")
+    result = download_hero_icons(
+        force=force,
+        heroes_path=heroes_path,
+        out_dir=out_dir,
+        reporter=print,
+        error_reporter=lambda message: print(message, file=sys.stderr),
+    )
+    print(
+        f"\nDone — {result.downloaded} downloaded, {result.skipped} skipped, "
+        f"{result.failed} failed -> {result.out_dir}"
+    )
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/scripts/fetch_item_icons.py
+++ b/scripts/fetch_item_icons.py
@@ -19,17 +19,19 @@ Usage::
 from __future__ import annotations
 
 import argparse
-import json
-import ssl
 import sys
-import time
-import urllib.request
 from collections.abc import Sequence
 from pathlib import Path
 
-_ITEMS_JSON = Path(__file__).parent.parent / "src" / "gem" / "data" / "items.json"
-_OUT_DIR = Path(__file__).parent.parent / "src" / "gem" / "data" / "item_icons"
-_CDN = "https://cdn.dota2.com/apps/dota2/images/dota_react/items/{short}.png"
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from gem.reports.asset_cache import (  # noqa: E402
+    ITEMS_JSON as _ITEMS_JSON,
+    SOURCE_ITEM_ICON_DIR as _OUT_DIR,
+    download_item_icons,
+    item_icon_shorts,
+    missing_item_icons,
+)
 
 
 def _short(item_key: str) -> str:
@@ -37,14 +39,7 @@ def _short(item_key: str) -> str:
 
 
 def _item_shorts(items_path: Path, *, include_recipes: bool = False) -> tuple[str, ...]:
-    items: dict = json.loads(items_path.read_text(encoding="utf-8"))
-    shorts = []
-    for item_key in sorted(items):
-        short = _short(item_key)
-        if short.startswith("recipe_") and not include_recipes:
-            continue
-        shorts.append(short)
-    return tuple(shorts)
+    return item_icon_shorts(items_path, include_recipes=include_recipes)
 
 
 def missing_icon_shorts(
@@ -53,11 +48,7 @@ def missing_icon_shorts(
     *,
     include_recipes: bool = False,
 ) -> tuple[str, ...]:
-    return tuple(
-        short
-        for short in _item_shorts(items_path, include_recipes=include_recipes)
-        if not (out_dir / f"{short}.png").exists()
-    )
+    return missing_item_icons(items_path, out_dir, include_recipes=include_recipes)
 
 
 def check(
@@ -84,33 +75,18 @@ def fetch(
     *,
     include_recipes: bool = False,
 ) -> None:
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    ctx = ssl.create_default_context()
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE
-
-    ok = failed = skipped = 0
-    for short in _item_shorts(items_path, include_recipes=include_recipes):
-        out_path = out_dir / f"{short}.png"
-        if out_path.exists() and not force:
-            skipped += 1
-            continue
-
-        url = _CDN.format(short=short)
-        try:
-            req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
-            with urllib.request.urlopen(req, timeout=10, context=ctx) as resp:
-                data = resp.read()
-            out_path.write_bytes(data)
-            print(f"  OK  {short}")
-            ok += 1
-            time.sleep(0.05)
-        except Exception as exc:
-            print(f"  FAIL {short}  ({exc})", file=sys.stderr)
-            failed += 1
-
-    print(f"\nDone — {ok} downloaded, {skipped} skipped, {failed} failed -> {out_dir}")
+    result = download_item_icons(
+        force=force,
+        items_path=items_path,
+        out_dir=out_dir,
+        include_recipes=include_recipes,
+        reporter=print,
+        error_reporter=lambda message: print(message, file=sys.stderr),
+    )
+    print(
+        f"\nDone — {result.downloaded} downloaded, {result.skipped} skipped, "
+        f"{result.failed} failed -> {result.out_dir}"
+    )
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/src/gem/cli.py
+++ b/src/gem/cli.py
@@ -10,6 +10,9 @@ Subcommands
 
 ``batch``
     Parse many replays in parallel — parquet or dataframe output.
+
+``reports assets``
+    Inspect and populate the local asset cache used by HTML reports.
 """
 
 from __future__ import annotations
@@ -18,6 +21,7 @@ import argparse
 import sys
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from rich.align import Align
 from rich.box import HEAVY
@@ -29,6 +33,9 @@ from rich.text import Text
 
 from gem import __version__, parse, parse_to_json, parse_to_parquet
 from gem.results.models import ParsedMatch
+
+if TYPE_CHECKING:
+    from gem.reports.asset_cache import IconDownloadResult
 
 # ---------------------------------------------------------------------------
 # Argument parser
@@ -47,7 +54,9 @@ def _build_parser() -> argparse.ArgumentParser:
             "  python -m gem batch replays/ --format parquet --output ./out\n"
             "  python -m gem batch replays/ --format dataframe --output ./out\n"
             "  python -m gem batch replays/ --workers 4 --recursive\n"
-            "  python -m gem parse match.dem --progress --timings"
+            "  python -m gem parse match.dem --progress --timings\n"
+            "  python -m gem reports assets status\n"
+            "  python -m gem reports assets download --icons"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -112,6 +121,83 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     _add_common_flags(batch_cmd)
 
+    # ── reports subcommand ──────────────────────────────────────────────────
+    reports_cmd = subparsers.add_parser(
+        "reports",
+        help="Utilities for HTML report generation.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    _add_common_flags(reports_cmd)
+    reports_subparsers = reports_cmd.add_subparsers(dest="reports_command", required=True)
+
+    assets_cmd = reports_subparsers.add_parser(
+        "assets",
+        help="Inspect and populate the local report asset cache.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    assets_subparsers = assets_cmd.add_subparsers(dest="assets_command", required=True)
+
+    asset_path_cmd = assets_subparsers.add_parser(
+        "path",
+        help="Show report asset cache paths.",
+    )
+    _add_asset_dir_flag(asset_path_cmd)
+
+    asset_status_cmd = assets_subparsers.add_parser(
+        "status",
+        help="Show which report assets are present or missing.",
+    )
+    _add_asset_dir_flag(asset_status_cmd)
+    asset_status_cmd.add_argument(
+        "--include-recipes",
+        action="store_true",
+        help="Include recipe_* item icons in the item-icon completeness check.",
+    )
+    asset_status_cmd.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit with status 1 when any report asset kind is incomplete.",
+    )
+
+    asset_download_cmd = assets_subparsers.add_parser(
+        "download",
+        help="Download report icon assets into the cache.",
+    )
+    _add_asset_dir_flag(asset_download_cmd)
+    asset_download_cmd.add_argument(
+        "--icons",
+        action="store_true",
+        help="Download both hero and item icons.",
+    )
+    asset_download_cmd.add_argument(
+        "--hero-icons",
+        action="store_true",
+        help="Download hero portrait icons.",
+    )
+    asset_download_cmd.add_argument(
+        "--item-icons",
+        action="store_true",
+        help="Download item and rune icons.",
+    )
+    asset_download_cmd.add_argument("--force", action="store_true", help="Re-download files.")
+    asset_download_cmd.add_argument(
+        "--include-recipes",
+        action="store_true",
+        help="Include recipe_* item icons.",
+    )
+
+    asset_map_cmd = assets_subparsers.add_parser(
+        "add-map",
+        help="Copy a local map image into the report asset cache.",
+    )
+    _add_asset_dir_flag(asset_map_cmd)
+    asset_map_cmd.add_argument("path", type=Path, help="Path to a local map image.")
+    asset_map_cmd.add_argument(
+        "--name",
+        default=None,
+        help="Destination filename inside the cache (default: source filename).",
+    )
+
     return parser
 
 
@@ -122,6 +208,15 @@ def _add_common_flags(p: argparse.ArgumentParser) -> None:
     p.add_argument("--no-banner", action="store_true", help="Hide ASCII art banner.")
     p.add_argument("--progress", action="store_true", help="Show live progress.")
     p.add_argument("--timings", action="store_true", help="Show timing breakdown at the end.")
+
+
+def _add_asset_dir_flag(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
+        "--asset-dir",
+        type=Path,
+        default=None,
+        help="Report asset cache root (default: GEM_REPORT_ASSET_DIR or the user cache).",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -470,6 +565,149 @@ def _run_batch(args: argparse.Namespace, console: Console) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Report asset handlers
+# ---------------------------------------------------------------------------
+
+
+def _run_reports(args: argparse.Namespace, console: Console) -> None:
+    if args.reports_command == "assets":
+        _run_report_assets(args, console)
+
+
+def _run_report_assets(args: argparse.Namespace, console: Console) -> None:
+    if args.assets_command == "path":
+        _run_assets_path(args, console)
+    elif args.assets_command == "status":
+        _run_assets_status(args, console)
+    elif args.assets_command == "download":
+        _run_assets_download(args, console)
+    elif args.assets_command == "add-map":
+        _run_assets_add_map(args, console)
+
+
+def _run_assets_path(args: argparse.Namespace, console: Console) -> None:
+    from gem.reports.asset_cache import REPORT_ASSET_ENV, report_asset_paths
+
+    paths = report_asset_paths(args.asset_dir)
+    table = Table(title="Report asset cache paths", show_header=True, header_style="bold")
+    table.add_column("Kind", style="cyan", no_wrap=True)
+    table.add_column("Path", overflow="fold")
+    table.add_row("Root", str(paths.root))
+    table.add_row("Hero icons", str(paths.hero_icon_dir))
+    table.add_row("Item icons", str(paths.item_icon_dir))
+    table.add_row("Map images", str(paths.map_dir))
+    console.print(table)
+    console.print(f"[dim]Override with --asset-dir or {REPORT_ASSET_ENV}.[/dim]")
+
+
+def _run_assets_status(args: argparse.Namespace, console: Console) -> None:
+    from gem.reports.asset_cache import AssetKindStatus, report_asset_status
+
+    status = report_asset_status(
+        root=args.asset_dir,
+        include_recipes=args.include_recipes,
+    )
+
+    table = Table(title=f"Report asset status: {status.root}", show_header=True)
+    table.add_column("Kind", style="cyan", no_wrap=True)
+    table.add_column("Present", justify="right")
+    table.add_column("Path", overflow="fold")
+    table.add_column("Missing")
+
+    def add_row(kind: AssetKindStatus) -> None:
+        missing = _format_missing(kind.missing)
+        style = "green" if kind.complete else "yellow"
+        table.add_row(
+            kind.label,
+            f"[{style}]{kind.present}/{kind.expected}[/{style}]",
+            str(kind.path),
+            missing,
+        )
+
+    add_row(status.hero_icons)
+    add_row(status.item_icons)
+    add_row(status.maps)
+    console.print(table)
+
+    if args.strict and not status.complete:
+        sys.exit(1)
+
+
+def _format_missing(missing: tuple[str, ...]) -> str:
+    if not missing:
+        return "[green]complete[/green]"
+    preview = ", ".join(missing[:8])
+    if len(missing) > 8:
+        preview += f", ... (+{len(missing) - 8})"
+    return preview
+
+
+def _run_assets_download(args: argparse.Namespace, console: Console) -> None:
+    from gem.reports.asset_cache import (
+        download_hero_icons,
+        download_item_icons,
+        ensure_report_asset_dirs,
+    )
+
+    paths = ensure_report_asset_dirs(args.asset_dir)
+    selection_given = args.icons or args.hero_icons or args.item_icons
+    download_heroes = args.icons or args.hero_icons or not selection_given
+    download_items = args.icons or args.item_icons or not selection_given
+
+    stderr = Console(stderr=True)
+
+    def out(message: str) -> None:
+        console.print(message, highlight=False)
+
+    def err(message: str) -> None:
+        stderr.print(message, highlight=False)
+
+    failures = 0
+    if download_heroes:
+        result = download_hero_icons(
+            force=args.force,
+            out_dir=paths.hero_icon_dir,
+            reporter=out,
+            error_reporter=err,
+        )
+        _print_download_result(result, console)
+        failures += result.failed
+
+    if download_items:
+        result = download_item_icons(
+            force=args.force,
+            out_dir=paths.item_icon_dir,
+            include_recipes=args.include_recipes,
+            reporter=out,
+            error_reporter=err,
+        )
+        _print_download_result(result, console)
+        failures += result.failed
+
+    if failures:
+        sys.exit(1)
+
+
+def _print_download_result(result: IconDownloadResult, console: Console) -> None:
+    console.print(
+        f"[green]Done[/green] {result.label}: {result.downloaded} downloaded, "
+        f"{result.skipped} skipped, {result.failed} failed -> {result.out_dir}"
+    )
+
+
+def _run_assets_add_map(args: argparse.Namespace, console: Console) -> None:
+    from gem.reports.asset_cache import add_map_image
+
+    try:
+        dest = add_map_image(args.path, root=args.asset_dir, name=args.name)
+    except FileNotFoundError:
+        Console(stderr=True).print(f"[red]Error:[/red] map image not found: {args.path}")
+        sys.exit(2)
+
+    console.print(f"[green]✓[/green] Added map image: [bold]{dest}[/bold]")
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
@@ -482,7 +720,7 @@ def main() -> None:
     argv = sys.argv[1:]
     if argv:
         first_positional = next((a for a in argv if not a.startswith("-")), None)
-        if first_positional is not None and first_positional not in ("parse", "batch"):
+        if first_positional is not None and first_positional not in ("parse", "batch", "reports"):
             idx = argv.index(first_positional)
             argv = argv[:idx] + ["parse"] + argv[idx:]
             sys.argv = [sys.argv[0]] + argv
@@ -496,14 +734,21 @@ def main() -> None:
     json_to_stdout = args.subcommand == "parse" and args.format == "json" and args.output is None
     console = Console(stderr=json_to_stdout)
 
-    emit_banner = not args.quiet and not args.no_banner and not json_to_stdout
+    emit_banner = (
+        args.subcommand != "reports"
+        and not args.quiet
+        and not args.no_banner
+        and not json_to_stdout
+    )
     if emit_banner:
         _print_banner(console)
 
     if args.subcommand == "parse":
         _run_parse(args, console)
-    else:
+    elif args.subcommand == "batch":
         _run_batch(args, console)
+    else:
+        _run_reports(args, console)
 
 
 if __name__ == "__main__":

--- a/src/gem/reports/README.md
+++ b/src/gem/reports/README.md
@@ -94,7 +94,7 @@ lists are identical.
 `build_html_report(match, *, assets, options, map_b64)` in `builder.py` is the
 entry point. In order, it:
 
-1. Resolves `assets` (default `ReportAssets()`) and `options` (default
+1. Resolves `assets` (default `ReportAssets.auto()`) and `options` (default
    `ReportOptions()`), calls `configure_assets(assets)` to point the icon
    loaders at the right directories and clear stale icon caches, and loads the
    map image to base64 via `load_map_base64` unless a `map_b64` was passed.
@@ -124,10 +124,11 @@ map_b64)` is a backward-compatible alias for the old example-helper name and
 just forwards to `build_html_report`.
 
 `__init__.py` exports the supported surface: `ReportAssets`, `ReportOptions`,
-`build_html`, `build_html_report`, `write_html_report`. The public package
-re-exports `gem.reports` so `gem.reports.build_html_report(match)` works
-(`api.py:68`); `examples/match_report.py` is a thin CLI wrapper over
-`write_html_report`.
+the asset-cache helpers (`report_asset_paths`, `report_asset_status`,
+`add_map_image`, etc.), `build_html`, `build_html_report`, and
+`write_html_report`. The public package re-exports `gem.reports` so
+`gem.reports.build_html_report(match)` works (`api.py:68`);
+`examples/match_report.py` is a thin CLI wrapper over `write_html_report`.
 
 ## Tabs Are JS-Driven, Not Pure CSS
 
@@ -144,12 +145,25 @@ in `sections/combat.py`; only the filter *handler* lives in `builder.py`.
 
 ## Assets: Base64 Icons And Map Images
 
-`assets.py` owns asset loading and the inline-icon caches:
+`assets.py` owns asset loading and the inline-icon caches, while
+`asset_cache.py` owns the user-cache layout and setup helpers:
 
 - `ReportAssets` is a frozen dataclass of three optional paths: `map_image`,
   `hero_icon_dir`, `item_icon_dir`. `gem` does **not** ship map images or icon
-  caches in the wheel — callers point these at locally-fetched assets (see the
-  `scripts/fetch_*_icons.py` tooling).
+  caches in the wheel. `ReportAssets.auto()` checks the configured user cache
+  first, then uses the source-checkout icon directories as a development
+  fallback when no explicit cache root is passed.
+- The report asset cache root is `GEM_REPORT_ASSET_DIR` when set, otherwise the
+  platform user cache (`~/Library/Caches/gem-dota/reports` on macOS,
+  `%LOCALAPPDATA%/gem-dota/reports` on Windows, or
+  `$XDG_CACHE_HOME/gem-dota/reports` / `~/.cache/gem-dota/reports` on Linux).
+  It contains `hero_icons/`, `item_icons/`, and `maps/`.
+- Users can inspect or populate the cache with
+  `python -m gem reports assets status`,
+  `python -m gem reports assets download --icons`, and
+  `python -m gem reports assets add-map assets/maps/Game_map_7.40.jpg`.
+  The older `scripts/fetch_*_icons.py` entry points are compatibility wrappers
+  around the same package functions.
 - Module-global dicts `ITEM_ICON_B64` and `HERO_ICON_B64` map short names to
   `"data:image/png;base64,..."` URIs. `configure_assets` resets them on every
   build so a second report with different asset dirs can't inherit stale icons.

--- a/src/gem/reports/__init__.py
+++ b/src/gem/reports/__init__.py
@@ -1,12 +1,38 @@
 """HTML report generation for parsed Dota 2 matches."""
 
+from gem.reports.asset_cache import (
+    ReportAssetPaths,
+    ReportAssetStatus,
+    add_map_image,
+    default_report_asset_dir,
+    ensure_report_asset_dirs,
+    report_asset_paths,
+    report_asset_status,
+)
 from gem.reports.assets import ReportAssets
 from gem.reports.builder import ReportOptions, build_html, build_html_report, write_html_report
+from gem.reports.player_names import (
+    apply_opendota_player_names,
+    apply_opendota_player_names_from_path,
+    display_player_name,
+    is_displayable_player_name,
+)
 
 __all__ = [
     "ReportAssets",
+    "ReportAssetPaths",
+    "ReportAssetStatus",
     "ReportOptions",
+    "add_map_image",
+    "apply_opendota_player_names",
+    "apply_opendota_player_names_from_path",
     "build_html",
     "build_html_report",
+    "default_report_asset_dir",
+    "display_player_name",
+    "ensure_report_asset_dirs",
+    "is_displayable_player_name",
+    "report_asset_paths",
+    "report_asset_status",
     "write_html_report",
 ]

--- a/src/gem/reports/_movement.py
+++ b/src/gem/reports/_movement.py
@@ -10,6 +10,7 @@ import plotly.graph_objects as go
 
 from gem.catalog import ability_display, hero_display, item_display, league_name
 from gem.reports._formatting import MAP_XMAX, MAP_XMIN, MAP_YMAX, MAP_YMIN
+from gem.reports.player_names import display_player_name
 from gem.results.models import ParsedMatch, ParsedPlayer
 
 # ---------------------------------------------------------------------------
@@ -256,9 +257,10 @@ def build_figure(
         color = _SLOT_COLORS[pp.player_id]
         team = "Radiant" if pp.team == 2 else "Dire"
         name = hero_display(pp.hero_name)
+        player_name = display_player_name(pp)
         label = (
-            f"{pp.player_name} · {name}"
-            if pp.player_name
+            f"{player_name} · {name}"
+            if player_name
             else f"[{team[0]}{pp.player_id % 5 + 1}] {name}"
         )
         xs = [_world_to_frac(wx, wy)[0] for _, wx, wy in pp.position_log]
@@ -282,9 +284,10 @@ def build_figure(
         color = _SLOT_COLORS[pp.player_id]
         team = "Radiant" if pp.team == 2 else "Dire"
         name = hero_display(pp.hero_name)
+        player_name = display_player_name(pp)
         label = (
-            f"{pp.player_name} · {name}"
-            if pp.player_name
+            f"{player_name} · {name}"
+            if player_name
             else f"[{team[0]}{pp.player_id % 5 + 1}] {name}"
         )
         first_tick, first_wx, first_wy = pp.position_log[0]
@@ -316,10 +319,11 @@ def build_figure(
             color = _SLOT_COLORS[pp.player_id]
             name = hero_display(pp.hero_name)
             team = "Radiant" if pp.team == 2 else "Dire"
-            ann_text = f"{pp.player_name} · {name}" if pp.player_name else name
+            player_name = display_player_name(pp)
+            ann_text = f"{player_name} · {name}" if player_name else name
             label = (
-                f"{pp.player_name} · {name}"
-                if pp.player_name
+                f"{player_name} · {name}"
+                if player_name
                 else f"[{team[0]}{pp.player_id % 5 + 1}] {name}"
             )
             window = [(t, wx, wy) for t, wx, wy in pp.position_log if t <= tick][-_TRAIL:]

--- a/src/gem/reports/asset_cache.py
+++ b/src/gem/reports/asset_cache.py
@@ -1,0 +1,464 @@
+"""Report asset cache discovery, status, and download helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shutil
+import ssl
+import time
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from gem.reports.assets import ReportAssets
+
+REPORT_ASSET_ENV = "GEM_REPORT_ASSET_DIR"
+DEFAULT_MAP_NAME = "Game_map_7.40.jpg"
+
+HERO_ICON_SUBDIR = "hero_icons"
+ITEM_ICON_SUBDIR = "item_icons"
+MAP_SUBDIR = "maps"
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+HEROES_JSON = DATA_DIR / "heroes.json"
+ITEMS_JSON = DATA_DIR / "items.json"
+SOURCE_HERO_ICON_DIR = DATA_DIR / HERO_ICON_SUBDIR
+SOURCE_ITEM_ICON_DIR = DATA_DIR / ITEM_ICON_SUBDIR
+
+_IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".webp"}
+_HERO_CDN_URLS = (
+    "https://steamcdn-a.akamaihd.net/apps/dota2/images/heroes/{short}_icon.png",
+    "https://cdn.dota2.com/apps/dota2/images/heroes/{short}_icon.png",
+    "https://cdn.cloudflare.steamstatic.com/apps/dota2/images/dota_react/heroes/icons/{short}.png",
+    "https://cdn.stratz.com/images/dota2/heroes/{short}_icon.png",
+)
+_ITEM_CDN_URLS = (
+    "https://cdn.dota2.com/apps/dota2/images/dota_react/items/{short}.png",
+    "https://cdn.cloudflare.steamstatic.com/apps/dota2/images/items/{short}_lg.png",
+)
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+# Some heroes use a different short name on the CDN.
+_HERO_CDN_OVERRIDES: dict[str, str] = {
+    "dawnbreaker": "dawnbreaker",
+    "kez": "kez",
+    "marci": "marci",
+    "muerta": "muerta",
+    "primal_beast": "primal_beast",
+    "ringmaster": "ringmaster",
+    "void_spirit": "void_spirit",
+}
+
+
+@dataclass(frozen=True)
+class ReportAssetPaths:
+    """Filesystem locations used for local report assets."""
+
+    root: Path
+    hero_icon_dir: Path
+    item_icon_dir: Path
+    map_dir: Path
+
+
+@dataclass(frozen=True)
+class AssetKindStatus:
+    """Status for one asset kind in a report asset cache."""
+
+    label: str
+    path: Path
+    expected: int
+    present: int
+    missing: tuple[str, ...]
+
+    @property
+    def complete(self) -> bool:
+        return not self.missing
+
+
+@dataclass(frozen=True)
+class ReportAssetStatus:
+    """Status snapshot for a complete report asset cache."""
+
+    root: Path
+    hero_icons: AssetKindStatus
+    item_icons: AssetKindStatus
+    maps: AssetKindStatus
+
+    @property
+    def complete(self) -> bool:
+        return self.hero_icons.complete and self.item_icons.complete and self.maps.complete
+
+
+@dataclass(frozen=True)
+class IconDownloadResult:
+    """Summary of one icon download run."""
+
+    label: str
+    out_dir: Path
+    downloaded: int
+    skipped: int
+    failed: int
+
+
+def default_report_asset_dir() -> Path:
+    """Return the default user cache directory for report assets.
+
+    Set ``GEM_REPORT_ASSET_DIR`` to override this location.
+    """
+
+    configured = os.environ.get(REPORT_ASSET_ENV)
+    if configured:
+        return Path(configured).expanduser()
+
+    system = platform.system()
+    if system == "Darwin":
+        base = Path("~/Library/Caches").expanduser()
+    elif system == "Windows":
+        base = Path(os.environ.get("LOCALAPPDATA", "~/AppData/Local")).expanduser()
+    else:
+        base = Path(os.environ.get("XDG_CACHE_HOME", "~/.cache")).expanduser()
+
+    return base / "gem-dota" / "reports"
+
+
+def report_asset_paths(root: str | Path | None = None) -> ReportAssetPaths:
+    """Resolve the cache subdirectories used by reports."""
+
+    root_path = Path(root).expanduser() if root is not None else default_report_asset_dir()
+    return ReportAssetPaths(
+        root=root_path,
+        hero_icon_dir=root_path / HERO_ICON_SUBDIR,
+        item_icon_dir=root_path / ITEM_ICON_SUBDIR,
+        map_dir=root_path / MAP_SUBDIR,
+    )
+
+
+def ensure_report_asset_dirs(root: str | Path | None = None) -> ReportAssetPaths:
+    """Create and return the report asset cache directories."""
+
+    paths = report_asset_paths(root)
+    paths.hero_icon_dir.mkdir(parents=True, exist_ok=True)
+    paths.item_icon_dir.mkdir(parents=True, exist_ok=True)
+    paths.map_dir.mkdir(parents=True, exist_ok=True)
+    return paths
+
+
+def auto_report_assets(
+    *,
+    root: str | Path | None = None,
+    fallback_map: str | Path | None = None,
+    map_name: str = DEFAULT_MAP_NAME,
+) -> ReportAssets:
+    """Build a ``ReportAssets`` value from the configured cache.
+
+    The user cache is checked first. In source checkouts, the local
+    ``src/gem/data/*_icons`` directories are used as a development fallback
+    when no explicit cache root is supplied. ``fallback_map`` is useful for
+    examples that keep a map image in the repository instead of the user cache.
+    """
+
+    paths = report_asset_paths(root)
+    use_source_fallback = root is None
+
+    map_image = _choose_map(paths.map_dir, map_name)
+    if map_image is None:
+        map_image = _existing_file(fallback_map)
+
+    hero_icon_dir = _populated_icon_dir(paths.hero_icon_dir)
+    item_icon_dir = _populated_icon_dir(paths.item_icon_dir)
+    if use_source_fallback:
+        hero_icon_dir = hero_icon_dir or _populated_icon_dir(SOURCE_HERO_ICON_DIR)
+        item_icon_dir = item_icon_dir or _populated_icon_dir(SOURCE_ITEM_ICON_DIR)
+
+    return ReportAssets(
+        map_image=map_image,
+        hero_icon_dir=hero_icon_dir,
+        item_icon_dir=item_icon_dir,
+    )
+
+
+def report_asset_status(
+    *,
+    root: str | Path | None = None,
+    include_recipes: bool = False,
+    map_name: str = DEFAULT_MAP_NAME,
+) -> ReportAssetStatus:
+    """Return cache completeness for maps and hero/item icons."""
+
+    paths = report_asset_paths(root)
+    hero_expected = hero_icon_shorts()
+    item_expected = item_icon_shorts(include_recipes=include_recipes)
+    hero_missing = missing_hero_icons(out_dir=paths.hero_icon_dir)
+    item_missing = missing_item_icons(out_dir=paths.item_icon_dir, include_recipes=include_recipes)
+    map_files = _map_files(paths.map_dir)
+    map_missing = () if map_files else (map_name,)
+
+    return ReportAssetStatus(
+        root=paths.root,
+        hero_icons=AssetKindStatus(
+            label="Hero icons",
+            path=paths.hero_icon_dir,
+            expected=len(hero_expected),
+            present=len(hero_expected) - len(hero_missing),
+            missing=hero_missing,
+        ),
+        item_icons=AssetKindStatus(
+            label="Item icons",
+            path=paths.item_icon_dir,
+            expected=len(item_expected),
+            present=len(item_expected) - len(item_missing),
+            missing=item_missing,
+        ),
+        maps=AssetKindStatus(
+            label="Map images",
+            path=paths.map_dir,
+            expected=1,
+            present=1 if map_files else 0,
+            missing=map_missing,
+        ),
+    )
+
+
+def add_map_image(
+    source: str | Path,
+    *,
+    root: str | Path | None = None,
+    name: str | None = None,
+) -> Path:
+    """Copy a map image into the report asset cache and return its new path."""
+
+    source_path = Path(source).expanduser()
+    if not source_path.exists():
+        raise FileNotFoundError(source_path)
+
+    paths = ensure_report_asset_dirs(root)
+    dest = paths.map_dir / (name or source_path.name)
+    shutil.copy2(source_path, dest)
+    return dest
+
+
+def hero_icon_shorts(heroes_path: str | Path = HEROES_JSON) -> tuple[str, ...]:
+    """Return expected hero icon short names from ``heroes.json``."""
+
+    heroes: dict[str, object] = json.loads(Path(heroes_path).read_text(encoding="utf-8"))
+    return tuple(_hero_short(npc_name) for npc_name in sorted(heroes))
+
+
+def item_icon_shorts(
+    items_path: str | Path = ITEMS_JSON,
+    *,
+    include_recipes: bool = False,
+) -> tuple[str, ...]:
+    """Return expected item icon short names from ``items.json``."""
+
+    items: dict[str, object] = json.loads(Path(items_path).read_text(encoding="utf-8"))
+    shorts: list[str] = []
+    for item_key in sorted(items):
+        short = _item_short(item_key)
+        if short.startswith("recipe_") and not include_recipes:
+            continue
+        shorts.append(short)
+    return tuple(shorts)
+
+
+def missing_hero_icons(
+    heroes_path: str | Path = HEROES_JSON,
+    out_dir: str | Path | None = None,
+) -> tuple[str, ...]:
+    """Return hero short names missing from an icon directory."""
+
+    icon_dir = (
+        Path(out_dir).expanduser() if out_dir is not None else report_asset_paths().hero_icon_dir
+    )
+    return tuple(
+        short
+        for short in hero_icon_shorts(heroes_path)
+        if not _is_png_file(icon_dir / f"{short}.png")
+    )
+
+
+def missing_item_icons(
+    items_path: str | Path = ITEMS_JSON,
+    out_dir: str | Path | None = None,
+    *,
+    include_recipes: bool = False,
+) -> tuple[str, ...]:
+    """Return item short names missing from an icon directory."""
+
+    icon_dir = (
+        Path(out_dir).expanduser() if out_dir is not None else report_asset_paths().item_icon_dir
+    )
+    return tuple(
+        short
+        for short in item_icon_shorts(items_path, include_recipes=include_recipes)
+        if not _is_png_file(icon_dir / f"{short}.png")
+    )
+
+
+def download_hero_icons(
+    *,
+    force: bool = False,
+    heroes_path: str | Path = HEROES_JSON,
+    out_dir: str | Path | None = None,
+    reporter: Callable[[str], None] | None = None,
+    error_reporter: Callable[[str], None] | None = None,
+) -> IconDownloadResult:
+    """Download missing hero icons into the report asset cache."""
+
+    icon_dir = _download_dir(out_dir, HERO_ICON_SUBDIR)
+    ctx = _cdn_ssl_context()
+    downloaded = failed = skipped = 0
+
+    for short in hero_icon_shorts(heroes_path):
+        out_path = icon_dir / f"{short}.png"
+        if _is_png_file(out_path) and not force:
+            skipped += 1
+            continue
+
+        cdn_short = _HERO_CDN_OVERRIDES.get(short, short)
+        urls = [url.format(short=cdn_short) for url in _HERO_CDN_URLS]
+        if _download_first(urls, out_path, ctx):
+            downloaded += 1
+            _emit(reporter, f"  OK  {short}")
+            time.sleep(0.05)
+        else:
+            failed += 1
+            _emit(error_reporter, f"  FAIL {short}")
+
+    return IconDownloadResult(
+        label="hero icons",
+        out_dir=icon_dir,
+        downloaded=downloaded,
+        skipped=skipped,
+        failed=failed,
+    )
+
+
+def download_item_icons(
+    *,
+    force: bool = False,
+    items_path: str | Path = ITEMS_JSON,
+    out_dir: str | Path | None = None,
+    include_recipes: bool = False,
+    reporter: Callable[[str], None] | None = None,
+    error_reporter: Callable[[str], None] | None = None,
+) -> IconDownloadResult:
+    """Download missing item icons into the report asset cache."""
+
+    icon_dir = _download_dir(out_dir, ITEM_ICON_SUBDIR)
+    ctx = _cdn_ssl_context()
+    downloaded = failed = skipped = 0
+
+    for short in item_icon_shorts(items_path, include_recipes=include_recipes):
+        out_path = icon_dir / f"{short}.png"
+        if out_path.exists() and not force:
+            skipped += 1
+            continue
+
+        urls = [url.format(short=short) for url in _ITEM_CDN_URLS]
+        if _download_first(urls, out_path, ctx):
+            downloaded += 1
+            _emit(reporter, f"  OK  {short}")
+            time.sleep(0.05)
+        else:
+            failed += 1
+            _emit(error_reporter, f"  FAIL {short}")
+
+    return IconDownloadResult(
+        label="item icons",
+        out_dir=icon_dir,
+        downloaded=downloaded,
+        skipped=skipped,
+        failed=failed,
+    )
+
+
+def _hero_short(npc_name: str) -> str:
+    return npc_name.removeprefix("npc_dota_hero_")
+
+
+def _item_short(item_key: str) -> str:
+    return item_key.removeprefix("item_")
+
+
+def _download_dir(out_dir: str | Path | None, subdir: str) -> Path:
+    if out_dir is not None:
+        icon_dir = Path(out_dir).expanduser()
+        icon_dir.mkdir(parents=True, exist_ok=True)
+        return icon_dir
+
+    paths = ensure_report_asset_dirs()
+    return paths.hero_icon_dir if subdir == HERO_ICON_SUBDIR else paths.item_icon_dir
+
+
+def _cdn_ssl_context() -> ssl.SSLContext:
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+def _download_first(urls: list[str], out_path: Path, ctx: ssl.SSLContext) -> bool:
+    for url in urls:
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+            with urllib.request.urlopen(req, timeout=10, context=ctx) as resp:
+                data = resp.read()
+            if not _is_png_bytes(data):
+                continue
+            out_path.write_bytes(data)
+            return True
+        except Exception:
+            continue
+    return False
+
+
+def _emit(reporter: Callable[[str], None] | None, message: str) -> None:
+    if reporter is not None:
+        reporter(message)
+
+
+def _existing_file(path: str | Path | None) -> Path | None:
+    if path is None:
+        return None
+    candidate = Path(path).expanduser()
+    return candidate if candidate.exists() else None
+
+
+def _populated_icon_dir(path: Path) -> Path | None:
+    if not path.is_dir():
+        return None
+    return path if any(_is_png_file(icon) for icon in path.glob("*.png")) else None
+
+
+def _is_png_file(path: Path) -> bool:
+    if not path.exists():
+        return False
+    try:
+        with path.open("rb") as fh:
+            return _is_png_bytes(fh.read(len(_PNG_MAGIC)))
+    except OSError:
+        return False
+
+
+def _is_png_bytes(data: bytes) -> bool:
+    return data.startswith(_PNG_MAGIC)
+
+
+def _map_files(path: Path) -> tuple[Path, ...]:
+    if not path.is_dir():
+        return ()
+    return tuple(
+        sorted(p for p in path.iterdir() if p.is_file() and p.suffix.lower() in _IMAGE_SUFFIXES)
+    )
+
+
+def _choose_map(path: Path, map_name: str) -> Path | None:
+    preferred = path / map_name
+    if preferred.exists():
+        return preferred
+    files = _map_files(path)
+    return files[0] if files else None

--- a/src/gem/reports/asset_cache.py
+++ b/src/gem/reports/asset_cache.py
@@ -354,7 +354,7 @@ def download_item_icons(
 
     for short in item_icon_shorts(items_path, include_recipes=include_recipes):
         out_path = icon_dir / f"{short}.png"
-        if out_path.exists() and not force:
+        if _is_png_file(out_path) and not force:
             skipped += 1
             continue
 

--- a/src/gem/reports/assets.py
+++ b/src/gem/reports/assets.py
@@ -25,6 +25,20 @@ class ReportAssets:
     hero_icon_dir: str | Path | None = None
     item_icon_dir: str | Path | None = None
 
+    @classmethod
+    def auto(
+        cls,
+        *,
+        root: str | Path | None = None,
+        fallback_map: str | Path | None = None,
+        map_name: str = "Game_map_7.40.jpg",
+    ) -> ReportAssets:
+        """Discover local report assets from the configured asset cache."""
+
+        from gem.reports.asset_cache import auto_report_assets
+
+        return auto_report_assets(root=root, fallback_map=fallback_map, map_name=map_name)
+
 
 # Global caches: short_name → "data:image/png;base64,..." (populated at build time)
 ITEM_ICON_B64: dict[str, str] = {}
@@ -36,6 +50,7 @@ HERO_PLACEHOLDER_B64 = (
     "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ"
     "AAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
 )
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
 
 
 def configure_assets(assets: ReportAssets | None = None) -> None:
@@ -78,7 +93,7 @@ def load_item_icons(short_names: list[str], assets: ReportAssets | None = None) 
         if short in ITEM_ICON_B64:
             continue
         path = icon_dir / f"{short}.png"
-        if path.exists():
+        if _is_png_file(path):
             ITEM_ICON_B64[short] = (
                 "data:image/png;base64," + base64.b64encode(path.read_bytes()).decode()
             )
@@ -107,7 +122,7 @@ def load_hero_icons(npc_names: list[str], assets: ReportAssets | None = None) ->
         if short in HERO_ICON_B64:
             continue
         path = icon_dir / f"{short}.png"
-        if path.exists():
+        if _is_png_file(path):
             HERO_ICON_B64[short] = (
                 "data:image/png;base64," + base64.b64encode(path.read_bytes()).decode()
             )
@@ -117,3 +132,13 @@ def hero_icon_src(npc_name: str) -> str:
     """Return a base64 data URI for a hero portrait, or the placeholder."""
     short = npc_name.removeprefix("npc_dota_hero_")
     return HERO_ICON_B64.get(short, HERO_PLACEHOLDER_B64)
+
+
+def _is_png_file(path: Path) -> bool:
+    if not path.exists():
+        return False
+    try:
+        with path.open("rb") as fh:
+            return fh.read(len(_PNG_MAGIC)).startswith(_PNG_MAGIC)
+    except OSError:
+        return False

--- a/src/gem/reports/builder.py
+++ b/src/gem/reports/builder.py
@@ -236,7 +236,7 @@ def build_html_report(
     Returns:
         Complete HTML string.
     """
-    assets = assets or ReportAssets()
+    assets = assets if assets is not None else ReportAssets.auto()
     options = options or ReportOptions()
     configure_assets(assets)
     if map_b64 is None:

--- a/src/gem/reports/player_names.py
+++ b/src/gem/reports/player_names.py
@@ -1,0 +1,73 @@
+"""Player-name helpers for report rendering."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from gem.results.models import ParsedMatch, ParsedPlayer
+
+
+def is_displayable_player_name(name: str | None) -> bool:
+    """Return whether a replay/API player name is suitable for report display."""
+    if not name:
+        return False
+    stripped = name.strip()
+    if not stripped or "\ufffd" in stripped:
+        return False
+    return stripped.isprintable()
+
+
+def display_player_name(player: ParsedPlayer | None) -> str:
+    """Return the player name to show in reports, or ``""`` when unavailable."""
+    if player is None or not is_displayable_player_name(player.player_name):
+        return ""
+    return player.player_name.strip()
+
+
+def apply_opendota_player_names(
+    match: ParsedMatch,
+    opendota_match: Mapping[str, Any],
+    *,
+    overwrite: bool = True,
+) -> ParsedMatch:
+    """Apply clean OpenDota player display names to a parsed match.
+
+    Replay ``CDOTA_PlayerResource`` names can occasionally contain binary-looking
+    payloads. OpenDota match JSON carries the public ``personaname`` for the same
+    player slots, so reports can use that sidecar data when callers have it.
+    """
+    players_by_id = {player.player_id: player for player in match.players}
+    for od_player in opendota_match.get("players") or []:
+        if not isinstance(od_player, Mapping):
+            continue
+        player_slot = od_player.get("player_slot")
+        if not isinstance(player_slot, int):
+            continue
+        player = players_by_id.get(_opendota_slot_to_player_id(player_slot))
+        if player is None:
+            continue
+        name = od_player.get("personaname") or od_player.get("name")
+        if not isinstance(name, str) or not is_displayable_player_name(name):
+            continue
+        if overwrite or not display_player_name(player):
+            player.player_name = name.strip()
+    return match
+
+
+def apply_opendota_player_names_from_path(
+    match: ParsedMatch,
+    path: str | Path,
+    *,
+    overwrite: bool = True,
+) -> ParsedMatch:
+    """Load OpenDota match JSON from *path* and apply its player names."""
+    with Path(path).open(encoding="utf-8") as fh:
+        opendota_match = json.load(fh)
+    return apply_opendota_player_names(match, opendota_match, overwrite=overwrite)
+
+
+def _opendota_slot_to_player_id(player_slot: int) -> int:
+    return player_slot if player_slot < 128 else (player_slot - 128) + 5

--- a/src/gem/reports/sections/combat.py
+++ b/src/gem/reports/sections/combat.py
@@ -36,6 +36,7 @@ from gem.reports.assets import (
     load_hero_icons,
     load_item_icons,
 )
+from gem.reports.player_names import display_player_name
 from gem.reports.sections._shared import (
     _DIRE_COLORS,
     _RADIANT_COLORS,
@@ -721,7 +722,7 @@ def build_teamfights(match: ParsedMatch, map_b64: str | None) -> str:
                 pp = slot_to_player.get(slot, ParsedPlayer(player_id=slot))
                 team_cls = "radiant" if pp.team == 2 else "dire"
                 died_cls = " died" if slot in died_slots else ""
-                pname = e(pp.player_name or "")
+                pname = e(display_player_name(pp))
                 hname = e(hero(pp.hero_name))
                 src = hero_icon_src(pp.hero_name)
                 parts.append(
@@ -749,7 +750,7 @@ def build_teamfights(match: ParsedMatch, map_b64: str | None) -> str:
                 parts.append(
                     f'<tr class="{row_cls}">'
                     f"<td>{hero_cell(pp.hero_name, pp.team)}"
-                    f'<div style="color:#8b949e;font-size:11px">{e(pp.player_name or "")}</div></td>'
+                    f'<div style="color:#8b949e;font-size:11px">{e(display_player_name(pp))}</div></td>'
                     f'<td class="r">{getattr(tfp, "damage_dealt", 0):,}</td>'
                     f'<td class="r">{getattr(tfp, "damage_taken", 0):,}</td>'
                     f'<td class="r">{getattr(tfp, "deaths", 0):,}</td>'

--- a/src/gem/reports/sections/match.py
+++ b/src/gem/reports/sections/match.py
@@ -26,6 +26,7 @@ from gem.reports.assets import (
     hero_icon_src,
     load_hero_icons,
 )
+from gem.reports.player_names import display_player_name
 from gem.results.models import (
     ParsedMatch,
     ParsedPlayer,
@@ -85,7 +86,8 @@ def build_header(
     for pp in match.players:
         if pp.team not in (2, 3):
             continue
-        player_label = e(pp.player_name) if pp.player_name else "—"
+        player_name = display_player_name(pp)
+        player_label = e(player_name) if player_name else "—"
         if pp.account_id:
             player_label = (
                 f'<a href="https://www.opendota.com/players/{pp.account_id}" '
@@ -680,7 +682,7 @@ def build_draft(match: ParsedMatch) -> str:
             name = hero_display(ev.hero_name) if ev.hero_name else f"ID {ev.hero_id}"
             src = hero_icon_src(ev.hero_name) if ev.hero_name else HERO_PLACEHOLDER_B64
             pp = hero_to_player.get(ev.hero_name)
-            player_name = pp.player_name if pp and pp.player_name else ""
+            player_name = display_player_name(pp)
             time_str = fmt_tick(ev.tick) if ev.tick else ""
             player_html = f'<div class="dp-player">{e(player_name)}</div>' if player_name else ""
             cards.append(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -177,3 +177,30 @@ class TestCli:
         out = capsys.readouterr().out
         assert "Examples:" in out
         assert "python -m gem match.dem --format json" in out
+
+    def test_reports_assets_path_command(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setattr(
+            "sys.argv",
+            ["gem", "reports", "assets", "path", "--asset-dir", str(tmp_path)],
+        )
+
+        main()
+
+        out = capsys.readouterr().out
+        assert "Report asset cache paths" in out
+        assert "Hero icons" in out
+        assert "Item icons" in out
+
+    def test_reports_assets_status_command(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setattr(
+            "sys.argv",
+            ["gem", "reports", "assets", "status", "--asset-dir", str(tmp_path)],
+        )
+
+        main()
+
+        out = capsys.readouterr().out
+        assert "Report asset status" in out
+        assert "Hero icons" in out
+        assert "Item icons" in out
+        assert "Map images" in out

--- a/tests/test_fetch_icons.py
+++ b/tests/test_fetch_icons.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 from scripts import fetch_hero_icons, fetch_item_icons
 
+_PNG_BYTES = b"\x89PNG\r\n\x1a\nfake-png"
+
 
 def test_item_icon_check_ignores_recipe_items_by_default(tmp_path: Path) -> None:
     items_path = tmp_path / "items.json"
@@ -20,7 +22,7 @@ def test_item_icon_check_ignores_recipe_items_by_default(tmp_path: Path) -> None
     )
     icon_dir = tmp_path / "item_icons"
     icon_dir.mkdir()
-    (icon_dir / "blink.png").write_bytes(b"png")
+    (icon_dir / "blink.png").write_bytes(_PNG_BYTES)
 
     assert fetch_item_icons.missing_icon_shorts(items_path, icon_dir) == ("conjurers_catalyst",)
     assert fetch_item_icons.missing_icon_shorts(
@@ -50,7 +52,7 @@ def test_item_icon_check_returns_nonzero_for_missing_non_recipe_icons(
     )
     icon_dir = tmp_path / "item_icons"
     icon_dir.mkdir()
-    (icon_dir / "blink.png").write_bytes(b"png")
+    (icon_dir / "blink.png").write_bytes(_PNG_BYTES)
 
     status = fetch_item_icons.main(
         ["--check", "--items", str(items_path), "--out-dir", str(icon_dir)]
@@ -71,7 +73,7 @@ def test_hero_icon_check_returns_zero_when_icons_are_complete(tmp_path: Path, ca
     )
     icon_dir = tmp_path / "hero_icons"
     icon_dir.mkdir()
-    (icon_dir / "axe.png").write_bytes(b"png")
+    (icon_dir / "axe.png").write_bytes(_PNG_BYTES)
 
     status = fetch_hero_icons.main(
         ["--check", "--heroes", str(heroes_path), "--out-dir", str(icon_dir)]
@@ -95,7 +97,7 @@ def test_hero_icon_check_reports_missing_icons(tmp_path: Path, capsys) -> None:
     )
     icon_dir = tmp_path / "hero_icons"
     icon_dir.mkdir()
-    (icon_dir / "axe.png").write_bytes(b"png")
+    (icon_dir / "axe.png").write_bytes(_PNG_BYTES)
 
     status = fetch_hero_icons.main(
         ["--check", "--heroes", str(heroes_path), "--out-dir", str(icon_dir)]

--- a/tests/test_report_assets.py
+++ b/tests/test_report_assets.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import gem.reports.asset_cache as asset_cache
+from gem.reports import ReportAssets, add_map_image, report_asset_status
+
+_PNG_BYTES = b"\x89PNG\r\n\x1a\nfake-png"
+
+
+def test_report_assets_auto_uses_cache_icons_and_fallback_map(tmp_path: Path) -> None:
+    root = tmp_path / "cache"
+    hero_dir = root / "hero_icons"
+    item_dir = root / "item_icons"
+    hero_dir.mkdir(parents=True)
+    item_dir.mkdir(parents=True)
+    (hero_dir / "axe.png").write_bytes(_PNG_BYTES)
+    (item_dir / "blink.png").write_bytes(_PNG_BYTES)
+    fallback_map = tmp_path / "Game_map_7.40.jpg"
+    fallback_map.write_bytes(b"map")
+
+    assets = ReportAssets.auto(root=root, fallback_map=fallback_map)
+
+    assert assets.hero_icon_dir == hero_dir
+    assert assets.item_icon_dir == item_dir
+    assert assets.map_image == fallback_map
+
+
+def test_report_assets_auto_prefers_cached_map(tmp_path: Path) -> None:
+    root = tmp_path / "cache"
+    map_dir = root / "maps"
+    map_dir.mkdir(parents=True)
+    cached_map = map_dir / "Game_map_7.40.jpg"
+    cached_map.write_bytes(b"map")
+    fallback_map = tmp_path / "fallback.jpg"
+    fallback_map.write_bytes(b"fallback")
+
+    assets = ReportAssets.auto(root=root, fallback_map=fallback_map)
+
+    assert assets.map_image == cached_map
+
+
+def test_report_asset_status_reports_missing_assets(tmp_path: Path) -> None:
+    root = tmp_path / "cache"
+    hero_dir = root / "hero_icons"
+    hero_dir.mkdir(parents=True)
+    (hero_dir / "axe.png").write_bytes(_PNG_BYTES)
+
+    status = report_asset_status(root=root)
+
+    assert status.root == root
+    assert status.hero_icons.expected > 0
+    assert status.hero_icons.present >= 1
+    assert "axe" not in status.hero_icons.missing
+    assert status.item_icons.missing
+    assert status.maps.missing == ("Game_map_7.40.jpg",)
+
+
+def test_add_map_image_copies_into_cache(tmp_path: Path) -> None:
+    source = tmp_path / "source-map.jpg"
+    source.write_bytes(b"map")
+
+    dest = add_map_image(source, root=tmp_path / "cache", name="Game_map_7.40.jpg")
+
+    assert dest == tmp_path / "cache" / "maps" / "Game_map_7.40.jpg"
+    assert dest.read_bytes() == b"map"
+
+
+def test_item_download_uses_legacy_lg_fallback_for_missing_react_icon(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    items_path = tmp_path / "items.json"
+    items_path.write_text('{"eternal_shroud": {"id": 1}}', encoding="utf-8")
+    out_dir = tmp_path / "item_icons"
+    calls: list[str] = []
+
+    class Response:
+        def __enter__(self) -> Response:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return _PNG_BYTES
+
+    def fake_urlopen(request: Any, *, timeout: int, context: object) -> Response:
+        url = request.full_url
+        calls.append(url)
+        if "dota_react/items" in url:
+            raise OSError("missing react icon")
+        assert timeout == 10
+        assert context is not None
+        return Response()
+
+    monkeypatch.setattr(asset_cache.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(asset_cache.time, "sleep", lambda _seconds: None)
+
+    result = asset_cache.download_item_icons(items_path=items_path, out_dir=out_dir)
+
+    assert result.downloaded == 1
+    assert result.failed == 0
+    assert calls == [
+        "https://cdn.dota2.com/apps/dota2/images/dota_react/items/eternal_shroud.png",
+        "https://cdn.cloudflare.steamstatic.com/apps/dota2/images/items/eternal_shroud_lg.png",
+    ]
+    assert (out_dir / "eternal_shroud.png").read_bytes() == _PNG_BYTES
+
+
+def test_download_skips_non_png_responses_before_fallback(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    items_path = tmp_path / "items.json"
+    items_path.write_text('{"wind_lace": {"id": 1}}', encoding="utf-8")
+    out_dir = tmp_path / "item_icons"
+    responses = [b"not-a-png", _PNG_BYTES]
+
+    class Response:
+        def __init__(self, data: bytes) -> None:
+            self._data = data
+
+        def __enter__(self) -> Response:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return self._data
+
+    def fake_urlopen(request: Any, *, timeout: int, context: object) -> Response:
+        assert request.full_url
+        assert timeout == 10
+        assert context is not None
+        return Response(responses.pop(0))
+
+    monkeypatch.setattr(asset_cache.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(asset_cache.time, "sleep", lambda _seconds: None)
+
+    result = asset_cache.download_item_icons(items_path=items_path, out_dir=out_dir)
+
+    assert result.downloaded == 1
+    assert result.failed == 0
+    assert (out_dir / "wind_lace.png").read_bytes() == _PNG_BYTES
+
+
+def test_invalid_existing_icon_is_redownloaded_without_force(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    heroes_path = tmp_path / "heroes.json"
+    heroes_path.write_text('{"npc_dota_hero_ringmaster": {"id": 1}}', encoding="utf-8")
+    out_dir = tmp_path / "hero_icons"
+    out_dir.mkdir()
+    out_path = out_dir / "ringmaster.png"
+    out_path.write_bytes(b"RIFF-webp")
+
+    class Response:
+        def __enter__(self) -> Response:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return _PNG_BYTES
+
+    def fake_urlopen(request: Any, *, timeout: int, context: object) -> Response:
+        url = request.full_url
+        if "dota_react/heroes/icons" not in url:
+            raise OSError("try next fallback")
+        assert timeout == 10
+        assert context is not None
+        return Response()
+
+    monkeypatch.setattr(asset_cache.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(asset_cache.time, "sleep", lambda _seconds: None)
+
+    result = asset_cache.download_hero_icons(heroes_path=heroes_path, out_dir=out_dir)
+
+    assert result.downloaded == 1
+    assert result.skipped == 0
+    assert result.failed == 0
+    assert out_path.read_bytes() == _PNG_BYTES

--- a/tests/test_report_assets.py
+++ b/tests/test_report_assets.py
@@ -147,6 +147,46 @@ def test_download_skips_non_png_responses_before_fallback(
     assert (out_dir / "wind_lace.png").read_bytes() == _PNG_BYTES
 
 
+def test_invalid_existing_item_icon_is_redownloaded_without_force(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    items_path = tmp_path / "items.json"
+    items_path.write_text('{"eternal_shroud": {"id": 1}}', encoding="utf-8")
+    out_dir = tmp_path / "item_icons"
+    out_dir.mkdir()
+    out_path = out_dir / "eternal_shroud.png"
+    out_path.write_bytes(b"<html>cdn error</html>")
+
+    class Response:
+        def __enter__(self) -> Response:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return _PNG_BYTES
+
+    def fake_urlopen(request: Any, *, timeout: int, context: object) -> Response:
+        url = request.full_url
+        if "dota_react/items" in url:
+            raise OSError("missing react icon")
+        assert timeout == 10
+        assert context is not None
+        return Response()
+
+    monkeypatch.setattr(asset_cache.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(asset_cache.time, "sleep", lambda _seconds: None)
+
+    result = asset_cache.download_item_icons(items_path=items_path, out_dir=out_dir)
+
+    assert result.downloaded == 1
+    assert result.skipped == 0
+    assert result.failed == 0
+    assert out_path.read_bytes() == _PNG_BYTES
+
+
 def test_invalid_existing_icon_is_redownloaded_without_force(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-from gem.reports import ReportOptions, build_html_report, write_html_report
+from gem.reports import (
+    ReportOptions,
+    apply_opendota_player_names,
+    build_html_report,
+    is_displayable_player_name,
+    write_html_report,
+)
 from gem.results.models import ParsedMatch, ParsedPlayer
 
 
@@ -28,6 +34,46 @@ def test_build_html_report_smoke_without_assets() -> None:
     assert "<title>Smoke Report</title>" in html
     assert "Match ID" in html
     assert "123456789" in html
+
+
+def test_player_name_display_gate_rejects_binary_looking_text() -> None:
+    assert is_displayable_player_name("叽叽喳喳")
+    assert is_displayable_player_name("宇宙にきらめく エメラルド")
+    assert not is_displayable_player_name("0�ɛ�\x01")
+    assert not is_displayable_player_name("�\x17�#�\x01")
+
+
+def test_build_html_report_omits_malformed_replay_player_names() -> None:
+    match = _minimal_match()
+    match.players[0].player_name = "0�ɛ�\x01"
+
+    html = build_html_report(match, options=ReportOptions(include_movement=False))
+
+    assert "\ufffd" not in html
+    assert "\x01" not in html
+
+
+def test_opendota_player_names_make_reports_display_clean_cjk_names() -> None:
+    match = _minimal_match()
+    match.players[0].player_name = "0�ɛ�\x01"
+    match.players[1].player_name = "�\x17�#�\x01"
+
+    apply_opendota_player_names(
+        match,
+        {
+            "players": [
+                {"player_slot": 0, "personaname": "烟弹漏油"},
+                {"player_slot": 128, "personaname": "李火旺"},
+            ],
+        },
+    )
+    html = build_html_report(match, options=ReportOptions(include_movement=False))
+
+    assert match.players[0].player_name == "烟弹漏油"
+    assert match.players[1].player_name == "李火旺"
+    assert "烟弹漏油" in html
+    assert "李火旺" in html
+    assert "\ufffd" not in html
 
 
 def test_write_html_report_returns_written_path(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- add report asset cache discovery/status/download helpers and CLI commands under `python -m gem reports assets`
- validate downloaded/cached icon files as PNGs and add fallback CDN paths for hero and item icons
- apply clean OpenDota player names in report examples and filter malformed replay names in report rendering

## Verification
- `uv run pytest` -> 1668 passed, 3 skipped, 53 deselected
- `uv run mypy src/gem/reports src/gem/cli.py` -> passed
- `uv run ruff check src/ tests/ scripts/fetch_hero_icons.py scripts/fetch_item_icons.py examples/match_report.py` -> passed
- live asset smoke: `python -m gem reports assets download --icons --asset-dir /tmp/gem-report-assets-live-smoke`, then `status --strict` -> hero 127/127, item 409/409, map 1/1
- generated report with live cache and checked no replacement characters