### PR TITLE
docs: polish landing, architecture, changelog + fix reference table rendering

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,8 +1,6 @@
 import { defineConfig } from "vitepress";
-import { withMermaid } from "vitepress-plugin-mermaid";
 
-export default withMermaid(
-  defineConfig({
+export default defineConfig({
   title: "gem-dota",
   description: "A Python Dota 2 replay parser.",
   base: "/gem-dota/",
@@ -76,9 +74,4 @@ export default withMermaid(
       provider: "local",
     },
   },
-  // Mermaid runtime options — themed to follow VitePress light/dark.
-  mermaid: {
-    theme: "default",
-  },
-  }),
-);
+});

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -195,6 +195,40 @@ body {
   border-color: color-mix(in srgb, var(--gem-accent), transparent 52%);
 }
 
+/* ---- Changelog: minimalist, single-tone callouts ------------------ */
+/* The changelog uses tip/info/warning blocks purely for structure, not
+   severity, so flatten them all to one neutral tone on that page only.
+   Scoped via `pageClass: changelog-minimal` in the page frontmatter so
+   semantic colors stay intact everywhere else in the docs. */
+.changelog-minimal .custom-block.tip,
+.changelog-minimal .custom-block.info,
+.changelog-minimal .custom-block.warning {
+  border-color: var(--vp-c-divider);
+  background: var(--gem-surface-soft);
+}
+
+.changelog-minimal .custom-block.tip .custom-block-title,
+.changelog-minimal .custom-block.info .custom-block-title,
+.changelog-minimal .custom-block.warning .custom-block-title {
+  color: var(--vp-c-text-1);
+}
+
+.changelog-minimal .custom-block.tip a,
+.changelog-minimal .custom-block.info a,
+.changelog-minimal .custom-block.warning a {
+  color: var(--vp-c-brand-1);
+}
+
+/* Inline code inside these blocks otherwise inherits the block's accent
+   (e.g. amber in `warning`); pin it to the normal code colors so chips read
+   identically across every changelog block. */
+.changelog-minimal .custom-block.tip code,
+.changelog-minimal .custom-block.info code,
+.changelog-minimal .custom-block.warning code {
+  background: var(--vp-code-bg);
+  color: var(--vp-code-color);
+}
+
 /* ---- Hero: copy then replay readout (stacked) --------------------- */
 
 .gem-hero {
@@ -241,98 +275,6 @@ body {
   gap: 0.72rem;
   margin-top: 1.5rem;
 }
-
-/* Signature element: a replay decoding from bytes to a typed object. */
-.gem-readout {
-  overflow: hidden;
-  margin: 0 0 1.8rem;
-  border: 1px solid color-mix(in srgb, var(--vp-c-brand-1), transparent 56%);
-  border-radius: calc(var(--gem-radius) + 2px);
-  background:
-    radial-gradient(120% 120% at 100% 0%, rgba(94, 224, 160, 0.12), transparent 55%),
-    #0b1410;
-  box-shadow: 0 22px 48px rgba(7, 18, 12, 0.3);
-  font-family: var(--vp-font-family-mono);
-  animation: gem-rise 560ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
-  animation-delay: 90ms;
-}
-
-.gem-readout-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 0.6rem 0.95rem;
-  border-bottom: 1px solid rgba(135, 231, 179, 0.16);
-  background: rgba(135, 231, 179, 0.05);
-}
-
-.gem-readout-name {
-  color: #d6efe1;
-  font-size: 0.82rem;
-  font-weight: 600;
-}
-
-.gem-readout-meta {
-  color: #6f8a7d;
-  font-size: 0.74rem;
-}
-
-.gem-readout-stream {
-  display: flex;
-  flex-direction: column;
-  padding: 0.5rem 0.4rem 0.7rem;
-}
-
-.gem-readout-row {
-  display: grid;
-  grid-template-columns: 4.2rem minmax(0, auto) 1fr;
-  align-items: baseline;
-  gap: 0.7rem;
-  padding: 0.34rem 0.6rem;
-  border-radius: 6px;
-  font-size: 0.8rem;
-  white-space: nowrap;
-  animation: gem-feed 460ms ease both;
-}
-
-.gem-readout-row:nth-child(1) { animation-delay: 0.32s; }
-.gem-readout-row:nth-child(2) { animation-delay: 0.46s; }
-.gem-readout-row:nth-child(3) { animation-delay: 0.6s; }
-.gem-readout-row:nth-child(4) { animation-delay: 0.74s; }
-.gem-readout-row:nth-child(5) { animation-delay: 0.92s; }
-
-.gem-readout-row i {
-  color: #4f7d66;
-  font-style: normal;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  font-size: 0.68rem;
-}
-
-.gem-readout-row b {
-  color: #87e7b3;
-  font-weight: 600;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.gem-readout-row em {
-  color: #7f9c8e;
-  font-style: normal;
-  text-align: right;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.gem-readout-row--out {
-  margin-top: 0.25rem;
-  background: rgba(94, 224, 160, 0.1);
-}
-
-.gem-readout-row--out i { color: var(--gem-accent); }
-.gem-readout-row--out b { color: #effff5; }
-.gem-readout-row--out em { color: #b7d9c8; }
 
 /* ---- Trust strip --------------------------------------------------- */
 
@@ -606,19 +548,6 @@ a.gem-trust-item:hover {
   color: #ffb4a8;
 }
 
-.mermaid {
-  display: flex;
-  justify-content: center;
-  margin: 1.5rem auto;
-}
-
-.mermaid svg {
-  width: 100%;
-  max-width: 860px;
-  height: auto;
-  border-radius: var(--gem-radius);
-}
-
 .arch-layers {
   display: flex;
   flex-direction: column;
@@ -704,6 +633,90 @@ a.gem-trust-item:hover {
 
 .arch-layer--output .arch-badge {
   background: rgba(233, 30, 99, 0.16);
+}
+
+/* ---- Pipeline flow (CSS, replaces Mermaid) ------------------------- */
+
+.arch-flow {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0;
+  margin: 1.5rem 0;
+}
+
+.arch-flow-node {
+  display: flex;
+  flex-direction: column;
+  gap: 0.18rem;
+  padding: 0.7rem 1rem;
+  border: 1px solid var(--vp-c-divider);
+  border-left-width: 3px;
+  border-radius: var(--gem-radius);
+  background: var(--gem-surface);
+  box-shadow: 0 1px 0 rgba(20, 34, 27, 0.03);
+}
+
+.arch-flow-title {
+  font-size: 0.78rem;
+  font-weight: 760;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--vp-c-text-1);
+}
+
+.arch-flow-desc {
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--vp-c-text-2);
+}
+
+.arch-flow-desc code {
+  font-size: 0.82em;
+}
+
+/* Downward connectors between stages. */
+.arch-flow-arrow {
+  align-self: center;
+  padding: 0.15rem 0;
+  color: var(--vp-c-brand-1);
+  font-size: 1.15rem;
+  line-height: 1;
+}
+
+/* Parallel branch: Events + Extractors both consume schema state and
+   both feed assembly. */
+.arch-flow-split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.7rem;
+}
+
+/* Reuse the per-layer accent colors from the "Layers at a glance" band so
+   a given layer reads the same color in both the flow and the inventory. */
+.arch-flow--io {
+  border-left-color: #7c4dff;
+  background: rgba(103, 80, 164, 0.06);
+}
+
+.arch-flow--parse {
+  border-left-color: #2196f3;
+  background: rgba(33, 150, 243, 0.06);
+}
+
+.arch-flow--extract {
+  border-left-color: #009688;
+  background: rgba(0, 150, 136, 0.06);
+}
+
+.arch-flow--assemble {
+  border-left-color: #ff9800;
+  background: rgba(255, 152, 0, 0.06);
+}
+
+.arch-flow--output {
+  border-left-color: #e91e63;
+  background: rgba(233, 30, 99, 0.06);
 }
 
 .output-table {
@@ -810,6 +823,10 @@ a.gem-trust-item:hover {
   .arch-layer {
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .arch-flow-split {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,55 +5,59 @@ This page shows how the modules fit together and what each layer produces.
 
 ## Pipeline
 
-```mermaid
-flowchart TD
-    A(["gem.parse()  /  gem.parse_to_dataframe()"])
+Data flows top to bottom in a single pass. The schema layer feeds two parallel
+consumers — event processing and the extractors — which both fan back into
+assembly.
 
-    subgraph BINARY ["Binary decoding"]
-        direction LR
-        B["binary/stream.py<br/>outer frames"] --> C["binary/reader.py<br/>bits & varints"]
-    end
+<div class="arch-flow">
 
-    subgraph SCHEMA ["Schema & state"]
-        direction LR
-        D["schema/sendtable/<br/>serializer tree"] --> E["schema/field_decoder/<br/>type dispatch"]
-        D --> F["schema/field_path/<br/>Huffman paths"]
-        G["state/string_table.py<br/>key-value tables"]
-        H["state/entities.py<br/>delta updates"]
-    end
+  <div class="arch-flow-node arch-flow--io">
+    <span class="arch-flow-title">Entry point</span>
+    <span class="arch-flow-desc"><code>gem.parse()</code> · <code>gem.parse_to_dataframe()</code></span>
+  </div>
 
-    subgraph EVENTS ["Events"]
-        direction LR
-        I["state/game_events.py"]
-        J["combat/log.py"]
-    end
+  <div class="arch-flow-arrow" aria-hidden="true">↓</div>
 
-    subgraph EXTRACT ["Extractors"]
-        direction LR
-        X1["players"]
-        X2["objectives"]
-        X3["wards"]
-        X4["courier"]
-        X5["draft"]
-        X6["teamfights"]
-    end
+  <div class="arch-flow-node arch-flow--parse">
+    <span class="arch-flow-title">Binary decoding</span>
+    <span class="arch-flow-desc">Outer demo frames → bits, bytes, and varints</span>
+  </div>
 
-    subgraph ASSEMBLE ["Assembly"]
-        K["combat/aggregator.py"] --> L["results/assembly.py"]
-    end
+  <div class="arch-flow-arrow" aria-hidden="true">↓</div>
 
-    O(["ParsedMatch"])
-    P(["dict[str, DataFrame]  /  JSON  /  Parquet"])
+  <div class="arch-flow-node arch-flow--parse">
+    <span class="arch-flow-title">Schema &amp; state</span>
+    <span class="arch-flow-desc">Serializer tree, field decoders, string tables, entity deltas</span>
+  </div>
 
-    A --> BINARY
-    BINARY --> SCHEMA
-    SCHEMA --> EVENTS
-    SCHEMA --> EXTRACT
-    EVENTS --> ASSEMBLE
-    EXTRACT --> ASSEMBLE
-    ASSEMBLE --> O
-    O --> P
-```
+  <div class="arch-flow-arrow arch-flow-arrow--split" aria-hidden="true">↓</div>
+
+  <div class="arch-flow-split">
+    <div class="arch-flow-node arch-flow--parse">
+      <span class="arch-flow-title">Events</span>
+      <span class="arch-flow-desc">Game events &amp; the combat log (S1 + S2)</span>
+    </div>
+    <div class="arch-flow-node arch-flow--extract">
+      <span class="arch-flow-title">Extractors</span>
+      <span class="arch-flow-desc">Players, objectives, wards, courier, draft, teamfights</span>
+    </div>
+  </div>
+
+  <div class="arch-flow-arrow arch-flow-arrow--merge" aria-hidden="true">↓</div>
+
+  <div class="arch-flow-node arch-flow--assemble">
+    <span class="arch-flow-title">Assembly</span>
+    <span class="arch-flow-desc">Combat aggregation → typed result assembly</span>
+  </div>
+
+  <div class="arch-flow-arrow" aria-hidden="true">↓</div>
+
+  <div class="arch-flow-node arch-flow--output">
+    <span class="arch-flow-title">Output</span>
+    <span class="arch-flow-desc"><code>ParsedMatch</code> → DataFrames · JSON · Parquet</span>
+  </div>
+
+</div>
 
 ## Layers at a glance
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,7 @@
+---
+pageClass: changelog-minimal
+---
+
 # Changelog
 
 This page is a curated narrative summary of the parser, validation, and report changes that materially affect how `gem` behaves today.

--- a/docs/cookbook/bits-and-bytes-primer.md
+++ b/docs/cookbook/bits-and-bytes-primer.md
@@ -1,4 +1,4 @@
-# Bits & Bytes Primer (Dota Replay Context)
+# Bits & Bytes Primer
 
 This page is a practical prerequisite for parser deep dives.
 

--- a/docs/cookbook/proto-fields/base-gcmessages.md
+++ b/docs/cookbook/proto-fields/base-gcmessages.md
@@ -25,12 +25,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def_id` | `uint32` | `optional` | `` |  |
-| 2 | `quantity` | `uint32` | `optional` | `` |  |
-| 3 | `cost_in_local_currency` | `uint32` | `optional` | `` |  |
-| 4 | `purchase_type` | `uint32` | `optional` | `` |  |
-| 5 | `source_reference_id` | `uint64` | `optional` | `` |  |
-| 6 | `price_index` | `int32` | `optional` | `` |  |
+| 1 | `item_def_id` | `uint32` | `optional` |  |  |
+| 2 | `quantity` | `uint32` | `optional` |  |  |
+| 3 | `cost_in_local_currency` | `uint32` | `optional` |  |  |
+| 4 | `purchase_type` | `uint32` | `optional` |  |  |
+| 5 | `source_reference_id` | `uint64` | `optional` |  |  |
+| 6 | `price_index` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -42,10 +42,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `country` | `string` | `optional` | `` |  |
-| 2 | `language` | `int32` | `optional` | `` |  |
-| 3 | `currency` | `int32` | `optional` | `` |  |
-| 4 | `line_items` | `.CGCStorePurchaseInit_LineItem` | `repeated` | `` |  |
+| 1 | `country` | `string` | `optional` |  |  |
+| 2 | `language` | `int32` | `optional` |  |  |
+| 3 | `currency` | `int32` | `optional` |  |  |
+| 4 | `line_items` | `.CGCStorePurchaseInit_LineItem` | `repeated` |  |  |
 
 </details>
 
@@ -57,8 +57,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `int32` | `optional` | `` |  |
-| 2 | `txn_id` | `uint64` | `optional` | `` |  |
+| 1 | `result` | `int32` | `optional` |  |  |
+| 2 | `txn_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -70,11 +70,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 4 | `relay_codes` | `fixed32` | `repeated` | `` | packed = true |
-| 5 | `relay_pings` | `uint32` | `repeated` | `` | packed = true |
-| 8 | `region_codes` | `uint32` | `repeated` | `` | packed = true |
-| 9 | `region_pings` | `uint32` | `repeated` | `` | packed = true |
-| 10 | `region_ping_failed_bitmask` | `uint32` | `optional` | `` |  |
+| 4 | `relay_codes` | `fixed32` | `repeated` |  | packed = true |
+| 5 | `relay_pings` | `uint32` | `repeated` |  | packed = true |
+| 8 | `region_codes` | `uint32` | `repeated` |  | packed = true |
+| 9 | `region_pings` | `uint32` | `repeated` |  | packed = true |
+| 10 | `region_ping_failed_bitmask` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -86,11 +86,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steam_id` | `fixed64` | `optional` | `` |  |
-| 2 | `client_version` | `uint32` | `optional` | `` |  |
-| 3 | `team_id` | `uint32` | `optional` | `` |  |
-| 4 | `as_coach` | `bool` | `optional` | `` |  |
-| 5 | `ping_data` | `.CMsgClientPingData` | `optional` | `` |  |
+| 1 | `steam_id` | `fixed64` | `optional` |  |  |
+| 2 | `client_version` | `uint32` | `optional` |  |  |
+| 3 | `team_id` | `uint32` | `optional` |  |  |
+| 4 | `as_coach` | `bool` | `optional` |  |  |
+| 5 | `ping_data` | `.CMsgClientPingData` | `optional` |  |  |
 
 </details>
 
@@ -102,8 +102,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steam_id` | `fixed64` | `optional` | `` |  |
-| 2 | `client_version` | `uint32` | `optional` | `` |  |
+| 1 | `steam_id` | `fixed64` | `optional` |  |  |
+| 2 | `client_version` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -115,9 +115,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `group_id` | `uint64` | `optional` | `` |  |
-| 2 | `steam_id` | `fixed64` | `optional` | `` |  |
-| 3 | `user_offline` | `bool` | `optional` | `` |  |
+| 1 | `group_id` | `uint64` | `optional` |  |  |
+| 2 | `steam_id` | `fixed64` | `optional` |  |  |
+| 3 | `user_offline` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -129,10 +129,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `party_id` | `uint64` | `optional` | `` |  |
-| 2 | `accept` | `bool` | `optional` | `` |  |
-| 3 | `client_version` | `uint32` | `optional` | `` |  |
-| 8 | `ping_data` | `.CMsgClientPingData` | `optional` | `` |  |
+| 1 | `party_id` | `uint64` | `optional` |  |  |
+| 2 | `accept` | `bool` | `optional` |  |  |
+| 3 | `client_version` | `uint32` | `optional` |  |  |
+| 8 | `ping_data` | `.CMsgClientPingData` | `optional` |  |  |
 
 </details>
 
@@ -144,11 +144,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `lobby_id` | `fixed64` | `optional` | `` |  |
-| 2 | `accept` | `bool` | `optional` | `` |  |
-| 3 | `client_version` | `uint32` | `optional` | `` |  |
-| 6 | `custom_game_crc` | `fixed64` | `optional` | `` |  |
-| 7 | `custom_game_timestamp` | `fixed32` | `optional` | `` |  |
+| 1 | `lobby_id` | `fixed64` | `optional` |  |  |
+| 2 | `accept` | `bool` | `optional` |  |  |
+| 3 | `client_version` | `uint32` | `optional` |  |  |
+| 6 | `custom_game_crc` | `fixed64` | `optional` |  |  |
+| 7 | `custom_game_timestamp` | `fixed32` | `optional` |  |  |
 
 </details>
 
@@ -160,7 +160,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steam_id` | `fixed64` | `optional` | `` |  |
+| 1 | `steam_id` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -184,9 +184,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `status` | `.ECustomGameInstallStatus` | `optional` | `` | default = k_ECustomGameInstallStatus_Unknown |
-| 2 | `message` | `string` | `optional` | `` |  |
-| 3 | `latest_timestamp_from_steam` | `fixed32` | `optional` | `` |  |
+| 1 | `status` | `.ECustomGameInstallStatus` | `optional` |  | default = k_ECustomGameInstallStatus_Unknown |
+| 2 | `message` | `string` | `optional` |  |  |
+| 3 | `latest_timestamp_from_steam` | `fixed32` | `optional` |  |  |
 
 </details>
 
@@ -198,7 +198,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `custom_game_install_status` | `.CMsgCustomGameInstallStatus` | `optional` | `` |  |
+| 1 | `custom_game_install_status` | `.CMsgCustomGameInstallStatus` | `optional` |  |  |
 
 </details>
 
@@ -210,7 +210,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `lobby_id` | `fixed64` | `optional` | `` |  |
+| 1 | `lobby_id` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -222,14 +222,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `additional_backpack_slots` | `uint32` | `optional` | `` | default = 0 |
-| 2 | `trial_account` | `bool` | `optional` | `` | default = false |
-| 3 | `eligible_for_online_play` | `bool` | `optional` | `` | default = true |
-| 4 | `need_to_choose_most_helpful_friend` | `bool` | `optional` | `` |  |
-| 5 | `in_coaches_list` | `bool` | `optional` | `` |  |
-| 6 | `trade_ban_expiration` | `fixed32` | `optional` | `` |  |
-| 7 | `duel_ban_expiration` | `fixed32` | `optional` | `` |  |
-| 9 | `made_first_purchase` | `bool` | `optional` | `` | default = false |
+| 1 | `additional_backpack_slots` | `uint32` | `optional` |  | default = 0 |
+| 2 | `trial_account` | `bool` | `optional` |  | default = false |
+| 3 | `eligible_for_online_play` | `bool` | `optional` |  | default = true |
+| 4 | `need_to_choose_most_helpful_friend` | `bool` | `optional` |  |  |
+| 5 | `in_coaches_list` | `bool` | `optional` |  |  |
+| 6 | `trade_ban_expiration` | `fixed32` | `optional` |  |  |
+| 7 | `duel_ban_expiration` | `fixed32` | `optional` |  |  |
+| 9 | `made_first_purchase` | `bool` | `optional` |  | default = false |
 
 </details>
 
@@ -241,8 +241,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `strange_part_item_id` | `uint64` | `optional` | `` |  |
-| 2 | `item_item_id` | `uint64` | `optional` | `` |  |
+| 1 | `strange_part_item_id` | `uint64` | `optional` |  |  |
+| 2 | `item_item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -254,8 +254,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `upgrade_item_id` | `uint64` | `optional` | `` |  |
-| 2 | `pennant_item_id` | `uint64` | `optional` | `` |  |
+| 1 | `upgrade_item_id` | `uint64` | `optional` |  |  |
+| 2 | `pennant_item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -267,8 +267,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `essence_item_id` | `uint64` | `optional` | `` |  |
-| 2 | `egg_item_id` | `uint64` | `optional` | `` |  |
+| 1 | `essence_item_id` | `uint64` | `optional` |  |  |
+| 2 | `egg_item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -280,9 +280,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `def_index` | `uint32` | `optional` | `` | default = 65535 |
-| 2 | `value` | `uint32` | `optional` | `` |  |
-| 3 | `value_bytes` | `bytes` | `optional` | `` |  |
+| 1 | `def_index` | `uint32` | `optional` |  | default = 65535 |
+| 2 | `value` | `uint32` | `optional` |  |  |
+| 3 | `value_bytes` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -294,8 +294,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `new_class` | `uint32` | `optional` | `` |  |
-| 2 | `new_slot` | `uint32` | `optional` | `` |  |
+| 1 | `new_class` | `uint32` | `optional` |  |  |
+| 2 | `new_slot` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -307,20 +307,20 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `uint64` | `optional` | `` |  |
-| 2 | `account_id` | `uint32` | `optional` | `` |  |
-| 3 | `inventory` | `uint32` | `optional` | `` |  |
-| 4 | `def_index` | `uint32` | `optional` | `` |  |
-| 5 | `quantity` | `uint32` | `optional` | `` | default = 1 |
-| 6 | `level` | `uint32` | `optional` | `` | default = 1 |
-| 7 | `quality` | `uint32` | `optional` | `` | default = 4 |
-| 8 | `flags` | `uint32` | `optional` | `` | default = 0 |
-| 9 | `origin` | `uint32` | `optional` | `` | default = 0 |
-| 12 | `attribute` | `.CSOEconItemAttribute` | `repeated` | `` |  |
-| 13 | `interior_item` | `.CSOEconItem` | `optional` | `` |  |
-| 15 | `style` | `uint32` | `optional` | `` | default = 0 |
-| 16 | `original_id` | `uint64` | `optional` | `` |  |
-| 18 | `equipped_state` | `.CSOEconItemEquipped` | `repeated` | `` |  |
+| 1 | `id` | `uint64` | `optional` |  |  |
+| 2 | `account_id` | `uint32` | `optional` |  |  |
+| 3 | `inventory` | `uint32` | `optional` |  |  |
+| 4 | `def_index` | `uint32` | `optional` |  |  |
+| 5 | `quantity` | `uint32` | `optional` |  | default = 1 |
+| 6 | `level` | `uint32` | `optional` |  | default = 1 |
+| 7 | `quality` | `uint32` | `optional` |  | default = 4 |
+| 8 | `flags` | `uint32` | `optional` |  | default = 0 |
+| 9 | `origin` | `uint32` | `optional` |  | default = 0 |
+| 12 | `attribute` | `.CSOEconItemAttribute` | `repeated` |  |  |
+| 13 | `interior_item` | `.CSOEconItem` | `optional` |  |  |
+| 15 | `style` | `uint32` | `optional` |  | default = 0 |
+| 16 | `original_id` | `uint64` | `optional` |  |  |
+| 18 | `equipped_state` | `.CSOEconItemEquipped` | `repeated` |  |  |
 
 </details>
 
@@ -332,7 +332,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `sort_type` | `uint32` | `optional` | `` |  |
+| 1 | `sort_type` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -344,12 +344,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `inventory` | `uint32` | `optional` | `` |  |
-| 3 | `def_index` | `uint32` | `optional` | `` |  |
-| 4 | `quality` | `uint32` | `optional` | `` |  |
-| 5 | `rarity` | `uint32` | `optional` | `` |  |
-| 6 | `origin` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `inventory` | `uint32` | `optional` |  |  |
+| 3 | `def_index` | `uint32` | `optional` |  |  |
+| 4 | `quality` | `uint32` | `optional` |  |  |
+| 5 | `rarity` | `uint32` | `optional` |  |  |
+| 6 | `origin` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -361,7 +361,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_positions` | `.CMsgSetItemPositions.ItemPosition` | `repeated` | `` |  |
+| 1 | `item_positions` | `.CMsgSetItemPositions.ItemPosition` | `repeated` |  |  |
 
 </details>
 
@@ -373,8 +373,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `uint64` | `optional` | `` |  |
-| 2 | `position` | `uint32` | `optional` | `` |  |
+| 1 | `item_id` | `uint64` | `optional` |  |  |
+| 2 | `position` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -386,7 +386,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `txn_id` | `uint64` | `optional` | `` |  |
+| 1 | `txn_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -398,7 +398,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `uint32` | `optional` | `` |  |
+| 1 | `result` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -410,7 +410,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `txn_id` | `uint64` | `optional` | `` |  |
+| 1 | `txn_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -422,8 +422,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `uint32` | `optional` | `` |  |
-| 2 | `item_ids` | `uint64` | `repeated` | `` |  |
+| 1 | `result` | `uint32` | `optional` |  |  |
+| 2 | `item_ids` | `uint64` | `repeated` |  |  |
 
 </details>
 
@@ -435,7 +435,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `group_id` | `uint32` | `optional` | `` |  |
+| 1 | `group_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -447,8 +447,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `sdo_type` | `uint32` | `optional` | `` |  |
-| 2 | `key_uint64` | `uint64` | `optional` | `` |  |
+| 1 | `sdo_type` | `uint32` | `optional` |  |  |
+| 2 | `key_uint64` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -472,7 +472,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key_name` | `string` | `optional` | `` |  |
+| 1 | `key_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -484,7 +484,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `server_version` | `uint32` | `optional` | `` |  |
+| 1 | `server_version` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -496,7 +496,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `client_version` | `uint32` | `optional` | `` |  |
+| 1 | `client_version` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -520,9 +520,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tool_item_id` | `uint64` | `optional` | `` |  |
-| 2 | `item_item_id` | `uint64` | `optional` | `` |  |
-| 3 | `item_socket_id` | `uint32` | `optional` | `` | default = 65535 |
+| 1 | `tool_item_id` | `uint64` | `optional` |  |  |
+| 2 | `item_item_id` | `uint64` | `optional` |  |  |
+| 3 | `item_socket_id` | `uint32` | `optional` |  | default = 65535 |
 
 </details>
 
@@ -534,8 +534,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `uint64` | `optional` | `` |  |
-| 2 | `response` | `.CMsgExtractGemsResponse.EExtractGems` | `optional` | `` | default = k_ExtractGems_Succeeded |
+| 1 | `item_id` | `uint64` | `optional` |  |  |
+| 2 | `response` | `.CMsgExtractGemsResponse.EExtractGems` | `optional` |  | default = k_ExtractGems_Succeeded |
 
 </details>
 
@@ -547,9 +547,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tool_item_id` | `uint64` | `optional` | `` |  |
-| 2 | `item_item_id` | `uint64` | `optional` | `` |  |
-| 3 | `unusual` | `bool` | `optional` | `` |  |
+| 1 | `tool_item_id` | `uint64` | `optional` |  |  |
+| 2 | `item_item_id` | `uint64` | `optional` |  |  |
+| 3 | `unusual` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -561,9 +561,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `uint64` | `optional` | `` |  |
-| 2 | `updated_socket_index` | `uint32` | `repeated` | `` |  |
-| 3 | `response` | `.CMsgAddSocketResponse.EAddSocket` | `optional` | `` | default = k_AddSocket_Succeeded |
+| 1 | `item_id` | `uint64` | `optional` |  |  |
+| 2 | `updated_socket_index` | `uint32` | `repeated` |  |  |
+| 3 | `response` | `.CMsgAddSocketResponse.EAddSocket` | `optional` |  | default = k_AddSocket_Succeeded |
 
 </details>
 
@@ -575,8 +575,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `gem_item_id` | `uint64` | `optional` | `` |  |
-| 2 | `socket_index` | `uint32` | `optional` | `` | default = 65535 |
+| 1 | `gem_item_id` | `uint64` | `optional` |  |  |
+| 2 | `socket_index` | `uint32` | `optional` |  | default = 65535 |
 
 </details>
 
@@ -588,8 +588,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_item_id` | `uint64` | `optional` | `` |  |
-| 2 | `gems_to_socket` | `.CMsgAddItemToSocketData` | `repeated` | `` |  |
+| 1 | `item_item_id` | `uint64` | `optional` |  |  |
+| 2 | `gems_to_socket` | `.CMsgAddItemToSocketData` | `repeated` |  |  |
 
 </details>
 
@@ -601,9 +601,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_item_id` | `uint64` | `optional` | `` |  |
-| 2 | `updated_socket_index` | `uint32` | `repeated` | `` |  |
-| 3 | `response` | `.CMsgAddItemToSocketResponse.EAddGem` | `optional` | `` | default = k_AddGem_Succeeded |
+| 1 | `item_item_id` | `uint64` | `optional` |  |  |
+| 2 | `updated_socket_index` | `uint32` | `repeated` |  |  |
+| 3 | `response` | `.CMsgAddItemToSocketResponse.EAddGem` | `optional` |  | default = k_AddGem_Succeeded |
 
 </details>
 
@@ -615,8 +615,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_item_id` | `uint64` | `optional` | `` |  |
-| 2 | `socket_index` | `uint32` | `optional` | `` | default = 65535 |
+| 1 | `item_item_id` | `uint64` | `optional` |  |  |
+| 2 | `socket_index` | `uint32` | `optional` |  | default = 65535 |
 
 </details>
 
@@ -628,7 +628,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgResetStrangeGemCountResponse.EResetGem` | `optional` | `` | default = k_ResetGem_Succeeded |
+| 1 | `response` | `.CMsgResetStrangeGemCountResponse.EResetGem` | `optional` |  | default = k_ResetGem_Succeeded |
 
 </details>
 
@@ -640,9 +640,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `file_name` | `string` | `optional` | `` |  |
-| 2 | `client_version` | `uint32` | `optional` | `` |  |
-| 3 | `poll_id` | `uint32` | `optional` | `` |  |
+| 1 | `file_name` | `string` | `optional` |  |  |
+| 2 | `client_version` | `uint32` | `optional` |  |  |
+| 3 | `poll_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -654,9 +654,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `poll_id` | `uint32` | `optional` | `` |  |
-| 2 | `file_size` | `uint32` | `optional` | `` |  |
-| 3 | `file_crc` | `uint32` | `optional` | `` |  |
+| 1 | `poll_id` | `uint32` | `optional` |  |  |
+| 2 | `file_size` | `uint32` | `optional` |  |  |
+| 3 | `file_crc` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -668,8 +668,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `op_id` | `uint64` | `optional` | `` |  |
-| 2 | `group_code` | `uint32` | `optional` | `` |  |
+| 1 | `op_id` | `uint64` | `optional` |  |  |
+| 2 | `group_code` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -681,8 +681,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `success` | `bool` | `optional` | `` |  |
-| 2 | `source_gc` | `int32` | `optional` | `` | default = -1 |
+| 1 | `success` | `bool` | `optional` |  |  |
+| 2 | `source_gc` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -706,7 +706,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `welcome_messages` | `.CExtraMsgBlock` | `repeated` | `` |  |
+| 1 | `welcome_messages` | `.CExtraMsgBlock` | `repeated` |  |  |
 
 </details>
 
@@ -718,7 +718,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `con_vars` | `.CMsgApplyRemoteConVars.ConVar` | `repeated` | `` |  |
+| 1 | `con_vars` | `.CMsgApplyRemoteConVars.ConVar` | `repeated` |  |  |
 
 </details>
 
@@ -730,11 +730,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `value` | `string` | `optional` | `` |  |
-| 3 | `version_min` | `uint32` | `optional` | `` |  |
-| 4 | `version_max` | `uint32` | `optional` | `` |  |
-| 5 | `platform` | `.EGCPlatform` | `optional` | `` | default = k_eGCPlatform_None |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `value` | `string` | `optional` |  |  |
+| 3 | `version_min` | `uint32` | `optional` |  |  |
+| 4 | `version_max` | `uint32` | `optional` |  |  |
+| 5 | `platform` | `.EGCPlatform` | `optional` |  | default = k_eGCPlatform_None |
 
 </details>
 
@@ -746,7 +746,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `msg` | `.CMsgApplyRemoteConVars` | `optional` | `` |  |
+| 1 | `msg` | `.CMsgApplyRemoteConVars` | `optional` |  |  |
 
 </details>
 
@@ -758,7 +758,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `msg` | `.CMsgApplyRemoteConVars` | `optional` | `` |  |
+| 1 | `msg` | `.CMsgApplyRemoteConVars` | `optional` |  |  |
 
 </details>
 
@@ -770,9 +770,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `report` | `string` | `optional` | `` |  |
-| 2 | `secure_allowed` | `bool` | `optional` | `` |  |
-| 3 | `diagnostics` | `.CMsgClientToGCIntegrityStatus.keyvalue` | `repeated` | `` |  |
+| 1 | `report` | `string` | `optional` |  |  |
+| 2 | `secure_allowed` | `bool` | `optional` |  |  |
+| 3 | `diagnostics` | `.CMsgClientToGCIntegrityStatus.keyvalue` | `repeated` |  |  |
 
 </details>
 
@@ -784,10 +784,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `uint32` | `optional` | `` |  |
-| 2 | `extended` | `uint32` | `optional` | `` |  |
-| 3 | `value` | `uint64` | `optional` | `` |  |
-| 4 | `string_value` | `string` | `optional` | `` |  |
+| 1 | `id` | `uint32` | `optional` |  |  |
+| 2 | `extended` | `uint32` | `optional` |  |  |
+| 3 | `value` | `uint64` | `optional` |  |  |
+| 4 | `string_value` | `string` | `optional` |  |  |
 
 </details>
 
@@ -799,7 +799,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `metrics` | `.CMsgClientToGCAggregateMetrics.SingleMetric` | `repeated` | `` |  |
+| 1 | `metrics` | `.CMsgClientToGCAggregateMetrics.SingleMetric` | `repeated` |  |  |
 
 </details>
 
@@ -811,8 +811,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `metric_name` | `string` | `optional` | `` |  |
-| 2 | `metric_count` | `uint32` | `optional` | `` |  |
+| 1 | `metric_name` | `string` | `optional` |  |  |
+| 2 | `metric_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -824,7 +824,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `upload_rate_modifier` | `float` | `optional` | `` |  |
+| 1 | `upload_rate_modifier` | `float` | `optional` |  |  |
 
 </details>
 
@@ -836,7 +836,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `access_tokens` | `.CMsgSteamLearnAccessTokens` | `optional` | `` |  |
+| 1 | `access_tokens` | `.CMsgSteamLearnAccessTokens` | `optional` |  |  |
 
 </details>
 
@@ -848,7 +848,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `use_http` | `bool` | `optional` | `` |  |
+| 1 | `use_http` | `bool` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/c-peer2peer-netmessages.md
+++ b/docs/cookbook/proto-fields/c-peer2peer-netmessages.md
@@ -24,7 +24,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `text` | `bytes` | `optional` | `` |  |
+| 1 | `text` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -36,7 +36,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `voice_data` | `bytes` | `optional` | `` |  |
+| 1 | `voice_data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -48,8 +48,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `audio` | `.CMsgVoiceAudio` | `optional` | `` |  |
-| 2 | `broadcast_group` | `uint32` | `optional` | `` |  |
+| 1 | `audio` | `.CMsgVoiceAudio` | `optional` |  |  |
+| 2 | `broadcast_group` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -61,8 +61,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `send_time` | `uint64` | `optional` | `` |  |
-| 2 | `is_reply` | `bool` | `optional` | `` |  |
+| 1 | `send_time` | `uint64` | `optional` |  |  |
+| 2 | `is_reply` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -74,10 +74,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `body_parts` | `.CP2P_VRAvatarPosition.COrientation` | `repeated` | `` |  |
-| 2 | `hat_id` | `int32` | `optional` | `` |  |
-| 3 | `scene_id` | `int32` | `optional` | `` |  |
-| 4 | `world_scale` | `int32` | `optional` | `` |  |
+| 1 | `body_parts` | `.CP2P_VRAvatarPosition.COrientation` | `repeated` |  |  |
+| 2 | `hat_id` | `int32` | `optional` |  |  |
+| 3 | `scene_id` | `int32` | `optional` |  |  |
+| 4 | `world_scale` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -89,8 +89,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `pos` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `ang` | `.CMsgQAngle` | `optional` | `` |  |
+| 1 | `pos` | `.CMsgVector` | `optional` |  |  |
+| 2 | `ang` | `.CMsgQAngle` | `optional` |  |  |
 
 </details>
 
@@ -102,14 +102,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `demo_tick` | `int32` | `optional` | `` |  |
-| 2 | `paused` | `bool` | `optional` | `` |  |
-| 3 | `tv_listen_voice_indices` | `uint64` | `optional` | `` |  |
-| 4 | `dota_spectator_mode` | `int32` | `optional` | `` |  |
-| 5 | `dota_spectator_watching_broadcaster` | `bool` | `optional` | `` |  |
-| 6 | `dota_spectator_hero_index` | `int32` | `optional` | `` |  |
-| 7 | `dota_spectator_autospeed` | `int32` | `optional` | `` |  |
-| 8 | `dota_replay_speed` | `int32` | `optional` | `` |  |
+| 1 | `demo_tick` | `int32` | `optional` |  |  |
+| 2 | `paused` | `bool` | `optional` |  |  |
+| 3 | `tv_listen_voice_indices` | `uint64` | `optional` |  |  |
+| 4 | `dota_spectator_mode` | `int32` | `optional` |  |  |
+| 5 | `dota_spectator_watching_broadcaster` | `bool` | `optional` |  |  |
+| 6 | `dota_spectator_hero_index` | `int32` | `optional` |  |  |
+| 7 | `dota_spectator_autospeed` | `int32` | `optional` |  |  |
+| 8 | `dota_replay_speed` | `int32` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/clientmessages.md
+++ b/docs/cookbook/proto-fields/clientmessages.md
@@ -19,8 +19,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_name` | `string` | `optional` | `` |  |
-| 2 | `data` | `bytes` | `optional` | `` |  |
+| 1 | `event_name` | `string` | `optional` |  |  |
+| 2 | `data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -32,9 +32,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_name` | `string` | `optional` | `` |  |
-| 2 | `data` | `bytes` | `optional` | `` |  |
-| 3 | `player_slot` | `int32` | `optional` | `` | default = -1 |
+| 1 | `event_name` | `string` | `optional` |  |  |
+| 2 | `data` | `bytes` | `optional` |  |  |
+| 3 | `player_slot` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -46,11 +46,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event` | `.EClientUIEvent` | `optional` | `` | default = EClientUIEvent_Invalid |
-| 2 | `ent_ehandle` | `uint32` | `optional` | `` |  |
-| 3 | `client_ehandle` | `uint32` | `optional` | `` |  |
-| 4 | `data1` | `string` | `optional` | `` |  |
-| 5 | `data2` | `string` | `optional` | `` |  |
+| 1 | `event` | `.EClientUIEvent` | `optional` |  | default = EClientUIEvent_Invalid |
+| 2 | `ent_ehandle` | `uint32` | `optional` |  |  |
+| 3 | `client_ehandle` | `uint32` | `optional` |  |  |
+| 4 | `data1` | `string` | `optional` |  |  |
+| 5 | `data2` | `string` | `optional` |  |  |
 
 </details>
 
@@ -62,7 +62,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `visible` | `bool` | `optional` | `` |  |
+| 1 | `visible` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -74,9 +74,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `has_panel` | `bool` | `optional` | `` |  |
-| 2 | `client_ehandle` | `uint32` | `optional` | `` |  |
-| 3 | `literal_hand_type` | `uint32` | `optional` | `` |  |
+| 1 | `has_panel` | `bool` | `optional` |  |  |
+| 2 | `client_ehandle` | `uint32` | `optional` |  |  |
+| 3 | `literal_hand_type` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -88,7 +88,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `angle` | `float` | `optional` | `` |  |
+| 1 | `angle` | `float` | `optional` |  |  |
 
 </details>
 
@@ -100,7 +100,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_slot` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_slot` | `int32` | `optional` |  | default = -1 |
 
 </details>
 

--- a/docs/cookbook/proto-fields/connectionless-netmessages.md
+++ b/docs/cookbook/proto-fields/connectionless-netmessages.md
@@ -23,8 +23,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `localhost_process_id` | `uint64` | `optional` | `` |  |
-| 2 | `key` | `uint64` | `optional` | `` |  |
+| 1 | `localhost_process_id` | `uint64` | `optional` |  |  |
+| 2 | `key` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -36,16 +36,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `host_version` | `uint32` | `optional` | `` |  |
-| 2 | `auth_protocol` | `uint32` | `optional` | `` |  |
-| 3 | `challenge_number` | `uint32` | `optional` | `` |  |
-| 4 | `reservation_cookie` | `fixed64` | `optional` | `` |  |
-| 5 | `low_violence` | `bool` | `optional` | `` |  |
-| 6 | `encrypted_password` | `bytes` | `optional` | `` |  |
-| 7 | `splitplayers` | `.CCLCMsg_SplitPlayerConnect` | `repeated` | `` |  |
-| 8 | `auth_steam` | `bytes` | `optional` | `` |  |
-| 9 | `challenge_context` | `string` | `optional` | `` |  |
-| 10 | `localhost_same_process_check` | `.C2S_CONNECT_SameProcessCheck` | `optional` | `` |  |
+| 1 | `host_version` | `uint32` | `optional` |  |  |
+| 2 | `auth_protocol` | `uint32` | `optional` |  |  |
+| 3 | `challenge_number` | `uint32` | `optional` |  |  |
+| 4 | `reservation_cookie` | `fixed64` | `optional` |  |  |
+| 5 | `low_violence` | `bool` | `optional` |  |  |
+| 6 | `encrypted_password` | `bytes` | `optional` |  |  |
+| 7 | `splitplayers` | `.CCLCMsg_SplitPlayerConnect` | `repeated` |  |  |
+| 8 | `auth_steam` | `bytes` | `optional` |  |  |
+| 9 | `challenge_context` | `string` | `optional` |  |  |
+| 10 | `localhost_same_process_check` | `.C2S_CONNECT_SameProcessCheck` | `optional` |  |  |
 
 </details>
 
@@ -57,8 +57,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `addon_name` | `string` | `optional` | `` |  |
-| 2 | `localhost_same_process_check` | `.C2S_CONNECT_SameProcessCheck` | `optional` | `` |  |
+| 1 | `addon_name` | `string` | `optional` |  |  |
+| 2 | `localhost_same_process_check` | `.C2S_CONNECT_SameProcessCheck` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/demo.md
+++ b/docs/cookbook/proto-fields/demo.md
@@ -19,21 +19,21 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `demo_file_stamp` | `string` | `required` | `` |  |
-| 2 | `patch_version` | `int32` | `optional` | `` |  |
-| 3 | `server_name` | `string` | `optional` | `` |  |
-| 4 | `client_name` | `string` | `optional` | `` |  |
-| 5 | `map_name` | `string` | `optional` | `` |  |
-| 6 | `game_directory` | `string` | `optional` | `` |  |
-| 7 | `fullpackets_version` | `int32` | `optional` | `` |  |
-| 8 | `allow_clientside_entities` | `bool` | `optional` | `` |  |
-| 9 | `allow_clientside_particles` | `bool` | `optional` | `` |  |
-| 10 | `addons` | `string` | `optional` | `` |  |
-| 11 | `demo_version_name` | `string` | `optional` | `` |  |
-| 12 | `demo_version_guid` | `string` | `optional` | `` |  |
-| 13 | `build_num` | `int32` | `optional` | `` |  |
-| 14 | `game` | `string` | `optional` | `` |  |
-| 15 | `server_start_tick` | `int32` | `optional` | `` |  |
+| 1 | `demo_file_stamp` | `string` | `required` |  |  |
+| 2 | `patch_version` | `int32` | `optional` |  |  |
+| 3 | `server_name` | `string` | `optional` |  |  |
+| 4 | `client_name` | `string` | `optional` |  |  |
+| 5 | `map_name` | `string` | `optional` |  |  |
+| 6 | `game_directory` | `string` | `optional` |  |  |
+| 7 | `fullpackets_version` | `int32` | `optional` |  |  |
+| 8 | `allow_clientside_entities` | `bool` | `optional` |  |  |
+| 9 | `allow_clientside_particles` | `bool` | `optional` |  |  |
+| 10 | `addons` | `string` | `optional` |  |  |
+| 11 | `demo_version_name` | `string` | `optional` |  |  |
+| 12 | `demo_version_guid` | `string` | `optional` |  |  |
+| 13 | `build_num` | `int32` | `optional` |  |  |
+| 14 | `game` | `string` | `optional` |  |  |
+| 15 | `server_start_tick` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -45,8 +45,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 4 | `dota` | `.CGameInfo.CDotaGameInfo` | `optional` | `` |  |
-| 5 | `cs` | `.CGameInfo.CCSGameInfo` | `optional` | `` |  |
+| 4 | `dota` | `.CGameInfo.CDotaGameInfo` | `optional` |  |  |
+| 5 | `cs` | `.CGameInfo.CCSGameInfo` | `optional` |  |  |
 
 </details>
 
@@ -58,17 +58,17 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `game_mode` | `int32` | `optional` | `` |  |
-| 3 | `game_winner` | `int32` | `optional` | `` |  |
-| 4 | `player_info` | `.CGameInfo.CDotaGameInfo.CPlayerInfo` | `repeated` | `` |  |
-| 5 | `leagueid` | `uint32` | `optional` | `` |  |
-| 6 | `picks_bans` | `.CGameInfo.CDotaGameInfo.CHeroSelectEvent` | `repeated` | `` |  |
-| 7 | `radiant_team_id` | `uint32` | `optional` | `` |  |
-| 8 | `dire_team_id` | `uint32` | `optional` | `` |  |
-| 9 | `radiant_team_tag` | `string` | `optional` | `` |  |
-| 10 | `dire_team_tag` | `string` | `optional` | `` |  |
-| 11 | `end_time` | `uint32` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `game_mode` | `int32` | `optional` |  |  |
+| 3 | `game_winner` | `int32` | `optional` |  |  |
+| 4 | `player_info` | `.CGameInfo.CDotaGameInfo.CPlayerInfo` | `repeated` |  |  |
+| 5 | `leagueid` | `uint32` | `optional` |  |  |
+| 6 | `picks_bans` | `.CGameInfo.CDotaGameInfo.CHeroSelectEvent` | `repeated` |  |  |
+| 7 | `radiant_team_id` | `uint32` | `optional` |  |  |
+| 8 | `dire_team_id` | `uint32` | `optional` |  |  |
+| 9 | `radiant_team_tag` | `string` | `optional` |  |  |
+| 10 | `dire_team_tag` | `string` | `optional` |  |  |
+| 11 | `end_time` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -80,11 +80,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_name` | `string` | `optional` | `` |  |
-| 2 | `player_name` | `string` | `optional` | `` |  |
-| 3 | `is_fake_client` | `bool` | `optional` | `` |  |
-| 4 | `steamid` | `uint64` | `optional` | `` |  |
-| 5 | `game_team` | `int32` | `optional` | `` |  |
+| 1 | `hero_name` | `string` | `optional` |  |  |
+| 2 | `player_name` | `string` | `optional` |  |  |
+| 3 | `is_fake_client` | `bool` | `optional` |  |  |
+| 4 | `steamid` | `uint64` | `optional` |  |  |
+| 5 | `game_team` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -96,9 +96,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `is_pick` | `bool` | `optional` | `` |  |
-| 2 | `team` | `uint32` | `optional` | `` |  |
-| 3 | `hero_id` | `int32` | `optional` | `` |  |
+| 1 | `is_pick` | `bool` | `optional` |  |  |
+| 2 | `team` | `uint32` | `optional` |  |  |
+| 3 | `hero_id` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -110,7 +110,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `round_start_ticks` | `int32` | `repeated` | `` |  |
+| 1 | `round_start_ticks` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -122,10 +122,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `playback_time` | `float` | `optional` | `` |  |
-| 2 | `playback_ticks` | `int32` | `optional` | `` |  |
-| 3 | `playback_frames` | `int32` | `optional` | `` |  |
-| 4 | `game_info` | `.CGameInfo` | `optional` | `` |  |
+| 1 | `playback_time` | `float` | `optional` |  |  |
+| 2 | `playback_ticks` | `int32` | `optional` |  |  |
+| 3 | `playback_frames` | `int32` | `optional` |  |  |
+| 4 | `game_info` | `.CGameInfo` | `optional` |  |  |
 
 </details>
 
@@ -137,7 +137,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 3 | `data` | `bytes` | `optional` | `` |  |
+| 3 | `data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -149,8 +149,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `string_table` | `.CDemoStringTables` | `optional` | `` |  |
-| 2 | `packet` | `.CDemoPacket` | `optional` | `` |  |
+| 1 | `string_table` | `.CDemoStringTables` | `optional` |  |  |
+| 2 | `packet` | `.CDemoPacket` | `optional` |  |  |
 
 </details>
 
@@ -162,10 +162,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data` | `bytes` | `optional` | `` |  |
-| 2 | `steam_id` | `fixed64` | `optional` | `` |  |
-| 3 | `signature` | `fixed64` | `optional` | `` |  |
-| 4 | `version` | `int32` | `optional` | `` |  |
+| 1 | `data` | `bytes` | `optional` |  |  |
+| 2 | `steam_id` | `fixed64` | `optional` |  |  |
+| 3 | `signature` | `fixed64` | `optional` |  |  |
+| 4 | `version` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -189,7 +189,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cmdstring` | `string` | `optional` | `` |  |
+| 1 | `cmdstring` | `string` | `optional` |  |  |
 
 </details>
 
@@ -201,7 +201,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data` | `bytes` | `optional` | `` |  |
+| 1 | `data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -213,7 +213,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `classes` | `.CDemoClassInfo.class_t` | `repeated` | `` |  |
+| 1 | `classes` | `.CDemoClassInfo.class_t` | `repeated` |  |  |
 
 </details>
 
@@ -225,9 +225,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `class_id` | `int32` | `optional` | `` |  |
-| 2 | `network_name` | `string` | `optional` | `` |  |
-| 3 | `table_name` | `string` | `optional` | `` |  |
+| 1 | `class_id` | `int32` | `optional` |  |  |
+| 2 | `network_name` | `string` | `optional` |  |  |
+| 3 | `table_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -239,8 +239,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `callback_index` | `int32` | `optional` | `` |  |
-| 2 | `data` | `bytes` | `optional` | `` |  |
+| 1 | `callback_index` | `int32` | `optional` |  |  |
+| 2 | `data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -252,7 +252,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `save_id` | `string` | `repeated` | `` |  |
+| 1 | `save_id` | `string` | `repeated` |  |  |
 
 </details>
 
@@ -264,9 +264,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `entity_id` | `sint32` | `optional` | `` |  |
-| 2 | `tick` | `int32` | `optional` | `` |  |
-| 3 | `data` | `bytes` | `optional` | `` |  |
+| 1 | `entity_id` | `sint32` | `optional` |  |  |
+| 2 | `tick` | `int32` | `optional` |  |  |
+| 3 | `data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -278,11 +278,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `entity_id` | `sint32` | `optional` | `` |  |
-| 2 | `start_tick` | `int32` | `optional` | `` |  |
-| 3 | `end_tick` | `int32` | `optional` | `` |  |
-| 4 | `data` | `bytes` | `optional` | `` |  |
-| 5 | `data_checksum` | `int64` | `optional` | `` |  |
+| 1 | `entity_id` | `sint32` | `optional` |  |  |
+| 2 | `start_tick` | `int32` | `optional` |  |  |
+| 3 | `end_tick` | `int32` | `optional` |  |  |
+| 4 | `data` | `bytes` | `optional` |  |  |
+| 5 | `data_checksum` | `int64` | `optional` |  |  |
 
 </details>
 
@@ -294,7 +294,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tables` | `.CDemoStringTables.table_t` | `repeated` | `` |  |
+| 1 | `tables` | `.CDemoStringTables.table_t` | `repeated` |  |  |
 
 </details>
 
@@ -306,8 +306,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `str` | `string` | `optional` | `` |  |
-| 2 | `data` | `bytes` | `optional` | `` |  |
+| 1 | `str` | `string` | `optional` |  |  |
+| 2 | `data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -319,10 +319,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `table_name` | `string` | `optional` | `` |  |
-| 2 | `items` | `.CDemoStringTables.items_t` | `repeated` | `` |  |
-| 3 | `items_clientside` | `.CDemoStringTables.items_t` | `repeated` | `` |  |
-| 4 | `table_flags` | `int32` | `optional` | `` |  |
+| 1 | `table_name` | `string` | `optional` |  |  |
+| 2 | `items` | `.CDemoStringTables.items_t` | `repeated` |  |  |
+| 3 | `items_clientside` | `.CDemoStringTables.items_t` | `repeated` |  |  |
+| 4 | `table_flags` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -346,8 +346,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cmd_number` | `int32` | `optional` | `` |  |
-| 2 | `data` | `bytes` | `optional` | `` |  |
+| 1 | `cmd_number` | `int32` | `optional` |  |  |
+| 2 | `data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -359,7 +359,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 3 | `msgs` | `bytes` | `repeated` | `` |  |
+| 3 | `msgs` | `bytes` | `repeated` |  |  |
 
 </details>
 
@@ -371,7 +371,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data` | `bytes` | `optional` | `` |  |
+| 1 | `data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -383,8 +383,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `initial_spawn_group` | `.CDemoRecovery.DemoInitialSpawnGroupEntry` | `optional` | `` |  |
-| 2 | `spawn_group_message` | `bytes` | `optional` | `` |  |
+| 1 | `initial_spawn_group` | `.CDemoRecovery.DemoInitialSpawnGroupEntry` | `optional` |  |  |
+| 2 | `spawn_group_message` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -396,8 +396,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `spawngrouphandle` | `uint32` | `optional` | `` |  |
-| 2 | `was_created` | `bool` | `optional` | `` |  |
+| 1 | `spawngrouphandle` | `uint32` | `optional` |  |  |
+| 2 | `was_created` | `bool` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-broadcastmessages.md
+++ b/docs/cookbook/proto-fields/dota-broadcastmessages.md
@@ -19,8 +19,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `type` | `.EDotaBroadcastMessages` | `optional` | `` | default = DOTA_BM_LANLobbyRequest |
-| 2 | `msg` | `bytes` | `optional` | `` |  |
+| 1 | `type` | `.EDotaBroadcastMessages` | `optional` |  | default = DOTA_BM_LANLobbyRequest |
+| 2 | `msg` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -44,15 +44,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `uint64` | `optional` | `` |  |
-| 2 | `tournament_id` | `uint32` | `optional` | `` |  |
-| 3 | `tournament_game_id` | `uint32` | `optional` | `` |  |
-| 4 | `members` | `.CDOTABroadcastMsg_LANLobbyReply.CLobbyMember` | `repeated` | `` |  |
-| 5 | `requires_pass_key` | `bool` | `optional` | `` |  |
-| 6 | `leader_account_id` | `uint32` | `optional` | `` |  |
-| 7 | `game_mode` | `uint32` | `optional` | `` |  |
-| 8 | `name` | `string` | `optional` | `` |  |
-| 9 | `players` | `uint32` | `optional` | `` |  |
+| 1 | `id` | `uint64` | `optional` |  |  |
+| 2 | `tournament_id` | `uint32` | `optional` |  |  |
+| 3 | `tournament_game_id` | `uint32` | `optional` |  |  |
+| 4 | `members` | `.CDOTABroadcastMsg_LANLobbyReply.CLobbyMember` | `repeated` |  |  |
+| 5 | `requires_pass_key` | `bool` | `optional` |  |  |
+| 6 | `leader_account_id` | `uint32` | `optional` |  |  |
+| 7 | `game_mode` | `uint32` | `optional` |  |  |
+| 8 | `name` | `string` | `optional` |  |  |
+| 9 | `players` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -64,8 +64,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `player_name` | `string` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `player_name` | `string` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-clientmessages.md
+++ b/docs/cookbook/proto-fields/dota-clientmessages.md
@@ -25,7 +25,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `location_ping` | `.CDOTAMsg_LocationPing` | `optional` | `` |  |
+| 1 | `location_ping` | `.CDOTAMsg_LocationPing` | `optional` |  |  |
 
 </details>
 
@@ -37,7 +37,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_alert` | `.CDOTAMsg_ItemAlert` | `optional` | `` |  |
+| 1 | `item_alert` | `.CDOTAMsg_ItemAlert` | `optional` |  |  |
 
 </details>
 
@@ -49,13 +49,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_entindex` | `int32` | `optional` | `` | default = -1 |
-| 2 | `rune_type` | `int32` | `optional` | `` | default = -1 |
-| 3 | `item_level` | `int32` | `optional` | `` | default = -1 |
-| 4 | `primary_charges` | `int32` | `optional` | `` | default = -1 |
-| 5 | `secondary_charges` | `int32` | `optional` | `` | default = -1 |
-| 6 | `ability_id` | `int32` | `optional` | `` | default = -1 |
-| 7 | `owner_entindex` | `int32` | `optional` | `` | default = -1 |
+| 1 | `item_entindex` | `int32` | `optional` |  | default = -1 |
+| 2 | `rune_type` | `int32` | `optional` |  | default = -1 |
+| 3 | `item_level` | `int32` | `optional` |  | default = -1 |
+| 4 | `primary_charges` | `int32` | `optional` |  | default = -1 |
+| 5 | `secondary_charges` | `int32` | `optional` |  | default = -1 |
+| 6 | `ability_id` | `int32` | `optional` |  | default = -1 |
+| 7 | `owner_entindex` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -67,8 +67,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `buff_internal_index` | `int32` | `optional` | `` |  |
-| 2 | `target_entindex` | `int32` | `optional` | `` | default = -1 |
+| 1 | `buff_internal_index` | `int32` | `optional` |  |  |
+| 2 | `target_entindex` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -80,8 +80,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `buff_internal_index` | `int32` | `optional` | `` |  |
-| 2 | `target_entindex` | `int32` | `optional` | `` | default = -1 |
+| 1 | `buff_internal_index` | `int32` | `optional` |  |  |
+| 2 | `target_entindex` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -93,8 +93,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_entindex` | `int32` | `optional` | `` | default = -1 |
-| 2 | `show_raw_values` | `bool` | `optional` | `` |  |
+| 1 | `target_entindex` | `int32` | `optional` |  | default = -1 |
+| 2 | `show_raw_values` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -106,9 +106,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `spawner_entindex` | `int32` | `optional` | `` | default = -1 |
-| 2 | `unit_entindex` | `int32` | `optional` | `` | default = -1 |
-| 3 | `stack_request` | `bool` | `optional` | `` |  |
+| 1 | `spawner_entindex` | `int32` | `optional` |  | default = -1 |
+| 2 | `unit_entindex` | `int32` | `optional` |  | default = -1 |
+| 3 | `stack_request` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -120,7 +120,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `negative` | `bool` | `optional` | `` |  |
+| 1 | `negative` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -132,7 +132,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `negative` | `bool` | `optional` | `` |  |
+| 1 | `negative` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -144,7 +144,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `mapline` | `.CDOTAMsg_MapLine` | `optional` | `` |  |
+| 1 | `mapline` | `.CDOTAMsg_MapLine` | `optional` |  |  |
 
 </details>
 
@@ -156,7 +156,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ratio` | `float` | `optional` | `` |  |
+| 1 | `ratio` | `float` | `optional` |  |  |
 
 </details>
 
@@ -168,8 +168,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `mode` | `.CDOTAClientMsg_UnitsAutoAttackMode.EMode` | `optional` | `` | default = INVALID |
-| 2 | `unit_type` | `.CDOTAClientMsg_UnitsAutoAttackMode.EUnitType` | `optional` | `` | default = NORMAL |
+| 1 | `mode` | `.CDOTAClientMsg_UnitsAutoAttackMode.EMode` | `optional` |  | default = INVALID |
+| 2 | `unit_type` | `.CDOTAClientMsg_UnitsAutoAttackMode.EUnitType` | `optional` |  | default = NORMAL |
 
 </details>
 
@@ -181,7 +181,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `enabled` | `bool` | `optional` | `` |  |
+| 1 | `enabled` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -193,7 +193,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `enabled` | `bool` | `optional` | `` |  |
+| 1 | `enabled` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -205,7 +205,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `enabled` | `bool` | `optional` | `` |  |
+| 1 | `enabled` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -217,7 +217,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `enabled` | `bool` | `optional` | `` |  |
+| 1 | `enabled` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -229,9 +229,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ability_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `default` | `bool` | `optional` | `` |  |
-| 3 | `enabled` | `bool` | `optional` | `` |  |
+| 1 | `ability_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `default` | `bool` | `optional` |  |  |
+| 3 | `enabled` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -243,7 +243,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `search` | `string` | `optional` | `` |  |
+| 1 | `search` | `string` | `optional` |  |  |
 
 </details>
 
@@ -267,7 +267,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `mode` | `uint32` | `optional` | `` |  |
+| 1 | `mode` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -279,9 +279,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `flag` | `uint32` | `optional` | `` |  |
-| 3 | `state` | `bool` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `flag` | `uint32` | `optional` |  |  |
+| 3 | `state` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -293,7 +293,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -305,7 +305,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -317,7 +317,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `worldline` | `.CDOTAMsg_WorldLine` | `optional` | `` |  |
+| 1 | `worldline` | `.CDOTAMsg_WorldLine` | `optional` |  |  |
 
 </details>
 
@@ -341,9 +341,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `chat_message_id` | `uint32` | `optional` | `` | default = 4294967295 |
-| 2 | `param_hero_id` | `int32` | `optional` | `` |  |
-| 3 | `emoticon_id` | `uint32` | `optional` | `` |  |
+| 1 | `chat_message_id` | `uint32` | `optional` |  | default = 4294967295 |
+| 2 | `param_hero_id` | `int32` | `optional` |  |  |
+| 3 | `emoticon_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -355,7 +355,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `statpopup` | `.CDOTAMsg_SendStatPopup` | `optional` | `` |  |
+| 1 | `statpopup` | `.CDOTAMsg_SendStatPopup` | `optional` |  |  |
 
 </details>
 
@@ -367,7 +367,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `dismissallmsg` | `.CDOTAMsg_DismissAllStatPopups` | `optional` | `` |  |
+| 1 | `dismissallmsg` | `.CDOTAMsg_DismissAllStatPopups` | `optional` |  |  |
 
 </details>
 
@@ -379,8 +379,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `chosen_lane` | `uint32` | `optional` | `` |  |
-| 2 | `helper_enabled` | `bool` | `optional` | `` |  |
+| 1 | `chosen_lane` | `uint32` | `optional` |  |  |
+| 2 | `helper_enabled` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -392,9 +392,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `purchasable` | `bool` | `optional` | `` | default = false |
-| 3 | `top_level_item_ability_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `item_ability_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `purchasable` | `bool` | `optional` |  | default = false |
+| 3 | `top_level_item_ability_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -406,8 +406,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `items` | `.CDOTAClientMsg_UpdateQuickBuyItem` | `repeated` | `` |  |
-| 2 | `goal_item_ability_ids` | `int32` | `repeated` | `` |  |
+| 1 | `items` | `.CDOTAClientMsg_UpdateQuickBuyItem` | `repeated` |  |  |
+| 2 | `goal_item_ability_ids` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -419,13 +419,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `action` | `.CDOTAClientMsg_QuickBuyAction.EActionType` | `optional` | `` | default = INVALID |
-| 2 | `item_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `slot_index` | `int32` | `optional` | `` |  |
-| 4 | `purchaser_entindex` | `int32` | `optional` | `` | default = -1 |
-| 5 | `new_slot_index` | `int32` | `optional` | `` |  |
-| 6 | `top_level_item` | `bool` | `optional` | `` |  |
-| 7 | `old_slot_ability_ids` | `int32` | `repeated` | `` |  |
+| 1 | `action` | `.CDOTAClientMsg_QuickBuyAction.EActionType` | `optional` |  | default = INVALID |
+| 2 | `item_ability_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `slot_index` | `int32` | `optional` |  |  |
+| 4 | `purchaser_entindex` | `int32` | `optional` |  | default = -1 |
+| 5 | `new_slot_index` | `int32` | `optional` |  |  |
+| 6 | `top_level_item` | `bool` | `optional` |  |  |
+| 7 | `old_slot_ability_ids` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -437,7 +437,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `choice_index` | `int32` | `optional` | `` |  |
+| 1 | `choice_index` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -449,9 +449,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `gold_remaining` | `uint32` | `optional` | `` |  |
-| 3 | `suggestion_player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `item_ability_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `gold_remaining` | `uint32` | `optional` |  |  |
+| 3 | `suggestion_player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -475,10 +475,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `gold_cost` | `int32` | `optional` | `` |  |
-| 3 | `item_cooldown_seconds` | `int32` | `optional` | `` |  |
-| 4 | `show_buyback` | `bool` | `optional` | `` |  |
+| 1 | `item_ability_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `gold_cost` | `int32` | `optional` |  |  |
+| 3 | `item_cooldown_seconds` | `int32` | `optional` |  |  |
+| 4 | `show_buyback` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -490,7 +490,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `showcase` | `bool` | `optional` | `` |  |
+| 1 | `showcase` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -502,7 +502,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `zoom_amount` | `float` | `optional` | `` |  |
+| 1 | `zoom_amount` | `float` | `optional` |  |  |
 
 </details>
 
@@ -514,7 +514,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cameraman` | `bool` | `optional` | `` |  |
+| 1 | `cameraman` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -526,7 +526,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `enabled` | `bool` | `optional` | `` |  |
+| 1 | `enabled` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -538,7 +538,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `fillwithbots` | `bool` | `optional` | `` |  |
+| 1 | `fillwithbots` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -550,7 +550,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `owner_player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `owner_player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -562,7 +562,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data` | `bytes` | `optional` | `` |  |
+| 1 | `data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -574,14 +574,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `hero_id_to_spawn` | `int32` | `optional` | `` |  |
-| 3 | `preview_items` | `.CDOTAClientMsg_DemoHero.PreviewItem` | `repeated` | `` |  |
-| 4 | `item_ids` | `uint64` | `repeated` | `` |  |
-| 5 | `style_index_override` | `uint32` | `optional` | `` | default = 255 |
-| 6 | `keep_existing_demohero` | `bool` | `optional` | `` |  |
-| 7 | `item_data` | `.CSOEconItem` | `repeated` | `` |  |
-| 8 | `hero_variant` | `int32` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `hero_id_to_spawn` | `int32` | `optional` |  |  |
+| 3 | `preview_items` | `.CDOTAClientMsg_DemoHero.PreviewItem` | `repeated` |  |  |
+| 4 | `item_ids` | `uint64` | `repeated` |  |  |
+| 5 | `style_index_override` | `uint32` | `optional` |  | default = 255 |
+| 6 | `keep_existing_demohero` | `bool` | `optional` |  |  |
+| 7 | `item_data` | `.CSOEconItem` | `repeated` |  |  |
+| 8 | `hero_variant` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -593,8 +593,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def` | `uint32` | `optional` | `` |  |
-| 2 | `item_style` | `uint32` | `optional` | `` | default = 255 |
+| 1 | `item_def` | `uint32` | `optional` |  |  |
+| 2 | `item_style` | `uint32` | `optional` |  | default = 255 |
 
 </details>
 
@@ -606,9 +606,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `slot_id` | `uint32` | `optional` | `` |  |
-| 3 | `sequence_id` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `slot_id` | `uint32` | `optional` |  |  |
+| 3 | `sequence_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -620,10 +620,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 2 | `slot_id` | `uint32` | `optional` | `` |  |
-| 3 | `sequence_id` | `uint32` | `optional` | `` |  |
-| 4 | `hero_id` | `int32` | `optional` | `` |  |
+| 1 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 2 | `slot_id` | `uint32` | `optional` |  |  |
+| 3 | `sequence_id` | `uint32` | `optional` |  |  |
+| 4 | `hero_id` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -635,7 +635,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `wager_amount` | `uint32` | `optional` | `` |  |
+| 1 | `wager_amount` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -647,7 +647,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `wager_token_item_id` | `uint64` | `optional` | `` |  |
+| 1 | `wager_token_item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -659,7 +659,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `announce_wager` | `bool` | `optional` | `` |  |
+| 1 | `announce_wager` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -671,7 +671,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -683,7 +683,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `recipient_player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `recipient_player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -695,8 +695,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `orders` | `.CDOTAMsg_UnitOrder` | `repeated` | `` |  |
-| 2 | `last_order_latency` | `uint32` | `optional` | `` |  |
+| 1 | `orders` | `.CDOTAMsg_UnitOrder` | `repeated` |  |  |
+| 2 | `last_order_latency` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -708,8 +708,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_entindex` | `int32` | `optional` | `` | default = -1 |
-| 2 | `damage_taken` | `uint32` | `optional` | `` |  |
+| 1 | `target_entindex` | `int32` | `optional` |  | default = -1 |
+| 2 | `damage_taken` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -721,10 +721,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_entindex` | `int32` | `optional` | `` | default = -1 |
-| 2 | `ability_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `slot` | `int32` | `optional` | `` |  |
-| 4 | `learned` | `bool` | `optional` | `` |  |
+| 1 | `target_entindex` | `int32` | `optional` |  | default = -1 |
+| 2 | `ability_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `slot` | `int32` | `optional` |  |  |
+| 4 | `learned` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -736,12 +736,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_entindex` | `int32` | `optional` | `` | default = -1 |
-| 2 | `damage_taken` | `uint32` | `optional` | `` |  |
-| 3 | `item_type` | `uint32` | `optional` | `` |  |
-| 4 | `item_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 5 | `hero_name` | `string` | `optional` | `` |  |
-| 6 | `damage_color` | `string` | `optional` | `` |  |
+| 1 | `target_entindex` | `int32` | `optional` |  | default = -1 |
+| 2 | `damage_taken` | `uint32` | `optional` |  |  |
+| 3 | `item_type` | `uint32` | `optional` |  |  |
+| 4 | `item_ability_id` | `int32` | `optional` |  | default = -1 |
+| 5 | `hero_name` | `string` | `optional` |  |  |
+| 6 | `damage_color` | `string` | `optional` |  |  |
 
 </details>
 
@@ -765,13 +765,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `quest_id` | `uint32` | `optional` | `` |  |
-| 2 | `challenge_id` | `uint32` | `optional` | `` |  |
-| 3 | `progress` | `uint32` | `optional` | `` |  |
-| 4 | `goal` | `uint32` | `optional` | `` |  |
-| 5 | `query` | `uint32` | `optional` | `` |  |
-| 6 | `fail_gametime` | `float` | `optional` | `` |  |
-| 7 | `item_ability_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `quest_id` | `uint32` | `optional` |  |  |
+| 2 | `challenge_id` | `uint32` | `optional` |  |  |
+| 3 | `progress` | `uint32` | `optional` |  |  |
+| 4 | `goal` | `uint32` | `optional` |  |  |
+| 5 | `query` | `uint32` | `optional` |  |  |
+| 6 | `fail_gametime` | `float` | `optional` |  |  |
+| 7 | `item_ability_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -783,8 +783,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `mode` | `int32` | `optional` | `` |  |
-| 2 | `show_message` | `bool` | `optional` | `` |  |
+| 1 | `mode` | `int32` | `optional` |  |  |
+| 2 | `show_message` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -796,8 +796,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ability_index` | `uint32` | `optional` | `` |  |
-| 2 | `target_entindex` | `int32` | `optional` | `` | default = -1 |
+| 1 | `ability_index` | `uint32` | `optional` |  |  |
+| 2 | `target_entindex` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -809,8 +809,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `enemy_player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `enemy_starting_position` | `uint32` | `optional` | `` |  |
+| 1 | `enemy_player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `enemy_starting_position` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -822,9 +822,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ward_index` | `uint32` | `optional` | `` |  |
-| 2 | `ward_x` | `float` | `optional` | `` |  |
-| 3 | `ward_y` | `float` | `optional` | `` |  |
+| 1 | `ward_index` | `uint32` | `optional` |  |  |
+| 2 | `ward_x` | `float` | `optional` |  |  |
+| 3 | `ward_y` | `float` | `optional` |  |  |
 
 </details>
 
@@ -836,9 +836,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `channel_type` | `uint32` | `optional` | `` |  |
-| 2 | `roll_min` | `uint32` | `optional` | `` |  |
-| 3 | `roll_max` | `uint32` | `optional` | `` |  |
+| 1 | `channel_type` | `uint32` | `optional` |  |  |
+| 2 | `roll_min` | `uint32` | `optional` |  |  |
+| 3 | `roll_max` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -850,7 +850,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `channel_type` | `uint32` | `optional` | `` |  |
+| 1 | `channel_type` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -874,7 +874,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_preferences` | `.CDOTAClientMsg_SuggestItemPreference.ItemPreference` | `repeated` | `` |  |
+| 1 | `item_preferences` | `.CDOTAClientMsg_SuggestItemPreference.ItemPreference` | `repeated` |  |  |
 
 </details>
 
@@ -886,8 +886,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `preference` | `.EItemSuggestPreference` | `optional` | `` | default = k_EItemSuggestPreference_None |
+| 1 | `item_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `preference` | `.EItemSuggestPreference` | `optional` |  | default = k_EItemSuggestPreference_None |
 
 </details>
 
@@ -899,7 +899,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `is_out_of_items` | `bool` | `optional` | `` |  |
+| 1 | `is_out_of_items` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -911,7 +911,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `is_out_of_items` | `bool` | `optional` | `` |  |
+| 1 | `is_out_of_items` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -923,7 +923,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `variant` | `uint32` | `optional` | `` |  |
+| 1 | `variant` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -935,7 +935,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -947,7 +947,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tip_displayed` | `bool` | `optional` | `` |  |
+| 1 | `tip_displayed` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -959,10 +959,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `game_time` | `float` | `optional` | `` |  |
-| 2 | `duration` | `float` | `optional` | `` |  |
-| 3 | `recent_player_death` | `bool` | `optional` | `` |  |
-| 4 | `player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `game_time` | `float` | `optional` |  |  |
+| 2 | `duration` | `float` | `optional` |  |  |
+| 3 | `recent_player_death` | `bool` | `optional` |  |  |
+| 4 | `player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -974,10 +974,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `requested_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `ctrl_is_down` | `bool` | `optional` | `` |  |
-| 3 | `requested_hero_id` | `int32` | `optional` | `` |  |
-| 4 | `requested_facet_key` | `uint64` | `optional` | `` |  |
+| 1 | `requested_ability_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `ctrl_is_down` | `bool` | `optional` |  |  |
+| 3 | `requested_hero_id` | `int32` | `optional` |  |  |
+| 4 | `requested_facet_key` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -989,8 +989,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `option` | `uint32` | `optional` | `` |  |
-| 2 | `force_recalculate` | `bool` | `optional` | `` |  |
+| 1 | `option` | `uint32` | `optional` |  |  |
+| 2 | `force_recalculate` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1002,8 +1002,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guide_workshop_id` | `uint64` | `optional` | `` |  |
-| 2 | `is_plus_guide` | `bool` | `optional` | `` |  |
+| 1 | `guide_workshop_id` | `uint64` | `optional` |  |  |
+| 2 | `is_plus_guide` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1015,10 +1015,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_hero_id` | `int32` | `optional` | `` |  |
-| 2 | `source_hero_id` | `int32` | `optional` | `` |  |
-| 3 | `damage_amount` | `int32` | `optional` | `` |  |
-| 4 | `broadcast` | `bool` | `optional` | `` |  |
+| 1 | `target_hero_id` | `int32` | `optional` |  |  |
+| 2 | `source_hero_id` | `int32` | `optional` |  |  |
+| 3 | `damage_amount` | `int32` | `optional` |  |  |
+| 4 | `broadcast` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1030,8 +1030,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `event_id` | `int32` | `optional` | `` |  |
+| 1 | `target_player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `event_id` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1043,8 +1043,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `item_def_index` | `uint32` | `optional` | `` |  |
+| 1 | `target_player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `item_def_index` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1056,7 +1056,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def_index` | `uint32` | `optional` | `` |  |
+| 1 | `item_def_index` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1068,7 +1068,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tip_text` | `string` | `optional` | `` |  |
+| 1 | `tip_text` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1080,7 +1080,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_entindex` | `int32` | `optional` | `` | default = -1 |
+| 1 | `target_entindex` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -1092,7 +1092,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `map_variant` | `uint32` | `optional` | `` | default = 255 |
+| 1 | `map_variant` | `uint32` | `optional` |  | default = 255 |
 
 </details>
 
@@ -1104,8 +1104,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `order_id` | `int32` | `optional` | `` |  |
-| 2 | `data` | `int32` | `optional` | `` |  |
+| 1 | `order_id` | `int32` | `optional` |  |  |
+| 2 | `data` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1117,10 +1117,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `behavior` | `.EDOTAVersusScenePlayerBehavior` | `optional` | `` | default = VS_PLAYER_BEHAVIOR_PLAY_ACTIVITY |
-| 2 | `play_activity` | `.VersusScene_PlayActivity` | `optional` | `` |  |
-| 3 | `chat_wheel` | `.VersusScene_ChatWheel` | `optional` | `` |  |
-| 4 | `playback_rate` | `.VersusScene_PlaybackRate` | `optional` | `` |  |
+| 1 | `behavior` | `.EDOTAVersusScenePlayerBehavior` | `optional` |  | default = VS_PLAYER_BEHAVIOR_PLAY_ACTIVITY |
+| 2 | `play_activity` | `.VersusScene_PlayActivity` | `optional` |  |  |
+| 3 | `chat_wheel` | `.VersusScene_ChatWheel` | `optional` |  |  |
+| 4 | `playback_rate` | `.VersusScene_PlaybackRate` | `optional` |  |  |
 
 </details>
 
@@ -1132,8 +1132,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_entindex` | `int32` | `optional` | `` | default = -1 |
-| 2 | `slot_index` | `int32` | `optional` | `` |  |
+| 1 | `target_entindex` | `int32` | `optional` |  | default = -1 |
+| 2 | `slot_index` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1145,9 +1145,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `reason` | `.EOverwatchReportReason` | `optional` | `` | default = k_EOverwatchReportReason_Unknown |
-| 4 | `seconds_ago` | `uint32` | `optional` | `` |  |
+| 1 | `target_player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `reason` | `.EOverwatchReportReason` | `optional` |  | default = k_EOverwatchReportReason_Unknown |
+| 4 | `seconds_ago` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1159,7 +1159,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `target_player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -1171,7 +1171,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `target_player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -1183,10 +1183,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `source_player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `target_player_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `target_entindex` | `int32` | `optional` | `` | default = -1 |
-| 4 | `alert_type` | `uint32` | `optional` | `` |  |
+| 1 | `source_player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `target_player_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `target_entindex` | `int32` | `optional` |  | default = -1 |
+| 4 | `alert_type` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1198,28 +1198,28 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `average_frame_time` | `float` | `optional` | `` |  |
-| 2 | `max_frame_time` | `float` | `optional` | `` |  |
-| 3 | `average_compute_time` | `float` | `optional` | `` |  |
-| 4 | `max_compute_time` | `float` | `optional` | `` |  |
-| 5 | `average_client_tick_time` | `float` | `optional` | `` |  |
-| 6 | `max_client_tick_time` | `float` | `optional` | `` |  |
-| 7 | `average_client_simulate_time` | `float` | `optional` | `` |  |
-| 8 | `max_client_simulate_time` | `float` | `optional` | `` |  |
-| 9 | `average_output_time` | `float` | `optional` | `` |  |
-| 10 | `max_output_time` | `float` | `optional` | `` |  |
-| 11 | `average_wait_for_rendering_to_complete_time` | `float` | `optional` | `` |  |
-| 12 | `max_wait_for_rendering_to_complete_time` | `float` | `optional` | `` |  |
-| 13 | `average_swap_time` | `float` | `optional` | `` |  |
-| 14 | `max_swap_time` | `float` | `optional` | `` |  |
-| 15 | `average_frame_update_time` | `float` | `optional` | `` |  |
-| 16 | `max_frame_update_time` | `float` | `optional` | `` |  |
-| 17 | `average_idle_time` | `float` | `optional` | `` |  |
-| 18 | `max_idle_time` | `float` | `optional` | `` |  |
-| 19 | `average_input_processing_time` | `float` | `optional` | `` |  |
-| 20 | `max_input_processing_time` | `float` | `optional` | `` |  |
-| 21 | `average_missed_snapshot_rate` | `float` | `optional` | `` |  |
-| 22 | `max_missed_snapshot_rate` | `float` | `optional` | `` |  |
+| 1 | `average_frame_time` | `float` | `optional` |  |  |
+| 2 | `max_frame_time` | `float` | `optional` |  |  |
+| 3 | `average_compute_time` | `float` | `optional` |  |  |
+| 4 | `max_compute_time` | `float` | `optional` |  |  |
+| 5 | `average_client_tick_time` | `float` | `optional` |  |  |
+| 6 | `max_client_tick_time` | `float` | `optional` |  |  |
+| 7 | `average_client_simulate_time` | `float` | `optional` |  |  |
+| 8 | `max_client_simulate_time` | `float` | `optional` |  |  |
+| 9 | `average_output_time` | `float` | `optional` |  |  |
+| 10 | `max_output_time` | `float` | `optional` |  |  |
+| 11 | `average_wait_for_rendering_to_complete_time` | `float` | `optional` |  |  |
+| 12 | `max_wait_for_rendering_to_complete_time` | `float` | `optional` |  |  |
+| 13 | `average_swap_time` | `float` | `optional` |  |  |
+| 14 | `max_swap_time` | `float` | `optional` |  |  |
+| 15 | `average_frame_update_time` | `float` | `optional` |  |  |
+| 16 | `max_frame_update_time` | `float` | `optional` |  |  |
+| 17 | `average_idle_time` | `float` | `optional` |  |  |
+| 18 | `max_idle_time` | `float` | `optional` |  |  |
+| 19 | `average_input_processing_time` | `float` | `optional` |  |  |
+| 20 | `max_input_processing_time` | `float` | `optional` |  |  |
+| 21 | `average_missed_snapshot_rate` | `float` | `optional` |  |  |
+| 22 | `max_missed_snapshot_rate` | `float` | `optional` |  |  |
 
 </details>
 
@@ -1231,10 +1231,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `unsubscribe` | `bool` | `optional` | `` |  |
-| 2 | `tip_id` | `int32` | `optional` | `` |  |
-| 3 | `prior_display_count` | `int32` | `optional` | `` |  |
-| 4 | `variants_seen` | `int32` | `repeated` | `` |  |
+| 1 | `unsubscribe` | `bool` | `optional` |  |  |
+| 2 | `tip_id` | `int32` | `optional` |  |  |
+| 3 | `prior_display_count` | `int32` | `optional` |  |  |
+| 4 | `variants_seen` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -1246,7 +1246,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tips` | `.CDOTAClientMsg_ContextualTips_Subscribe_Entry` | `repeated` | `` |  |
+| 1 | `tips` | `.CDOTAClientMsg_ContextualTips_Subscribe_Entry` | `repeated` |  |  |
 
 </details>
 
@@ -1258,8 +1258,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `channel_type` | `uint32` | `optional` | `` |  |
-| 2 | `message_text` | `string` | `optional` | `` |  |
+| 1 | `channel_type` | `uint32` | `optional` |  |  |
+| 2 | `message_text` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1271,8 +1271,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `challenger_player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `accepter_player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `challenger_player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `accepter_player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -1284,9 +1284,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `neutral_item_index` | `int32` | `optional` | `` |  |
-| 2 | `target_entindex` | `int32` | `optional` | `` | default = -1 |
-| 3 | `slot_index` | `int32` | `optional` | `` |  |
+| 1 | `neutral_item_index` | `int32` | `optional` |  |  |
+| 2 | `target_entindex` | `int32` | `optional` |  | default = -1 |
+| 3 | `slot_index` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1298,8 +1298,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_entindex` | `int32` | `optional` | `` | default = -1 |
-| 2 | `slot_index` | `int32` | `optional` | `` |  |
+| 1 | `target_entindex` | `int32` | `optional` |  | default = -1 |
+| 2 | `slot_index` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1311,7 +1311,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -1323,7 +1323,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -1335,8 +1335,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `role_idx` | `int32` | `optional` | `` |  |
-| 2 | `desired` | `bool` | `optional` | `` |  |
+| 1 | `role_idx` | `int32` | `optional` |  |  |
+| 2 | `desired` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1348,7 +1348,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team` | `int32` | `optional` | `` |  |
+| 1 | `team` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1360,13 +1360,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ability_entindex` | `uint32` | `optional` | `` | default = 16777215 |
-| 2 | `ctrl_held` | `bool` | `optional` | `` |  |
-| 3 | `owner_entindex` | `int32` | `optional` | `` | default = -1 |
-| 4 | `ability_id` | `int32` | `optional` | `` | default = -1 |
-| 5 | `primary_charges` | `uint32` | `optional` | `` |  |
-| 6 | `secondary_charges` | `uint32` | `optional` | `` |  |
-| 7 | `reclaim_time` | `float` | `optional` | `` |  |
+| 1 | `ability_entindex` | `uint32` | `optional` |  | default = 16777215 |
+| 2 | `ctrl_held` | `bool` | `optional` |  |  |
+| 3 | `owner_entindex` | `int32` | `optional` |  | default = -1 |
+| 4 | `ability_id` | `int32` | `optional` |  | default = -1 |
+| 5 | `primary_charges` | `uint32` | `optional` |  |  |
+| 6 | `secondary_charges` | `uint32` | `optional` |  |  |
+| 7 | `reclaim_time` | `float` | `optional` |  |  |
 
 </details>
 
@@ -1378,7 +1378,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `token_ids` | `uint32` | `repeated` | `` |  |
+| 1 | `token_ids` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -1390,9 +1390,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `facet_strhash` | `uint32` | `optional` | `` |  |
-| 2 | `hero_entindex` | `uint32` | `optional` | `` | default = 16777215 |
-| 3 | `ctrl_held` | `bool` | `optional` | `` |  |
+| 1 | `facet_strhash` | `uint32` | `optional` |  |  |
+| 2 | `hero_entindex` | `uint32` | `optional` |  | default = 16777215 |
+| 3 | `ctrl_held` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1404,8 +1404,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ability_entindex` | `uint32` | `optional` | `` | default = 16777215 |
-| 2 | `ctrl_held` | `bool` | `optional` | `` |  |
+| 1 | `ability_entindex` | `uint32` | `optional` |  | default = 16777215 |
+| 2 | `ctrl_held` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1417,7 +1417,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `overworld_id` | `uint32` | `optional` | `` |  |
+| 1 | `overworld_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1429,7 +1429,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `negative` | `bool` | `optional` | `` |  |
+| 1 | `negative` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1441,7 +1441,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `negative` | `bool` | `optional` | `` |  |
+| 1 | `negative` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1465,9 +1465,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `neutral_item_index` | `int32` | `optional` | `` |  |
-| 2 | `item_tier` | `int32` | `optional` | `` |  |
-| 3 | `enhancement_index` | `int32` | `optional` | `` |  |
+| 1 | `neutral_item_index` | `int32` | `optional` |  |  |
+| 2 | `item_tier` | `int32` | `optional` |  |  |
+| 3 | `enhancement_index` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1479,7 +1479,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `timer_alert_type` | `.ETimerAlertType` | `optional` | `` | default = k_TimerAlertType_PowerRune |
+| 1 | `timer_alert_type` | `.ETimerAlertType` | `optional` |  | default = k_TimerAlertType_PowerRune |
 
 </details>
 
@@ -1491,7 +1491,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_entindex` | `int32` | `optional` | `` | default = -1 |
+| 1 | `target_entindex` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -1503,7 +1503,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `auto_deliver` | `bool` | `optional` | `` |  |
+| 1 | `auto_deliver` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1515,8 +1515,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_entindex` | `int32` | `optional` | `` | default = -1 |
-| 2 | `is_auto_deliver` | `bool` | `optional` | `` |  |
+| 1 | `target_entindex` | `int32` | `optional` |  | default = -1 |
+| 2 | `is_auto_deliver` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1528,7 +1528,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `investigation_index` | `uint32` | `optional` | `` |  |
+| 1 | `investigation_index` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1540,8 +1540,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `investigation_state_index` | `uint32` | `optional` | `` |  |
-| 2 | `ctrl_pressed` | `bool` | `optional` | `` |  |
+| 1 | `investigation_state_index` | `uint32` | `optional` |  |  |
+| 2 | `ctrl_pressed` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1553,7 +1553,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `blessing` | `int32` | `optional` | `` | default = -1 |
+| 1 | `blessing` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -1565,9 +1565,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `aghanim_id` | `uint32` | `optional` | `` |  |
-| 2 | `scepter` | `bool` | `optional` | `` |  |
-| 3 | `target_entindex` | `int32` | `optional` | `` | default = -1 |
+| 1 | `aghanim_id` | `uint32` | `optional` |  |  |
+| 2 | `scepter` | `bool` | `optional` |  |  |
+| 3 | `target_entindex` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -1579,7 +1579,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ability_to_imbue` | `int32` | `optional` | `` | default = -1 |
+| 1 | `ability_to_imbue` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -1591,8 +1591,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tick` | `uint32` | `optional` | `` |  |
-| 2 | `missed_snapshot_rate` | `float` | `optional` | `` |  |
+| 1 | `tick` | `uint32` | `optional` |  |  |
+| 2 | `missed_snapshot_rate` | `float` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-commonmessages.md
+++ b/docs/cookbook/proto-fields/dota-commonmessages.md
@@ -23,9 +23,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `x` | `int32` | `optional` | `` |  |
-| 2 | `y` | `int32` | `optional` | `` |  |
-| 3 | `grid_nav_directions` | `bytes` | `optional` | `` |  |
+| 1 | `x` | `int32` | `optional` |  |  |
+| 2 | `y` | `int32` | `optional` |  |  |
+| 3 | `grid_nav_directions` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -37,13 +37,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `x` | `int32` | `optional` | `` |  |
-| 2 | `y` | `int32` | `optional` | `` |  |
-| 3 | `target` | `int32` | `optional` | `` | default = -1 |
-| 4 | `direct_ping` | `bool` | `optional` | `` |  |
-| 5 | `type` | `uint32` | `optional` | `` | default = 4294967295 |
-| 6 | `ping_source` | `.EPingSource` | `optional` | `` | default = k_ePingSource_Default |
-| 7 | `waypoint_path` | `.CDOTAMsg_PingWaypointPath` | `optional` | `` |  |
+| 1 | `x` | `int32` | `optional` |  |  |
+| 2 | `y` | `int32` | `optional` |  |  |
+| 3 | `target` | `int32` | `optional` |  | default = -1 |
+| 4 | `direct_ping` | `bool` | `optional` |  |  |
+| 5 | `type` | `uint32` | `optional` |  | default = 4294967295 |
+| 6 | `ping_source` | `.EPingSource` | `optional` |  | default = k_ePingSource_Default |
+| 7 | `waypoint_path` | `.CDOTAMsg_PingWaypointPath` | `optional` |  |  |
 
 </details>
 
@@ -55,9 +55,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `x` | `int32` | `optional` | `` |  |
-| 2 | `y` | `int32` | `optional` | `` |  |
-| 3 | `item_ability_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `x` | `int32` | `optional` |  |  |
+| 2 | `y` | `int32` | `optional` |  |  |
+| 3 | `item_ability_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -69,9 +69,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `x` | `int32` | `optional` | `` |  |
-| 2 | `y` | `int32` | `optional` | `` |  |
-| 3 | `initial` | `bool` | `optional` | `` |  |
+| 1 | `x` | `int32` | `optional` |  |  |
+| 2 | `y` | `int32` | `optional` |  |  |
+| 3 | `initial` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -83,11 +83,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `x` | `int32` | `optional` | `` |  |
-| 2 | `y` | `int32` | `optional` | `` |  |
-| 3 | `z` | `int32` | `optional` | `` |  |
-| 4 | `initial` | `bool` | `optional` | `` |  |
-| 5 | `end` | `bool` | `optional` | `` |  |
+| 1 | `x` | `int32` | `optional` |  |  |
+| 2 | `y` | `int32` | `optional` |  |  |
+| 3 | `z` | `int32` | `optional` |  |  |
+| 4 | `initial` | `bool` | `optional` |  |  |
+| 5 | `end` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -99,13 +99,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `style` | `.EDOTAStatPopupTypes` | `optional` | `` | default = k_EDOTA_SPT_Textline |
-| 2 | `stat_strings` | `string` | `repeated` | `` |  |
-| 3 | `stat_images` | `int32` | `repeated` | `` |  |
-| 4 | `stat_image_types` | `int32` | `repeated` | `` |  |
-| 5 | `duration` | `float` | `optional` | `` |  |
-| 6 | `use_html` | `bool` | `optional` | `` |  |
-| 7 | `movie_name` | `string` | `optional` | `` |  |
+| 1 | `style` | `.EDOTAStatPopupTypes` | `optional` |  | default = k_EDOTA_SPT_Textline |
+| 2 | `stat_strings` | `string` | `repeated` |  |  |
+| 3 | `stat_images` | `int32` | `repeated` |  |  |
+| 4 | `stat_image_types` | `int32` | `repeated` |  |  |
+| 5 | `duration` | `float` | `optional` |  |  |
+| 6 | `use_html` | `bool` | `optional` |  |  |
+| 7 | `movie_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -117,7 +117,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `time_delay` | `float` | `optional` | `` |  |
+| 1 | `time_delay` | `float` | `optional` |  |  |
 
 </details>
 
@@ -129,9 +129,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `x` | `uint32` | `optional` | `` |  |
-| 2 | `y` | `uint32` | `optional` | `` |  |
-| 3 | `tgtpath` | `string` | `optional` | `` |  |
+| 1 | `x` | `uint32` | `optional` |  |  |
+| 2 | `y` | `uint32` | `optional` |  |  |
+| 3 | `tgtpath` | `string` | `optional` |  |  |
 
 </details>
 
@@ -143,13 +143,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `order_type` | `.dotaunitorder_t` | `optional` | `` | default = DOTA_UNIT_ORDER_NONE |
-| 3 | `units` | `int32` | `repeated` | `` |  |
-| 4 | `target_index` | `int32` | `optional` | `` | default = 0 |
-| 5 | `ability_index` | `int32` | `optional` | `` | default = -1 |
-| 6 | `position` | `.CMsgVector` | `optional` | `` |  |
-| 8 | `sequence_number` | `int32` | `optional` | `` |  |
-| 9 | `flags` | `uint32` | `optional` | `` |  |
+| 2 | `order_type` | `.dotaunitorder_t` | `optional` |  | default = DOTA_UNIT_ORDER_NONE |
+| 3 | `units` | `int32` | `repeated` |  |  |
+| 4 | `target_index` | `int32` | `optional` |  | default = 0 |
+| 5 | `ability_index` | `int32` | `optional` |  | default = -1 |
+| 6 | `position` | `.CMsgVector` | `optional` |  |  |
+| 8 | `sequence_number` | `int32` | `optional` |  |  |
+| 9 | `flags` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -161,8 +161,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `activities` | `.VersusScene_PlayActivity.ActivityInfo` | `repeated` | `` |  |
-| 2 | `playback_rate` | `float` | `optional` | `` |  |
+| 1 | `activities` | `.VersusScene_PlayActivity.ActivityInfo` | `repeated` |  |  |
+| 2 | `playback_rate` | `float` | `optional` |  |  |
 
 </details>
 
@@ -174,9 +174,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `activity` | `string` | `optional` | `` |  |
-| 2 | `disable_auto_kill` | `bool` | `optional` | `` |  |
-| 3 | `force_looping` | `bool` | `optional` | `` |  |
+| 1 | `activity` | `string` | `optional` |  |  |
+| 2 | `disable_auto_kill` | `bool` | `optional` |  |  |
+| 3 | `force_looping` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -188,8 +188,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `chat_message_id` | `uint32` | `optional` | `` | default = 4294967295 |
-| 2 | `emoticon_id` | `uint32` | `optional` | `` |  |
+| 1 | `chat_message_id` | `uint32` | `optional` |  | default = 4294967295 |
+| 2 | `emoticon_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -201,7 +201,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `rate` | `float` | `optional` | `` |  |
+| 1 | `rate` | `float` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-fighting-game-p2p-messages.md
+++ b/docs/cookbook/proto-fields/dota-fighting-game-p2p-messages.md
@@ -24,14 +24,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `last_acked_frame` | `int32` | `optional` | `` |  |
-| 2 | `player_id` | `uint32` | `optional` | `` |  |
-| 3 | `last_crc_frame` | `int32` | `optional` | `` |  |
-| 4 | `last_crc_value` | `uint32` | `optional` | `` |  |
-| 5 | `now` | `float` | `optional` | `` |  |
-| 6 | `peer_ack_time` | `float` | `optional` | `` |  |
-| 7 | `input_start_frame` | `int32` | `optional` | `` |  |
-| 8 | `input_sample` | `.CMsgFightingGame_GameData_Fighting.InputSample` | `repeated` | `` |  |
+| 1 | `last_acked_frame` | `int32` | `optional` |  |  |
+| 2 | `player_id` | `uint32` | `optional` |  |  |
+| 3 | `last_crc_frame` | `int32` | `optional` |  |  |
+| 4 | `last_crc_value` | `uint32` | `optional` |  |  |
+| 5 | `now` | `float` | `optional` |  |  |
+| 6 | `peer_ack_time` | `float` | `optional` |  |  |
+| 7 | `input_start_frame` | `int32` | `optional` |  |  |
+| 8 | `input_sample` | `.CMsgFightingGame_GameData_Fighting.InputSample` | `repeated` |  |  |
 
 </details>
 
@@ -43,7 +43,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `button_mask` | `uint32` | `optional` | `` |  |
+| 1 | `button_mask` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -55,12 +55,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cursor_index` | `uint32` | `optional` | `` |  |
-| 2 | `selected_hero_id` | `int32` | `optional` | `` |  |
-| 3 | `selected_style` | `uint32` | `optional` | `` |  |
-| 4 | `econ_item_refs` | `.CMsgFightingGame_GameData_CharacterSelect.Item` | `repeated` | `` |  |
-| 5 | `message_ack` | `int64` | `optional` | `` |  |
-| 6 | `confirmed_style` | `bool` | `optional` | `` |  |
+| 1 | `cursor_index` | `uint32` | `optional` |  |  |
+| 2 | `selected_hero_id` | `int32` | `optional` |  |  |
+| 3 | `selected_style` | `uint32` | `optional` |  |  |
+| 4 | `econ_item_refs` | `.CMsgFightingGame_GameData_CharacterSelect.Item` | `repeated` |  |  |
+| 5 | `message_ack` | `int64` | `optional` |  |  |
+| 6 | `confirmed_style` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -72,8 +72,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def` | `uint32` | `optional` | `` |  |
-| 2 | `style_index` | `uint32` | `optional` | `` | default = 255 |
+| 1 | `item_def` | `uint32` | `optional` |  |  |
+| 2 | `style_index` | `uint32` | `optional` |  | default = 255 |
 
 </details>
 
@@ -85,10 +85,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `now` | `float` | `optional` | `` |  |
-| 2 | `peer_ack_time` | `float` | `optional` | `` |  |
-| 3 | `proposed_start_time` | `float` | `optional` | `` |  |
-| 4 | `accepted_start_time` | `float` | `optional` | `` |  |
+| 1 | `now` | `float` | `optional` |  |  |
+| 2 | `peer_ack_time` | `float` | `optional` |  |  |
+| 3 | `proposed_start_time` | `float` | `optional` |  |  |
+| 4 | `accepted_start_time` | `float` | `optional` |  |  |
 
 </details>
 
@@ -100,7 +100,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `state` | `.CP2P_FightingGame_GameData.EState` | `optional` | `` | default = k_ChoosingCharacter |
+| 1 | `state` | `.CP2P_FightingGame_GameData.EState` | `optional` |  | default = k_ChoosingCharacter |
 | 2 | `fight` | `.CMsgFightingGame_GameData_Fighting` | `oneof` | `state_data` |  |
 | 3 | `character_select` | `.CMsgFightingGame_GameData_CharacterSelect` | `oneof` | `state_data` |  |
 | 4 | `loaded` | `.CMsgFightingGame_GameData_Loaded` | `oneof` | `state_data` |  |

--- a/docs/cookbook/proto-fields/dota-gcmessages-client-bingo.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-client-bingo.md
@@ -31,9 +31,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `stat_id` | `uint32` | `optional` | `` |  |
-| 2 | `stat_threshold` | `int32` | `optional` | `` |  |
-| 3 | `upgrade_level` | `uint32` | `optional` | `` |  |
+| 1 | `stat_id` | `uint32` | `optional` |  |  |
+| 2 | `stat_threshold` | `int32` | `optional` |  |  |
+| 3 | `upgrade_level` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -45,7 +45,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `token_count` | `uint32` | `optional` | `` |  |
+| 1 | `token_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -57,7 +57,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `squares` | `.CMsgBingoSquare` | `repeated` | `` |  |
+| 1 | `squares` | `.CMsgBingoSquare` | `repeated` |  |  |
 
 </details>
 
@@ -69,8 +69,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `bingo_cards` | `.CMsgBingoUserData.BingoCardsEntry` | `repeated` | `` |  |
-| 2 | `bingo_tokens` | `.CMsgBingoUserData.BingoTokensEntry` | `repeated` | `` |  |
+| 1 | `bingo_cards` | `.CMsgBingoUserData.BingoCardsEntry` | `repeated` |  |  |
+| 2 | `bingo_tokens` | `.CMsgBingoUserData.BingoTokensEntry` | `repeated` |  |  |
 
 </details>
 
@@ -82,8 +82,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `.CMsgBingoCard` | `optional` | `` |  |
+| 1 | `key` | `uint32` | `optional` |  |  |
+| 2 | `value` | `.CMsgBingoCard` | `optional` |  |  |
 
 </details>
 
@@ -95,8 +95,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `.CMsgBingoTokens` | `optional` | `` |  |
+| 1 | `key` | `uint32` | `optional` |  |  |
+| 2 | `value` | `.CMsgBingoTokens` | `optional` |  |  |
 
 </details>
 
@@ -108,7 +108,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -120,8 +120,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCBingoGetUserDataResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `user_data` | `.CMsgBingoUserData` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCBingoGetUserDataResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `user_data` | `.CMsgBingoUserData` | `optional` |  |  |
 
 </details>
 
@@ -133,8 +133,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `stat_id` | `uint32` | `optional` | `` |  |
-| 2 | `stat_value` | `int32` | `optional` | `` |  |
+| 1 | `stat_id` | `uint32` | `optional` |  |  |
+| 2 | `stat_value` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -146,7 +146,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `stats_data` | `.CMsgBingoIndividualStatData` | `repeated` | `` |  |
+| 1 | `stats_data` | `.CMsgBingoIndividualStatData` | `repeated` |  |  |
 
 </details>
 
@@ -158,8 +158,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 2 | `league_phase` | `uint32` | `optional` | `` |  |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 2 | `league_phase` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -171,8 +171,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCBingoGetStatsDataResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `stats_data` | `.CMsgBingoStatsData` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCBingoGetStatsDataResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `stats_data` | `.CMsgBingoStatsData` | `optional` |  |  |
 
 </details>
 
@@ -184,8 +184,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 2 | `user_data` | `.CMsgBingoUserData` | `optional` | `` |  |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 2 | `user_data` | `.CMsgBingoUserData` | `optional` |  |  |
 
 </details>
 
@@ -197,9 +197,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 2 | `league_phase` | `uint32` | `optional` | `` |  |
-| 3 | `row_index` | `uint32` | `optional` | `` |  |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 2 | `league_phase` | `uint32` | `optional` |  |  |
+| 3 | `row_index` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -211,7 +211,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCBingoClaimRowResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCBingoClaimRowResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -223,8 +223,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 2 | `league_phase` | `uint32` | `optional` | `` |  |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 2 | `league_phase` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -236,7 +236,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCBingoShuffleCardResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCBingoShuffleCardResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -248,10 +248,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 2 | `league_phase` | `uint32` | `optional` | `` |  |
-| 3 | `square_index` | `uint32` | `optional` | `` |  |
-| 4 | `action` | `.CMsgClientToGCBingoModifySquare.EModifyAction` | `optional` | `` | default = k_eRerollStat |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 2 | `league_phase` | `uint32` | `optional` |  |  |
+| 3 | `square_index` | `uint32` | `optional` |  |  |
+| 4 | `action` | `.CMsgClientToGCBingoModifySquare.EModifyAction` | `optional` |  | default = k_eRerollStat |
 
 </details>
 
@@ -263,7 +263,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCBingoModifySquareResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCBingoModifySquareResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -275,8 +275,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 2 | `league_phase` | `uint32` | `optional` | `` |  |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 2 | `league_phase` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -288,7 +288,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCBingoDevRerollCardResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCBingoDevRerollCardResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -300,9 +300,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 2 | `league_phase` | `uint32` | `optional` | `` |  |
-| 3 | `token_count` | `int32` | `optional` | `` |  |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 2 | `league_phase` | `uint32` | `optional` |  |  |
+| 3 | `token_count` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -314,7 +314,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCBingoDevAddTokensResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCBingoDevAddTokensResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -326,7 +326,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -338,7 +338,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCBingoDevClearInventoryResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCBingoDevClearInventoryResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-client-candy-shop.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-client-candy-shop.md
@@ -31,8 +31,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `candy_type` | `uint32` | `optional` | `` |  |
-| 2 | `candy_count` | `uint32` | `optional` | `` |  |
+| 1 | `candy_type` | `uint32` | `optional` |  |  |
+| 2 | `candy_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -44,7 +44,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `candy_counts` | `.CMsgCandyShopCandyCount` | `repeated` | `` |  |
+| 1 | `candy_counts` | `.CMsgCandyShopCandyCount` | `repeated` |  |  |
 
 </details>
 
@@ -56,9 +56,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `recipe_id` | `uint32` | `optional` | `` |  |
-| 2 | `input` | `.CMsgCandyShopCandyQuantity` | `optional` | `` |  |
-| 3 | `output` | `.CMsgCandyShopCandyQuantity` | `optional` | `` |  |
+| 1 | `recipe_id` | `uint32` | `optional` |  |  |
+| 2 | `input` | `.CMsgCandyShopCandyQuantity` | `optional` |  |  |
+| 3 | `output` | `.CMsgCandyShopCandyQuantity` | `optional` |  |  |
 
 </details>
 
@@ -70,7 +70,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def` | `uint32` | `optional` | `` |  |
+| 1 | `item_def` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -82,8 +82,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 2 | `action_id` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 2 | `action_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -95,8 +95,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 2 | `points` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 2 | `points` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -108,13 +108,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `reward_id` | `uint32` | `optional` | `` |  |
-| 2 | `reward_option_id` | `uint32` | `optional` | `` |  |
-| 3 | `price` | `.CMsgCandyShopCandyQuantity` | `optional` | `` |  |
-| 4 | `reward_type` | `.ECandyShopRewardType` | `optional` | `` | default = k_eCandyShopRewardType_None |
-| 5 | `item_data` | `.CMsgCandyShopRewardData_Item` | `optional` | `` |  |
-| 6 | `event_action_data` | `.CMsgCandyShopRewardData_EventAction` | `optional` | `` |  |
-| 7 | `event_points_data` | `.CMsgCandyShopRewardData_EventPoints` | `optional` | `` |  |
+| 1 | `reward_id` | `uint32` | `optional` |  |  |
+| 2 | `reward_option_id` | `uint32` | `optional` |  |  |
+| 3 | `price` | `.CMsgCandyShopCandyQuantity` | `optional` |  |  |
+| 4 | `reward_type` | `.ECandyShopRewardType` | `optional` |  | default = k_eCandyShopRewardType_None |
+| 5 | `item_data` | `.CMsgCandyShopRewardData_Item` | `optional` |  |  |
+| 6 | `event_action_data` | `.CMsgCandyShopRewardData_EventAction` | `optional` |  |  |
+| 7 | `event_points_data` | `.CMsgCandyShopRewardData_EventPoints` | `optional` |  |  |
 
 </details>
 
@@ -126,15 +126,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `inventory_max` | `uint32` | `optional` | `` |  |
-| 2 | `inventory` | `.CMsgCandyShopCandyQuantity` | `optional` | `` |  |
-| 3 | `exchange_recipe_max` | `uint32` | `optional` | `` |  |
-| 4 | `exchange_reset_timestamp` | `fixed32` | `optional` | `` |  |
-| 5 | `exchange_recipes` | `.CMsgCandyShopExchangeRecipe` | `repeated` | `` |  |
-| 6 | `active_reward_max` | `uint32` | `optional` | `` |  |
-| 7 | `active_rewards` | `.CMsgCandyShopReward` | `repeated` | `` |  |
-| 8 | `reroll_charges_max` | `uint32` | `optional` | `` |  |
-| 9 | `reroll_charges` | `uint32` | `optional` | `` |  |
+| 1 | `inventory_max` | `uint32` | `optional` |  |  |
+| 2 | `inventory` | `.CMsgCandyShopCandyQuantity` | `optional` |  |  |
+| 3 | `exchange_recipe_max` | `uint32` | `optional` |  |  |
+| 4 | `exchange_reset_timestamp` | `fixed32` | `optional` |  |  |
+| 5 | `exchange_recipes` | `.CMsgCandyShopExchangeRecipe` | `repeated` |  |  |
+| 6 | `active_reward_max` | `uint32` | `optional` |  |  |
+| 7 | `active_rewards` | `.CMsgCandyShopReward` | `repeated` |  |  |
+| 8 | `reroll_charges_max` | `uint32` | `optional` |  |  |
+| 9 | `reroll_charges` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -146,7 +146,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `candy_shop_id` | `uint32` | `optional` | `` |  |
+| 1 | `candy_shop_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -158,8 +158,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCCandyShopGetUserDataResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `user_data` | `.CMsgCandyShopUserData` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCCandyShopGetUserDataResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `user_data` | `.CMsgCandyShopUserData` | `optional` |  |  |
 
 </details>
 
@@ -171,8 +171,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `candy_shop_id` | `uint32` | `optional` | `` |  |
-| 2 | `user_data` | `.CMsgCandyShopUserData` | `optional` | `` |  |
+| 1 | `candy_shop_id` | `uint32` | `optional` |  |  |
+| 2 | `user_data` | `.CMsgCandyShopUserData` | `optional` |  |  |
 
 </details>
 
@@ -184,8 +184,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `candy_shop_id` | `uint32` | `optional` | `` |  |
-| 2 | `reward_id` | `uint64` | `optional` | `` |  |
+| 1 | `candy_shop_id` | `uint32` | `optional` |  |  |
+| 2 | `reward_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -197,7 +197,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCCandyShopPurchaseRewardResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCCandyShopPurchaseRewardResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -209,8 +209,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `candy_shop_id` | `uint32` | `optional` | `` |  |
-| 2 | `bag_count` | `uint32` | `optional` | `` |  |
+| 1 | `candy_shop_id` | `uint32` | `optional` |  |  |
+| 2 | `bag_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -222,7 +222,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCCandyShopOpenBagsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCCandyShopOpenBagsResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -234,8 +234,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `candy_shop_id` | `uint32` | `optional` | `` |  |
-| 2 | `recipe_id` | `uint32` | `optional` | `` |  |
+| 1 | `candy_shop_id` | `uint32` | `optional` |  |  |
+| 2 | `recipe_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -247,7 +247,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCCandyShopDoExchangeResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCCandyShopDoExchangeResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -259,9 +259,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `candy_shop_id` | `uint32` | `optional` | `` |  |
-| 2 | `input` | `.CMsgCandyShopCandyQuantity` | `optional` | `` |  |
-| 3 | `output` | `.CMsgCandyShopCandyQuantity` | `optional` | `` |  |
+| 1 | `candy_shop_id` | `uint32` | `optional` |  |  |
+| 2 | `input` | `.CMsgCandyShopCandyQuantity` | `optional` |  |  |
+| 3 | `output` | `.CMsgCandyShopCandyQuantity` | `optional` |  |  |
 
 </details>
 
@@ -273,7 +273,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCCandyShopDoVariableExchangeResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCCandyShopDoVariableExchangeResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -285,7 +285,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `candy_shop_id` | `uint32` | `optional` | `` |  |
+| 1 | `candy_shop_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -297,7 +297,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCCandyShopRerollRewardsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCCandyShopRerollRewardsResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -321,8 +321,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `candy_shop_id` | `uint32` | `optional` | `` |  |
-| 2 | `candy_quantity` | `.CMsgCandyShopCandyQuantity` | `optional` | `` |  |
+| 1 | `candy_shop_id` | `uint32` | `optional` |  |  |
+| 2 | `candy_quantity` | `.CMsgCandyShopCandyQuantity` | `optional` |  |  |
 
 </details>
 
@@ -334,7 +334,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CCandyShopDev.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CCandyShopDev.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -346,7 +346,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `candy_shop_id` | `uint32` | `optional` | `` |  |
+| 1 | `candy_shop_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -358,7 +358,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CCandyShopDev.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CCandyShopDev.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -370,8 +370,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `candy_shop_id` | `uint32` | `optional` | `` |  |
-| 2 | `quantity` | `uint32` | `optional` | `` |  |
+| 1 | `candy_shop_id` | `uint32` | `optional` |  |  |
+| 2 | `quantity` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -383,7 +383,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CCandyShopDev.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CCandyShopDev.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -395,7 +395,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `candy_shop_id` | `uint32` | `optional` | `` |  |
+| 1 | `candy_shop_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -407,7 +407,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CCandyShopDev.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CCandyShopDev.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -419,8 +419,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `candy_shop_id` | `uint32` | `optional` | `` |  |
-| 2 | `reroll_charges` | `uint32` | `optional` | `` |  |
+| 1 | `candy_shop_id` | `uint32` | `optional` |  |  |
+| 2 | `reroll_charges` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -432,7 +432,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CCandyShopDev.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CCandyShopDev.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -444,7 +444,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `candy_shop_id` | `uint32` | `optional` | `` |  |
+| 1 | `candy_shop_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -456,7 +456,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CCandyShopDev.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CCandyShopDev.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-client-chat.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-client-chat.md
@@ -23,8 +23,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `private_chat_channel_name` | `string` | `optional` | `` |  |
-| 2 | `invited_account_id` | `uint32` | `optional` | `` |  |
+| 1 | `private_chat_channel_name` | `string` | `optional` |  |  |
+| 2 | `invited_account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -36,8 +36,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `private_chat_channel_name` | `string` | `optional` | `` |  |
-| 2 | `kick_account_id` | `uint32` | `optional` | `` |  |
+| 1 | `private_chat_channel_name` | `string` | `optional` |  |  |
+| 2 | `kick_account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -49,8 +49,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `private_chat_channel_name` | `string` | `optional` | `` |  |
-| 2 | `promote_account_id` | `uint32` | `optional` | `` |  |
+| 1 | `private_chat_channel_name` | `string` | `optional` |  |  |
+| 2 | `promote_account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -62,8 +62,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `private_chat_channel_name` | `string` | `optional` | `` |  |
-| 2 | `demote_account_id` | `uint32` | `optional` | `` |  |
+| 1 | `private_chat_channel_name` | `string` | `optional` |  |  |
+| 2 | `demote_account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -75,9 +75,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `private_chat_channel_name` | `string` | `optional` | `` |  |
-| 2 | `result` | `.CMsgGCToClientPrivateChatResponse.Result` | `optional` | `` | default = SUCCESS |
-| 3 | `username` | `string` | `optional` | `` |  |
+| 1 | `private_chat_channel_name` | `string` | `optional` |  |  |
+| 2 | `result` | `.CMsgGCToClientPrivateChatResponse.Result` | `optional` |  | default = SUCCESS |
+| 3 | `username` | `string` | `optional` |  |  |
 
 </details>
 
@@ -89,9 +89,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `channel_name` | `string` | `optional` | `` |  |
-| 4 | `channel_type` | `.DOTAChatChannelType_t` | `optional` | `` | default = DOTAChannelType_Regional |
-| 5 | `silent_rejection` | `bool` | `optional` | `` |  |
+| 2 | `channel_name` | `string` | `optional` |  |  |
+| 4 | `channel_type` | `.DOTAChatChannelType_t` | `optional` |  | default = DOTAChannelType_Regional |
+| 5 | `silent_rejection` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -103,7 +103,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `channel_id` | `uint64` | `optional` | `` |  |
+| 1 | `channel_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -115,8 +115,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `channel_id` | `uint64` | `optional` | `` |  |
-| 2 | `channel_user_id` | `uint32` | `optional` | `` |  |
+| 1 | `channel_id` | `uint64` | `optional` |  |  |
+| 2 | `channel_user_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -128,9 +128,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `channel_id` | `uint64` | `optional` | `` |  |
-| 2 | `account_id` | `uint32` | `optional` | `` |  |
-| 3 | `duration` | `uint32` | `optional` | `` |  |
+| 1 | `channel_id` | `uint64` | `optional` |  |  |
+| 2 | `account_id` | `uint32` | `optional` |  |  |
+| 3 | `duration` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -142,48 +142,48 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `channel_id` | `uint64` | `optional` | `` |  |
-| 3 | `persona_name` | `string` | `optional` | `` |  |
-| 4 | `text` | `string` | `optional` | `` |  |
-| 5 | `timestamp` | `uint32` | `optional` | `` |  |
-| 6 | `suggest_invite_account_id` | `uint32` | `optional` | `` |  |
-| 7 | `suggest_invite_name` | `string` | `optional` | `` |  |
-| 8 | `fantasy_draft_owner_account_id` | `uint32` | `optional` | `` |  |
-| 9 | `fantasy_draft_player_account_id` | `uint32` | `optional` | `` |  |
-| 10 | `event_id` | `uint32` | `optional` | `` |  |
-| 11 | `suggest_invite_to_lobby` | `bool` | `optional` | `` |  |
-| 13 | `coin_flip` | `bool` | `optional` | `` |  |
-| 14 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 15 | `share_profile_account_id` | `uint32` | `optional` | `` |  |
-| 16 | `channel_user_id` | `uint32` | `optional` | `` |  |
-| 17 | `dice_roll` | `.CMsgDOTAChatMessage.DiceRoll` | `optional` | `` |  |
-| 18 | `share_party_id` | `uint64` | `optional` | `` |  |
-| 19 | `share_lobby_id` | `uint64` | `optional` | `` |  |
-| 20 | `share_lobby_custom_game_id` | `uint64` | `optional` | `` |  |
-| 21 | `share_lobby_passkey` | `string` | `optional` | `` |  |
-| 22 | `private_chat_channel_id` | `uint32` | `optional` | `` |  |
-| 23 | `status` | `uint32` | `optional` | `` |  |
-| 24 | `legacy_battle_cup_victory` | `bool` | `optional` | `` |  |
-| 25 | `badge_level` | `uint32` | `optional` | `` |  |
-| 26 | `suggest_pick_hero_id` | `int32` | `optional` | `` |  |
-| 27 | `suggest_pick_hero_role` | `string` | `optional` | `` |  |
-| 29 | `battle_cup_streak` | `uint32` | `optional` | `` |  |
-| 30 | `suggest_ban_hero_id` | `int32` | `optional` | `` |  |
-| 32 | `trivia_answer` | `.CMsgDOTAChatMessage.TriviaAnswered` | `optional` | `` |  |
-| 33 | `requested_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 34 | `chat_flags` | `uint32` | `optional` | `` |  |
-| 35 | `started_finding_match` | `bool` | `optional` | `` |  |
-| 36 | `ctrl_is_down` | `bool` | `optional` | `` |  |
-| 37 | `favorite_team_id` | `uint32` | `optional` | `` |  |
-| 38 | `favorite_team_quality` | `uint32` | `optional` | `` |  |
-| 39 | `suggest_player_draft_pick` | `int32` | `optional` | `` | default = -1 |
-| 40 | `player_draft_pick` | `.CMsgDOTAChatMessage.PlayerDraftPick` | `optional` | `` |  |
-| 41 | `chat_wheel_message` | `.CMsgDOTAChatMessage.ChatWheelMessage` | `optional` | `` |  |
-| 42 | `event_level` | `uint32` | `optional` | `` |  |
-| 43 | `suggest_pick_hero_facet` | `uint32` | `optional` | `` |  |
-| 44 | `requested_hero_id` | `int32` | `optional` | `` |  |
-| 45 | `requested_hero_facet_key` | `uint64` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `channel_id` | `uint64` | `optional` |  |  |
+| 3 | `persona_name` | `string` | `optional` |  |  |
+| 4 | `text` | `string` | `optional` |  |  |
+| 5 | `timestamp` | `uint32` | `optional` |  |  |
+| 6 | `suggest_invite_account_id` | `uint32` | `optional` |  |  |
+| 7 | `suggest_invite_name` | `string` | `optional` |  |  |
+| 8 | `fantasy_draft_owner_account_id` | `uint32` | `optional` |  |  |
+| 9 | `fantasy_draft_player_account_id` | `uint32` | `optional` |  |  |
+| 10 | `event_id` | `uint32` | `optional` |  |  |
+| 11 | `suggest_invite_to_lobby` | `bool` | `optional` |  |  |
+| 13 | `coin_flip` | `bool` | `optional` |  |  |
+| 14 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 15 | `share_profile_account_id` | `uint32` | `optional` |  |  |
+| 16 | `channel_user_id` | `uint32` | `optional` |  |  |
+| 17 | `dice_roll` | `.CMsgDOTAChatMessage.DiceRoll` | `optional` |  |  |
+| 18 | `share_party_id` | `uint64` | `optional` |  |  |
+| 19 | `share_lobby_id` | `uint64` | `optional` |  |  |
+| 20 | `share_lobby_custom_game_id` | `uint64` | `optional` |  |  |
+| 21 | `share_lobby_passkey` | `string` | `optional` |  |  |
+| 22 | `private_chat_channel_id` | `uint32` | `optional` |  |  |
+| 23 | `status` | `uint32` | `optional` |  |  |
+| 24 | `legacy_battle_cup_victory` | `bool` | `optional` |  |  |
+| 25 | `badge_level` | `uint32` | `optional` |  |  |
+| 26 | `suggest_pick_hero_id` | `int32` | `optional` |  |  |
+| 27 | `suggest_pick_hero_role` | `string` | `optional` |  |  |
+| 29 | `battle_cup_streak` | `uint32` | `optional` |  |  |
+| 30 | `suggest_ban_hero_id` | `int32` | `optional` |  |  |
+| 32 | `trivia_answer` | `.CMsgDOTAChatMessage.TriviaAnswered` | `optional` |  |  |
+| 33 | `requested_ability_id` | `int32` | `optional` |  | default = -1 |
+| 34 | `chat_flags` | `uint32` | `optional` |  |  |
+| 35 | `started_finding_match` | `bool` | `optional` |  |  |
+| 36 | `ctrl_is_down` | `bool` | `optional` |  |  |
+| 37 | `favorite_team_id` | `uint32` | `optional` |  |  |
+| 38 | `favorite_team_quality` | `uint32` | `optional` |  |  |
+| 39 | `suggest_player_draft_pick` | `int32` | `optional` |  | default = -1 |
+| 40 | `player_draft_pick` | `.CMsgDOTAChatMessage.PlayerDraftPick` | `optional` |  |  |
+| 41 | `chat_wheel_message` | `.CMsgDOTAChatMessage.ChatWheelMessage` | `optional` |  |  |
+| 42 | `event_level` | `uint32` | `optional` |  |  |
+| 43 | `suggest_pick_hero_facet` | `uint32` | `optional` |  |  |
+| 44 | `requested_hero_id` | `int32` | `optional` |  |  |
+| 45 | `requested_hero_facet_key` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -195,9 +195,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `roll_min` | `int32` | `optional` | `` |  |
-| 2 | `roll_max` | `int32` | `optional` | `` |  |
-| 3 | `result` | `int32` | `optional` | `` |  |
+| 1 | `roll_min` | `int32` | `optional` |  |  |
+| 2 | `roll_max` | `int32` | `optional` |  |  |
+| 3 | `result` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -209,11 +209,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `question_id` | `uint32` | `optional` | `` |  |
-| 2 | `answer_index` | `uint32` | `optional` | `` |  |
-| 3 | `party_questions_correct` | `uint32` | `optional` | `` |  |
-| 4 | `party_questions_viewed` | `uint32` | `optional` | `` |  |
-| 5 | `party_trivia_points` | `uint32` | `optional` | `` |  |
+| 1 | `question_id` | `uint32` | `optional` |  |  |
+| 2 | `answer_index` | `uint32` | `optional` |  |  |
+| 3 | `party_questions_correct` | `uint32` | `optional` |  |  |
+| 4 | `party_questions_viewed` | `uint32` | `optional` |  |  |
+| 5 | `party_trivia_points` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -225,8 +225,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `team` | `int32` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `team` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -238,10 +238,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `message_id` | `uint32` | `optional` | `` | default = 4294967295 |
-| 2 | `emoticon_id` | `uint32` | `optional` | `` |  |
-| 3 | `message_text` | `string` | `optional` | `` |  |
-| 4 | `hero_badge_tier` | `uint32` | `optional` | `` |  |
+| 1 | `message_id` | `uint32` | `optional` |  | default = 4294967295 |
+| 2 | `emoticon_id` | `uint32` | `optional` |  |  |
+| 3 | `message_text` | `string` | `optional` |  |  |
+| 4 | `hero_badge_tier` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -253,10 +253,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steam_id` | `fixed64` | `optional` | `` |  |
-| 2 | `persona_name` | `string` | `optional` | `` |  |
-| 3 | `channel_user_id` | `uint32` | `optional` | `` |  |
-| 4 | `status` | `uint32` | `optional` | `` |  |
+| 1 | `steam_id` | `fixed64` | `optional` |  |  |
+| 2 | `persona_name` | `string` | `optional` |  |  |
+| 3 | `channel_user_id` | `uint32` | `optional` |  |  |
+| 4 | `status` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -268,17 +268,17 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `uint32` | `optional` | `` |  |
-| 2 | `channel_name` | `string` | `optional` | `` |  |
-| 3 | `channel_id` | `fixed64` | `optional` | `` |  |
-| 4 | `max_members` | `uint32` | `optional` | `` |  |
-| 5 | `members` | `.CMsgDOTAChatMember` | `repeated` | `` |  |
-| 6 | `channel_type` | `.DOTAChatChannelType_t` | `optional` | `` | default = DOTAChannelType_Regional |
-| 7 | `result` | `.CMsgDOTAJoinChatChannelResponse.Result` | `optional` | `` | default = JOIN_SUCCESS |
-| 8 | `gc_initiated_join` | `bool` | `optional` | `` |  |
-| 9 | `channel_user_id` | `uint32` | `optional` | `` |  |
-| 10 | `welcome_message` | `string` | `optional` | `` |  |
-| 11 | `special_privileges` | `.EChatSpecialPrivileges` | `optional` | `` | default = k_EChatSpecialPrivileges_None |
+| 1 | `response` | `uint32` | `optional` |  |  |
+| 2 | `channel_name` | `string` | `optional` |  |  |
+| 3 | `channel_id` | `fixed64` | `optional` |  |  |
+| 4 | `max_members` | `uint32` | `optional` |  |  |
+| 5 | `members` | `.CMsgDOTAChatMember` | `repeated` |  |  |
+| 6 | `channel_type` | `.DOTAChatChannelType_t` | `optional` |  | default = DOTAChannelType_Regional |
+| 7 | `result` | `.CMsgDOTAJoinChatChannelResponse.Result` | `optional` |  | default = JOIN_SUCCESS |
+| 8 | `gc_initiated_join` | `bool` | `optional` |  |  |
+| 9 | `channel_user_id` | `uint32` | `optional` |  |  |
+| 10 | `welcome_message` | `string` | `optional` |  |  |
+| 11 | `special_privileges` | `.EChatSpecialPrivileges` | `optional` |  | default = k_EChatSpecialPrivileges_None |
 
 </details>
 
@@ -290,11 +290,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `channel_id` | `fixed64` | `optional` | `` |  |
-| 2 | `persona_name` | `string` | `optional` | `` |  |
-| 3 | `steam_id` | `fixed64` | `optional` | `` |  |
-| 4 | `channel_user_id` | `uint32` | `optional` | `` |  |
-| 5 | `status` | `uint32` | `optional` | `` |  |
+| 1 | `channel_id` | `fixed64` | `optional` |  |  |
+| 2 | `persona_name` | `string` | `optional` |  |  |
+| 3 | `steam_id` | `fixed64` | `optional` |  |  |
+| 4 | `channel_user_id` | `uint32` | `optional` |  |  |
+| 5 | `status` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -306,9 +306,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `channel_id` | `fixed64` | `optional` | `` |  |
-| 2 | `steam_id` | `fixed64` | `optional` | `` |  |
-| 3 | `channel_user_id` | `uint32` | `optional` | `` |  |
+| 1 | `channel_id` | `fixed64` | `optional` |  |  |
+| 2 | `steam_id` | `fixed64` | `optional` |  |  |
+| 3 | `channel_user_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -332,7 +332,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `channels` | `.CMsgDOTARequestChatChannelListResponse.ChatChannel` | `repeated` | `` |  |
+| 1 | `channels` | `.CMsgDOTARequestChatChannelListResponse.ChatChannel` | `repeated` |  |  |
 
 </details>
 
@@ -344,9 +344,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `channel_name` | `string` | `optional` | `` |  |
-| 2 | `num_members` | `uint32` | `optional` | `` |  |
-| 3 | `channel_type` | `.DOTAChatChannelType_t` | `optional` | `` | default = DOTAChannelType_Regional |
+| 1 | `channel_name` | `string` | `optional` |  |  |
+| 2 | `num_members` | `uint32` | `optional` |  |  |
+| 3 | `channel_type` | `.DOTAChatChannelType_t` | `optional` |  | default = DOTAChannelType_Regional |
 
 </details>
 
@@ -358,8 +358,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `channel_id` | `fixed64` | `optional` | `` |  |
-| 2 | `members` | `.CMsgDOTAChatGetUserListResponse.Member` | `repeated` | `` |  |
+| 1 | `channel_id` | `fixed64` | `optional` |  |  |
+| 2 | `members` | `.CMsgDOTAChatGetUserListResponse.Member` | `repeated` |  |  |
 
 </details>
 
@@ -371,10 +371,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steam_id` | `fixed64` | `optional` | `` |  |
-| 2 | `persona_name` | `string` | `optional` | `` |  |
-| 3 | `channel_user_id` | `uint32` | `optional` | `` |  |
-| 4 | `status` | `uint32` | `optional` | `` |  |
+| 1 | `steam_id` | `fixed64` | `optional` |  |  |
+| 2 | `persona_name` | `string` | `optional` |  |  |
+| 3 | `channel_user_id` | `uint32` | `optional` |  |  |
+| 4 | `status` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -386,8 +386,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `channel_name` | `string` | `optional` | `` |  |
-| 2 | `channel_type` | `.DOTAChatChannelType_t` | `optional` | `` | default = DOTAChannelType_Regional |
+| 1 | `channel_name` | `string` | `optional` |  |  |
+| 2 | `channel_type` | `.DOTAChatChannelType_t` | `optional` |  | default = DOTAChannelType_Regional |
 
 </details>
 
@@ -399,9 +399,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `channel_name` | `string` | `optional` | `` |  |
-| 2 | `channel_type` | `.DOTAChatChannelType_t` | `optional` | `` | default = DOTAChannelType_Regional |
-| 3 | `member_count` | `uint32` | `optional` | `` |  |
+| 1 | `channel_name` | `string` | `optional` |  |  |
+| 2 | `channel_type` | `.DOTAChatChannelType_t` | `optional` |  | default = DOTAChannelType_Regional |
+| 3 | `member_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -413,8 +413,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `enable_all_regions` | `bool` | `optional` | `` |  |
-| 2 | `enabled_regions` | `.CMsgDOTAChatRegionsEnabled.Region` | `repeated` | `` |  |
+| 1 | `enable_all_regions` | `bool` | `optional` |  |  |
+| 2 | `enabled_regions` | `.CMsgDOTAChatRegionsEnabled.Region` | `repeated` |  |  |
 
 </details>
 
@@ -426,10 +426,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `min_latitude` | `float` | `optional` | `` |  |
-| 2 | `max_latitude` | `float` | `optional` | `` |  |
-| 3 | `min_longitude` | `float` | `optional` | `` |  |
-| 4 | `max_longitude` | `float` | `optional` | `` |  |
+| 1 | `min_latitude` | `float` | `optional` |  |  |
+| 2 | `max_latitude` | `float` | `optional` |  |  |
+| 3 | `min_longitude` | `float` | `optional` |  |  |
+| 4 | `max_longitude` | `float` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-client-coaching.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-client-coaching.md
@@ -24,13 +24,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `match_outcome` | `.EMatchOutcome` | `optional` | `` | default = k_EMatchOutcome_Unknown |
-| 3 | `coached_team` | `uint32` | `optional` | `` |  |
-| 4 | `start_time` | `fixed32` | `optional` | `` |  |
-| 5 | `duration` | `uint32` | `optional` | `` |  |
-| 6 | `teammate_ratings` | `.ECoachTeammateRating` | `repeated` | `` |  |
-| 7 | `coach_flags` | `uint32` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `match_outcome` | `.EMatchOutcome` | `optional` |  | default = k_EMatchOutcome_Unknown |
+| 3 | `coached_team` | `uint32` | `optional` |  |  |
+| 4 | `start_time` | `fixed32` | `optional` |  |  |
+| 5 | `duration` | `uint32` | `optional` |  |  |
+| 6 | `teammate_ratings` | `.ECoachTeammateRating` | `repeated` |  |  |
+| 7 | `coach_flags` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -42,9 +42,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `member_flags` | `uint32` | `optional` | `` |  |
-| 3 | `member_session_rating` | `.ECoachTeammateRating` | `optional` | `` | default = k_ECoachTeammateRating_None |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `member_flags` | `uint32` | `optional` |  |  |
+| 3 | `member_session_rating` | `.ECoachTeammateRating` | `optional` |  | default = k_ECoachTeammateRating_None |
 
 </details>
 
@@ -56,15 +56,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `private_coaching_session_id` | `uint64` | `optional` | `` |  |
-| 2 | `requested_timestamp` | `fixed32` | `optional` | `` |  |
-| 3 | `requested_language` | `uint32` | `optional` | `` |  |
-| 4 | `coaching_session_state` | `.EPrivateCoachingSessionState` | `optional` | `` | default = k_ePrivateCoachingSessionState_Invalid |
-| 5 | `session_members` | `.CMsgPrivateCoachingSessionMember` | `repeated` | `` |  |
-| 6 | `current_lobby_id` | `uint64` | `optional` | `` |  |
-| 7 | `current_server_steam_id` | `uint64` | `optional` | `` |  |
-| 8 | `accepted_timestamp` | `fixed32` | `optional` | `` |  |
-| 9 | `completed_timestamp` | `fixed32` | `optional` | `` |  |
+| 1 | `private_coaching_session_id` | `uint64` | `optional` |  |  |
+| 2 | `requested_timestamp` | `fixed32` | `optional` |  |  |
+| 3 | `requested_language` | `uint32` | `optional` |  |  |
+| 4 | `coaching_session_state` | `.EPrivateCoachingSessionState` | `optional` |  | default = k_ePrivateCoachingSessionState_Invalid |
+| 5 | `session_members` | `.CMsgPrivateCoachingSessionMember` | `repeated` |  |  |
+| 6 | `current_lobby_id` | `uint64` | `optional` |  |  |
+| 7 | `current_server_steam_id` | `uint64` | `optional` |  |  |
+| 8 | `accepted_timestamp` | `fixed32` | `optional` |  |  |
+| 9 | `completed_timestamp` | `fixed32` | `optional` |  |  |
 
 </details>
 
@@ -76,8 +76,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `requester_competitive_rank_tier` | `uint32` | `optional` | `` |  |
-| 2 | `requester_games_played` | `uint32` | `optional` | `` |  |
+| 1 | `requester_competitive_rank_tier` | `uint32` | `optional` |  |  |
+| 2 | `requester_games_played` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -89,8 +89,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `coaching_session` | `.CMsgPrivateCoachingSession` | `optional` | `` |  |
-| 2 | `coaching_session_status` | `.CMsgPrivateCoachingSessionStatus` | `optional` | `` |  |
+| 1 | `coaching_session` | `.CMsgPrivateCoachingSession` | `optional` |  |  |
+| 2 | `coaching_session_status` | `.CMsgPrivateCoachingSessionStatus` | `optional` |  |  |
 
 </details>
 
@@ -102,7 +102,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `available_coaching_sessions` | `.CMsgAvailablePrivateCoachingSession` | `repeated` | `` |  |
+| 1 | `available_coaching_sessions` | `.CMsgAvailablePrivateCoachingSession` | `repeated` |  |  |
 
 </details>
 
@@ -114,7 +114,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `coaching_session_count` | `uint32` | `optional` | `` |  |
+| 1 | `coaching_session_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -138,8 +138,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCRequestPlayerCoachMatchesResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `coach_matches` | `.CMsgPlayerCoachMatch` | `repeated` | `` |  |
+| 1 | `result` | `.CMsgClientToGCRequestPlayerCoachMatchesResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `coach_matches` | `.CMsgPlayerCoachMatch` | `repeated` |  |  |
 
 </details>
 
@@ -151,7 +151,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -163,8 +163,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCRequestPlayerCoachMatchResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `coach_match` | `.CMsgPlayerCoachMatch` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCRequestPlayerCoachMatchResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `coach_match` | `.CMsgPlayerCoachMatch` | `optional` |  |  |
 
 </details>
 
@@ -176,10 +176,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `coach_account_id` | `uint32` | `optional` | `` |  |
-| 3 | `rating` | `.ECoachTeammateRating` | `optional` | `` | default = k_ECoachTeammateRating_None |
-| 4 | `reason` | `string` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `coach_account_id` | `uint32` | `optional` |  |  |
+| 3 | `rating` | `.ECoachTeammateRating` | `optional` |  | default = k_ECoachTeammateRating_None |
+| 4 | `reason` | `string` | `optional` |  |  |
 
 </details>
 
@@ -191,7 +191,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCSubmitCoachTeammateRatingResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCSubmitCoachTeammateRatingResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -203,7 +203,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `coach_match` | `.CMsgPlayerCoachMatch` | `optional` | `` |  |
+| 1 | `coach_match` | `.CMsgPlayerCoachMatch` | `optional` |  |  |
 
 </details>
 
@@ -215,7 +215,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `language` | `uint32` | `optional` | `` |  |
+| 1 | `language` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -227,8 +227,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCRequestPrivateCoachingSessionResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `coaching_session` | `.CMsgPrivateCoachingSession` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCRequestPrivateCoachingSessionResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `coaching_session` | `.CMsgPrivateCoachingSession` | `optional` |  |  |
 
 </details>
 
@@ -240,7 +240,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `coaching_session_id` | `uint64` | `optional` | `` |  |
+| 1 | `coaching_session_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -252,8 +252,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCAcceptPrivateCoachingSessionResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `coaching_session` | `.CMsgPrivateCoachingSession` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCAcceptPrivateCoachingSessionResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `coaching_session` | `.CMsgPrivateCoachingSession` | `optional` |  |  |
 
 </details>
 
@@ -277,7 +277,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCLeavePrivateCoachingSessionResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCLeavePrivateCoachingSessionResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -301,8 +301,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCGetCurrentPrivateCoachingSessionResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `current_session` | `.CMsgPrivateCoachingSession` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCGetCurrentPrivateCoachingSessionResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `current_session` | `.CMsgPrivateCoachingSession` | `optional` |  |  |
 
 </details>
 
@@ -314,7 +314,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `coaching_session` | `.CMsgPrivateCoachingSession` | `optional` | `` |  |
+| 1 | `coaching_session` | `.CMsgPrivateCoachingSession` | `optional` |  |  |
 
 </details>
 
@@ -326,8 +326,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `coaching_session_id` | `uint64` | `optional` | `` |  |
-| 2 | `session_rating` | `.ECoachTeammateRating` | `optional` | `` | default = k_ECoachTeammateRating_None |
+| 1 | `coaching_session_id` | `uint64` | `optional` |  |  |
+| 2 | `session_rating` | `.ECoachTeammateRating` | `optional` |  | default = k_ECoachTeammateRating_None |
 
 </details>
 
@@ -339,7 +339,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCSubmitPrivateCoachingSessionRatingResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCSubmitPrivateCoachingSessionRatingResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -351,7 +351,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `language` | `uint32` | `optional` | `` |  |
+| 1 | `language` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -363,8 +363,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCGetAvailablePrivateCoachingSessionsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `available_sessions_list` | `.CMsgAvailablePrivateCoachingSessionList` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCGetAvailablePrivateCoachingSessionsResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `available_sessions_list` | `.CMsgAvailablePrivateCoachingSessionList` | `optional` |  |  |
 
 </details>
 
@@ -388,8 +388,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCGetAvailablePrivateCoachingSessionsSummaryResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `coaching_session_summary` | `.CMsgAvailablePrivateCoachingSessionSummary` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCGetAvailablePrivateCoachingSessionsSummaryResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `coaching_session_summary` | `.CMsgAvailablePrivateCoachingSessionSummary` | `optional` |  |  |
 
 </details>
 
@@ -413,7 +413,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCJoinPrivateCoachingSessionLobbyResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCJoinPrivateCoachingSessionLobbyResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -425,7 +425,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_account_id` | `uint32` | `optional` | `` |  |
+| 1 | `target_account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -437,7 +437,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCCoachFriendResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCCoachFriendResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -449,8 +449,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `coach_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `response` | `.ELobbyMemberCoachRequestState` | `optional` | `` | default = k_eLobbyMemberCoachRequestState_None |
+| 1 | `coach_account_id` | `uint32` | `optional` |  |  |
+| 2 | `response` | `.ELobbyMemberCoachRequestState` | `optional` |  | default = k_eLobbyMemberCoachRequestState_None |
 
 </details>
 
@@ -462,7 +462,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCRespondToCoachFriendRequestResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCRespondToCoachFriendRequestResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-client-craftworks.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-client-craftworks.md
@@ -32,7 +32,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `component_inventory` | `.CMsgCraftworksComponents` | `optional` | `` |  |
+| 1 | `component_inventory` | `.CMsgCraftworksComponents` | `optional` |  |  |
 
 </details>
 
@@ -44,7 +44,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `craftworks_id` | `uint32` | `optional` | `` |  |
+| 1 | `craftworks_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -56,8 +56,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCCraftworksGetUserDataResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `user_data` | `.CMsgCraftworksUserData` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCCraftworksGetUserDataResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `user_data` | `.CMsgCraftworksUserData` | `optional` |  |  |
 
 </details>
 
@@ -69,8 +69,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `craftworks_id` | `uint32` | `optional` | `` |  |
-| 2 | `user_data` | `.CMsgCraftworksUserData` | `optional` | `` |  |
+| 1 | `craftworks_id` | `uint32` | `optional` |  |  |
+| 2 | `user_data` | `.CMsgCraftworksUserData` | `optional` |  |  |
 
 </details>
 
@@ -82,8 +82,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `craftworks_id` | `uint32` | `optional` | `` |  |
-| 2 | `recipe_id` | `uint64` | `optional` | `` |  |
+| 1 | `craftworks_id` | `uint32` | `optional` |  |  |
+| 2 | `recipe_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -95,8 +95,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCCraftworksCraftRecipeResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `claim_response` | `.CMsgDOTAClaimEventActionResponse` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCCraftworksCraftRecipeResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `claim_response` | `.CMsgDOTAClaimEventActionResponse` | `optional` |  |  |
 
 </details>
 
@@ -108,9 +108,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `craftworks_id` | `uint32` | `optional` | `` |  |
-| 2 | `components` | `.CMsgCraftworksComponents` | `optional` | `` |  |
-| 3 | `operation` | `.CMsgClientToGCCraftworksDevModifyComponents.EOperation` | `optional` | `` | default = k_eAddComponents |
+| 1 | `craftworks_id` | `uint32` | `optional` |  |  |
+| 2 | `components` | `.CMsgCraftworksComponents` | `optional` |  |  |
+| 3 | `operation` | `.CMsgClientToGCCraftworksDevModifyComponents.EOperation` | `optional` |  | default = k_eAddComponents |
 
 </details>
 
@@ -122,7 +122,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCCraftworksDevModifyComponentsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCCraftworksDevModifyComponentsResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-client-fantasy.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-client-fantasy.md
@@ -23,22 +23,22 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `country_code` | `string` | `optional` | `` |  |
-| 4 | `fantasy_role` | `.Fantasy_Roles` | `optional` | `` | default = FANTASY_ROLE_UNDEFINED |
-| 5 | `team_id` | `uint32` | `optional` | `` |  |
-| 6 | `team_name` | `string` | `optional` | `` |  |
-| 7 | `team_tag` | `string` | `optional` | `` |  |
-| 8 | `sponsor` | `string` | `optional` | `` |  |
-| 11 | `real_name` | `string` | `optional` | `` |  |
-| 13 | `total_earnings` | `uint32` | `optional` | `` |  |
-| 14 | `results` | `.CMsgDOTAPlayerInfo.Results` | `repeated` | `` |  |
-| 15 | `team_url_logo` | `string` | `optional` | `` |  |
-| 16 | `audit_entries` | `.CMsgDOTAPlayerInfo.AuditEntry` | `repeated` | `` |  |
-| 17 | `team_abbreviation` | `string` | `optional` | `` |  |
-| 18 | `pro_registration` | `.CMsgDOTAPlayerInfo.ProRegistration` | `repeated` | `` |  |
-| 19 | `has_played_in_international` | `bool` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `country_code` | `string` | `optional` |  |  |
+| 4 | `fantasy_role` | `.Fantasy_Roles` | `optional` |  | default = FANTASY_ROLE_UNDEFINED |
+| 5 | `team_id` | `uint32` | `optional` |  |  |
+| 6 | `team_name` | `string` | `optional` |  |  |
+| 7 | `team_tag` | `string` | `optional` |  |  |
+| 8 | `sponsor` | `string` | `optional` |  |  |
+| 11 | `real_name` | `string` | `optional` |  |  |
+| 13 | `total_earnings` | `uint32` | `optional` |  |  |
+| 14 | `results` | `.CMsgDOTAPlayerInfo.Results` | `repeated` |  |  |
+| 15 | `team_url_logo` | `string` | `optional` |  |  |
+| 16 | `audit_entries` | `.CMsgDOTAPlayerInfo.AuditEntry` | `repeated` |  |  |
+| 17 | `team_abbreviation` | `string` | `optional` |  |  |
+| 18 | `pro_registration` | `.CMsgDOTAPlayerInfo.ProRegistration` | `repeated` |  |  |
+| 19 | `has_played_in_international` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -50,9 +50,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 2 | `placement` | `uint32` | `optional` | `` |  |
-| 3 | `earnings` | `uint32` | `optional` | `` |  |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 2 | `placement` | `uint32` | `optional` |  |  |
+| 3 | `earnings` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -64,12 +64,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `start_timestamp` | `uint32` | `optional` | `` |  |
-| 2 | `end_timestamp` | `uint32` | `optional` | `` |  |
-| 3 | `team_id` | `uint32` | `optional` | `` |  |
-| 4 | `team_name` | `string` | `optional` | `` |  |
-| 5 | `team_tag` | `string` | `optional` | `` |  |
-| 6 | `team_url_logo` | `string` | `optional` | `` |  |
+| 1 | `start_timestamp` | `uint32` | `optional` |  |  |
+| 2 | `end_timestamp` | `uint32` | `optional` |  |  |
+| 3 | `team_id` | `uint32` | `optional` |  |  |
+| 4 | `team_name` | `string` | `optional` |  |  |
+| 5 | `team_tag` | `string` | `optional` |  |  |
+| 6 | `team_url_logo` | `string` | `optional` |  |  |
 
 </details>
 
@@ -81,8 +81,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `registration_period` | `uint32` | `optional` | `` |  |
-| 2 | `timestamp` | `uint32` | `optional` | `` |  |
+| 1 | `registration_period` | `uint32` | `optional` |  |  |
+| 2 | `timestamp` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -94,8 +94,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_infos` | `.CMsgDOTAPlayerInfo` | `repeated` | `` |  |
-| 2 | `retry_time` | `uint32` | `optional` | `` |  |
+| 1 | `player_infos` | `.CMsgDOTAPlayerInfo` | `repeated` |  |  |
+| 2 | `retry_time` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -107,10 +107,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `timestamp` | `uint32` | `optional` | `` |  |
-| 2 | `team_id` | `uint32` | `optional` | `` |  |
-| 3 | `member_account_ids` | `uint32` | `repeated` | `` |  |
-| 4 | `coach_account_id` | `uint32` | `optional` | `` |  |
+| 1 | `timestamp` | `uint32` | `optional` |  |  |
+| 2 | `team_id` | `uint32` | `optional` |  |  |
+| 3 | `member_account_ids` | `uint32` | `repeated` |  |  |
+| 4 | `coach_account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -122,10 +122,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_info` | `.CMsgDOTAPlayerInfo` | `optional` | `` |  |
-| 2 | `prediction_info` | `.CMsgDOTADPCProfileInfo.PredictionInfo` | `optional` | `` |  |
-| 3 | `fantasy_info` | `.CMsgDOTADPCProfileInfo.FantasyInfo` | `optional` | `` |  |
-| 4 | `disabled_notifications` | `uint32` | `repeated` | `` |  |
+| 1 | `player_info` | `.CMsgDOTAPlayerInfo` | `optional` |  |  |
+| 2 | `prediction_info` | `.CMsgDOTADPCProfileInfo.PredictionInfo` | `optional` |  |  |
+| 3 | `fantasy_info` | `.CMsgDOTADPCProfileInfo.FantasyInfo` | `optional` |  |  |
+| 4 | `disabled_notifications` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -137,8 +137,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `percent` | `uint32` | `optional` | `` |  |
-| 2 | `shard_winnings` | `int32` | `optional` | `` |  |
+| 1 | `percent` | `uint32` | `optional` |  |  |
+| 2 | `shard_winnings` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -150,10 +150,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `top_90_finishes` | `uint32` | `optional` | `` |  |
-| 2 | `top_75_finishes` | `uint32` | `optional` | `` |  |
-| 3 | `top_50_finishes` | `uint32` | `optional` | `` |  |
-| 4 | `shard_winnings` | `uint32` | `optional` | `` |  |
+| 1 | `top_90_finishes` | `uint32` | `optional` |  |  |
+| 2 | `top_75_finishes` | `uint32` | `optional` |  |  |
+| 3 | `top_50_finishes` | `uint32` | `optional` |  |  |
+| 4 | `shard_winnings` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -165,7 +165,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `leaderboards` | `.CMsgDOTALeaderboards.RegionLeaderboard` | `repeated` | `` |  |
+| 2 | `leaderboards` | `.CMsgDOTALeaderboards.RegionLeaderboard` | `repeated` |  |  |
 
 </details>
 
@@ -177,8 +177,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `division` | `uint32` | `optional` | `` |  |
-| 2 | `account_ids` | `uint32` | `repeated` | `` |  |
+| 1 | `division` | `uint32` | `optional` |  |  |
+| 2 | `account_ids` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -190,9 +190,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 2 | `winner_id` | `uint32` | `optional` | `` |  |
-| 3 | `runnerup_id` | `uint32` | `optional` | `` |  |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 2 | `winner_id` | `uint32` | `optional` |  |  |
+| 3 | `runnerup_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -204,8 +204,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `selection_index` | `.DOTA_2013PassportSelectionIndices` | `optional` | `` | default = PP13_SEL_ALLSTAR_PLAYER_0 |
-| 2 | `selection` | `uint32` | `optional` | `` |  |
+| 1 | `selection_index` | `.DOTA_2013PassportSelectionIndices` | `optional` |  | default = PP13_SEL_ALLSTAR_PLAYER_0 |
+| 2 | `selection` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -217,8 +217,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steam_id` | `uint64` | `optional` | `` |  |
-| 2 | `stamp_level` | `uint32` | `optional` | `` |  |
+| 1 | `steam_id` | `uint64` | `optional` |  |  |
+| 2 | `stamp_level` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -230,7 +230,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `challenge_id` | `uint32` | `optional` | `` |  |
+| 1 | `challenge_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -242,10 +242,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_votes` | `.CMsgDOTAPassportVoteTeamGuess` | `repeated` | `` |  |
-| 2 | `generic_selections` | `.CMsgDOTAPassportVoteGenericSelection` | `repeated` | `` |  |
-| 3 | `stamped_players` | `.CMsgDOTAPassportStampedPlayer` | `repeated` | `` |  |
-| 4 | `player_card_challenges` | `.CMsgDOTAPassportPlayerCardChallenge` | `repeated` | `` |  |
+| 1 | `team_votes` | `.CMsgDOTAPassportVoteTeamGuess` | `repeated` |  |  |
+| 2 | `generic_selections` | `.CMsgDOTAPassportVoteGenericSelection` | `repeated` |  |  |
+| 3 | `stamped_players` | `.CMsgDOTAPassportStampedPlayer` | `repeated` |  |  |
+| 4 | `player_card_challenges` | `.CMsgDOTAPassportPlayerCardChallenge` | `repeated` |  |  |
 
 </details>
 
@@ -257,8 +257,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 3 | `fantasy_period` | `uint32` | `optional` | `` | default = 4294967295 |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 3 | `fantasy_period` | `uint32` | `optional` |  | default = 4294967295 |
 
 </details>
 
@@ -270,11 +270,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCGetPlayerCardRosterResponse.Result` | `optional` | `` | default = SUCCESS |
-| 2 | `player_card_item_id` | `uint64` | `repeated` | `` |  |
-| 3 | `score` | `float` | `optional` | `` |  |
-| 4 | `finalized` | `bool` | `optional` | `` |  |
-| 5 | `percentile` | `float` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCGetPlayerCardRosterResponse.Result` | `optional` |  | default = SUCCESS |
+| 2 | `player_card_item_id` | `uint64` | `repeated` |  |  |
+| 3 | `score` | `float` | `optional` |  |  |
+| 4 | `finalized` | `bool` | `optional` |  |  |
+| 5 | `percentile` | `float` | `optional` |  |  |
 
 </details>
 
@@ -286,7 +286,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_timestamps` | `.CMsgClientToGCBatchGetPlayerCardRosterRequest.LeagueTimestamp` | `repeated` | `` |  |
+| 1 | `league_timestamps` | `.CMsgClientToGCBatchGetPlayerCardRosterRequest.LeagueTimestamp` | `repeated` |  |  |
 
 </details>
 
@@ -298,8 +298,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 3 | `fantasy_period` | `uint32` | `optional` | `` | default = 4294967295 |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 3 | `fantasy_period` | `uint32` | `optional` |  | default = 4294967295 |
 
 </details>
 
@@ -311,7 +311,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `responses` | `.CMsgClientToGCBatchGetPlayerCardRosterResponse.RosterResponse` | `repeated` | `` |  |
+| 1 | `responses` | `.CMsgClientToGCBatchGetPlayerCardRosterResponse.RosterResponse` | `repeated` |  |  |
 
 </details>
 
@@ -323,14 +323,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 2 | `deprecated_timestamp` | `uint32` | `optional` | `` |  |
-| 3 | `result` | `.CMsgClientToGCBatchGetPlayerCardRosterResponse.Result` | `optional` | `` | default = SUCCESS |
-| 4 | `player_card_item_id` | `uint64` | `repeated` | `` |  |
-| 5 | `score` | `float` | `optional` | `` |  |
-| 6 | `finalized` | `bool` | `optional` | `` |  |
-| 7 | `percentile` | `float` | `optional` | `` |  |
-| 8 | `fantasy_period` | `uint32` | `optional` | `` | default = 4294967295 |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 2 | `deprecated_timestamp` | `uint32` | `optional` |  |  |
+| 3 | `result` | `.CMsgClientToGCBatchGetPlayerCardRosterResponse.Result` | `optional` |  | default = SUCCESS |
+| 4 | `player_card_item_id` | `uint64` | `repeated` |  |  |
+| 5 | `score` | `float` | `optional` |  |  |
+| 6 | `finalized` | `bool` | `optional` |  |  |
+| 7 | `percentile` | `float` | `optional` |  |  |
+| 8 | `fantasy_period` | `uint32` | `optional` |  | default = 4294967295 |
 
 </details>
 
@@ -342,12 +342,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 2 | `deprecated_timestamp` | `uint32` | `optional` | `` |  |
-| 3 | `slot` | `uint32` | `optional` | `` |  |
-| 4 | `player_card_item_id` | `uint64` | `optional` | `` |  |
-| 5 | `event_id` | `uint32` | `optional` | `` |  |
-| 6 | `fantasy_period` | `uint32` | `optional` | `` | default = 4294967295 |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 2 | `deprecated_timestamp` | `uint32` | `optional` |  |  |
+| 3 | `slot` | `uint32` | `optional` |  |  |
+| 4 | `player_card_item_id` | `uint64` | `optional` |  |  |
+| 5 | `event_id` | `uint32` | `optional` |  |  |
+| 6 | `fantasy_period` | `uint32` | `optional` |  | default = 4294967295 |
 
 </details>
 
@@ -359,7 +359,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCSetPlayerCardRosterResponse.Result` | `optional` | `` | default = SUCCESS |
+| 1 | `result` | `.CMsgClientToGCSetPlayerCardRosterResponse.Result` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -371,7 +371,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_infos` | `.CMsgDOTAFantasyDPCLeagueStatus.LeagueInfo` | `repeated` | `` |  |
+| 1 | `league_infos` | `.CMsgDOTAFantasyDPCLeagueStatus.LeagueInfo` | `repeated` |  |  |
 
 </details>
 
@@ -383,12 +383,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 2 | `league_name` | `string` | `optional` | `` |  |
-| 3 | `start_timestamp` | `uint32` | `optional` | `` |  |
-| 4 | `end_timestamp` | `uint32` | `optional` | `` |  |
-| 5 | `day_timestamps` | `uint32` | `repeated` | `` |  |
-| 8 | `status` | `.CMsgDOTAFantasyDPCLeagueStatus.ERosterStatus` | `optional` | `` | default = UNSET |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 2 | `league_name` | `string` | `optional` |  |  |
+| 3 | `start_timestamp` | `uint32` | `optional` |  |  |
+| 4 | `end_timestamp` | `uint32` | `optional` |  |  |
+| 5 | `day_timestamps` | `uint32` | `repeated` |  |  |
+| 8 | `status` | `.CMsgDOTAFantasyDPCLeagueStatus.ERosterStatus` | `optional` |  | default = UNSET |
 
 </details>
 
@@ -400,9 +400,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `players` | `.CMsgDOTADPCSearchResults.Player` | `repeated` | `` |  |
-| 2 | `teams` | `.CMsgDOTADPCSearchResults.Team` | `repeated` | `` |  |
-| 3 | `leagues` | `.CMsgDOTADPCSearchResults.League` | `repeated` | `` |  |
+| 1 | `players` | `.CMsgDOTADPCSearchResults.Player` | `repeated` |  |  |
+| 2 | `teams` | `.CMsgDOTADPCSearchResults.Team` | `repeated` |  |  |
+| 3 | `leagues` | `.CMsgDOTADPCSearchResults.League` | `repeated` |  |  |
 
 </details>
 
@@ -414,9 +414,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `uint32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `real_name` | `string` | `optional` | `` |  |
+| 1 | `id` | `uint32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `real_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -428,9 +428,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `uint32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `url` | `string` | `optional` | `` |  |
+| 1 | `id` | `uint32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `url` | `string` | `optional` |  |  |
 
 </details>
 
@@ -442,8 +442,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `uint32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
+| 1 | `id` | `uint32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -455,7 +455,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `teams` | `.CMsgDOTADPCTeamFavoriteRankings.Team` | `repeated` | `` |  |
+| 1 | `teams` | `.CMsgDOTADPCTeamFavoriteRankings.Team` | `repeated` |  |  |
 
 </details>
 
@@ -467,8 +467,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_id` | `uint32` | `optional` | `` |  |
-| 2 | `favorites` | `uint32` | `optional` | `` |  |
+| 1 | `team_id` | `uint32` | `optional` |  |  |
+| 2 | `favorites` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -480,8 +480,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `fantasy_period` | `uint32` | `optional` | `` | default = 4294967295 |
-| 2 | `tablets` | `.CMsgDotaFantasyCraftingTabletPeriodData.Tablet` | `repeated` | `` |  |
+| 1 | `fantasy_period` | `uint32` | `optional` |  | default = 4294967295 |
+| 2 | `tablets` | `.CMsgDotaFantasyCraftingTabletPeriodData.Tablet` | `repeated` |  |  |
 
 </details>
 
@@ -493,11 +493,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `type` | `.Fantasy_Gem_Type` | `optional` | `` | default = FANTASY_GEM_TYPE_RUBY |
-| 2 | `slot` | `uint32` | `optional` | `` |  |
-| 3 | `shape` | `uint32` | `optional` | `` |  |
-| 4 | `quality` | `uint32` | `optional` | `` |  |
-| 5 | `stat` | `.Fantasy_Scoring` | `optional` | `` | default = FANTASY_SCORING_KILLS |
+| 1 | `type` | `.Fantasy_Gem_Type` | `optional` |  | default = FANTASY_GEM_TYPE_RUBY |
+| 2 | `slot` | `uint32` | `optional` |  |  |
+| 3 | `shape` | `uint32` | `optional` |  |  |
+| 4 | `quality` | `uint32` | `optional` |  |  |
+| 5 | `stat` | `.Fantasy_Scoring` | `optional` |  | default = FANTASY_SCORING_KILLS |
 
 </details>
 
@@ -509,15 +509,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tablet_id` | `uint32` | `optional` | `` |  |
-| 2 | `tablet_level` | `uint32` | `optional` | `` |  |
-| 3 | `fantasy_role` | `.Fantasy_Roles` | `optional` | `` | default = FANTASY_ROLE_UNDEFINED |
-| 4 | `account_id` | `uint32` | `optional` | `` |  |
-| 5 | `prefix` | `uint32` | `optional` | `` |  |
-| 6 | `suffix` | `uint32` | `optional` | `` |  |
-| 7 | `gems` | `.CMsgDotaFantasyCraftingTabletPeriodData.Gem` | `repeated` | `` |  |
-| 8 | `score` | `float` | `optional` | `` |  |
-| 9 | `best_series` | `uint32` | `optional` | `` |  |
+| 1 | `tablet_id` | `uint32` | `optional` |  |  |
+| 2 | `tablet_level` | `uint32` | `optional` |  |  |
+| 3 | `fantasy_role` | `.Fantasy_Roles` | `optional` |  | default = FANTASY_ROLE_UNDEFINED |
+| 4 | `account_id` | `uint32` | `optional` |  |  |
+| 5 | `prefix` | `uint32` | `optional` |  |  |
+| 6 | `suffix` | `uint32` | `optional` |  |  |
+| 7 | `gems` | `.CMsgDotaFantasyCraftingTabletPeriodData.Gem` | `repeated` |  |  |
+| 8 | `score` | `float` | `optional` |  |  |
+| 9 | `best_series` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -529,7 +529,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tablet_period_data` | `.CMsgDotaFantasyCraftingTabletData.TabletPeriodDataEntry` | `repeated` | `` |  |
+| 1 | `tablet_period_data` | `.CMsgDotaFantasyCraftingTabletData.TabletPeriodDataEntry` | `repeated` |  |  |
 
 </details>
 
@@ -541,8 +541,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `.CMsgDotaFantasyCraftingTabletPeriodData` | `optional` | `` |  |
+| 1 | `key` | `uint32` | `optional` |  |  |
+| 2 | `value` | `.CMsgDotaFantasyCraftingTabletPeriodData` | `optional` |  |  |
 
 </details>
 
@@ -554,9 +554,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `available_rolls` | `uint32` | `repeated` | `` |  |
-| 2 | `period_roll_tokens` | `.CMsgDotaFantasyCraftingUserData.PeriodRollTokensEntry` | `repeated` | `` |  |
-| 3 | `period_scores` | `.CMsgDotaFantasyCraftingUserData.PeriodScoresEntry` | `repeated` | `` |  |
+| 1 | `available_rolls` | `uint32` | `repeated` |  |  |
+| 2 | `period_roll_tokens` | `.CMsgDotaFantasyCraftingUserData.PeriodRollTokensEntry` | `repeated` |  |  |
+| 3 | `period_scores` | `.CMsgDotaFantasyCraftingUserData.PeriodScoresEntry` | `repeated` |  |  |
 
 </details>
 
@@ -568,8 +568,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `total_score` | `float` | `optional` | `` |  |
-| 2 | `percentile` | `float` | `optional` | `` |  |
+| 1 | `total_score` | `float` | `optional` |  |  |
+| 2 | `percentile` | `float` | `optional` |  |  |
 
 </details>
 
@@ -581,8 +581,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `uint32` | `optional` | `` |  |
+| 1 | `key` | `uint32` | `optional` |  |  |
+| 2 | `value` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -594,8 +594,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `.CMsgDotaFantasyCraftingUserData.PeriodScore` | `optional` | `` |  |
+| 1 | `key` | `uint32` | `optional` |  |  |
+| 2 | `value` | `.CMsgDotaFantasyCraftingUserData.PeriodScore` | `optional` |  |  |
 
 </details>
 
@@ -607,7 +607,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cache_entries` | `.CMsgDotaFantasyCraftingDataCache.CacheEntry` | `repeated` | `` |  |
+| 1 | `cache_entries` | `.CMsgDotaFantasyCraftingDataCache.CacheEntry` | `repeated` |  |  |
 
 </details>
 
@@ -619,9 +619,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `fantasy_league` | `uint32` | `optional` | `` |  |
-| 3 | `cache_data` | `.CMsgGCToClientFantasyCraftingDataUpdated` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `fantasy_league` | `uint32` | `optional` |  |  |
+| 3 | `cache_data` | `.CMsgGCToClientFantasyCraftingDataUpdated` | `optional` |  |  |
 
 </details>
 
@@ -633,8 +633,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `fantasy_league` | `uint32` | `optional` | `` |  |
-| 2 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `fantasy_league` | `uint32` | `optional` |  |  |
+| 2 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -646,9 +646,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCFantasyCraftingGetDataResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `user_data` | `.CMsgDotaFantasyCraftingUserData` | `optional` | `` |  |
-| 4 | `tablet_data` | `.CMsgDotaFantasyCraftingTabletData` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCFantasyCraftingGetDataResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `user_data` | `.CMsgDotaFantasyCraftingUserData` | `optional` |  |  |
+| 4 | `tablet_data` | `.CMsgDotaFantasyCraftingTabletData` | `optional` |  |  |
 
 </details>
 
@@ -660,10 +660,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `fantasy_league` | `uint32` | `optional` | `` |  |
-| 2 | `tablet_id` | `uint32` | `optional` | `` |  |
-| 3 | `operation_id` | `uint32` | `optional` | `` |  |
-| 4 | `extra_data` | `uint64` | `optional` | `` |  |
+| 1 | `fantasy_league` | `uint32` | `optional` |  |  |
+| 2 | `tablet_id` | `uint32` | `optional` |  |  |
+| 3 | `operation_id` | `uint32` | `optional` |  |  |
+| 4 | `extra_data` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -675,15 +675,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCFantasyCraftingPerformOperationResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `operation_id` | `uint32` | `optional` | `` |  |
-| 3 | `player_choices` | `uint32` | `repeated` | `` |  |
-| 4 | `prefix_choices` | `uint32` | `repeated` | `` |  |
-| 5 | `suffix_choices` | `uint32` | `repeated` | `` |  |
-| 6 | `title_choices` | `.CMsgClientToGCFantasyCraftingPerformOperationResponse.TitleChoice` | `repeated` | `` |  |
-| 7 | `tablet_id` | `uint32` | `optional` | `` |  |
-| 8 | `user_data` | `.CMsgDotaFantasyCraftingUserData` | `optional` | `` |  |
-| 9 | `tablet_data` | `.CMsgDotaFantasyCraftingTabletData` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCFantasyCraftingPerformOperationResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `operation_id` | `uint32` | `optional` |  |  |
+| 3 | `player_choices` | `uint32` | `repeated` |  |  |
+| 4 | `prefix_choices` | `uint32` | `repeated` |  |  |
+| 5 | `suffix_choices` | `uint32` | `repeated` |  |  |
+| 6 | `title_choices` | `.CMsgClientToGCFantasyCraftingPerformOperationResponse.TitleChoice` | `repeated` |  |  |
+| 7 | `tablet_id` | `uint32` | `optional` |  |  |
+| 8 | `user_data` | `.CMsgDotaFantasyCraftingUserData` | `optional` |  |  |
+| 9 | `tablet_data` | `.CMsgDotaFantasyCraftingTabletData` | `optional` |  |  |
 
 </details>
 
@@ -695,8 +695,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `prefix_choice` | `uint32` | `optional` | `` |  |
-| 2 | `suffix_choice` | `uint32` | `optional` | `` |  |
+| 1 | `prefix_choice` | `uint32` | `optional` |  |  |
+| 2 | `suffix_choice` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -708,9 +708,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `fantasy_league` | `uint32` | `optional` | `` |  |
-| 2 | `user_data` | `.CMsgDotaFantasyCraftingUserData` | `optional` | `` |  |
-| 4 | `tablet_data` | `.CMsgDotaFantasyCraftingTabletData` | `optional` | `` |  |
+| 1 | `fantasy_league` | `uint32` | `optional` |  |  |
+| 2 | `user_data` | `.CMsgDotaFantasyCraftingUserData` | `optional` |  |  |
+| 4 | `tablet_data` | `.CMsgDotaFantasyCraftingTabletData` | `optional` |  |  |
 
 </details>
 
@@ -722,11 +722,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `fantasy_league` | `uint32` | `optional` | `` |  |
-| 2 | `reset_tablet` | `bool` | `optional` | `` |  |
-| 3 | `modify_tokens` | `uint32` | `optional` | `` |  |
-| 5 | `fantasy_period` | `uint32` | `optional` | `` | default = 4294967295 |
-| 6 | `upgrade_tablets` | `bool` | `optional` | `` |  |
+| 1 | `fantasy_league` | `uint32` | `optional` |  |  |
+| 2 | `reset_tablet` | `bool` | `optional` |  |  |
+| 3 | `modify_tokens` | `uint32` | `optional` |  |  |
+| 5 | `fantasy_period` | `uint32` | `optional` |  | default = 4294967295 |
+| 6 | `upgrade_tablets` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -738,9 +738,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCFantasyCraftingDevModifyTabletResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `user_data` | `.CMsgDotaFantasyCraftingUserData` | `optional` | `` |  |
-| 3 | `tablet_data` | `.CMsgDotaFantasyCraftingTabletData` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCFantasyCraftingDevModifyTabletResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `user_data` | `.CMsgDotaFantasyCraftingUserData` | `optional` |  |  |
+| 3 | `tablet_data` | `.CMsgDotaFantasyCraftingTabletData` | `optional` |  |  |
 
 </details>
 
@@ -752,8 +752,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `fantasy_league` | `uint32` | `optional` | `` |  |
-| 2 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `fantasy_league` | `uint32` | `optional` |  |  |
+| 2 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -765,8 +765,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCFantasyCraftingSelectPlayerResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `tablet_data` | `.CMsgDotaFantasyCraftingTabletData` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCFantasyCraftingSelectPlayerResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `tablet_data` | `.CMsgDotaFantasyCraftingTabletData` | `optional` |  |  |
 
 </details>
 
@@ -778,8 +778,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `fantasy_league` | `uint32` | `optional` | `` |  |
-| 2 | `account_ids` | `uint32` | `repeated` | `` |  |
+| 1 | `fantasy_league` | `uint32` | `optional` |  |  |
+| 2 | `account_ids` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -791,9 +791,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCFantasyCraftingGenerateTabletsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `user_data` | `.CMsgDotaFantasyCraftingUserData` | `optional` | `` |  |
-| 3 | `tablet_data` | `.CMsgDotaFantasyCraftingTabletData` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCFantasyCraftingGenerateTabletsResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `user_data` | `.CMsgDotaFantasyCraftingUserData` | `optional` |  |  |
+| 3 | `tablet_data` | `.CMsgDotaFantasyCraftingTabletData` | `optional` |  |  |
 
 </details>
 
@@ -805,7 +805,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `fantasy_league` | `uint32` | `optional` | `` |  |
+| 1 | `fantasy_league` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -817,8 +817,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGcFantasyCraftingUpgradeTabletsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 3 | `tablet_data` | `.CMsgDotaFantasyCraftingTabletData` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGcFantasyCraftingUpgradeTabletsResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 3 | `tablet_data` | `.CMsgDotaFantasyCraftingTabletData` | `optional` |  |  |
 
 </details>
 
@@ -830,7 +830,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `fantasy_league` | `uint32` | `optional` | `` |  |
+| 1 | `fantasy_league` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -842,8 +842,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCFantasyCraftingRerollOptionsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `user_data` | `.CMsgDotaFantasyCraftingUserData` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCFantasyCraftingRerollOptionsResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `user_data` | `.CMsgDotaFantasyCraftingUserData` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-client-guild-events.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-client-guild-events.md
@@ -23,12 +23,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `contract_id` | `uint64` | `optional` | `` |  |
-| 2 | `challenge_instance_id` | `uint32` | `optional` | `` |  |
-| 3 | `challenge_parameter` | `uint32` | `optional` | `` |  |
-| 4 | `challenge_timestamp` | `uint32` | `optional` | `` |  |
-| 5 | `assigned_account_id` | `uint32` | `optional` | `` |  |
-| 6 | `contract_flags` | `uint32` | `optional` | `` |  |
+| 1 | `contract_id` | `uint64` | `optional` |  |  |
+| 2 | `challenge_instance_id` | `uint32` | `optional` |  |  |
+| 3 | `challenge_parameter` | `uint32` | `optional` |  |  |
+| 4 | `challenge_timestamp` | `uint32` | `optional` |  |  |
+| 5 | `assigned_account_id` | `uint32` | `optional` |  |  |
+| 6 | `contract_flags` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -40,7 +40,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `contract` | `.CMsgGuildContract` | `optional` | `` |  |
+| 1 | `contract` | `.CMsgGuildContract` | `optional` |  |  |
 
 </details>
 
@@ -52,15 +52,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_points` | `uint32` | `optional` | `` |  |
-| 2 | `contracts_refreshed_timestamp` | `uint32` | `optional` | `` |  |
-| 3 | `contract_slots` | `.CMsgGuildContractSlot` | `repeated` | `` |  |
-| 4 | `completed_challenge_count` | `uint32` | `optional` | `` |  |
-| 5 | `challenges_refresh_timestamp` | `uint32` | `optional` | `` |  |
-| 6 | `guild_weekly_percentile` | `uint32` | `optional` | `` |  |
-| 7 | `guild_weekly_last_timestamp` | `uint32` | `optional` | `` |  |
-| 8 | `last_weekly_claim_time` | `uint32` | `optional` | `` |  |
-| 9 | `guild_current_percentile` | `uint32` | `optional` | `` |  |
+| 1 | `guild_points` | `uint32` | `optional` |  |  |
+| 2 | `contracts_refreshed_timestamp` | `uint32` | `optional` |  |  |
+| 3 | `contract_slots` | `.CMsgGuildContractSlot` | `repeated` |  |  |
+| 4 | `completed_challenge_count` | `uint32` | `optional` |  |  |
+| 5 | `challenges_refresh_timestamp` | `uint32` | `optional` |  |  |
+| 6 | `guild_weekly_percentile` | `uint32` | `optional` |  |  |
+| 7 | `guild_weekly_last_timestamp` | `uint32` | `optional` |  |  |
+| 8 | `last_weekly_claim_time` | `uint32` | `optional` |  |  |
+| 9 | `guild_current_percentile` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -72,8 +72,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `contracts_refreshed_timestamp` | `uint32` | `optional` | `` |  |
-| 2 | `contracts` | `.CMsgGuildContract` | `repeated` | `` |  |
+| 1 | `contracts_refreshed_timestamp` | `uint32` | `optional` |  |  |
+| 2 | `contracts` | `.CMsgGuildContract` | `repeated` |  |  |
 
 </details>
 
@@ -85,11 +85,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `challenge_instance_id` | `uint32` | `optional` | `` |  |
-| 2 | `challenge_parameter` | `uint32` | `optional` | `` |  |
-| 3 | `challenge_timestamp` | `uint32` | `optional` | `` |  |
-| 4 | `challenge_progress` | `uint32` | `optional` | `` |  |
-| 5 | `challenge_flags` | `uint32` | `optional` | `` |  |
+| 1 | `challenge_instance_id` | `uint32` | `optional` |  |  |
+| 2 | `challenge_parameter` | `uint32` | `optional` |  |  |
+| 3 | `challenge_timestamp` | `uint32` | `optional` |  |  |
+| 4 | `challenge_progress` | `uint32` | `optional` |  |  |
+| 5 | `challenge_flags` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -101,8 +101,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `guild_points_earned` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `guild_points_earned` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -114,8 +114,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
 
 </details>
 
@@ -127,9 +127,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCRequestAccountGuildEventDataResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 3 | `event_data` | `.CMsgAccountGuildEventData` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCRequestAccountGuildEventDataResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 3 | `event_data` | `.CMsgAccountGuildEventData` | `optional` |  |  |
 
 </details>
 
@@ -141,11 +141,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 3 | `update_flags` | `uint32` | `optional` | `` |  |
-| 4 | `guild_event_data` | `.CMsgAccountGuildEventData` | `optional` | `` |  |
-| 5 | `contracts_updated` | `bool` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 3 | `update_flags` | `uint32` | `optional` |  |  |
+| 4 | `guild_event_data` | `.CMsgAccountGuildEventData` | `optional` |  |  |
+| 5 | `contracts_updated` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -157,8 +157,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
 
 </details>
 
@@ -170,9 +170,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCRequestActiveGuildContractsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `active_contracts` | `.CMsgGuildActiveContracts` | `optional` | `` |  |
-| 3 | `active_challenges` | `.CMsgGuildChallenge` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCRequestActiveGuildContractsResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `active_contracts` | `.CMsgGuildActiveContracts` | `optional` |  |  |
+| 3 | `active_challenges` | `.CMsgGuildChallenge` | `optional` |  |  |
 
 </details>
 
@@ -184,8 +184,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
 
 </details>
 
@@ -197,10 +197,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 3 | `contract_id` | `uint64` | `optional` | `` |  |
-| 4 | `contract_slot` | `uint32` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 3 | `contract_id` | `uint64` | `optional` |  |  |
+| 4 | `contract_slot` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -212,7 +212,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCSelectGuildContractResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCSelectGuildContractResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -224,8 +224,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
 
 </details>
 
@@ -237,8 +237,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCRequestActiveGuildChallengeResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `active_challenge` | `.CMsgGuildChallenge` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCRequestActiveGuildChallengeResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `active_challenge` | `.CMsgGuildChallenge` | `optional` |  |  |
 
 </details>
 
@@ -250,9 +250,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 3 | `active_challenge` | `.CMsgGuildChallenge` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 3 | `active_challenge` | `.CMsgGuildChallenge` | `optional` |  |  |
 
 </details>
 
@@ -264,8 +264,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
 
 </details>
 
@@ -277,8 +277,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCRequestGuildEventMembersResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `members` | `.CMsgGuildEventMember` | `repeated` | `` |  |
+| 1 | `result` | `.CMsgClientToGCRequestGuildEventMembersResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `members` | `.CMsgGuildEventMember` | `repeated` |  |  |
 
 </details>
 
@@ -290,14 +290,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 2 | `region` | `uint32` | `optional` | `` |  |
-| 3 | `last_updated` | `uint32` | `optional` | `` |  |
-| 4 | `guild_id` | `uint32` | `repeated` | `` | packed = true |
-| 5 | `rank` | `uint32` | `repeated` | `` | packed = true |
-| 6 | `current_percentile` | `uint32` | `repeated` | `` | packed = true |
-| 7 | `weekly_percentile` | `uint32` | `repeated` | `` | packed = true |
-| 8 | `points` | `uint32` | `repeated` | `` | packed = true |
+| 1 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 2 | `region` | `uint32` | `optional` |  |  |
+| 3 | `last_updated` | `uint32` | `optional` |  |  |
+| 4 | `guild_id` | `uint32` | `repeated` |  | packed = true |
+| 5 | `rank` | `uint32` | `repeated` |  | packed = true |
+| 6 | `current_percentile` | `uint32` | `repeated` |  | packed = true |
+| 7 | `weekly_percentile` | `uint32` | `repeated` |  | packed = true |
+| 8 | `points` | `uint32` | `repeated` |  | packed = true |
 
 </details>
 
@@ -309,8 +309,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
 
 </details>
 
@@ -322,8 +322,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCClaimLeaderboardRewardsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `event_points` | `uint32` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCClaimLeaderboardRewardsResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `event_points` | `uint32` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-client-guild.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-client-guild.md
@@ -23,23 +23,23 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_name` | `string` | `optional` | `` |  |
-| 2 | `guild_tag` | `string` | `optional` | `` |  |
-| 3 | `created_timestamp` | `uint32` | `optional` | `` |  |
-| 4 | `guild_language` | `uint32` | `optional` | `` |  |
-| 5 | `guild_flags` | `uint32` | `optional` | `` |  |
-| 7 | `guild_logo` | `uint64` | `optional` | `` |  |
-| 8 | `guild_region` | `uint32` | `optional` | `` |  |
-| 9 | `guild_chat_group_id` | `uint64` | `optional` | `` |  |
-| 10 | `guild_description` | `string` | `optional` | `` |  |
-| 11 | `default_chat_channel_id` | `uint64` | `optional` | `` |  |
-| 12 | `guild_primary_color` | `uint32` | `optional` | `` |  |
-| 13 | `guild_secondary_color` | `uint32` | `optional` | `` |  |
-| 14 | `guild_pattern` | `uint32` | `optional` | `` |  |
-| 15 | `guild_refresh_time_offset` | `uint32` | `optional` | `` |  |
-| 16 | `guild_required_rank_tier` | `uint32` | `optional` | `` |  |
-| 17 | `guild_motd_timestamp` | `uint32` | `optional` | `` |  |
-| 18 | `guild_motd` | `string` | `optional` | `` |  |
+| 1 | `guild_name` | `string` | `optional` |  |  |
+| 2 | `guild_tag` | `string` | `optional` |  |  |
+| 3 | `created_timestamp` | `uint32` | `optional` |  |  |
+| 4 | `guild_language` | `uint32` | `optional` |  |  |
+| 5 | `guild_flags` | `uint32` | `optional` |  |  |
+| 7 | `guild_logo` | `uint64` | `optional` |  |  |
+| 8 | `guild_region` | `uint32` | `optional` |  |  |
+| 9 | `guild_chat_group_id` | `uint64` | `optional` |  |  |
+| 10 | `guild_description` | `string` | `optional` |  |  |
+| 11 | `default_chat_channel_id` | `uint64` | `optional` |  |  |
+| 12 | `guild_primary_color` | `uint32` | `optional` |  |  |
+| 13 | `guild_secondary_color` | `uint32` | `optional` |  |  |
+| 14 | `guild_pattern` | `uint32` | `optional` |  |  |
+| 15 | `guild_refresh_time_offset` | `uint32` | `optional` |  |  |
+| 16 | `guild_required_rank_tier` | `uint32` | `optional` |  |  |
+| 17 | `guild_motd_timestamp` | `uint32` | `optional` |  |  |
+| 18 | `guild_motd` | `string` | `optional` |  |  |
 
 </details>
 
@@ -51,9 +51,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_info` | `.CMsgGuildInfo` | `optional` | `` |  |
-| 2 | `member_count` | `uint32` | `optional` | `` |  |
-| 3 | `event_points` | `.CMsgGuildSummary.EventPoints` | `repeated` | `` |  |
+| 1 | `guild_info` | `.CMsgGuildInfo` | `optional` |  |  |
+| 2 | `member_count` | `uint32` | `optional` |  |  |
+| 3 | `event_points` | `.CMsgGuildSummary.EventPoints` | `repeated` |  |  |
 
 </details>
 
@@ -65,12 +65,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `guild_points` | `uint32` | `optional` | `` |  |
-| 3 | `guild_rank` | `uint32` | `optional` | `` |  |
-| 4 | `guild_weekly_rank` | `uint32` | `optional` | `` |  |
-| 5 | `guild_weekly_percentile` | `uint32` | `optional` | `` |  |
-| 6 | `guild_current_percentile` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `guild_points` | `uint32` | `optional` |  |  |
+| 3 | `guild_rank` | `uint32` | `optional` |  |  |
+| 4 | `guild_weekly_rank` | `uint32` | `optional` |  |  |
+| 5 | `guild_weekly_percentile` | `uint32` | `optional` |  |  |
+| 6 | `guild_current_percentile` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -82,10 +82,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `role_id` | `uint32` | `optional` | `` |  |
-| 2 | `role_name` | `string` | `optional` | `` |  |
-| 3 | `role_flags` | `uint32` | `optional` | `` |  |
-| 4 | `role_order` | `uint32` | `optional` | `` |  |
+| 1 | `role_id` | `uint32` | `optional` |  |  |
+| 2 | `role_name` | `string` | `optional` |  |  |
+| 3 | `role_flags` | `uint32` | `optional` |  |  |
+| 4 | `role_order` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -97,10 +97,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `member_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `member_role_id` | `uint32` | `optional` | `` |  |
-| 3 | `member_joined_timestamp` | `uint32` | `optional` | `` |  |
-| 4 | `member_last_active_timestamp` | `uint32` | `optional` | `` |  |
+| 1 | `member_account_id` | `uint32` | `optional` |  |  |
+| 2 | `member_role_id` | `uint32` | `optional` |  |  |
+| 3 | `member_joined_timestamp` | `uint32` | `optional` |  |  |
+| 4 | `member_last_active_timestamp` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -112,9 +112,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `requester_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `target_account_id` | `uint32` | `optional` | `` |  |
-| 3 | `timestamp_sent` | `uint32` | `optional` | `` |  |
+| 1 | `requester_account_id` | `uint32` | `optional` |  |  |
+| 2 | `target_account_id` | `uint32` | `optional` |  |  |
+| 3 | `timestamp_sent` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -126,11 +126,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `guild_info` | `.CMsgGuildInfo` | `optional` | `` |  |
-| 3 | `guild_roles` | `.CMsgGuildRole` | `repeated` | `` |  |
-| 4 | `guild_members` | `.CMsgGuildMember` | `repeated` | `` |  |
-| 5 | `guild_invites` | `.CMsgGuildInvite` | `repeated` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `guild_info` | `.CMsgGuildInfo` | `optional` |  |  |
+| 3 | `guild_roles` | `.CMsgGuildRole` | `repeated` |  |  |
+| 4 | `guild_members` | `.CMsgGuildMember` | `repeated` |  |  |
+| 5 | `guild_invites` | `.CMsgGuildInvite` | `repeated` |  |  |
 
 </details>
 
@@ -142,9 +142,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `requester_account_id` | `uint32` | `optional` | `` |  |
-| 3 | `timestamp_sent` | `uint32` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `requester_account_id` | `uint32` | `optional` |  |  |
+| 3 | `timestamp_sent` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -156,8 +156,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_ids` | `uint32` | `repeated` | `` |  |
-| 2 | `guild_invites` | `.CMsgAccountGuildInvite` | `repeated` | `` |  |
+| 1 | `guild_ids` | `uint32` | `repeated` |  |  |
+| 2 | `guild_invites` | `.CMsgAccountGuildInvite` | `repeated` |  |  |
 
 </details>
 
@@ -169,9 +169,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `guild_tag` | `string` | `optional` | `` |  |
-| 3 | `guild_flags` | `uint32` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `guild_tag` | `string` | `optional` |  |  |
+| 3 | `guild_flags` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -183,7 +183,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_persona_infos` | `.CMsgGuildPersonaInfo` | `repeated` | `` |  |
+| 1 | `guild_persona_infos` | `.CMsgGuildPersonaInfo` | `repeated` |  |  |
 
 </details>
 
@@ -195,12 +195,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `feed_event_id` | `uint64` | `optional` | `` |  |
-| 2 | `timestamp` | `uint32` | `optional` | `` |  |
-| 3 | `event_type` | `uint32` | `optional` | `` |  |
-| 4 | `param_uint_1` | `uint32` | `optional` | `` |  |
-| 5 | `param_uint_2` | `uint32` | `optional` | `` |  |
-| 6 | `param_uint_3` | `uint32` | `optional` | `` |  |
+| 1 | `feed_event_id` | `uint64` | `optional` |  |  |
+| 2 | `timestamp` | `uint32` | `optional` |  |  |
+| 3 | `event_type` | `uint32` | `optional` |  |  |
+| 4 | `param_uint_1` | `uint32` | `optional` |  |  |
+| 5 | `param_uint_2` | `uint32` | `optional` |  |  |
+| 6 | `param_uint_3` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -212,8 +212,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_info` | `.CMsgGuildInfo` | `optional` | `` |  |
-| 2 | `guild_chat_type` | `.EGuildChatType` | `optional` | `` | default = k_EGuildChatType_Unspecified |
+| 1 | `guild_info` | `.CMsgGuildInfo` | `optional` |  |  |
+| 2 | `guild_chat_type` | `.EGuildChatType` | `optional` |  | default = k_EGuildChatType_Unspecified |
 
 </details>
 
@@ -225,8 +225,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCCreateGuildResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `guild_id` | `uint32` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCCreateGuildResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `guild_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -238,9 +238,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `guild_info` | `.CMsgGuildInfo` | `optional` | `` |  |
-| 3 | `guild_chat_type` | `.EGuildChatType` | `optional` | `` | default = k_EGuildChatType_Unspecified |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `guild_info` | `.CMsgGuildInfo` | `optional` |  |  |
+| 3 | `guild_chat_type` | `.EGuildChatType` | `optional` |  | default = k_EGuildChatType_Unspecified |
 
 </details>
 
@@ -252,7 +252,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCSetGuildInfoResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCSetGuildInfoResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -264,7 +264,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -276,8 +276,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCRequestGuildDataResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `guild_data` | `.CMsgGuildData` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCRequestGuildDataResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `guild_data` | `.CMsgGuildData` | `optional` |  |  |
 
 </details>
 
@@ -289,8 +289,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_data` | `.CMsgGuildData` | `optional` | `` |  |
-| 2 | `update_flags` | `uint32` | `optional` | `` |  |
+| 1 | `guild_data` | `.CMsgGuildData` | `optional` |  |  |
+| 2 | `update_flags` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -302,8 +302,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `members_data` | `.CMsgGuildMember` | `repeated` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `members_data` | `.CMsgGuildMember` | `repeated` |  |  |
 
 </details>
 
@@ -327,8 +327,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCRequestGuildMembershipResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `guild_memberships` | `.CMsgAccountGuildMemberships` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCRequestGuildMembershipResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `guild_memberships` | `.CMsgAccountGuildMemberships` | `optional` |  |  |
 
 </details>
 
@@ -340,7 +340,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_memberships` | `.CMsgAccountGuildMemberships` | `optional` | `` |  |
+| 1 | `guild_memberships` | `.CMsgAccountGuildMemberships` | `optional` |  |  |
 
 </details>
 
@@ -352,7 +352,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -364,7 +364,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCJoinGuildResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCJoinGuildResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -376,7 +376,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -388,7 +388,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCLeaveGuildResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCLeaveGuildResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -400,8 +400,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `target_account_id` | `uint32` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `target_account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -413,7 +413,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCKickGuildMemberResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCKickGuildMemberResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -425,9 +425,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `target_account_id` | `uint32` | `optional` | `` |  |
-| 3 | `target_role_id` | `uint32` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `target_account_id` | `uint32` | `optional` |  |  |
+| 3 | `target_role_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -439,7 +439,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCSetGuildMemberRoleResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCSetGuildMemberRoleResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -451,8 +451,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `target_account_id` | `uint32` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `target_account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -464,7 +464,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCInviteToGuildResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCInviteToGuildResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -476,7 +476,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -488,7 +488,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCDeclineInviteToGuildResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCDeclineInviteToGuildResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -500,7 +500,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -512,7 +512,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCAcceptInviteToGuildResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCAcceptInviteToGuildResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -524,8 +524,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `target_account_id` | `uint32` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `target_account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -537,7 +537,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCCancelInviteToGuildResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCCancelInviteToGuildResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -549,9 +549,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `role_name` | `string` | `optional` | `` |  |
-| 3 | `role_flags` | `uint32` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `role_name` | `string` | `optional` |  |  |
+| 3 | `role_flags` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -563,8 +563,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCAddGuildRoleResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `role_id` | `uint32` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCAddGuildRoleResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `role_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -576,10 +576,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `role_id` | `uint32` | `optional` | `` |  |
-| 3 | `role_name` | `string` | `optional` | `` |  |
-| 4 | `role_flags` | `uint32` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `role_id` | `uint32` | `optional` |  |  |
+| 3 | `role_name` | `string` | `optional` |  |  |
+| 4 | `role_flags` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -591,7 +591,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCModifyGuildRoleResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCModifyGuildRoleResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -603,8 +603,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `role_id` | `uint32` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `role_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -616,7 +616,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCRemoveGuildRoleResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCRemoveGuildRoleResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -628,9 +628,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `requested_role_ids` | `uint32` | `repeated` | `` |  |
-| 3 | `previous_role_ids` | `uint32` | `repeated` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `requested_role_ids` | `uint32` | `repeated` |  |  |
+| 3 | `previous_role_ids` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -642,8 +642,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCSetGuildRoleOrderResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `confirmed_role_ids` | `uint32` | `repeated` | `` |  |
+| 1 | `result` | `.CMsgClientToGCSetGuildRoleOrderResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `confirmed_role_ids` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -655,8 +655,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `last_seen_id` | `uint64` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `last_seen_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -668,9 +668,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCRequestGuildFeedResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `guild_id` | `uint32` | `optional` | `` |  |
-| 3 | `feed_events` | `.CMsgGuildFeedEvent` | `repeated` | `` |  |
+| 1 | `result` | `.CMsgClientToGCRequestGuildFeedResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `guild_id` | `uint32` | `optional` |  |  |
+| 3 | `feed_events` | `.CMsgGuildFeedEvent` | `repeated` |  |  |
 
 </details>
 
@@ -682,7 +682,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -694,7 +694,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -706,7 +706,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCAddPlayerToGuildChatResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCAddPlayerToGuildChatResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -718,9 +718,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgFindGuildByTagResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `guild_id` | `uint32` | `optional` | `` |  |
-| 3 | `guild_summary` | `.CMsgGuildSummary` | `optional` | `` |  |
+| 1 | `result` | `.CMsgFindGuildByTagResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `guild_id` | `uint32` | `optional` |  |  |
+| 3 | `guild_summary` | `.CMsgGuildSummary` | `optional` |  |  |
 
 </details>
 
@@ -732,9 +732,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgSearchForOpenGuildsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `search_results` | `.CMsgSearchForOpenGuildsResponse.SearchResult` | `repeated` | `` |  |
-| 3 | `use_whitelist` | `bool` | `optional` | `` |  |
+| 1 | `result` | `.CMsgSearchForOpenGuildsResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `search_results` | `.CMsgSearchForOpenGuildsResponse.SearchResult` | `repeated` |  |  |
+| 3 | `use_whitelist` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -746,8 +746,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `guild_summary` | `.CMsgGuildSummary` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `guild_summary` | `.CMsgGuildSummary` | `optional` |  |  |
 
 </details>
 
@@ -759,8 +759,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `guild_content_flags` | `uint32` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `guild_content_flags` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -772,7 +772,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCReportGuildContentResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCReportGuildContentResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -784,7 +784,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -796,8 +796,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCRequestAccountGuildPersonaInfoResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `persona_info` | `.CMsgAccountGuildsPersonaInfo` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCRequestAccountGuildPersonaInfoResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `persona_info` | `.CMsgAccountGuildsPersonaInfo` | `optional` |  |  |
 
 </details>
 
@@ -809,7 +809,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_ids` | `uint32` | `repeated` | `` |  |
+| 1 | `account_ids` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -821,8 +821,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCRequestAccountGuildPersonaInfoBatchResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `persona_infos` | `.CMsgAccountGuildsPersonaInfo` | `repeated` | `` |  |
+| 1 | `result` | `.CMsgClientToGCRequestAccountGuildPersonaInfoBatchResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `persona_infos` | `.CMsgAccountGuildsPersonaInfo` | `repeated` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-client-match-management.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-client-match-management.md
@@ -27,26 +27,26 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key` | `string` | `optional` | `` |  |
-| 2 | `matchgroups` | `uint32` | `optional` | `` | default = 4294967295 |
-| 3 | `client_version` | `uint32` | `optional` | `` |  |
-| 4 | `game_modes` | `uint32` | `optional` | `` | default = 4294967295 |
-| 6 | `match_type` | `.MatchType` | `optional` | `` | default = MATCH_TYPE_CASUAL |
-| 7 | `matchlanguages` | `uint32` | `optional` | `` | default = 4294967295 |
-| 8 | `team_id` | `uint32` | `optional` | `` |  |
-| 10 | `game_language_enum` | `.MatchLanguages` | `optional` | `` | default = MATCH_LANGUAGE_INVALID |
-| 11 | `game_language_name` | `string` | `optional` | `` |  |
-| 12 | `ping_data` | `.CMsgClientPingData` | `optional` | `` |  |
-| 13 | `region_select_flags` | `uint32` | `optional` | `` |  |
-| 14 | `solo_queue` | `bool` | `optional` | `` |  |
-| 16 | `steam_clan_account_id` | `uint32` | `optional` | `` |  |
-| 17 | `is_challenge_match` | `bool` | `optional` | `` |  |
-| 18 | `lane_selection_flags` | `uint32` | `optional` | `` |  |
-| 19 | `high_priority_disabled` | `bool` | `optional` | `` |  |
-| 20 | `disable_experimental_gameplay` | `bool` | `optional` | `` |  |
-| 21 | `custom_game_difficulty_mask` | `uint32` | `optional` | `` |  |
-| 22 | `bot_difficulty_mask` | `uint32` | `optional` | `` |  |
-| 23 | `bot_script_index_mask` | `uint32` | `optional` | `` |  |
+| 1 | `key` | `string` | `optional` |  |  |
+| 2 | `matchgroups` | `uint32` | `optional` |  | default = 4294967295 |
+| 3 | `client_version` | `uint32` | `optional` |  |  |
+| 4 | `game_modes` | `uint32` | `optional` |  | default = 4294967295 |
+| 6 | `match_type` | `.MatchType` | `optional` |  | default = MATCH_TYPE_CASUAL |
+| 7 | `matchlanguages` | `uint32` | `optional` |  | default = 4294967295 |
+| 8 | `team_id` | `uint32` | `optional` |  |  |
+| 10 | `game_language_enum` | `.MatchLanguages` | `optional` |  | default = MATCH_LANGUAGE_INVALID |
+| 11 | `game_language_name` | `string` | `optional` |  |  |
+| 12 | `ping_data` | `.CMsgClientPingData` | `optional` |  |  |
+| 13 | `region_select_flags` | `uint32` | `optional` |  |  |
+| 14 | `solo_queue` | `bool` | `optional` |  |  |
+| 16 | `steam_clan_account_id` | `uint32` | `optional` |  |  |
+| 17 | `is_challenge_match` | `bool` | `optional` |  |  |
+| 18 | `lane_selection_flags` | `uint32` | `optional` |  |  |
+| 19 | `high_priority_disabled` | `bool` | `optional` |  |  |
+| 20 | `disable_experimental_gameplay` | `bool` | `optional` |  |  |
+| 21 | `custom_game_difficulty_mask` | `uint32` | `optional` |  |  |
+| 22 | `bot_difficulty_mask` | `uint32` | `optional` |  |  |
+| 23 | `bot_script_index_mask` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -58,12 +58,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `legacy_generic_eresult` | `uint32` | `optional` | `` | default = 2 |
-| 2 | `result` | `.EStartFindingMatchResult` | `optional` | `` | default = k_EStartFindingMatchResult_Invalid |
-| 3 | `error_token` | `string` | `optional` | `` |  |
-| 4 | `debug_message` | `string` | `optional` | `` |  |
-| 5 | `responsible_party_members` | `fixed64` | `repeated` | `` |  |
-| 6 | `result_metadata` | `uint32` | `optional` | `` |  |
+| 1 | `legacy_generic_eresult` | `uint32` | `optional` |  | default = 2 |
+| 2 | `result` | `.EStartFindingMatchResult` | `optional` |  | default = k_EStartFindingMatchResult_Invalid |
+| 3 | `error_token` | `string` | `optional` |  |  |
+| 4 | `debug_message` | `string` | `optional` |  |  |
+| 5 | `responsible_party_members` | `fixed64` | `repeated` |  |  |
+| 6 | `result_metadata` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -75,7 +75,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `accept_cooldown` | `bool` | `optional` | `` |  |
+| 1 | `accept_cooldown` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -87,11 +87,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `additional_slots` | `uint32` | `optional` | `` |  |
-| 2 | `match_type` | `.MatchType` | `optional` | `` | default = MATCH_TYPE_CASUAL |
-| 3 | `matchgroups` | `uint32` | `optional` | `` |  |
-| 4 | `client_version` | `uint32` | `optional` | `` |  |
-| 5 | `language` | `.MatchLanguages` | `optional` | `` | default = MATCH_LANGUAGE_INVALID |
+| 1 | `additional_slots` | `uint32` | `optional` |  |  |
+| 2 | `match_type` | `.MatchType` | `optional` |  | default = MATCH_TYPE_CASUAL |
+| 3 | `matchgroups` | `uint32` | `optional` |  |  |
+| 4 | `client_version` | `uint32` | `optional` |  |  |
+| 5 | `language` | `.MatchLanguages` | `optional` |  | default = MATCH_LANGUAGE_INVALID |
 
 </details>
 
@@ -103,9 +103,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `state` | `.DOTALobbyReadyState` | `optional` | `` | default = DOTALobbyReadyState_UNDECLARED |
-| 2 | `ready_up_key` | `fixed64` | `optional` | `` |  |
-| 3 | `hardware_specs` | `.CDOTAClientHardwareSpecs` | `optional` | `` |  |
+| 1 | `state` | `.DOTALobbyReadyState` | `optional` |  | default = DOTALobbyReadyState_UNDECLARED |
+| 2 | `ready_up_key` | `fixed64` | `optional` |  |  |
+| 3 | `hardware_specs` | `.CDOTAClientHardwareSpecs` | `optional` |  |  |
 
 </details>
 
@@ -117,12 +117,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `lobby_id` | `fixed64` | `optional` | `` |  |
-| 2 | `accepted_ids` | `uint32` | `repeated` | `` |  |
-| 3 | `declined_ids` | `uint32` | `repeated` | `` |  |
-| 4 | `accepted_indices` | `uint32` | `repeated` | `` |  |
-| 5 | `declined_indices` | `uint32` | `repeated` | `` |  |
-| 6 | `local_ready_state` | `.DOTALobbyReadyState` | `optional` | `` | default = DOTALobbyReadyState_UNDECLARED |
+| 1 | `lobby_id` | `fixed64` | `optional` |  |  |
+| 2 | `accepted_ids` | `uint32` | `repeated` |  |  |
+| 3 | `declined_ids` | `uint32` | `repeated` |  |  |
+| 4 | `accepted_indices` | `uint32` | `repeated` |  |  |
+| 5 | `declined_indices` | `uint32` | `repeated` |  |  |
+| 6 | `local_ready_state` | `.DOTALobbyReadyState` | `optional` |  | default = DOTALobbyReadyState_UNDECLARED |
 
 </details>
 
@@ -146,8 +146,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `version` | `int32` | `optional` | `` |  |
-| 2 | `data` | `bytes` | `optional` | `` |  |
+| 1 | `version` | `int32` | `optional` |  |  |
+| 2 | `data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -159,49 +159,49 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `lobby_id` | `uint64` | `optional` | `` |  |
-| 2 | `game_name` | `string` | `optional` | `` |  |
-| 3 | `team_details` | `.CLobbyTeamDetails` | `repeated` | `` |  |
-| 4 | `server_region` | `uint32` | `optional` | `` |  |
-| 5 | `game_mode` | `uint32` | `optional` | `` |  |
-| 6 | `cm_pick` | `.DOTA_CM_PICK` | `optional` | `` | default = DOTA_CM_RANDOM |
-| 9 | `bot_difficulty_radiant` | `.DOTABotDifficulty` | `optional` | `` | default = BOT_DIFFICULTY_PASSIVE |
-| 10 | `allow_cheats` | `bool` | `optional` | `` |  |
-| 11 | `fill_with_bots` | `bool` | `optional` | `` |  |
-| 13 | `allow_spectating` | `bool` | `optional` | `` |  |
-| 15 | `pass_key` | `string` | `optional` | `` |  |
-| 16 | `leagueid` | `uint32` | `optional` | `` |  |
-| 17 | `penalty_level_radiant` | `uint32` | `optional` | `` |  |
-| 18 | `penalty_level_dire` | `uint32` | `optional` | `` |  |
-| 20 | `series_type` | `uint32` | `optional` | `` |  |
-| 21 | `radiant_series_wins` | `uint32` | `optional` | `` |  |
-| 22 | `dire_series_wins` | `uint32` | `optional` | `` |  |
-| 23 | `allchat` | `bool` | `optional` | `` | default = false |
-| 24 | `dota_tv_delay` | `.LobbyDotaTVDelay` | `optional` | `` | default = LobbyDotaTV_120 |
-| 25 | `lan` | `bool` | `optional` | `` |  |
-| 26 | `custom_game_mode` | `string` | `optional` | `` |  |
-| 27 | `custom_map_name` | `string` | `optional` | `` |  |
-| 28 | `custom_difficulty` | `uint32` | `optional` | `` |  |
-| 29 | `custom_game_id` | `uint64` | `optional` | `` |  |
-| 30 | `custom_min_players` | `uint32` | `optional` | `` |  |
-| 31 | `custom_max_players` | `uint32` | `optional` | `` |  |
-| 33 | `visibility` | `.DOTALobbyVisibility` | `optional` | `` | default = DOTALobbyVisibility_Public |
-| 34 | `custom_game_crc` | `fixed64` | `optional` | `` |  |
-| 37 | `custom_game_timestamp` | `fixed32` | `optional` | `` |  |
-| 38 | `previous_match_override` | `uint64` | `optional` | `` |  |
-| 42 | `pause_setting` | `.LobbyDotaPauseSetting` | `optional` | `` | default = LobbyDotaPauseSetting_Unlimited |
-| 43 | `bot_difficulty_dire` | `.DOTABotDifficulty` | `optional` | `` | default = BOT_DIFFICULTY_PASSIVE |
-| 44 | `bot_radiant` | `uint64` | `optional` | `` |  |
-| 45 | `bot_dire` | `uint64` | `optional` | `` |  |
-| 46 | `selection_priority_rules` | `.DOTASelectionPriorityRules` | `optional` | `` | default = k_DOTASelectionPriorityRules_Manual |
-| 47 | `custom_game_penalties` | `bool` | `optional` | `` |  |
-| 48 | `lan_host_ping_location` | `string` | `optional` | `` |  |
-| 49 | `league_node_id` | `uint32` | `optional` | `` |  |
-| 50 | `requested_hero_ids` | `int32` | `repeated` | `` |  |
-| 51 | `scenario_save` | `.CMsgLobbyScenarioSave` | `optional` | `` |  |
-| 52 | `ability_draft_specific_details` | `.CMsgPracticeLobbySetDetails.AbilityDraftSpecificDetails` | `optional` | `` |  |
-| 53 | `do_player_draft` | `bool` | `optional` | `` |  |
-| 54 | `requested_hero_teams` | `int32` | `repeated` | `` |  |
+| 1 | `lobby_id` | `uint64` | `optional` |  |  |
+| 2 | `game_name` | `string` | `optional` |  |  |
+| 3 | `team_details` | `.CLobbyTeamDetails` | `repeated` |  |  |
+| 4 | `server_region` | `uint32` | `optional` |  |  |
+| 5 | `game_mode` | `uint32` | `optional` |  |  |
+| 6 | `cm_pick` | `.DOTA_CM_PICK` | `optional` |  | default = DOTA_CM_RANDOM |
+| 9 | `bot_difficulty_radiant` | `.DOTABotDifficulty` | `optional` |  | default = BOT_DIFFICULTY_PASSIVE |
+| 10 | `allow_cheats` | `bool` | `optional` |  |  |
+| 11 | `fill_with_bots` | `bool` | `optional` |  |  |
+| 13 | `allow_spectating` | `bool` | `optional` |  |  |
+| 15 | `pass_key` | `string` | `optional` |  |  |
+| 16 | `leagueid` | `uint32` | `optional` |  |  |
+| 17 | `penalty_level_radiant` | `uint32` | `optional` |  |  |
+| 18 | `penalty_level_dire` | `uint32` | `optional` |  |  |
+| 20 | `series_type` | `uint32` | `optional` |  |  |
+| 21 | `radiant_series_wins` | `uint32` | `optional` |  |  |
+| 22 | `dire_series_wins` | `uint32` | `optional` |  |  |
+| 23 | `allchat` | `bool` | `optional` |  | default = false |
+| 24 | `dota_tv_delay` | `.LobbyDotaTVDelay` | `optional` |  | default = LobbyDotaTV_120 |
+| 25 | `lan` | `bool` | `optional` |  |  |
+| 26 | `custom_game_mode` | `string` | `optional` |  |  |
+| 27 | `custom_map_name` | `string` | `optional` |  |  |
+| 28 | `custom_difficulty` | `uint32` | `optional` |  |  |
+| 29 | `custom_game_id` | `uint64` | `optional` |  |  |
+| 30 | `custom_min_players` | `uint32` | `optional` |  |  |
+| 31 | `custom_max_players` | `uint32` | `optional` |  |  |
+| 33 | `visibility` | `.DOTALobbyVisibility` | `optional` |  | default = DOTALobbyVisibility_Public |
+| 34 | `custom_game_crc` | `fixed64` | `optional` |  |  |
+| 37 | `custom_game_timestamp` | `fixed32` | `optional` |  |  |
+| 38 | `previous_match_override` | `uint64` | `optional` |  |  |
+| 42 | `pause_setting` | `.LobbyDotaPauseSetting` | `optional` |  | default = LobbyDotaPauseSetting_Unlimited |
+| 43 | `bot_difficulty_dire` | `.DOTABotDifficulty` | `optional` |  | default = BOT_DIFFICULTY_PASSIVE |
+| 44 | `bot_radiant` | `uint64` | `optional` |  |  |
+| 45 | `bot_dire` | `uint64` | `optional` |  |  |
+| 46 | `selection_priority_rules` | `.DOTASelectionPriorityRules` | `optional` |  | default = k_DOTASelectionPriorityRules_Manual |
+| 47 | `custom_game_penalties` | `bool` | `optional` |  |  |
+| 48 | `lan_host_ping_location` | `string` | `optional` |  |  |
+| 49 | `league_node_id` | `uint32` | `optional` |  |  |
+| 50 | `requested_hero_ids` | `int32` | `repeated` |  |  |
+| 51 | `scenario_save` | `.CMsgLobbyScenarioSave` | `optional` |  |  |
+| 52 | `ability_draft_specific_details` | `.CMsgPracticeLobbySetDetails.AbilityDraftSpecificDetails` | `optional` |  |  |
+| 53 | `do_player_draft` | `bool` | `optional` |  |  |
+| 54 | `requested_hero_teams` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -213,7 +213,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `shuffle_draft_order` | `bool` | `optional` | `` |  |
+| 1 | `shuffle_draft_order` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -225,10 +225,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `search_key` | `string` | `optional` | `` |  |
-| 5 | `pass_key` | `string` | `optional` | `` |  |
-| 6 | `client_version` | `uint32` | `optional` | `` |  |
-| 7 | `lobby_details` | `.CMsgPracticeLobbySetDetails` | `optional` | `` |  |
+| 1 | `search_key` | `string` | `optional` |  |  |
+| 5 | `pass_key` | `string` | `optional` |  |  |
+| 6 | `client_version` | `uint32` | `optional` |  |  |
+| 7 | `lobby_details` | `.CMsgPracticeLobbySetDetails` | `optional` |  |  |
 
 </details>
 
@@ -240,9 +240,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team` | `.DOTA_GC_TEAM` | `optional` | `` | default = DOTA_GC_TEAM_GOOD_GUYS |
-| 2 | `slot` | `uint32` | `optional` | `` |  |
-| 3 | `bot_difficulty` | `.DOTABotDifficulty` | `optional` | `` | default = BOT_DIFFICULTY_PASSIVE |
+| 1 | `team` | `.DOTA_GC_TEAM` | `optional` |  | default = DOTA_GC_TEAM_GOOD_GUYS |
+| 2 | `slot` | `uint32` | `optional` |  |  |
+| 3 | `bot_difficulty` | `.DOTABotDifficulty` | `optional` |  | default = BOT_DIFFICULTY_PASSIVE |
 
 </details>
 
@@ -254,7 +254,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team` | `.DOTA_GC_TEAM` | `optional` | `` | default = DOTA_GC_TEAM_GOOD_GUYS |
+| 1 | `team` | `.DOTA_GC_TEAM` | `optional` |  | default = DOTA_GC_TEAM_GOOD_GUYS |
 
 </details>
 
@@ -266,10 +266,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `channel` | `uint32` | `optional` | `` |  |
-| 2 | `preferred_description` | `string` | `optional` | `` |  |
-| 3 | `preferred_country_code` | `string` | `optional` | `` |  |
-| 4 | `preferred_language_code` | `string` | `optional` | `` |  |
+| 1 | `channel` | `uint32` | `optional` |  |  |
+| 2 | `preferred_description` | `string` | `optional` |  |  |
+| 3 | `preferred_country_code` | `string` | `optional` |  |  |
+| 4 | `preferred_language_code` | `string` | `optional` |  |  |
 
 </details>
 
@@ -281,7 +281,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `channel` | `uint32` | `optional` | `` |  |
+| 1 | `channel` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -305,7 +305,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 3 | `account_id` | `uint32` | `optional` | `` |  |
+| 3 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -317,7 +317,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -341,7 +341,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 5 | `client_version` | `uint32` | `optional` | `` |  |
+| 5 | `client_version` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -353,7 +353,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_id` | `uint32` | `optional` | `` |  |
+| 1 | `team_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -365,9 +365,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `pass_key` | `string` | `optional` | `` |  |
-| 3 | `region` | `uint32` | `optional` | `` |  |
-| 4 | `game_mode` | `.DOTA_GameMode` | `optional` | `` | default = DOTA_GAMEMODE_NONE |
+| 2 | `pass_key` | `string` | `optional` |  |  |
+| 3 | `region` | `uint32` | `optional` |  |  |
+| 4 | `game_mode` | `.DOTA_GameMode` | `optional` |  | default = DOTA_GAMEMODE_NONE |
 
 </details>
 
@@ -379,22 +379,22 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `uint64` | `optional` | `` | (key_field) = true |
-| 5 | `members` | `.CMsgPracticeLobbyListResponseEntry.CLobbyMember` | `repeated` | `` |  |
-| 6 | `requires_pass_key` | `bool` | `optional` | `` |  |
-| 7 | `leader_account_id` | `uint32` | `optional` | `` |  |
-| 10 | `name` | `string` | `optional` | `` |  |
-| 11 | `custom_game_mode` | `string` | `optional` | `` |  |
-| 12 | `game_mode` | `.DOTA_GameMode` | `optional` | `` | default = DOTA_GAMEMODE_NONE |
-| 13 | `friend_present` | `bool` | `optional` | `` |  |
-| 14 | `players` | `uint32` | `optional` | `` |  |
-| 15 | `custom_map_name` | `string` | `optional` | `` |  |
-| 16 | `max_player_count` | `uint32` | `optional` | `` |  |
-| 17 | `server_region` | `uint32` | `optional` | `` |  |
-| 19 | `league_id` | `uint32` | `optional` | `` |  |
-| 20 | `lan_host_ping_location` | `string` | `optional` | `` |  |
-| 21 | `min_player_count` | `uint32` | `optional` | `` |  |
-| 22 | `penalties_enabled` | `bool` | `optional` | `` |  |
+| 1 | `id` | `uint64` | `optional` |  | (key_field) = true |
+| 5 | `members` | `.CMsgPracticeLobbyListResponseEntry.CLobbyMember` | `repeated` |  |  |
+| 6 | `requires_pass_key` | `bool` | `optional` |  |  |
+| 7 | `leader_account_id` | `uint32` | `optional` |  |  |
+| 10 | `name` | `string` | `optional` |  |  |
+| 11 | `custom_game_mode` | `string` | `optional` |  |  |
+| 12 | `game_mode` | `.DOTA_GameMode` | `optional` |  | default = DOTA_GAMEMODE_NONE |
+| 13 | `friend_present` | `bool` | `optional` |  |  |
+| 14 | `players` | `uint32` | `optional` |  |  |
+| 15 | `custom_map_name` | `string` | `optional` |  |  |
+| 16 | `max_player_count` | `uint32` | `optional` |  |  |
+| 17 | `server_region` | `uint32` | `optional` |  |  |
+| 19 | `league_id` | `uint32` | `optional` |  |  |
+| 20 | `lan_host_ping_location` | `string` | `optional` |  |  |
+| 21 | `min_player_count` | `uint32` | `optional` |  |  |
+| 22 | `penalties_enabled` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -406,8 +406,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `player_name` | `string` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `player_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -419,7 +419,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `lobbies` | `.CMsgPracticeLobbyListResponseEntry` | `repeated` | `` |  |
+| 2 | `lobbies` | `.CMsgPracticeLobbyListResponseEntry` | `repeated` |  |  |
 
 </details>
 
@@ -431,8 +431,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `server_region` | `uint32` | `optional` | `` | default = 0 |
-| 2 | `game_mode` | `.DOTA_GameMode` | `optional` | `` | default = DOTA_GAMEMODE_NONE |
+| 1 | `server_region` | `uint32` | `optional` |  | default = 0 |
+| 2 | `game_mode` | `.DOTA_GameMode` | `optional` |  | default = DOTA_GAMEMODE_NONE |
 
 </details>
 
@@ -444,7 +444,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `lobbies` | `.CMsgPracticeLobbyListResponseEntry` | `repeated` | `` |  |
+| 1 | `lobbies` | `.CMsgPracticeLobbyListResponseEntry` | `repeated` |  |  |
 
 </details>
 
@@ -456,11 +456,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `lobby_id` | `uint64` | `optional` | `` |  |
-| 2 | `client_version` | `uint32` | `optional` | `` |  |
-| 3 | `pass_key` | `string` | `optional` | `` |  |
-| 4 | `custom_game_crc` | `fixed64` | `optional` | `` |  |
-| 5 | `custom_game_timestamp` | `fixed32` | `optional` | `` |  |
+| 1 | `lobby_id` | `uint64` | `optional` |  |  |
+| 2 | `client_version` | `uint32` | `optional` |  |  |
+| 3 | `pass_key` | `string` | `optional` |  |  |
+| 4 | `custom_game_crc` | `fixed64` | `optional` |  |  |
+| 5 | `custom_game_timestamp` | `fixed32` | `optional` |  |  |
 
 </details>
 
@@ -472,7 +472,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.DOTAJoinLobbyResult` | `optional` | `` | default = DOTA_JOIN_RESULT_SUCCESS |
+| 1 | `result` | `.DOTAJoinLobbyResult` | `optional` |  | default = DOTA_JOIN_RESULT_SUCCESS |
 
 </details>
 
@@ -484,7 +484,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `friends` | `uint32` | `repeated` | `` |  |
+| 1 | `friends` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -496,7 +496,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `lobbies` | `.CMsgPracticeLobbyListResponseEntry` | `repeated` | `` |  |
+| 1 | `lobbies` | `.CMsgPracticeLobbyListResponseEntry` | `repeated` |  |  |
 
 </details>
 
@@ -508,7 +508,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `server_region` | `uint32` | `optional` | `` |  |
+| 1 | `server_region` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -520,9 +520,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `custom_game_id` | `uint64` | `optional` | `` |  |
-| 2 | `lobby_count` | `uint32` | `optional` | `` |  |
-| 3 | `player_count` | `uint32` | `optional` | `` |  |
+| 1 | `custom_game_id` | `uint64` | `optional` |  |  |
+| 2 | `lobby_count` | `uint32` | `optional` |  |  |
+| 3 | `player_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -534,7 +534,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `game_modes` | `.CMsgJoinableCustomGameModesResponseEntry` | `repeated` | `` |  |
+| 1 | `game_modes` | `.CMsgJoinableCustomGameModesResponseEntry` | `repeated` |  |  |
 
 </details>
 
@@ -546,8 +546,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `server_region` | `uint32` | `optional` | `` |  |
-| 2 | `custom_game_id` | `uint64` | `optional` | `` |  |
+| 1 | `server_region` | `uint32` | `optional` |  |  |
+| 2 | `custom_game_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -559,22 +559,22 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `lobby_id` | `fixed64` | `optional` | `` |  |
-| 2 | `custom_game_id` | `uint64` | `optional` | `` |  |
-| 3 | `lobby_name` | `string` | `optional` | `` |  |
-| 4 | `member_count` | `uint32` | `optional` | `` |  |
-| 5 | `leader_account_id` | `uint32` | `optional` | `` |  |
-| 6 | `leader_name` | `string` | `optional` | `` |  |
-| 7 | `custom_map_name` | `string` | `optional` | `` |  |
-| 8 | `max_player_count` | `uint32` | `optional` | `` |  |
-| 9 | `server_region` | `uint32` | `optional` | `` |  |
-| 11 | `has_pass_key` | `bool` | `optional` | `` |  |
-| 12 | `lan_host_ping_location` | `string` | `optional` | `` |  |
-| 13 | `lobby_creation_time` | `uint32` | `optional` | `` |  |
-| 14 | `custom_game_timestamp` | `uint32` | `optional` | `` |  |
-| 15 | `custom_game_crc` | `uint64` | `optional` | `` |  |
-| 16 | `min_player_count` | `uint32` | `optional` | `` |  |
-| 17 | `penalties_enabled` | `bool` | `optional` | `` |  |
+| 1 | `lobby_id` | `fixed64` | `optional` |  |  |
+| 2 | `custom_game_id` | `uint64` | `optional` |  |  |
+| 3 | `lobby_name` | `string` | `optional` |  |  |
+| 4 | `member_count` | `uint32` | `optional` |  |  |
+| 5 | `leader_account_id` | `uint32` | `optional` |  |  |
+| 6 | `leader_name` | `string` | `optional` |  |  |
+| 7 | `custom_map_name` | `string` | `optional` |  |  |
+| 8 | `max_player_count` | `uint32` | `optional` |  |  |
+| 9 | `server_region` | `uint32` | `optional` |  |  |
+| 11 | `has_pass_key` | `bool` | `optional` |  |  |
+| 12 | `lan_host_ping_location` | `string` | `optional` |  |  |
+| 13 | `lobby_creation_time` | `uint32` | `optional` |  |  |
+| 14 | `custom_game_timestamp` | `uint32` | `optional` |  |  |
+| 15 | `custom_game_crc` | `uint64` | `optional` |  |  |
+| 16 | `min_player_count` | `uint32` | `optional` |  |  |
+| 17 | `penalties_enabled` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -586,7 +586,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `lobbies` | `.CMsgJoinableCustomLobbiesResponseEntry` | `repeated` | `` |  |
+| 1 | `lobbies` | `.CMsgJoinableCustomLobbiesResponseEntry` | `repeated` |  |  |
 
 </details>
 
@@ -598,13 +598,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `legacy_server_region` | `uint32` | `optional` | `` |  |
-| 2 | `custom_game_id` | `uint64` | `optional` | `` |  |
-| 3 | `client_version` | `uint32` | `optional` | `` |  |
-| 4 | `create_lobby_details` | `.CMsgPracticeLobbySetDetails` | `optional` | `` |  |
-| 5 | `allow_any_map` | `bool` | `optional` | `` |  |
-| 6 | `legacy_region_pings` | `.CMsgQuickJoinCustomLobby.LegacyRegionPing` | `repeated` | `` |  |
-| 7 | `ping_data` | `.CMsgClientPingData` | `optional` | `` |  |
+| 1 | `legacy_server_region` | `uint32` | `optional` |  |  |
+| 2 | `custom_game_id` | `uint64` | `optional` |  |  |
+| 3 | `client_version` | `uint32` | `optional` |  |  |
+| 4 | `create_lobby_details` | `.CMsgPracticeLobbySetDetails` | `optional` |  |  |
+| 5 | `allow_any_map` | `bool` | `optional` |  |  |
+| 6 | `legacy_region_pings` | `.CMsgQuickJoinCustomLobby.LegacyRegionPing` | `repeated` |  |  |
+| 7 | `ping_data` | `.CMsgClientPingData` | `optional` |  |  |
 
 </details>
 
@@ -616,9 +616,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `server_region` | `uint32` | `optional` | `` |  |
-| 2 | `ping` | `uint32` | `optional` | `` |  |
-| 3 | `region_code` | `fixed32` | `optional` | `` |  |
+| 1 | `server_region` | `uint32` | `optional` |  |  |
+| 2 | `ping` | `uint32` | `optional` |  |  |
+| 3 | `region_code` | `fixed32` | `optional` |  |  |
 
 </details>
 
@@ -630,7 +630,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.DOTAJoinLobbyResult` | `optional` | `` | default = DOTA_JOIN_RESULT_SUCCESS |
+| 1 | `result` | `.DOTAJoinLobbyResult` | `optional` |  | default = DOTA_JOIN_RESULT_SUCCESS |
 
 </details>
 
@@ -642,12 +642,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `search_key` | `string` | `optional` | `` |  |
-| 2 | `client_version` | `uint32` | `optional` | `` |  |
-| 3 | `difficulty_radiant` | `.DOTABotDifficulty` | `optional` | `` | default = BOT_DIFFICULTY_PASSIVE |
-| 4 | `team` | `.DOTA_GC_TEAM` | `optional` | `` | default = DOTA_GC_TEAM_GOOD_GUYS |
-| 5 | `game_mode` | `uint32` | `optional` | `` |  |
-| 6 | `difficulty_dire` | `.DOTABotDifficulty` | `optional` | `` | default = BOT_DIFFICULTY_PASSIVE |
+| 1 | `search_key` | `string` | `optional` |  |  |
+| 2 | `client_version` | `uint32` | `optional` |  |  |
+| 3 | `difficulty_radiant` | `.DOTABotDifficulty` | `optional` |  | default = BOT_DIFFICULTY_PASSIVE |
+| 4 | `team` | `.DOTA_GC_TEAM` | `optional` |  | default = DOTA_GC_TEAM_GOOD_GUYS |
+| 5 | `game_mode` | `uint32` | `optional` |  |  |
+| 6 | `difficulty_dire` | `.DOTABotDifficulty` | `optional` |  | default = BOT_DIFFICULTY_PASSIVE |
 
 </details>
 
@@ -659,7 +659,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `wants_coach` | `bool` | `optional` | `` |  |
+| 1 | `wants_coach` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -671,7 +671,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `new_leader_steamid` | `fixed64` | `optional` | `` |  |
+| 1 | `new_leader_steamid` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -683,8 +683,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `invited_steamids` | `fixed64` | `repeated` | `` |  |
-| 2 | `invited_groupids` | `fixed64` | `repeated` | `` |  |
+| 1 | `invited_steamids` | `fixed64` | `repeated` |  |  |
+| 2 | `invited_groupids` | `fixed64` | `repeated` |  |  |
 
 </details>
 
@@ -696,7 +696,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `open` | `bool` | `optional` | `` |  |
+| 1 | `open` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -708,7 +708,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `other_group_id` | `fixed64` | `optional` | `` |  |
+| 1 | `other_group_id` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -720,8 +720,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `initiator_group_id` | `fixed64` | `optional` | `` |  |
-| 2 | `accept` | `bool` | `optional` | `` |  |
+| 1 | `initiator_group_id` | `fixed64` | `optional` |  |  |
+| 2 | `accept` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -733,7 +733,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.EDOTAGroupMergeResult` | `optional` | `` | default = k_EDOTAGroupMergeResult_OK |
+| 1 | `result` | `.EDOTAGroupMergeResult` | `optional` |  | default = k_EDOTAGroupMergeResult_OK |
 
 </details>
 
@@ -745,16 +745,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `language` | `uint32` | `optional` | `` |  |
-| 2 | `match_id` | `uint64` | `optional` | `` |  |
-| 3 | `server_steam_id` | `fixed64` | `optional` | `` |  |
-| 4 | `stream_url` | `string` | `optional` | `` |  |
-| 5 | `stream_name` | `string` | `optional` | `` |  |
-| 6 | `league_id` | `uint32` | `optional` | `` |  |
-| 7 | `series_type` | `uint32` | `optional` | `` |  |
-| 8 | `series_game` | `uint32` | `optional` | `` |  |
-| 9 | `radiant_team` | `.CMsgSpectatorLobbyGameDetails.Team` | `optional` | `` |  |
-| 10 | `dire_team` | `.CMsgSpectatorLobbyGameDetails.Team` | `optional` | `` |  |
+| 1 | `language` | `uint32` | `optional` |  |  |
+| 2 | `match_id` | `uint64` | `optional` |  |  |
+| 3 | `server_steam_id` | `fixed64` | `optional` |  |  |
+| 4 | `stream_url` | `string` | `optional` |  |  |
+| 5 | `stream_name` | `string` | `optional` |  |  |
+| 6 | `league_id` | `uint32` | `optional` |  |  |
+| 7 | `series_type` | `uint32` | `optional` |  |  |
+| 8 | `series_game` | `uint32` | `optional` |  |  |
+| 9 | `radiant_team` | `.CMsgSpectatorLobbyGameDetails.Team` | `optional` |  |  |
+| 10 | `dire_team` | `.CMsgSpectatorLobbyGameDetails.Team` | `optional` |  |  |
 
 </details>
 
@@ -766,9 +766,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_id` | `uint32` | `optional` | `` |  |
-| 2 | `team_name` | `string` | `optional` | `` |  |
-| 3 | `team_logo` | `fixed64` | `optional` | `` |  |
+| 1 | `team_id` | `uint32` | `optional` |  |  |
+| 2 | `team_name` | `string` | `optional` |  |  |
+| 3 | `team_logo` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -780,10 +780,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `lobby_id` | `uint64` | `optional` | `` |  |
-| 2 | `lobby_name` | `string` | `optional` | `` |  |
-| 3 | `pass_key` | `string` | `optional` | `` |  |
-| 4 | `game_details` | `.CMsgSpectatorLobbyGameDetails` | `optional` | `` |  |
+| 1 | `lobby_id` | `uint64` | `optional` |  |  |
+| 2 | `lobby_name` | `string` | `optional` |  |  |
+| 3 | `pass_key` | `string` | `optional` |  |  |
+| 4 | `game_details` | `.CMsgSpectatorLobbyGameDetails` | `optional` |  |  |
 
 </details>
 
@@ -795,8 +795,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `client_version` | `uint32` | `optional` | `` |  |
-| 2 | `details` | `.CMsgSetSpectatorLobbyDetails` | `optional` | `` |  |
+| 1 | `client_version` | `uint32` | `optional` |  |  |
+| 2 | `details` | `.CMsgSetSpectatorLobbyDetails` | `optional` |  |  |
 
 </details>
 
@@ -820,7 +820,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `lobbies` | `.CMsgSpectatorLobbyListResponse.SpectatorLobby` | `repeated` | `` |  |
+| 1 | `lobbies` | `.CMsgSpectatorLobbyListResponse.SpectatorLobby` | `repeated` |  |  |
 
 </details>
 
@@ -832,12 +832,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `lobby_id` | `uint64` | `optional` | `` |  |
-| 2 | `game_name` | `string` | `optional` | `` |  |
-| 3 | `requires_pass_key` | `bool` | `optional` | `` |  |
-| 4 | `leader_account_id` | `uint32` | `optional` | `` |  |
-| 5 | `member_count` | `uint32` | `optional` | `` |  |
-| 7 | `game_details` | `.CMsgSpectatorLobbyGameDetails` | `optional` | `` |  |
+| 1 | `lobby_id` | `uint64` | `optional` |  |  |
+| 2 | `game_name` | `string` | `optional` |  |  |
+| 3 | `requires_pass_key` | `bool` | `optional` |  |  |
+| 4 | `leader_account_id` | `uint32` | `optional` |  |  |
+| 5 | `member_count` | `uint32` | `optional` |  |  |
+| 7 | `game_details` | `.CMsgSpectatorLobbyGameDetails` | `optional` |  |  |
 
 </details>
 
@@ -849,7 +849,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `server_steam_id` | `fixed64` | `optional` | `` |  |
+| 1 | `server_steam_id` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -861,8 +861,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `serialized_ticket` | `bytes` | `optional` | `` |  |
-| 2 | `message` | `string` | `optional` | `` |  |
+| 1 | `serialized_ticket` | `bytes` | `optional` |  |  |
+| 2 | `message` | `string` | `optional` |  |  |
 
 </details>
 
@@ -874,15 +874,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `legacy_time_expiry` | `fixed32` | `optional` | `` |  |
-| 2 | `legacy_authorized_steam_id` | `fixed64` | `optional` | `` |  |
-| 3 | `legacy_authorized_public_ip` | `fixed32` | `optional` | `` |  |
-| 4 | `legacy_gameserver_steam_id` | `fixed64` | `optional` | `` |  |
-| 5 | `legacy_gameserver_net_id` | `fixed64` | `optional` | `` |  |
-| 6 | `legacy_signature` | `bytes` | `optional` | `` |  |
-| 7 | `legacy_app_id` | `uint32` | `optional` | `` |  |
-| 8 | `legacy_extra_fields` | `bytes` | `repeated` | `` |  |
-| 16 | `serialized_ticket` | `bytes` | `optional` | `` |  |
+| 1 | `legacy_time_expiry` | `fixed32` | `optional` |  |  |
+| 2 | `legacy_authorized_steam_id` | `fixed64` | `optional` |  |  |
+| 3 | `legacy_authorized_public_ip` | `fixed32` | `optional` |  |  |
+| 4 | `legacy_gameserver_steam_id` | `fixed64` | `optional` |  |  |
+| 5 | `legacy_gameserver_net_id` | `fixed64` | `optional` |  |  |
+| 6 | `legacy_signature` | `bytes` | `optional` |  |  |
+| 7 | `legacy_app_id` | `uint32` | `optional` |  |  |
+| 8 | `legacy_extra_fields` | `bytes` | `repeated` |  |  |
+| 16 | `serialized_ticket` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -906,8 +906,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `lane_selection_flags` | `uint32` | `optional` | `` |  |
-| 2 | `high_priority_disabled` | `bool` | `optional` | `` |  |
+| 1 | `lane_selection_flags` | `uint32` | `optional` |  |  |
+| 2 | `high_priority_disabled` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -931,8 +931,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `lane_selection_flags` | `uint32` | `optional` | `` |  |
-| 2 | `high_priority_disabled` | `bool` | `optional` | `` |  |
+| 1 | `lane_selection_flags` | `uint32` | `optional` |  |  |
+| 2 | `high_priority_disabled` | `bool` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-client-showcase.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-client-showcase.md
@@ -31,10 +31,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `uint64` | `optional` | `` |  |
-| 2 | `original_id` | `uint64` | `optional` | `` |  |
-| 3 | `definition_index` | `uint32` | `optional` | `` |  |
-| 4 | `equipment_slot_index` | `int32` | `optional` | `` | default = -1 |
+| 1 | `id` | `uint64` | `optional` |  |  |
+| 2 | `original_id` | `uint64` | `optional` |  |  |
+| 3 | `definition_index` | `uint32` | `optional` |  |  |
+| 4 | `equipment_slot_index` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -46,7 +46,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `flags` | `uint32` | `optional` | `` |  |
+| 1 | `flags` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -58,8 +58,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data` | `.CMsgShowcaseItem_Trophy.Data` | `optional` | `` |  |
-| 2 | `trophy_id` | `uint32` | `optional` | `` |  |
+| 1 | `data` | `.CMsgShowcaseItem_Trophy.Data` | `optional` |  |  |
+| 2 | `trophy_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -71,7 +71,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `trophy_score` | `uint32` | `optional` | `` |  |
+| 1 | `trophy_score` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -83,8 +83,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data` | `.CMsgShowcaseItem_EconItem.Data` | `optional` | `` |  |
-| 2 | `ref` | `.CMsgShowcaseEconItemReference` | `optional` | `` |  |
+| 1 | `data` | `.CMsgShowcaseItem_EconItem.Data` | `optional` |  |  |
+| 2 | `ref` | `.CMsgShowcaseEconItemReference` | `optional` |  |  |
 
 </details>
 
@@ -96,7 +96,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `econ_item` | `.CSOEconItem` | `optional` | `` |  |
+| 1 | `econ_item` | `.CSOEconItem` | `optional` |  |  |
 
 </details>
 
@@ -108,18 +108,18 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data` | `.CMsgShowcaseItem_Hero.Data` | `optional` | `` |  |
-| 2 | `hero_id` | `int32` | `optional` | `` |  |
-| 3 | `econ_item_refs` | `.CMsgShowcaseEconItemReference` | `repeated` | `` |  |
-| 4 | `rotation` | `uint32` | `optional` | `` |  |
-| 5 | `flags` | `uint32` | `optional` | `` |  |
-| 6 | `plus_info` | `.CMsgHeroPlusInfo` | `optional` | `` |  |
-| 7 | `animation_name` | `string` | `optional` | `` |  |
-| 8 | `animation_playback_speed` | `uint32` | `optional` | `` | default = 100 |
-| 9 | `animation_offset` | `uint32` | `optional` | `` |  |
-| 10 | `zoom` | `uint32` | `optional` | `` | default = 100 |
-| 11 | `slot_index` | `uint32` | `optional` | `` |  |
-| 12 | `model_index` | `uint32` | `optional` | `` |  |
+| 1 | `data` | `.CMsgShowcaseItem_Hero.Data` | `optional` |  |  |
+| 2 | `hero_id` | `int32` | `optional` |  |  |
+| 3 | `econ_item_refs` | `.CMsgShowcaseEconItemReference` | `repeated` |  |  |
+| 4 | `rotation` | `uint32` | `optional` |  |  |
+| 5 | `flags` | `uint32` | `optional` |  |  |
+| 6 | `plus_info` | `.CMsgHeroPlusInfo` | `optional` |  |  |
+| 7 | `animation_name` | `string` | `optional` |  |  |
+| 8 | `animation_playback_speed` | `uint32` | `optional` |  | default = 100 |
+| 9 | `animation_offset` | `uint32` | `optional` |  |  |
+| 10 | `zoom` | `uint32` | `optional` |  | default = 100 |
+| 11 | `slot_index` | `uint32` | `optional` |  |  |
+| 12 | `model_index` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -131,9 +131,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `econ_items` | `.CSOEconItem` | `repeated` | `` |  |
-| 2 | `actual_hero_id` | `int32` | `optional` | `` |  |
-| 3 | `plus_hero_xp` | `uint32` | `optional` | `` |  |
+| 1 | `econ_items` | `.CSOEconItem` | `repeated` |  |  |
+| 2 | `actual_hero_id` | `int32` | `optional` |  |  |
+| 3 | `plus_hero_xp` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -145,9 +145,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data` | `.CMsgShowcaseItem_HeroIcon.Data` | `optional` | `` |  |
-| 2 | `hero_id` | `int32` | `optional` | `` |  |
-| 3 | `econ_item_ref` | `.CMsgShowcaseEconItemReference` | `optional` | `` |  |
+| 1 | `data` | `.CMsgShowcaseItem_HeroIcon.Data` | `optional` |  |  |
+| 2 | `hero_id` | `int32` | `optional` |  |  |
+| 3 | `econ_item_ref` | `.CMsgShowcaseEconItemReference` | `optional` |  |  |
 
 </details>
 
@@ -159,7 +159,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `econ_item` | `.CSOEconItem` | `optional` | `` |  |
+| 1 | `econ_item` | `.CSOEconItem` | `optional` |  |  |
 
 </details>
 
@@ -171,9 +171,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data` | `.CMsgShowcaseItem_PlayerMatch.Data` | `optional` | `` |  |
-| 2 | `match_id` | `uint64` | `optional` | `` |  |
-| 3 | `player_slot` | `uint32` | `optional` | `` |  |
+| 1 | `data` | `.CMsgShowcaseItem_PlayerMatch.Data` | `optional` |  |  |
+| 2 | `match_id` | `uint64` | `optional` |  |  |
+| 3 | `player_slot` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -185,14 +185,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `timestamp` | `uint32` | `optional` | `` |  |
-| 3 | `duration` | `uint32` | `optional` | `` |  |
-| 4 | `game_mode` | `.DOTA_GameMode` | `optional` | `` | default = DOTA_GAMEMODE_NONE |
-| 5 | `outcome` | `.CMsgShowcaseItem_PlayerMatch.EPlayerOutcome` | `optional` | `` | default = k_eInvalid |
-| 6 | `kills` | `uint32` | `optional` | `` |  |
-| 7 | `deaths` | `uint32` | `optional` | `` |  |
-| 8 | `assists` | `uint32` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `timestamp` | `uint32` | `optional` |  |  |
+| 3 | `duration` | `uint32` | `optional` |  |  |
+| 4 | `game_mode` | `.DOTA_GameMode` | `optional` |  | default = DOTA_GAMEMODE_NONE |
+| 5 | `outcome` | `.CMsgShowcaseItem_PlayerMatch.EPlayerOutcome` | `optional` |  | default = k_eInvalid |
+| 6 | `kills` | `uint32` | `optional` |  |  |
+| 7 | `deaths` | `uint32` | `optional` |  |  |
+| 8 | `assists` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -204,8 +204,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data` | `.CMsgShowcaseItem_ChatWheel.Data` | `optional` | `` |  |
-| 2 | `chat_wheel_message_id` | `uint32` | `optional` | `` | default = 4294967295 |
+| 1 | `data` | `.CMsgShowcaseItem_ChatWheel.Data` | `optional` |  |  |
+| 2 | `chat_wheel_message_id` | `uint32` | `optional` |  | default = 4294967295 |
 
 </details>
 
@@ -229,8 +229,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data` | `.CMsgShowcaseItem_Emoticon.Data` | `optional` | `` |  |
-| 2 | `emoticon_id` | `uint32` | `optional` | `` |  |
+| 1 | `data` | `.CMsgShowcaseItem_Emoticon.Data` | `optional` |  |  |
+| 2 | `emoticon_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -254,7 +254,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data` | `.CMsgShowcaseItem_SpiderGraph.Data` | `optional` | `` |  |
+| 1 | `data` | `.CMsgShowcaseItem_SpiderGraph.Data` | `optional` |  |  |
 
 </details>
 
@@ -278,7 +278,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data` | `.CMsgShowcaseItem_UserFeed.Data` | `optional` | `` |  |
+| 1 | `data` | `.CMsgShowcaseItem_UserFeed.Data` | `optional` |  |  |
 
 </details>
 
@@ -302,8 +302,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data` | `.CMsgShowcaseItem_Stat.Data` | `optional` | `` |  |
-| 2 | `stat_id` | `.CMsgDOTAProfileCard.EStatID` | `optional` | `` | default = k_eStat_Wins |
+| 1 | `data` | `.CMsgShowcaseItem_Stat.Data` | `optional` |  |  |
+| 2 | `stat_id` | `.CMsgDOTAProfileCard.EStatID` | `optional` |  | default = k_eStat_Wins |
 
 </details>
 
@@ -315,7 +315,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `stat_score` | `uint32` | `optional` | `` |  |
+| 1 | `stat_score` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -327,11 +327,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data` | `.CMsgShowcaseBackground.Data` | `optional` | `` |  |
-| 2 | `loading_screen_ref` | `.CMsgShowcaseEconItemReference` | `optional` | `` |  |
-| 3 | `dim` | `uint32` | `optional` | `` |  |
-| 4 | `blur` | `uint32` | `optional` | `` |  |
-| 5 | `background_id` | `uint32` | `optional` | `` |  |
+| 1 | `data` | `.CMsgShowcaseBackground.Data` | `optional` |  |  |
+| 2 | `loading_screen_ref` | `.CMsgShowcaseEconItemReference` | `optional` |  |  |
+| 3 | `dim` | `uint32` | `optional` |  |  |
+| 4 | `blur` | `uint32` | `optional` |  |  |
+| 5 | `background_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -343,7 +343,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `loading_screen` | `.CSOEconItem` | `optional` | `` |  |
+| 1 | `loading_screen` | `.CSOEconItem` | `optional` |  |  |
 
 </details>
 
@@ -386,16 +386,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `position_x` | `int32` | `optional` | `` |  |
-| 2 | `position_y` | `int32` | `optional` | `` |  |
-| 3 | `scale` | `uint32` | `optional` | `` |  |
-| 4 | `width` | `uint32` | `optional` | `` |  |
-| 5 | `height` | `uint32` | `optional` | `` |  |
-| 6 | `rotation` | `uint32` | `optional` | `` |  |
-| 7 | `parent_id` | `uint32` | `optional` | `` |  |
-| 8 | `parent_attachment_point_id` | `uint32` | `optional` | `` |  |
-| 9 | `attachment_anchor_x` | `uint32` | `optional` | `` |  |
-| 10 | `attachment_anchor_y` | `uint32` | `optional` | `` |  |
+| 1 | `position_x` | `int32` | `optional` |  |  |
+| 2 | `position_y` | `int32` | `optional` |  |  |
+| 3 | `scale` | `uint32` | `optional` |  |  |
+| 4 | `width` | `uint32` | `optional` |  |  |
+| 5 | `height` | `uint32` | `optional` |  |  |
+| 6 | `rotation` | `uint32` | `optional` |  |  |
+| 7 | `parent_id` | `uint32` | `optional` |  |  |
+| 8 | `parent_attachment_point_id` | `uint32` | `optional` |  |  |
+| 9 | `attachment_anchor_x` | `uint32` | `optional` |  |  |
+| 10 | `attachment_anchor_y` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -407,11 +407,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `showcase_item_id` | `uint32` | `optional` | `` |  |
-| 2 | `item_position` | `.CMsgShowcaseItemPosition` | `optional` | `` |  |
-| 3 | `item_data` | `.CMsgShowcaseItemData` | `optional` | `` |  |
-| 4 | `state` | `.EShowcaseItemState` | `optional` | `` | default = k_eShowcaseItemState_Ok |
-| 5 | `flags` | `uint32` | `optional` | `` |  |
+| 1 | `showcase_item_id` | `uint32` | `optional` |  |  |
+| 2 | `item_position` | `.CMsgShowcaseItemPosition` | `optional` |  |  |
+| 3 | `item_data` | `.CMsgShowcaseItemData` | `optional` |  |  |
+| 4 | `state` | `.EShowcaseItemState` | `optional` |  | default = k_eShowcaseItemState_Ok |
+| 5 | `flags` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -423,9 +423,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `showcase_items` | `.CMsgShowcaseItem` | `repeated` | `` |  |
-| 3 | `background` | `.CMsgShowcaseItem` | `optional` | `` |  |
-| 4 | `moderation_state` | `.CMsgShowcase.EModerationState` | `optional` | `` | default = k_eModerationState_Ok |
+| 1 | `showcase_items` | `.CMsgShowcaseItem` | `repeated` |  |  |
+| 3 | `background` | `.CMsgShowcaseItem` | `optional` |  |  |
+| 4 | `moderation_state` | `.CMsgShowcase.EModerationState` | `optional` |  | default = k_eModerationState_Ok |
 
 </details>
 
@@ -437,8 +437,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `showcase_type` | `.EShowcaseType` | `optional` | `` | default = k_eShowcaseType_Invalid |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `showcase_type` | `.EShowcaseType` | `optional` |  | default = k_eShowcaseType_Invalid |
 
 </details>
 
@@ -450,8 +450,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCShowcaseGetUserDataResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `showcase` | `.CMsgShowcase` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCShowcaseGetUserDataResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `showcase` | `.CMsgShowcase` | `optional` |  |  |
 
 </details>
 
@@ -463,9 +463,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `showcase_type` | `.EShowcaseType` | `optional` | `` | default = k_eShowcaseType_Invalid |
-| 2 | `showcase` | `.CMsgShowcase` | `optional` | `` |  |
-| 3 | `format_version` | `uint32` | `optional` | `` |  |
+| 1 | `showcase_type` | `.EShowcaseType` | `optional` |  | default = k_eShowcaseType_Invalid |
+| 2 | `showcase` | `.CMsgShowcase` | `optional` |  |  |
+| 3 | `format_version` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -477,9 +477,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCShowcaseSetUserDataResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `validated_showcase` | `.CMsgShowcase` | `optional` | `` |  |
-| 3 | `locked_until_timestamp` | `uint32` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCShowcaseSetUserDataResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `validated_showcase` | `.CMsgShowcase` | `optional` |  |  |
+| 3 | `locked_until_timestamp` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -491,9 +491,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `showcase_type` | `.EShowcaseType` | `optional` | `` | default = k_eShowcaseType_Invalid |
-| 3 | `report_comment` | `string` | `optional` | `` |  |
+| 1 | `target_account_id` | `uint32` | `optional` |  |  |
+| 2 | `showcase_type` | `.EShowcaseType` | `optional` |  | default = k_eShowcaseType_Invalid |
+| 3 | `report_comment` | `string` | `optional` |  |  |
 
 </details>
 
@@ -505,7 +505,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCShowcaseSubmitReportResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCShowcaseSubmitReportResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -517,9 +517,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `rollup_id` | `uint32` | `optional` | `` |  |
-| 2 | `start_timestamp` | `uint32` | `optional` | `` |  |
-| 3 | `end_timestamp` | `uint32` | `optional` | `` |  |
+| 1 | `rollup_id` | `uint32` | `optional` |  |  |
+| 2 | `start_timestamp` | `uint32` | `optional` |  |  |
+| 3 | `end_timestamp` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -531,7 +531,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `rollups` | `.CMsgShowcaseReportsRollupInfo` | `repeated` | `` |  |
+| 1 | `rollups` | `.CMsgShowcaseReportsRollupInfo` | `repeated` |  |  |
 
 </details>
 
@@ -543,9 +543,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `showcase_type` | `.EShowcaseType` | `optional` | `` | default = k_eShowcaseType_Invalid |
-| 3 | `report_count` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `showcase_type` | `.EShowcaseType` | `optional` |  | default = k_eShowcaseType_Invalid |
+| 3 | `report_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -557,8 +557,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `rollup_info` | `.CMsgShowcaseReportsRollupInfo` | `optional` | `` |  |
-| 2 | `rollup_entries` | `.CMsgShowcaseReportsRollupEntry` | `repeated` | `` |  |
+| 1 | `rollup_info` | `.CMsgShowcaseReportsRollupInfo` | `optional` |  |  |
+| 2 | `rollup_entries` | `.CMsgShowcaseReportsRollupEntry` | `repeated` |  |  |
 
 </details>
 
@@ -582,8 +582,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCShowcaseAdminGetReportsRollupListResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `rollup_list` | `.CMsgShowcaseReportsRollupList` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCShowcaseAdminGetReportsRollupListResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `rollup_list` | `.CMsgShowcaseReportsRollupList` | `optional` |  |  |
 
 </details>
 
@@ -595,7 +595,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `rollup_id` | `uint32` | `optional` | `` |  |
+| 1 | `rollup_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -607,8 +607,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCShowcaseAdminGetReportsRollupResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `rollup` | `.CMsgShowcaseReportsRollup` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCShowcaseAdminGetReportsRollupResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `rollup` | `.CMsgShowcaseReportsRollup` | `optional` |  |  |
 
 </details>
 
@@ -620,10 +620,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `showcase_type` | `.EShowcaseType` | `optional` | `` | default = k_eShowcaseType_Invalid |
-| 2 | `audit_action` | `.EShowcaseAuditAction` | `optional` | `` | default = k_eShowcaseAuditAction_Invalid |
-| 3 | `audit_data` | `uint64` | `optional` | `` |  |
-| 4 | `timestamp` | `uint32` | `optional` | `` |  |
+| 1 | `showcase_type` | `.EShowcaseType` | `optional` |  | default = k_eShowcaseType_Invalid |
+| 2 | `audit_action` | `.EShowcaseAuditAction` | `optional` |  | default = k_eShowcaseAuditAction_Invalid |
+| 3 | `audit_data` | `uint64` | `optional` |  |  |
+| 4 | `timestamp` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -635,10 +635,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `reporter_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `showcase_type` | `.EShowcaseType` | `optional` | `` | default = k_eShowcaseType_Invalid |
-| 3 | `report_timestamp` | `uint32` | `optional` | `` |  |
-| 4 | `report_comment` | `string` | `optional` | `` |  |
+| 1 | `reporter_account_id` | `uint32` | `optional` |  |  |
+| 2 | `showcase_type` | `.EShowcaseType` | `optional` |  | default = k_eShowcaseType_Invalid |
+| 3 | `report_timestamp` | `uint32` | `optional` |  |  |
+| 4 | `report_comment` | `string` | `optional` |  |  |
 
 </details>
 
@@ -650,9 +650,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `locked_until_timestamp` | `uint32` | `optional` | `` |  |
-| 2 | `audit_entries` | `.CMsgShowcaseAuditEntry` | `repeated` | `` |  |
-| 3 | `reports` | `.CMsgShowcaseReport` | `repeated` | `` |  |
+| 1 | `locked_until_timestamp` | `uint32` | `optional` |  |  |
+| 2 | `audit_entries` | `.CMsgShowcaseAuditEntry` | `repeated` |  |  |
+| 3 | `reports` | `.CMsgShowcaseReport` | `repeated` |  |  |
 
 </details>
 
@@ -664,7 +664,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -676,8 +676,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCShowcaseAdminGetUserDetailsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `user_details` | `.CMsgShowcaseAdminUserDetails` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCShowcaseAdminGetUserDetailsResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `user_details` | `.CMsgShowcaseAdminUserDetails` | `optional` |  |  |
 
 </details>
 
@@ -689,8 +689,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `showcase_type` | `.EShowcaseType` | `optional` | `` | default = k_eShowcaseType_Invalid |
+| 1 | `target_account_id` | `uint32` | `optional` |  |  |
+| 2 | `showcase_type` | `.EShowcaseType` | `optional` |  | default = k_eShowcaseType_Invalid |
 
 </details>
 
@@ -702,7 +702,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCShowcaseAdminResetResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCShowcaseAdminResetResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -714,8 +714,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `locked_until_timestamp` | `uint32` | `optional` | `` |  |
+| 1 | `target_account_id` | `uint32` | `optional` |  |  |
+| 2 | `locked_until_timestamp` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -727,7 +727,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCShowcaseAdminLockAccountResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCShowcaseAdminLockAccountResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -739,8 +739,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `showcase_type` | `.EShowcaseType` | `optional` | `` | default = k_eShowcaseType_Invalid |
+| 1 | `target_account_id` | `uint32` | `optional` |  |  |
+| 2 | `showcase_type` | `.EShowcaseType` | `optional` |  | default = k_eShowcaseType_Invalid |
 
 </details>
 
@@ -752,7 +752,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCShowcaseAdminConvictResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCShowcaseAdminConvictResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -764,8 +764,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `showcase_type` | `.EShowcaseType` | `optional` | `` | default = k_eShowcaseType_Invalid |
+| 1 | `target_account_id` | `uint32` | `optional` |  |  |
+| 2 | `showcase_type` | `.EShowcaseType` | `optional` |  | default = k_eShowcaseType_Invalid |
 
 </details>
 
@@ -777,7 +777,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCShowcaseAdminExonerateResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCShowcaseAdminExonerateResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -789,9 +789,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `showcase_type` | `.EShowcaseType` | `optional` | `` | default = k_eShowcaseType_Invalid |
-| 3 | `showcase_timestamp` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `showcase_type` | `.EShowcaseType` | `optional` |  | default = k_eShowcaseType_Invalid |
+| 3 | `showcase_timestamp` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -803,8 +803,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `start_timestamp` | `uint32` | `optional` | `` |  |
-| 2 | `result_count` | `uint32` | `optional` | `` |  |
+| 1 | `start_timestamp` | `uint32` | `optional` |  |  |
+| 2 | `result_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -816,8 +816,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCShowcaseModerationGetQueueResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `showcases` | `.CMsgShowcaseModerationInfo` | `repeated` | `` |  |
+| 1 | `response` | `.CMsgClientToGCShowcaseModerationGetQueueResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `showcases` | `.CMsgShowcaseModerationInfo` | `repeated` |  |  |
 
 </details>
 
@@ -829,10 +829,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `showcase_type` | `.EShowcaseType` | `optional` | `` | default = k_eShowcaseType_Invalid |
-| 3 | `showcase_timestamp` | `uint32` | `optional` | `` |  |
-| 4 | `approve` | `bool` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `showcase_type` | `.EShowcaseType` | `optional` |  | default = k_eShowcaseType_Invalid |
+| 3 | `showcase_timestamp` | `uint32` | `optional` |  |  |
+| 4 | `approve` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -844,7 +844,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCShowcaseModerationApplyModerationResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCShowcaseModerationApplyModerationResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-client-team.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-client-team.md
@@ -23,33 +23,33 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `members` | `.CMsgDOTATeamInfo.Member` | `repeated` | `` |  |
-| 2 | `team_id` | `uint32` | `optional` | `` |  |
-| 3 | `name` | `string` | `optional` | `` |  |
-| 4 | `tag` | `string` | `optional` | `` |  |
-| 5 | `time_created` | `uint32` | `optional` | `` |  |
-| 6 | `pro` | `bool` | `optional` | `` |  |
-| 8 | `pickup_team` | `bool` | `optional` | `` |  |
-| 9 | `ugc_logo` | `uint64` | `optional` | `` |  |
-| 10 | `ugc_base_logo` | `uint64` | `optional` | `` |  |
-| 11 | `ugc_banner_logo` | `uint64` | `optional` | `` |  |
-| 12 | `ugc_sponsor_logo` | `uint64` | `optional` | `` |  |
-| 13 | `country_code` | `string` | `optional` | `` |  |
-| 14 | `url` | `string` | `optional` | `` |  |
-| 15 | `wins` | `uint32` | `optional` | `` |  |
-| 16 | `losses` | `uint32` | `optional` | `` |  |
-| 19 | `games_played_total` | `uint32` | `optional` | `` |  |
-| 20 | `games_played_matchmaking` | `uint32` | `optional` | `` |  |
-| 24 | `url_logo` | `string` | `optional` | `` |  |
-| 29 | `region` | `.ELeagueRegion` | `optional` | `` | default = LEAGUE_REGION_UNSET |
-| 31 | `audit_entries` | `.CMsgDOTATeamInfo.AuditEntry` | `repeated` | `` |  |
-| 32 | `abbreviation` | `string` | `optional` | `` |  |
-| 33 | `member_stats` | `.CMsgDOTATeamInfo.MemberStats` | `repeated` | `` |  |
-| 34 | `team_stats` | `.CMsgDOTATeamInfo.TeamStats` | `optional` | `` |  |
-| 35 | `dpc_results` | `.CMsgDOTATeamInfo.DPCResult` | `repeated` | `` |  |
-| 37 | `color_primary` | `string` | `optional` | `` |  |
-| 38 | `color_secondary` | `string` | `optional` | `` |  |
-| 39 | `team_captain` | `uint32` | `optional` | `` |  |
+| 1 | `members` | `.CMsgDOTATeamInfo.Member` | `repeated` |  |  |
+| 2 | `team_id` | `uint32` | `optional` |  |  |
+| 3 | `name` | `string` | `optional` |  |  |
+| 4 | `tag` | `string` | `optional` |  |  |
+| 5 | `time_created` | `uint32` | `optional` |  |  |
+| 6 | `pro` | `bool` | `optional` |  |  |
+| 8 | `pickup_team` | `bool` | `optional` |  |  |
+| 9 | `ugc_logo` | `uint64` | `optional` |  |  |
+| 10 | `ugc_base_logo` | `uint64` | `optional` |  |  |
+| 11 | `ugc_banner_logo` | `uint64` | `optional` |  |  |
+| 12 | `ugc_sponsor_logo` | `uint64` | `optional` |  |  |
+| 13 | `country_code` | `string` | `optional` |  |  |
+| 14 | `url` | `string` | `optional` |  |  |
+| 15 | `wins` | `uint32` | `optional` |  |  |
+| 16 | `losses` | `uint32` | `optional` |  |  |
+| 19 | `games_played_total` | `uint32` | `optional` |  |  |
+| 20 | `games_played_matchmaking` | `uint32` | `optional` |  |  |
+| 24 | `url_logo` | `string` | `optional` |  |  |
+| 29 | `region` | `.ELeagueRegion` | `optional` |  | default = LEAGUE_REGION_UNSET |
+| 31 | `audit_entries` | `.CMsgDOTATeamInfo.AuditEntry` | `repeated` |  |  |
+| 32 | `abbreviation` | `string` | `optional` |  |  |
+| 33 | `member_stats` | `.CMsgDOTATeamInfo.MemberStats` | `repeated` |  |  |
+| 34 | `team_stats` | `.CMsgDOTATeamInfo.TeamStats` | `optional` |  |  |
+| 35 | `dpc_results` | `.CMsgDOTATeamInfo.DPCResult` | `repeated` |  |  |
+| 37 | `color_primary` | `string` | `optional` |  |  |
+| 38 | `color_secondary` | `string` | `optional` |  |  |
+| 39 | `team_captain` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -61,15 +61,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `picks` | `uint32` | `optional` | `` |  |
-| 3 | `wins` | `uint32` | `optional` | `` |  |
-| 4 | `bans` | `uint32` | `optional` | `` |  |
-| 5 | `avg_kills` | `float` | `optional` | `` |  |
-| 6 | `avg_deaths` | `float` | `optional` | `` |  |
-| 7 | `avg_assists` | `float` | `optional` | `` |  |
-| 8 | `avg_gpm` | `float` | `optional` | `` |  |
-| 9 | `avg_xpm` | `float` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `picks` | `uint32` | `optional` |  |  |
+| 3 | `wins` | `uint32` | `optional` |  |  |
+| 4 | `bans` | `uint32` | `optional` |  |  |
+| 5 | `avg_kills` | `float` | `optional` |  |  |
+| 6 | `avg_deaths` | `float` | `optional` |  |  |
+| 7 | `avg_assists` | `float` | `optional` |  |  |
+| 8 | `avg_gpm` | `float` | `optional` |  |  |
+| 9 | `avg_xpm` | `float` | `optional` |  |  |
 
 </details>
 
@@ -81,13 +81,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `wins_with_team` | `uint32` | `optional` | `` |  |
-| 3 | `losses_with_team` | `uint32` | `optional` | `` |  |
-| 4 | `top_heroes` | `.CMsgDOTATeamInfo.HeroStats` | `repeated` | `` |  |
-| 5 | `avg_kills` | `float` | `optional` | `` |  |
-| 6 | `avg_deaths` | `float` | `optional` | `` |  |
-| 7 | `avg_assists` | `float` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `wins_with_team` | `uint32` | `optional` |  |  |
+| 3 | `losses_with_team` | `uint32` | `optional` |  |  |
+| 4 | `top_heroes` | `.CMsgDOTATeamInfo.HeroStats` | `repeated` |  |  |
+| 5 | `avg_kills` | `float` | `optional` |  |  |
+| 6 | `avg_deaths` | `float` | `optional` |  |  |
+| 7 | `avg_assists` | `float` | `optional` |  |  |
 
 </details>
 
@@ -99,13 +99,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `played_heroes` | `.CMsgDOTATeamInfo.HeroStats` | `repeated` | `` |  |
-| 2 | `farming` | `float` | `optional` | `` |  |
-| 3 | `fighting` | `float` | `optional` | `` |  |
-| 4 | `versatility` | `float` | `optional` | `` |  |
-| 5 | `avg_kills` | `float` | `optional` | `` |  |
-| 6 | `avg_deaths` | `float` | `optional` | `` |  |
-| 7 | `avg_duration` | `float` | `optional` | `` |  |
+| 1 | `played_heroes` | `.CMsgDOTATeamInfo.HeroStats` | `repeated` |  |  |
+| 2 | `farming` | `float` | `optional` |  |  |
+| 3 | `fighting` | `float` | `optional` |  |  |
+| 4 | `versatility` | `float` | `optional` |  |  |
+| 5 | `avg_kills` | `float` | `optional` |  |  |
+| 6 | `avg_deaths` | `float` | `optional` |  |  |
+| 7 | `avg_duration` | `float` | `optional` |  |  |
 
 </details>
 
@@ -117,11 +117,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 2 | `standing` | `uint32` | `optional` | `` |  |
-| 3 | `points` | `uint32` | `optional` | `` |  |
-| 4 | `earnings` | `uint32` | `optional` | `` |  |
-| 5 | `timestamp` | `uint32` | `optional` | `` |  |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 2 | `standing` | `uint32` | `optional` |  |  |
+| 3 | `points` | `uint32` | `optional` |  |  |
+| 4 | `earnings` | `uint32` | `optional` |  |  |
+| 5 | `timestamp` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -133,12 +133,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `time_joined` | `uint32` | `optional` | `` |  |
-| 3 | `admin` | `bool` | `optional` | `` |  |
-| 6 | `pro_name` | `string` | `optional` | `` |  |
-| 8 | `role` | `.Fantasy_Roles` | `optional` | `` | default = FANTASY_ROLE_UNDEFINED |
-| 9 | `real_name` | `string` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `time_joined` | `uint32` | `optional` |  |  |
+| 3 | `admin` | `bool` | `optional` |  |  |
+| 6 | `pro_name` | `string` | `optional` |  |  |
+| 8 | `role` | `.Fantasy_Roles` | `optional` |  | default = FANTASY_ROLE_UNDEFINED |
+| 9 | `real_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -150,9 +150,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `audit_action` | `uint32` | `optional` | `` |  |
-| 2 | `timestamp` | `uint32` | `optional` | `` |  |
-| 3 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `audit_action` | `uint32` | `optional` |  |  |
+| 2 | `timestamp` | `uint32` | `optional` |  |  |
+| 3 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -164,8 +164,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 2 | `teams` | `.CMsgDOTATeamInfo` | `repeated` | `` |  |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 2 | `teams` | `.CMsgDOTATeamInfo` | `repeated` |  |  |
 
 </details>
 
@@ -177,7 +177,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `teams` | `.CMsgDOTATeamInfo` | `repeated` | `` |  |
+| 1 | `teams` | `.CMsgDOTATeamInfo` | `repeated` |  |  |
 
 </details>
 
@@ -189,8 +189,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cache_timestamp` | `uint32` | `optional` | `` |  |
-| 2 | `team_list` | `.CMsgDOTATeamInfoList` | `optional` | `` |  |
+| 1 | `cache_timestamp` | `uint32` | `optional` |  |  |
+| 2 | `team_list` | `.CMsgDOTATeamInfoList` | `optional` |  |  |
 
 </details>
 
@@ -214,16 +214,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `tag` | `string` | `optional` | `` |  |
-| 3 | `logo` | `uint64` | `optional` | `` |  |
-| 4 | `base_logo` | `uint64` | `optional` | `` |  |
-| 5 | `banner_logo` | `uint64` | `optional` | `` |  |
-| 6 | `sponsor_logo` | `uint64` | `optional` | `` |  |
-| 7 | `country_code` | `string` | `optional` | `` |  |
-| 8 | `url` | `string` | `optional` | `` |  |
-| 9 | `pickup_team` | `bool` | `optional` | `` |  |
-| 10 | `abbreviation` | `string` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `tag` | `string` | `optional` |  |  |
+| 3 | `logo` | `uint64` | `optional` |  |  |
+| 4 | `base_logo` | `uint64` | `optional` |  |  |
+| 5 | `banner_logo` | `uint64` | `optional` |  |  |
+| 6 | `sponsor_logo` | `uint64` | `optional` |  |  |
+| 7 | `country_code` | `string` | `optional` |  |  |
+| 8 | `url` | `string` | `optional` |  |  |
+| 9 | `pickup_team` | `bool` | `optional` |  |  |
+| 10 | `abbreviation` | `string` | `optional` |  |  |
 
 </details>
 
@@ -235,8 +235,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgDOTACreateTeamResponse.Result` | `optional` | `` | default = INVALID |
-| 2 | `team_id` | `uint32` | `optional` | `` |  |
+| 1 | `result` | `.CMsgDOTACreateTeamResponse.Result` | `optional` |  | default = INVALID |
+| 2 | `team_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -248,17 +248,17 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_id` | `uint32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `tag` | `string` | `optional` | `` |  |
-| 4 | `logo` | `uint64` | `optional` | `` |  |
-| 5 | `base_logo` | `uint64` | `optional` | `` |  |
-| 6 | `banner_logo` | `uint64` | `optional` | `` |  |
-| 7 | `sponsor_logo` | `uint64` | `optional` | `` |  |
-| 8 | `country_code` | `string` | `optional` | `` |  |
-| 9 | `url` | `string` | `optional` | `` |  |
-| 10 | `in_use_by_party` | `bool` | `optional` | `` |  |
-| 11 | `abbreviation` | `string` | `optional` | `` |  |
+| 1 | `team_id` | `uint32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `tag` | `string` | `optional` |  |  |
+| 4 | `logo` | `uint64` | `optional` |  |  |
+| 5 | `base_logo` | `uint64` | `optional` |  |  |
+| 6 | `banner_logo` | `uint64` | `optional` |  |  |
+| 7 | `sponsor_logo` | `uint64` | `optional` |  |  |
+| 8 | `country_code` | `string` | `optional` |  |  |
+| 9 | `url` | `string` | `optional` |  |  |
+| 10 | `in_use_by_party` | `bool` | `optional` |  |  |
+| 11 | `abbreviation` | `string` | `optional` |  |  |
 
 </details>
 
@@ -270,7 +270,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgDOTAEditTeamDetailsResponse.Result` | `optional` | `` | default = SUCCESS |
+| 1 | `result` | `.CMsgDOTAEditTeamDetailsResponse.Result` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -282,8 +282,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `team_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `team_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -295,9 +295,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.ETeamInviteResult` | `optional` | `` | default = TEAM_INVITE_SUCCESS |
-| 2 | `invitee_name` | `string` | `optional` | `` |  |
-| 3 | `required_play_time` | `uint32` | `optional` | `` |  |
+| 1 | `result` | `.ETeamInviteResult` | `optional` |  | default = TEAM_INVITE_SUCCESS |
+| 2 | `invitee_name` | `string` | `optional` |  |  |
+| 3 | `required_play_time` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -309,10 +309,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `inviter_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `team_name` | `string` | `optional` | `` |  |
-| 3 | `team_tag` | `string` | `optional` | `` |  |
-| 4 | `logo` | `uint64` | `optional` | `` |  |
+| 1 | `inviter_account_id` | `uint32` | `optional` |  |  |
+| 2 | `team_name` | `string` | `optional` |  |  |
+| 3 | `team_tag` | `string` | `optional` |  |  |
+| 4 | `logo` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -324,7 +324,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.ETeamInviteResult` | `optional` | `` | default = TEAM_INVITE_SUCCESS |
+| 1 | `result` | `.ETeamInviteResult` | `optional` |  | default = TEAM_INVITE_SUCCESS |
 
 </details>
 
@@ -336,8 +336,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.ETeamInviteResult` | `optional` | `` | default = TEAM_INVITE_SUCCESS |
-| 2 | `invitee_name` | `string` | `optional` | `` |  |
+| 1 | `result` | `.ETeamInviteResult` | `optional` |  | default = TEAM_INVITE_SUCCESS |
+| 2 | `invitee_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -349,8 +349,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.ETeamInviteResult` | `optional` | `` | default = TEAM_INVITE_SUCCESS |
-| 2 | `team_name` | `string` | `optional` | `` |  |
+| 1 | `result` | `.ETeamInviteResult` | `optional` |  | default = TEAM_INVITE_SUCCESS |
+| 2 | `team_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -362,8 +362,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `team_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `team_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -375,7 +375,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgDOTAKickTeamMemberResponse.Result` | `optional` | `` | default = SUCCESS |
+| 1 | `result` | `.CMsgDOTAKickTeamMemberResponse.Result` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -387,8 +387,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `new_admin_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `team_id` | `uint32` | `optional` | `` |  |
+| 1 | `new_admin_account_id` | `uint32` | `optional` |  |  |
+| 2 | `team_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -400,7 +400,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgDOTATransferTeamAdminResponse.Result` | `optional` | `` | default = SUCCESS |
+| 1 | `result` | `.CMsgDOTATransferTeamAdminResponse.Result` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -412,7 +412,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_id` | `uint32` | `optional` | `` |  |
+| 1 | `team_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -424,7 +424,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgDOTALeaveTeamResponse.Result` | `optional` | `` | default = SUCCESS |
+| 1 | `result` | `.CMsgDOTALeaveTeamResponse.Result` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -436,7 +436,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `access_rights` | `uint32` | `optional` | `` |  |
+| 1 | `access_rights` | `uint32` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-client-tournament.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-client-tournament.md
@@ -35,7 +35,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `divisions` | `.CMsgWeekendTourneySchedule.Division` | `repeated` | `` |  |
+| 1 | `divisions` | `.CMsgWeekendTourneySchedule.Division` | `repeated` |  |  |
 
 </details>
 
@@ -47,12 +47,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `division_code` | `uint32` | `optional` | `` |  |
-| 2 | `time_window_open` | `uint32` | `optional` | `` |  |
-| 3 | `time_window_close` | `uint32` | `optional` | `` |  |
-| 4 | `time_window_open_next` | `uint32` | `optional` | `` |  |
-| 5 | `trophy_id` | `uint32` | `optional` | `` |  |
-| 6 | `free_weekend` | `bool` | `optional` | `` |  |
+| 1 | `division_code` | `uint32` | `optional` |  |  |
+| 2 | `time_window_open` | `uint32` | `optional` |  |  |
+| 3 | `time_window_close` | `uint32` | `optional` |  |  |
+| 4 | `time_window_open_next` | `uint32` | `optional` |  |  |
+| 5 | `trophy_id` | `uint32` | `optional` |  |  |
+| 6 | `free_weekend` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -64,14 +64,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `participating` | `bool` | `optional` | `` |  |
-| 2 | `division_id` | `uint32` | `optional` | `` |  |
-| 3 | `buyin` | `uint32` | `optional` | `` |  |
-| 4 | `skill_level` | `uint32` | `optional` | `` |  |
-| 5 | `match_groups` | `uint32` | `optional` | `` |  |
-| 6 | `team_id` | `uint32` | `optional` | `` |  |
-| 7 | `pickup_team_name` | `string` | `optional` | `` |  |
-| 8 | `pickup_team_logo` | `uint64` | `optional` | `` |  |
+| 1 | `participating` | `bool` | `optional` |  |  |
+| 2 | `division_id` | `uint32` | `optional` |  |  |
+| 3 | `buyin` | `uint32` | `optional` |  |  |
+| 4 | `skill_level` | `uint32` | `optional` |  |  |
+| 5 | `match_groups` | `uint32` | `optional` |  |  |
+| 6 | `team_id` | `uint32` | `optional` |  |  |
+| 7 | `pickup_team_name` | `string` | `optional` |  |  |
+| 8 | `pickup_team_logo` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -95,17 +95,17 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tournament_id` | `uint32` | `optional` | `` |  |
-| 2 | `division_id` | `uint32` | `optional` | `` |  |
-| 3 | `schedule_time` | `uint32` | `optional` | `` |  |
-| 4 | `skill_level` | `uint32` | `optional` | `` |  |
-| 5 | `tournament_template` | `.ETournamentTemplate` | `optional` | `` | default = k_ETournamentTemplate_None |
-| 6 | `state` | `.ETournamentState` | `optional` | `` | default = k_ETournamentState_Unknown |
-| 7 | `teams` | `.CMsgDOTATournament.Team` | `repeated` | `` |  |
-| 8 | `games` | `.CMsgDOTATournament.Game` | `repeated` | `` |  |
-| 9 | `nodes` | `.CMsgDOTATournament.Node` | `repeated` | `` |  |
-| 10 | `state_seq_num` | `uint32` | `optional` | `` |  |
-| 11 | `season_trophy_id` | `uint32` | `optional` | `` |  |
+| 1 | `tournament_id` | `uint32` | `optional` |  |  |
+| 2 | `division_id` | `uint32` | `optional` |  |  |
+| 3 | `schedule_time` | `uint32` | `optional` |  |  |
+| 4 | `skill_level` | `uint32` | `optional` |  |  |
+| 5 | `tournament_template` | `.ETournamentTemplate` | `optional` |  | default = k_ETournamentTemplate_None |
+| 6 | `state` | `.ETournamentState` | `optional` |  | default = k_ETournamentState_Unknown |
+| 7 | `teams` | `.CMsgDOTATournament.Team` | `repeated` |  |  |
+| 8 | `games` | `.CMsgDOTATournament.Game` | `repeated` |  |  |
+| 9 | `nodes` | `.CMsgDOTATournament.Node` | `repeated` |  |  |
+| 10 | `state_seq_num` | `uint32` | `optional` |  |  |
+| 11 | `season_trophy_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -117,16 +117,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_gid` | `fixed64` | `optional` | `` |  |
-| 2 | `node_or_state` | `uint32` | `optional` | `` |  |
-| 3 | `players` | `uint32` | `repeated` | `` | packed = true |
-| 4 | `team_id` | `uint32` | `optional` | `` |  |
-| 5 | `team_name` | `string` | `optional` | `` |  |
-| 7 | `team_base_logo` | `uint64` | `optional` | `` |  |
-| 8 | `team_ui_logo` | `uint64` | `optional` | `` |  |
-| 9 | `player_buyin` | `uint32` | `repeated` | `` | packed = true |
-| 10 | `player_skill_level` | `uint32` | `repeated` | `` | packed = true |
-| 12 | `match_group_mask` | `uint32` | `optional` | `` |  |
+| 1 | `team_gid` | `fixed64` | `optional` |  |  |
+| 2 | `node_or_state` | `uint32` | `optional` |  |  |
+| 3 | `players` | `uint32` | `repeated` |  | packed = true |
+| 4 | `team_id` | `uint32` | `optional` |  |  |
+| 5 | `team_name` | `string` | `optional` |  |  |
+| 7 | `team_base_logo` | `uint64` | `optional` |  |  |
+| 8 | `team_ui_logo` | `uint64` | `optional` |  |  |
+| 9 | `player_buyin` | `uint32` | `repeated` |  | packed = true |
+| 10 | `player_skill_level` | `uint32` | `repeated` |  | packed = true |
+| 12 | `match_group_mask` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -138,12 +138,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `node_idx` | `uint32` | `optional` | `` |  |
-| 2 | `lobby_id` | `fixed64` | `optional` | `` |  |
-| 3 | `match_id` | `uint64` | `optional` | `` |  |
-| 4 | `team_a_good` | `bool` | `optional` | `` |  |
-| 5 | `state` | `.ETournamentGameState` | `optional` | `` | default = k_ETournamentGameState_Unknown |
-| 6 | `start_time` | `uint32` | `optional` | `` |  |
+| 1 | `node_idx` | `uint32` | `optional` |  |  |
+| 2 | `lobby_id` | `fixed64` | `optional` |  |  |
+| 3 | `match_id` | `uint64` | `optional` |  |  |
+| 4 | `team_a_good` | `bool` | `optional` |  |  |
+| 5 | `state` | `.ETournamentGameState` | `optional` |  | default = k_ETournamentGameState_Unknown |
+| 6 | `start_time` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -155,10 +155,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `node_id` | `uint32` | `optional` | `` |  |
-| 2 | `team_idx_a` | `uint32` | `optional` | `` |  |
-| 3 | `team_idx_b` | `uint32` | `optional` | `` |  |
-| 4 | `node_state` | `.ETournamentNodeState` | `optional` | `` | default = k_ETournamentNodeState_Unknown |
+| 1 | `node_id` | `uint32` | `optional` |  |  |
+| 2 | `team_idx_a` | `uint32` | `optional` |  |  |
+| 3 | `team_idx_b` | `uint32` | `optional` |  |  |
+| 4 | `node_state` | `.ETournamentNodeState` | `optional` |  | default = k_ETournamentNodeState_Unknown |
 
 </details>
 
@@ -170,13 +170,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `new_tournament_id` | `uint32` | `optional` | `` |  |
-| 2 | `event` | `.ETournamentEvent` | `optional` | `` | default = k_ETournamentEvent_None |
-| 3 | `new_tournament_state` | `.ETournamentState` | `optional` | `` | default = k_ETournamentState_Unknown |
-| 4 | `game_changes` | `.CMsgDOTATournamentStateChange.GameChange` | `repeated` | `` |  |
-| 5 | `team_changes` | `.CMsgDOTATournamentStateChange.TeamChange` | `repeated` | `` |  |
-| 6 | `merged_tournament_ids` | `uint32` | `repeated` | `` | packed = true |
-| 7 | `state_seq_num` | `uint32` | `optional` | `` |  |
+| 1 | `new_tournament_id` | `uint32` | `optional` |  |  |
+| 2 | `event` | `.ETournamentEvent` | `optional` |  | default = k_ETournamentEvent_None |
+| 3 | `new_tournament_state` | `.ETournamentState` | `optional` |  | default = k_ETournamentState_Unknown |
+| 4 | `game_changes` | `.CMsgDOTATournamentStateChange.GameChange` | `repeated` |  |  |
+| 5 | `team_changes` | `.CMsgDOTATournamentStateChange.TeamChange` | `repeated` |  |  |
+| 6 | `merged_tournament_ids` | `uint32` | `repeated` |  | packed = true |
+| 7 | `state_seq_num` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -188,8 +188,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `new_state` | `.ETournamentGameState` | `optional` | `` | default = k_ETournamentGameState_Unknown |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `new_state` | `.ETournamentGameState` | `optional` |  | default = k_ETournamentGameState_Unknown |
 
 </details>
 
@@ -201,9 +201,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_gid` | `uint64` | `optional` | `` |  |
-| 2 | `new_node_or_state` | `uint32` | `optional` | `` |  |
-| 3 | `old_node_or_state` | `uint32` | `optional` | `` |  |
+| 1 | `team_gid` | `uint64` | `optional` |  |  |
+| 2 | `new_node_or_state` | `uint32` | `optional` |  |  |
+| 3 | `old_node_or_state` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -215,16 +215,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `skill_level` | `uint32` | `optional` | `` |  |
-| 2 | `times_won_0` | `uint32` | `optional` | `` |  |
-| 3 | `times_won_1` | `uint32` | `optional` | `` |  |
-| 4 | `times_won_2` | `uint32` | `optional` | `` |  |
-| 5 | `times_won_3` | `uint32` | `optional` | `` |  |
-| 6 | `times_bye_and_lost` | `uint32` | `optional` | `` |  |
-| 7 | `times_bye_and_won` | `uint32` | `optional` | `` |  |
-| 8 | `total_games_won` | `uint32` | `optional` | `` |  |
-| 9 | `score` | `uint32` | `optional` | `` |  |
-| 10 | `times_unusual_champ` | `uint32` | `optional` | `` |  |
+| 1 | `skill_level` | `uint32` | `optional` |  |  |
+| 2 | `times_won_0` | `uint32` | `optional` |  |  |
+| 3 | `times_won_1` | `uint32` | `optional` |  |  |
+| 4 | `times_won_2` | `uint32` | `optional` |  |  |
+| 5 | `times_won_3` | `uint32` | `optional` |  |  |
+| 6 | `times_bye_and_lost` | `uint32` | `optional` |  |  |
+| 7 | `times_bye_and_won` | `uint32` | `optional` |  |  |
+| 8 | `total_games_won` | `uint32` | `optional` |  |  |
+| 9 | `score` | `uint32` | `optional` |  |  |
+| 10 | `times_unusual_champ` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -236,10 +236,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `season_trophy_id` | `uint32` | `optional` | `` |  |
-| 3 | `skill_levels` | `.CMsgDOTAWeekendTourneyPlayerSkillLevelStats` | `repeated` | `` |  |
-| 4 | `current_tier` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `season_trophy_id` | `uint32` | `optional` |  |  |
+| 3 | `skill_levels` | `.CMsgDOTAWeekendTourneyPlayerSkillLevelStats` | `repeated` |  |  |
+| 4 | `current_tier` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -251,8 +251,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `season_trophy_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `season_trophy_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -264,8 +264,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 3 | `tournaments` | `.CMsgDOTAWeekendTourneyPlayerHistory.Tournament` | `repeated` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 3 | `tournaments` | `.CMsgDOTAWeekendTourneyPlayerHistory.Tournament` | `repeated` |  |  |
 
 </details>
 
@@ -277,15 +277,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tournament_id` | `uint32` | `optional` | `` |  |
-| 2 | `start_time` | `uint32` | `optional` | `` |  |
-| 3 | `tournament_tier` | `uint32` | `optional` | `` |  |
-| 4 | `team_id` | `uint32` | `optional` | `` |  |
-| 5 | `team_date` | `uint32` | `optional` | `` |  |
-| 6 | `team_result` | `uint32` | `optional` | `` |  |
-| 7 | `account_id` | `uint32` | `repeated` | `` |  |
-| 8 | `team_name` | `string` | `optional` | `` |  |
-| 9 | `season_trophy_id` | `uint32` | `optional` | `` |  |
+| 1 | `tournament_id` | `uint32` | `optional` |  |  |
+| 2 | `start_time` | `uint32` | `optional` |  |  |
+| 3 | `tournament_tier` | `uint32` | `optional` |  |  |
+| 4 | `team_id` | `uint32` | `optional` |  |  |
+| 5 | `team_date` | `uint32` | `optional` |  |  |
+| 6 | `team_result` | `uint32` | `optional` |  |  |
+| 7 | `account_id` | `uint32` | `repeated` |  |  |
+| 8 | `team_name` | `string` | `optional` |  |  |
+| 9 | `season_trophy_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -297,7 +297,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `divisions` | `.CMsgDOTAWeekendTourneyParticipationDetails.Division` | `repeated` | `` |  |
+| 1 | `divisions` | `.CMsgDOTAWeekendTourneyParticipationDetails.Division` | `repeated` |  |  |
 
 </details>
 
@@ -309,14 +309,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tier` | `uint32` | `optional` | `` |  |
-| 2 | `players` | `uint32` | `optional` | `` |  |
-| 3 | `teams` | `uint32` | `optional` | `` |  |
-| 4 | `winning_teams` | `uint32` | `optional` | `` |  |
-| 5 | `players_streak_2` | `uint32` | `optional` | `` |  |
-| 6 | `players_streak_3` | `uint32` | `optional` | `` |  |
-| 7 | `players_streak_4` | `uint32` | `optional` | `` |  |
-| 8 | `players_streak_5` | `uint32` | `optional` | `` |  |
+| 1 | `tier` | `uint32` | `optional` |  |  |
+| 2 | `players` | `uint32` | `optional` |  |  |
+| 3 | `teams` | `uint32` | `optional` |  |  |
+| 4 | `winning_teams` | `uint32` | `optional` |  |  |
+| 5 | `players_streak_2` | `uint32` | `optional` |  |  |
+| 6 | `players_streak_3` | `uint32` | `optional` |  |  |
+| 7 | `players_streak_4` | `uint32` | `optional` |  |  |
+| 8 | `players_streak_5` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -328,9 +328,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `division_id` | `uint32` | `optional` | `` |  |
-| 2 | `schedule_time` | `uint32` | `optional` | `` |  |
-| 3 | `tiers` | `.CMsgDOTAWeekendTourneyParticipationDetails.Tier` | `repeated` | `` |  |
+| 1 | `division_id` | `uint32` | `optional` |  |  |
+| 2 | `schedule_time` | `uint32` | `optional` |  |  |
+| 3 | `tiers` | `.CMsgDOTAWeekendTourneyParticipationDetails.Tier` | `repeated` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-client-watch.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-client-watch.md
@@ -23,39 +23,39 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `activate_time` | `uint32` | `optional` | `` |  |
-| 2 | `deactivate_time` | `uint32` | `optional` | `` |  |
-| 3 | `server_steam_id` | `uint64` | `optional` | `` |  |
-| 4 | `lobby_id` | `uint64` | `optional` | `` |  |
-| 5 | `league_id` | `uint32` | `optional` | `` |  |
-| 6 | `lobby_type` | `uint32` | `optional` | `` |  |
-| 7 | `game_time` | `int32` | `optional` | `` |  |
-| 8 | `delay` | `uint32` | `optional` | `` |  |
-| 9 | `spectators` | `uint32` | `optional` | `` |  |
-| 10 | `game_mode` | `uint32` | `optional` | `` |  |
-| 11 | `average_mmr` | `uint32` | `optional` | `` |  |
-| 12 | `match_id` | `uint64` | `optional` | `` |  |
-| 13 | `series_id` | `uint32` | `optional` | `` |  |
-| 15 | `team_name_radiant` | `string` | `optional` | `` |  |
-| 16 | `team_name_dire` | `string` | `optional` | `` |  |
-| 17 | `sort_score` | `uint32` | `optional` | `` |  |
-| 18 | `last_update_time` | `float` | `optional` | `` |  |
-| 19 | `radiant_lead` | `int32` | `optional` | `` |  |
-| 20 | `radiant_score` | `uint32` | `optional` | `` |  |
-| 21 | `dire_score` | `uint32` | `optional` | `` |  |
-| 22 | `players` | `.CSourceTVGameSmall.Player` | `repeated` | `` |  |
-| 23 | `building_state` | `fixed32` | `optional` | `` |  |
-| 24 | `team_logo_radiant` | `fixed64` | `optional` | `` |  |
-| 25 | `team_logo_dire` | `fixed64` | `optional` | `` |  |
-| 26 | `weekend_tourney_tournament_id` | `uint32` | `optional` | `` |  |
-| 27 | `weekend_tourney_division` | `uint32` | `optional` | `` |  |
-| 28 | `weekend_tourney_skill_level` | `uint32` | `optional` | `` |  |
-| 29 | `weekend_tourney_bracket_round` | `uint32` | `optional` | `` |  |
-| 30 | `team_id_radiant` | `uint32` | `optional` | `` |  |
-| 31 | `team_id_dire` | `uint32` | `optional` | `` |  |
-| 32 | `custom_game_difficulty` | `uint32` | `optional` | `` |  |
-| 33 | `is_player_draft` | `bool` | `optional` | `` |  |
-| 34 | `is_watch_eligible` | `bool` | `optional` | `` |  |
+| 1 | `activate_time` | `uint32` | `optional` |  |  |
+| 2 | `deactivate_time` | `uint32` | `optional` |  |  |
+| 3 | `server_steam_id` | `uint64` | `optional` |  |  |
+| 4 | `lobby_id` | `uint64` | `optional` |  |  |
+| 5 | `league_id` | `uint32` | `optional` |  |  |
+| 6 | `lobby_type` | `uint32` | `optional` |  |  |
+| 7 | `game_time` | `int32` | `optional` |  |  |
+| 8 | `delay` | `uint32` | `optional` |  |  |
+| 9 | `spectators` | `uint32` | `optional` |  |  |
+| 10 | `game_mode` | `uint32` | `optional` |  |  |
+| 11 | `average_mmr` | `uint32` | `optional` |  |  |
+| 12 | `match_id` | `uint64` | `optional` |  |  |
+| 13 | `series_id` | `uint32` | `optional` |  |  |
+| 15 | `team_name_radiant` | `string` | `optional` |  |  |
+| 16 | `team_name_dire` | `string` | `optional` |  |  |
+| 17 | `sort_score` | `uint32` | `optional` |  |  |
+| 18 | `last_update_time` | `float` | `optional` |  |  |
+| 19 | `radiant_lead` | `int32` | `optional` |  |  |
+| 20 | `radiant_score` | `uint32` | `optional` |  |  |
+| 21 | `dire_score` | `uint32` | `optional` |  |  |
+| 22 | `players` | `.CSourceTVGameSmall.Player` | `repeated` |  |  |
+| 23 | `building_state` | `fixed32` | `optional` |  |  |
+| 24 | `team_logo_radiant` | `fixed64` | `optional` |  |  |
+| 25 | `team_logo_dire` | `fixed64` | `optional` |  |  |
+| 26 | `weekend_tourney_tournament_id` | `uint32` | `optional` |  |  |
+| 27 | `weekend_tourney_division` | `uint32` | `optional` |  |  |
+| 28 | `weekend_tourney_skill_level` | `uint32` | `optional` |  |  |
+| 29 | `weekend_tourney_bracket_round` | `uint32` | `optional` |  |  |
+| 30 | `team_id_radiant` | `uint32` | `optional` |  |  |
+| 31 | `team_id_dire` | `uint32` | `optional` |  |  |
+| 32 | `custom_game_difficulty` | `uint32` | `optional` |  |  |
+| 33 | `is_player_draft` | `bool` | `optional` |  |  |
+| 34 | `is_watch_eligible` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -67,10 +67,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `hero_id` | `int32` | `optional` | `` |  |
-| 3 | `team_slot` | `uint32` | `optional` | `` |  |
-| 4 | `team` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `hero_id` | `int32` | `optional` |  |  |
+| 3 | `team_slot` | `uint32` | `optional` |  |  |
+| 4 | `team` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -82,12 +82,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `search_key` | `string` | `optional` | `` |  |
-| 2 | `league_id` | `uint32` | `optional` | `` |  |
-| 3 | `hero_id` | `int32` | `optional` | `` |  |
-| 4 | `start_game` | `uint32` | `optional` | `` |  |
-| 5 | `game_list_index` | `uint32` | `optional` | `` |  |
-| 6 | `lobby_ids` | `uint64` | `repeated` | `` |  |
+| 1 | `search_key` | `string` | `optional` |  |  |
+| 2 | `league_id` | `uint32` | `optional` |  |  |
+| 3 | `hero_id` | `int32` | `optional` |  |  |
+| 4 | `start_game` | `uint32` | `optional` |  |  |
+| 5 | `game_list_index` | `uint32` | `optional` |  |  |
+| 6 | `lobby_ids` | `uint64` | `repeated` |  |  |
 
 </details>
 
@@ -99,15 +99,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `search_key` | `string` | `optional` | `` |  |
-| 2 | `league_id` | `uint32` | `optional` | `` |  |
-| 3 | `hero_id` | `int32` | `optional` | `` |  |
-| 4 | `start_game` | `uint32` | `optional` | `` |  |
-| 5 | `num_games` | `uint32` | `optional` | `` |  |
-| 6 | `game_list_index` | `uint32` | `optional` | `` |  |
-| 7 | `game_list` | `.CSourceTVGameSmall` | `repeated` | `` |  |
-| 8 | `specific_games` | `bool` | `optional` | `` |  |
-| 9 | `bot_game` | `.CSourceTVGameSmall` | `optional` | `` |  |
+| 1 | `search_key` | `string` | `optional` |  |  |
+| 2 | `league_id` | `uint32` | `optional` |  |  |
+| 3 | `hero_id` | `int32` | `optional` |  |  |
+| 4 | `start_game` | `uint32` | `optional` |  |  |
+| 5 | `num_games` | `uint32` | `optional` |  |  |
+| 6 | `game_list_index` | `uint32` | `optional` |  |  |
+| 7 | `game_list` | `.CSourceTVGameSmall` | `repeated` |  |  |
+| 8 | `specific_games` | `bool` | `optional` |  |  |
+| 9 | `bot_game` | `.CSourceTVGameSmall` | `optional` |  |  |
 
 </details>
 
@@ -119,7 +119,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `live_games` | `.CSourceTVGameSmall` | `repeated` | `` |  |
+| 1 | `live_games` | `.CSourceTVGameSmall` | `repeated` |  |  |
 
 </details>
 
@@ -155,7 +155,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_ids` | `uint64` | `repeated` | `` |  |
+| 1 | `match_ids` | `uint64` | `repeated` |  |  |
 
 </details>
 
@@ -167,8 +167,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `matches` | `.CMsgDOTAMatchMinimal` | `repeated` | `` |  |
-| 2 | `last_match` | `bool` | `optional` | `` |  |
+| 1 | `matches` | `.CMsgDOTAMatchMinimal` | `repeated` |  |  |
+| 2 | `last_match` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -180,7 +180,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `matches` | `.CMsgDOTAMatchMinimal` | `repeated` | `` |  |
+| 2 | `matches` | `.CMsgDOTAMatchMinimal` | `repeated` |  |  |
 
 </details>
 
@@ -192,7 +192,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `matches` | `.CMsgDOTAMatchMinimal` | `repeated` | `` |  |
+| 1 | `matches` | `.CMsgDOTAMatchMinimal` | `repeated` |  |  |
 
 </details>
 
@@ -204,8 +204,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steam_id` | `fixed64` | `optional` | `` |  |
-| 2 | `live` | `bool` | `optional` | `` |  |
+| 1 | `steam_id` | `fixed64` | `optional` |  |  |
+| 2 | `live` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -217,8 +217,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 4 | `server_steamid` | `fixed64` | `optional` | `` |  |
-| 5 | `watch_live_result` | `.CMsgSpectateFriendGameResponse.EWatchLiveResult` | `optional` | `` | default = SUCCESS |
+| 4 | `server_steamid` | `fixed64` | `optional` |  |  |
+| 5 | `watch_live_result` | `.CMsgSpectateFriendGameResponse.EWatchLiveResult` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -230,12 +230,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match` | `.CMsgDOTAMatchMinimal` | `optional` | `` |  |
-| 2 | `title` | `string` | `optional` | `` |  |
-| 3 | `description` | `string` | `optional` | `` |  |
-| 4 | `size` | `uint32` | `optional` | `` |  |
-| 5 | `tags` | `string` | `repeated` | `` |  |
-| 6 | `exists_on_disk` | `bool` | `optional` | `` |  |
+| 1 | `match` | `.CMsgDOTAMatchMinimal` | `optional` |  |  |
+| 2 | `title` | `string` | `optional` |  |  |
+| 3 | `description` | `string` | `optional` |  |  |
+| 4 | `size` | `uint32` | `optional` |  |  |
+| 5 | `tags` | `string` | `repeated` |  |  |
+| 6 | `exists_on_disk` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -247,8 +247,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `timestamp` | `uint32` | `optional` | `` |  |
-| 2 | `description` | `string` | `optional` | `` |  |
+| 1 | `timestamp` | `uint32` | `optional` |  |  |
+| 2 | `description` | `string` | `optional` |  |  |
 
 </details>
 
@@ -260,11 +260,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `server_steamid` | `fixed64` | `optional` | `` |  |
-| 2 | `client_version` | `uint32` | `optional` | `` |  |
-| 3 | `watch_server_steamid` | `fixed64` | `optional` | `` |  |
-| 4 | `lobby_id` | `uint64` | `optional` | `` |  |
-| 5 | `regions` | `uint32` | `repeated` | `` |  |
+| 1 | `server_steamid` | `fixed64` | `optional` |  |  |
+| 2 | `client_version` | `uint32` | `optional` |  |  |
+| 3 | `watch_server_steamid` | `fixed64` | `optional` |  |  |
+| 4 | `lobby_id` | `uint64` | `optional` |  |  |
+| 5 | `regions` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -288,14 +288,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `watch_game_result` | `.CMsgWatchGameResponse.WatchGameResult` | `optional` | `` | default = PENDING |
-| 2 | `source_tv_public_addr` | `uint32` | `optional` | `` |  |
-| 3 | `source_tv_private_addr` | `uint32` | `optional` | `` |  |
-| 4 | `source_tv_port` | `uint32` | `optional` | `` |  |
-| 5 | `game_server_steamid` | `fixed64` | `optional` | `` |  |
-| 6 | `watch_server_steamid` | `fixed64` | `optional` | `` |  |
-| 7 | `watch_tv_unique_secret_code` | `fixed64` | `optional` | `` |  |
-| 8 | `broadcast_url` | `string` | `optional` | `` |  |
+| 1 | `watch_game_result` | `.CMsgWatchGameResponse.WatchGameResult` | `optional` |  | default = PENDING |
+| 2 | `source_tv_public_addr` | `uint32` | `optional` |  |  |
+| 3 | `source_tv_private_addr` | `uint32` | `optional` |  |  |
+| 4 | `source_tv_port` | `uint32` | `optional` |  |  |
+| 5 | `game_server_steamid` | `fixed64` | `optional` |  |  |
+| 6 | `watch_server_steamid` | `fixed64` | `optional` |  |  |
+| 7 | `watch_tv_unique_secret_code` | `fixed64` | `optional` |  |  |
+| 8 | `broadcast_url` | `string` | `optional` |  |  |
 
 </details>
 
@@ -307,7 +307,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 5 | `game_server_steamid` | `fixed64` | `optional` | `` |  |
+| 5 | `game_server_steamid` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -319,16 +319,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `server_steam_id` | `fixed64` | `optional` | `` |  |
-| 3 | `live` | `bool` | `optional` | `` |  |
-| 4 | `team_name_radiant` | `string` | `optional` | `` |  |
-| 5 | `team_name_dire` | `string` | `optional` | `` |  |
-| 7 | `series_game` | `uint32` | `optional` | `` |  |
-| 9 | `upcoming_broadcast_timestamp` | `uint32` | `optional` | `` |  |
-| 10 | `allow_live_video` | `bool` | `optional` | `` |  |
-| 11 | `node_type` | `uint32` | `optional` | `` |  |
-| 12 | `node_name` | `string` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `server_steam_id` | `fixed64` | `optional` |  |  |
+| 3 | `live` | `bool` | `optional` |  |  |
+| 4 | `team_name_radiant` | `string` | `optional` |  |  |
+| 5 | `team_name_dire` | `string` | `optional` |  |  |
+| 7 | `series_game` | `uint32` | `optional` |  |  |
+| 9 | `upcoming_broadcast_timestamp` | `uint32` | `optional` |  |  |
+| 10 | `allow_live_video` | `bool` | `optional` |  |  |
+| 11 | `node_type` | `uint32` | `optional` |  |  |
+| 12 | `node_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -340,12 +340,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `series_id` | `uint32` | `optional` | `` |  |
-| 2 | `series_type` | `uint32` | `optional` | `` |  |
-| 3 | `team_1` | `.CMsgDOTASeries.TeamInfo` | `optional` | `` |  |
-| 4 | `team_2` | `.CMsgDOTASeries.TeamInfo` | `optional` | `` |  |
-| 5 | `match_minimal` | `.CMsgDOTAMatchMinimal` | `repeated` | `` |  |
-| 6 | `live_game` | `.CMsgDOTASeries.LiveGame` | `optional` | `` |  |
+| 1 | `series_id` | `uint32` | `optional` |  |  |
+| 2 | `series_type` | `uint32` | `optional` |  |  |
+| 3 | `team_1` | `.CMsgDOTASeries.TeamInfo` | `optional` |  |  |
+| 4 | `team_2` | `.CMsgDOTASeries.TeamInfo` | `optional` |  |  |
+| 5 | `match_minimal` | `.CMsgDOTAMatchMinimal` | `repeated` |  |  |
+| 6 | `live_game` | `.CMsgDOTASeries.LiveGame` | `optional` |  |  |
 
 </details>
 
@@ -357,10 +357,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_id` | `uint32` | `optional` | `` |  |
-| 2 | `team_name` | `string` | `optional` | `` |  |
-| 3 | `team_logo_url` | `string` | `optional` | `` |  |
-| 4 | `wager_count` | `uint32` | `optional` | `` |  |
+| 1 | `team_id` | `uint32` | `optional` |  |  |
+| 2 | `team_name` | `string` | `optional` |  |  |
+| 3 | `team_logo_url` | `string` | `optional` |  |  |
+| 4 | `wager_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -372,11 +372,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `server_steam_id` | `fixed64` | `optional` | `` |  |
-| 2 | `team_radiant` | `.CMsgDOTASeries.TeamInfo` | `optional` | `` |  |
-| 3 | `team_dire` | `.CMsgDOTASeries.TeamInfo` | `optional` | `` |  |
-| 4 | `team_radiant_score` | `uint32` | `optional` | `` |  |
-| 5 | `team_dire_score` | `uint32` | `optional` | `` |  |
+| 1 | `server_steam_id` | `fixed64` | `optional` |  |  |
+| 2 | `team_radiant` | `.CMsgDOTASeries.TeamInfo` | `optional` |  |  |
+| 3 | `team_dire` | `.CMsgDOTASeries.TeamInfo` | `optional` |  |  |
+| 4 | `team_radiant_score` | `uint32` | `optional` |  |  |
+| 5 | `team_dire_score` | `uint32` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-client.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-client.md
@@ -32,7 +32,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `time_end` | `uint32` | `optional` | `` |  |
+| 1 | `time_end` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -56,7 +56,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `initial_skill` | `uint32` | `optional` | `` |  |
+| 1 | `initial_skill` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -68,11 +68,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `matches` | `.CMsgDOTAMatch` | `repeated` | `` |  |
-| 2 | `series` | `.CMsgDOTARequestMatchesResponse.Series` | `repeated` | `` |  |
-| 3 | `request_id` | `uint32` | `optional` | `` |  |
-| 4 | `total_results` | `uint32` | `optional` | `` |  |
-| 5 | `results_remaining` | `uint32` | `optional` | `` |  |
+| 1 | `matches` | `.CMsgDOTAMatch` | `repeated` |  |  |
+| 2 | `series` | `.CMsgDOTARequestMatchesResponse.Series` | `repeated` |  |  |
+| 3 | `request_id` | `uint32` | `optional` |  |  |
+| 4 | `total_results` | `uint32` | `optional` |  |  |
+| 5 | `results_remaining` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -84,9 +84,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `matches` | `.CMsgDOTAMatch` | `repeated` | `` |  |
-| 2 | `series_id` | `uint32` | `optional` | `` |  |
-| 3 | `series_type` | `uint32` | `optional` | `` |  |
+| 1 | `matches` | `.CMsgDOTAMatch` | `repeated` |  |  |
+| 2 | `series_id` | `uint32` | `optional` |  |  |
+| 3 | `series_type` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -98,15 +98,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `.CMsgDOTAPopup.PopupID` | `optional` | `` | default = NONE |
-| 2 | `custom_text` | `string` | `optional` | `` |  |
-| 3 | `int_data` | `sint32` | `optional` | `` |  |
-| 4 | `popup_data` | `bytes` | `optional` | `` |  |
-| 5 | `loc_token_header` | `string` | `optional` | `` |  |
-| 6 | `loc_token_msg` | `string` | `optional` | `` |  |
-| 7 | `var_names` | `string` | `repeated` | `` |  |
-| 8 | `var_values` | `string` | `repeated` | `` |  |
-| 9 | `debug_text` | `string` | `optional` | `` |  |
+| 1 | `id` | `.CMsgDOTAPopup.PopupID` | `optional` |  | default = NONE |
+| 2 | `custom_text` | `string` | `optional` |  |  |
+| 3 | `int_data` | `sint32` | `optional` |  |  |
+| 4 | `popup_data` | `bytes` | `optional` |  |  |
+| 5 | `loc_token_header` | `string` | `optional` |  |  |
+| 6 | `loc_token_msg` | `string` | `optional` |  |  |
+| 7 | `var_names` | `string` | `repeated` |  |  |
+| 8 | `var_values` | `string` | `repeated` |  |  |
+| 9 | `debug_text` | `string` | `optional` |  |  |
 
 </details>
 
@@ -130,12 +130,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `num_positive_reports_remaining` | `uint32` | `optional` | `` |  |
-| 2 | `num_negative_reports_remaining` | `uint32` | `optional` | `` |  |
-| 3 | `num_positive_reports_total` | `uint32` | `optional` | `` |  |
-| 4 | `num_negative_reports_total` | `uint32` | `optional` | `` |  |
-| 5 | `num_comms_reports_remaining` | `uint32` | `optional` | `` |  |
-| 6 | `num_comms_reports_total` | `uint32` | `optional` | `` |  |
+| 1 | `num_positive_reports_remaining` | `uint32` | `optional` |  |  |
+| 2 | `num_negative_reports_remaining` | `uint32` | `optional` |  |  |
+| 3 | `num_positive_reports_total` | `uint32` | `optional` |  |  |
+| 4 | `num_negative_reports_total` | `uint32` | `optional` |  |  |
+| 5 | `num_comms_reports_remaining` | `uint32` | `optional` |  |  |
+| 6 | `num_comms_reports_total` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -147,10 +147,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `report_flags` | `uint32` | `optional` | `` |  |
-| 4 | `lobby_id` | `uint64` | `optional` | `` |  |
-| 5 | `comment` | `string` | `optional` | `` |  |
+| 1 | `target_account_id` | `uint32` | `optional` |  |  |
+| 2 | `report_flags` | `uint32` | `optional` |  |  |
+| 4 | `lobby_id` | `uint64` | `optional` |  |  |
+| 5 | `comment` | `string` | `optional` |  |  |
 
 </details>
 
@@ -162,10 +162,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `report_flags` | `uint32` | `optional` | `` |  |
-| 4 | `debug_message` | `string` | `optional` | `` |  |
-| 5 | `enum_result` | `.CMsgDOTASubmitPlayerReportResponse.EResult` | `optional` | `` | default = k_eInternalError |
+| 1 | `target_account_id` | `uint32` | `optional` |  |  |
+| 2 | `report_flags` | `uint32` | `optional` |  |  |
+| 4 | `debug_message` | `string` | `optional` |  |  |
+| 5 | `enum_result` | `.CMsgDOTASubmitPlayerReportResponse.EResult` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -177,9 +177,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_account_id` | `uint32` | `optional` | `` |  |
-| 4 | `lobby_id` | `uint64` | `optional` | `` |  |
-| 5 | `user_note` | `string` | `optional` | `` |  |
+| 1 | `target_account_id` | `uint32` | `optional` |  |  |
+| 4 | `lobby_id` | `uint64` | `optional` |  |  |
+| 5 | `user_note` | `string` | `optional` |  |  |
 
 </details>
 
@@ -191,9 +191,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `result` | `uint32` | `optional` | `` |  |
-| 3 | `debug_message` | `string` | `optional` | `` |  |
+| 1 | `target_account_id` | `uint32` | `optional` |  |  |
+| 2 | `result` | `uint32` | `optional` |  |  |
+| 3 | `debug_message` | `string` | `optional` |  |  |
 
 </details>
 
@@ -205,12 +205,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `report_reason` | `uint32` | `repeated` | `` |  |
-| 3 | `lobby_id` | `uint64` | `optional` | `` |  |
-| 4 | `game_time` | `float` | `optional` | `` |  |
-| 5 | `debug_slot` | `uint32` | `optional` | `` |  |
-| 6 | `debug_match_id` | `fixed64` | `optional` | `` |  |
+| 1 | `target_account_id` | `uint32` | `optional` |  |  |
+| 2 | `report_reason` | `uint32` | `repeated` |  |  |
+| 3 | `lobby_id` | `uint64` | `optional` |  |  |
+| 4 | `game_time` | `float` | `optional` |  |  |
+| 5 | `debug_slot` | `uint32` | `optional` |  |  |
+| 6 | `debug_match_id` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -222,10 +222,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `report_reason` | `uint32` | `repeated` | `` |  |
-| 4 | `debug_message` | `string` | `optional` | `` |  |
-| 5 | `enum_result` | `.CMsgDOTASubmitPlayerReportResponseV2.EResult` | `optional` | `` | default = k_eInternalError |
+| 1 | `target_account_id` | `uint32` | `optional` |  |  |
+| 2 | `report_reason` | `uint32` | `repeated` |  |  |
+| 4 | `debug_message` | `string` | `optional` |  |  |
+| 5 | `enum_result` | `.CMsgDOTASubmitPlayerReportResponseV2.EResult` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -237,7 +237,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_account_id` | `uint32` | `optional` | `` |  |
+| 1 | `target_account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -249,8 +249,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `eresult` | `uint32` | `optional` | `` |  |
+| 1 | `target_account_id` | `uint32` | `optional` |  |  |
+| 2 | `eresult` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -262,8 +262,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `mvp_account_id` | `uint32` | `repeated` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `mvp_account_id` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -275,7 +275,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_type` | `.MatchType` | `optional` | `` | default = MATCH_TYPE_CASUAL |
+| 1 | `match_type` | `.MatchType` | `optional` |  | default = MATCH_TYPE_CASUAL |
 
 </details>
 
@@ -287,7 +287,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -299,9 +299,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `uint32` | `optional` | `` |  |
-| 2 | `match` | `.CMsgDOTAMatch` | `optional` | `` |  |
-| 3 | `vote` | `.DOTAMatchVote` | `optional` | `` | default = DOTAMatchVote_INVALID |
+| 1 | `result` | `uint32` | `optional` |  |  |
+| 2 | `match` | `.CMsgDOTAMatch` | `optional` |  |  |
+| 3 | `vote` | `.DOTAMatchVote` | `optional` |  | default = DOTAMatchVote_INVALID |
 
 </details>
 
@@ -313,9 +313,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `uint32` | `optional` | `` |  |
-| 2 | `account_id` | `uint32` | `optional` | `` |  |
-| 3 | `league_passes` | `.CMsgDOTAProfileTickets.LeaguePass` | `repeated` | `` |  |
+| 1 | `result` | `uint32` | `optional` |  |  |
+| 2 | `account_id` | `uint32` | `optional` |  |  |
+| 3 | `league_passes` | `.CMsgDOTAProfileTickets.LeaguePass` | `repeated` |  |  |
 
 </details>
 
@@ -327,8 +327,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 2 | `item_def` | `uint32` | `optional` | `` |  |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 2 | `item_def` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -340,7 +340,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -352,7 +352,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `invites` | `.CMsgGCToClientPartySearchInvite` | `repeated` | `` |  |
+| 1 | `invites` | `.CMsgGCToClientPartySearchInvite` | `repeated` |  |  |
 
 </details>
 
@@ -364,25 +364,25 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 5 | `store_item_hash` | `uint32` | `optional` | `` |  |
-| 6 | `timeplayedconsecutively` | `uint32` | `optional` | `` |  |
-| 7 | `allow_3rd_party_match_history` | `bool` | `optional` | `` |  |
-| 13 | `last_ip_address` | `uint32` | `optional` | `` |  |
-| 17 | `profile_private` | `bool` | `optional` | `` |  |
-| 18 | `currency` | `uint32` | `optional` | `` |  |
-| 20 | `should_request_player_origin` | `bool` | `optional` | `` |  |
-| 22 | `gc_socache_file_version` | `uint32` | `optional` | `` |  |
-| 24 | `is_perfect_world_test_account` | `bool` | `optional` | `` |  |
-| 26 | `extra_messages` | `.CMsgDOTAWelcome.CExtraMsg` | `repeated` | `` |  |
-| 27 | `minimum_recent_item_id` | `uint64` | `optional` | `` |  |
-| 28 | `active_event` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 29 | `additional_user_message` | `uint32` | `optional` | `` |  |
-| 30 | `custom_game_whitelist_version` | `uint32` | `optional` | `` |  |
-| 31 | `party_search_friend_invites` | `.CMsgGCToClientPartySearchInvites` | `optional` | `` |  |
-| 32 | `remaining_playtime` | `int32` | `optional` | `` | default = -1 |
-| 33 | `disable_guild_persona_info` | `bool` | `optional` | `` |  |
-| 34 | `extra_message_blocks` | `.CExtraMsgBlock` | `repeated` | `` |  |
-| 35 | `active_event_for_display` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
+| 5 | `store_item_hash` | `uint32` | `optional` |  |  |
+| 6 | `timeplayedconsecutively` | `uint32` | `optional` |  |  |
+| 7 | `allow_3rd_party_match_history` | `bool` | `optional` |  |  |
+| 13 | `last_ip_address` | `uint32` | `optional` |  |  |
+| 17 | `profile_private` | `bool` | `optional` |  |  |
+| 18 | `currency` | `uint32` | `optional` |  |  |
+| 20 | `should_request_player_origin` | `bool` | `optional` |  |  |
+| 22 | `gc_socache_file_version` | `uint32` | `optional` |  |  |
+| 24 | `is_perfect_world_test_account` | `bool` | `optional` |  |  |
+| 26 | `extra_messages` | `.CMsgDOTAWelcome.CExtraMsg` | `repeated` |  |  |
+| 27 | `minimum_recent_item_id` | `uint64` | `optional` |  |  |
+| 28 | `active_event` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 29 | `additional_user_message` | `uint32` | `optional` |  |  |
+| 30 | `custom_game_whitelist_version` | `uint32` | `optional` |  |  |
+| 31 | `party_search_friend_invites` | `.CMsgGCToClientPartySearchInvites` | `optional` |  |  |
+| 32 | `remaining_playtime` | `int32` | `optional` |  | default = -1 |
+| 33 | `disable_guild_persona_info` | `bool` | `optional` |  |  |
+| 34 | `extra_message_blocks` | `.CExtraMsgBlock` | `repeated` |  |  |
+| 35 | `active_event_for_display` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
 
 </details>
 
@@ -394,8 +394,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `uint32` | `optional` | `` |  |
-| 2 | `contents` | `bytes` | `optional` | `` |  |
+| 1 | `id` | `uint32` | `optional` |  |  |
+| 2 | `contents` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -407,8 +407,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` | (key_field) = true |
-| 2 | `hero_id` | `int32` | `optional` | `` | (key_field) = true |
+| 1 | `account_id` | `uint32` | `optional` |  | (key_field) = true |
+| 2 | `hero_id` | `int32` | `optional` |  | (key_field) = true |
 
 </details>
 
@@ -420,8 +420,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `votes` | `.CMsgDOTAMatchVotes.PlayerVote` | `repeated` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `votes` | `.CMsgDOTAMatchVotes.PlayerVote` | `repeated` |  |  |
 
 </details>
 
@@ -433,8 +433,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `vote` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `vote` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -446,10 +446,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `players_searching` | `uint32` | `optional` | `` |  |
-| 2 | `auto_region_select_ping_penalty` | `sint32` | `optional` | `` |  |
-| 3 | `status` | `.EMatchGroupServerStatus` | `optional` | `` | default = k_EMatchGroupServerStatus_OK |
-| 4 | `auto_region_select_ping_penalty_custom` | `sint32` | `optional` | `` |  |
+| 1 | `players_searching` | `uint32` | `optional` |  |  |
+| 2 | `auto_region_select_ping_penalty` | `sint32` | `optional` |  |  |
+| 3 | `status` | `.EMatchGroupServerStatus` | `optional` |  | default = k_EMatchGroupServerStatus_OK |
+| 4 | `auto_region_select_ping_penalty_custom` | `sint32` | `optional` |  |  |
 
 </details>
 
@@ -473,9 +473,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `matchgroups_version` | `uint32` | `optional` | `` |  |
-| 7 | `legacy_searching_players_by_group_source2` | `uint32` | `repeated` | `` |  |
-| 8 | `match_groups` | `.CMsgMatchmakingMatchGroupInfo` | `repeated` | `` |  |
+| 1 | `matchgroups_version` | `uint32` | `optional` |  |  |
+| 7 | `legacy_searching_players_by_group_source2` | `uint32` | `repeated` |  |  |
+| 8 | `match_groups` | `.CMsgMatchmakingMatchGroupInfo` | `repeated` |  |  |
 
 </details>
 
@@ -487,7 +487,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `stats` | `.CMsgDOTAMatchmakingStatsResponse` | `optional` | `` |  |
+| 1 | `stats` | `.CMsgDOTAMatchmakingStatsResponse` | `optional` |  |  |
 
 </details>
 
@@ -499,7 +499,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `stats` | `.CMsgDOTAMatchmakingStatsResponse` | `optional` | `` |  |
+| 1 | `stats` | `.CMsgDOTAMatchmakingStatsResponse` | `optional` |  |  |
 
 </details>
 
@@ -511,7 +511,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `allow_3rd_party_match_history` | `bool` | `optional` | `` |  |
+| 1 | `allow_3rd_party_match_history` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -523,7 +523,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `eresult` | `uint32` | `optional` | `` | default = 2 |
+| 1 | `eresult` | `uint32` | `optional` |  | default = 2 |
 
 </details>
 
@@ -535,8 +535,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `accountid` | `uint32` | `optional` | `` |  |
-| 2 | `account_flags` | `uint32` | `optional` | `` |  |
+| 1 | `accountid` | `uint32` | `optional` |  |  |
+| 2 | `account_flags` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -548,7 +548,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `profile_private` | `bool` | `optional` | `` |  |
+| 1 | `profile_private` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -560,7 +560,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `eresult` | `uint32` | `optional` | `` |  |
+| 1 | `eresult` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -572,8 +572,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `league_id` | `uint32` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `league_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -597,8 +597,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `watch_type` | `.DOTA_WatchReplayType` | `optional` | `` | default = DOTA_WATCH_REPLAY_NORMAL |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `watch_type` | `.DOTA_WatchReplayType` | `optional` |  | default = DOTA_WATCH_REPLAY_NORMAL |
 
 </details>
 
@@ -610,7 +610,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -646,7 +646,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `standings` | `.CMsgGCGetHeroStandingsResponse.Hero` | `repeated` | `` |  |
+| 1 | `standings` | `.CMsgGCGetHeroStandingsResponse.Hero` | `repeated` |  |  |
 
 </details>
 
@@ -658,33 +658,33 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `wins` | `uint32` | `optional` | `` |  |
-| 3 | `losses` | `uint32` | `optional` | `` |  |
-| 4 | `win_streak` | `uint32` | `optional` | `` |  |
-| 5 | `best_win_streak` | `uint32` | `optional` | `` |  |
-| 6 | `avg_kills` | `float` | `optional` | `` |  |
-| 7 | `avg_deaths` | `float` | `optional` | `` |  |
-| 8 | `avg_assists` | `float` | `optional` | `` |  |
-| 9 | `avg_gpm` | `float` | `optional` | `` |  |
-| 10 | `avg_xpm` | `float` | `optional` | `` |  |
-| 11 | `best_kills` | `uint32` | `optional` | `` |  |
-| 12 | `best_assists` | `uint32` | `optional` | `` |  |
-| 13 | `best_gpm` | `uint32` | `optional` | `` |  |
-| 14 | `best_xpm` | `uint32` | `optional` | `` |  |
-| 15 | `performance` | `float` | `optional` | `` |  |
-| 16 | `wins_with_ally` | `uint32` | `optional` | `` |  |
-| 17 | `losses_with_ally` | `uint32` | `optional` | `` |  |
-| 18 | `wins_against_enemy` | `uint32` | `optional` | `` |  |
-| 19 | `losses_against_enemy` | `uint32` | `optional` | `` |  |
-| 20 | `networth_peak` | `uint32` | `optional` | `` |  |
-| 21 | `lasthit_peak` | `uint32` | `optional` | `` |  |
-| 22 | `deny_peak` | `uint32` | `optional` | `` |  |
-| 23 | `damage_peak` | `uint32` | `optional` | `` |  |
-| 24 | `longest_game_peak` | `uint32` | `optional` | `` |  |
-| 25 | `healing_peak` | `uint32` | `optional` | `` |  |
-| 26 | `avg_lasthits` | `float` | `optional` | `` |  |
-| 27 | `avg_denies` | `float` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `wins` | `uint32` | `optional` |  |  |
+| 3 | `losses` | `uint32` | `optional` |  |  |
+| 4 | `win_streak` | `uint32` | `optional` |  |  |
+| 5 | `best_win_streak` | `uint32` | `optional` |  |  |
+| 6 | `avg_kills` | `float` | `optional` |  |  |
+| 7 | `avg_deaths` | `float` | `optional` |  |  |
+| 8 | `avg_assists` | `float` | `optional` |  |  |
+| 9 | `avg_gpm` | `float` | `optional` |  |  |
+| 10 | `avg_xpm` | `float` | `optional` |  |  |
+| 11 | `best_kills` | `uint32` | `optional` |  |  |
+| 12 | `best_assists` | `uint32` | `optional` |  |  |
+| 13 | `best_gpm` | `uint32` | `optional` |  |  |
+| 14 | `best_xpm` | `uint32` | `optional` |  |  |
+| 15 | `performance` | `float` | `optional` |  |  |
+| 16 | `wins_with_ally` | `uint32` | `optional` |  |  |
+| 17 | `losses_with_ally` | `uint32` | `optional` |  |  |
+| 18 | `wins_against_enemy` | `uint32` | `optional` |  |  |
+| 19 | `losses_against_enemy` | `uint32` | `optional` |  |  |
+| 20 | `networth_peak` | `uint32` | `optional` |  |  |
+| 21 | `lasthit_peak` | `uint32` | `optional` |  |  |
+| 22 | `deny_peak` | `uint32` | `optional` |  |  |
+| 23 | `damage_peak` | `uint32` | `optional` |  |  |
+| 24 | `longest_game_peak` | `uint32` | `optional` |  |  |
+| 25 | `healing_peak` | `uint32` | `optional` |  |  |
+| 26 | `avg_lasthits` | `float` | `optional` |  |  |
+| 27 | `avg_denies` | `float` | `optional` |  |  |
 
 </details>
 
@@ -696,19 +696,19 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `kills` | `float` | `optional` | `` |  |
-| 3 | `deaths` | `float` | `optional` | `` |  |
-| 4 | `assists` | `float` | `optional` | `` |  |
-| 5 | `net_worth` | `float` | `optional` | `` |  |
-| 6 | `last_hits` | `float` | `optional` | `` |  |
-| 7 | `denies` | `float` | `optional` | `` |  |
-| 8 | `item_value` | `float` | `optional` | `` |  |
-| 9 | `support_gold_spent` | `float` | `optional` | `` |  |
-| 10 | `camps_stacked` | `float` | `optional` | `` |  |
-| 11 | `wards_placed` | `float` | `optional` | `` |  |
-| 12 | `dewards` | `float` | `optional` | `` |  |
-| 13 | `triple_kills` | `float` | `optional` | `` |  |
-| 14 | `rampages` | `float` | `optional` | `` |  |
+| 2 | `kills` | `float` | `optional` |  |  |
+| 3 | `deaths` | `float` | `optional` |  |  |
+| 4 | `assists` | `float` | `optional` |  |  |
+| 5 | `net_worth` | `float` | `optional` |  |  |
+| 6 | `last_hits` | `float` | `optional` |  |  |
+| 7 | `denies` | `float` | `optional` |  |  |
+| 8 | `item_value` | `float` | `optional` |  |  |
+| 9 | `support_gold_spent` | `float` | `optional` |  |  |
+| 10 | `camps_stacked` | `float` | `optional` |  |  |
+| 11 | `wards_placed` | `float` | `optional` |  |  |
+| 12 | `dewards` | `float` | `optional` |  |  |
+| 13 | `triple_kills` | `float` | `optional` |  |  |
+| 14 | `rampages` | `float` | `optional` |  |  |
 
 </details>
 
@@ -720,19 +720,19 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `kills` | `float` | `optional` | `` | default = 1 |
-| 3 | `deaths` | `float` | `optional` | `` | default = 1 |
-| 4 | `assists` | `float` | `optional` | `` | default = 1 |
-| 5 | `net_worth` | `float` | `optional` | `` | default = 1 |
-| 6 | `last_hits` | `float` | `optional` | `` | default = 1 |
-| 7 | `denies` | `float` | `optional` | `` | default = 1 |
-| 8 | `item_value` | `float` | `optional` | `` | default = 1 |
-| 9 | `support_gold_spent` | `float` | `optional` | `` | default = 1 |
-| 10 | `camps_stacked` | `float` | `optional` | `` | default = 1 |
-| 11 | `wards_placed` | `float` | `optional` | `` | default = 1 |
-| 12 | `dewards` | `float` | `optional` | `` | default = 1 |
-| 13 | `triple_kills` | `float` | `optional` | `` | default = 1 |
-| 14 | `rampages` | `float` | `optional` | `` | default = 1 |
+| 2 | `kills` | `float` | `optional` |  | default = 1 |
+| 3 | `deaths` | `float` | `optional` |  | default = 1 |
+| 4 | `assists` | `float` | `optional` |  | default = 1 |
+| 5 | `net_worth` | `float` | `optional` |  | default = 1 |
+| 6 | `last_hits` | `float` | `optional` |  | default = 1 |
+| 7 | `denies` | `float` | `optional` |  | default = 1 |
+| 8 | `item_value` | `float` | `optional` |  | default = 1 |
+| 9 | `support_gold_spent` | `float` | `optional` |  | default = 1 |
+| 10 | `camps_stacked` | `float` | `optional` |  | default = 1 |
+| 11 | `wards_placed` | `float` | `optional` |  | default = 1 |
+| 12 | `dewards` | `float` | `optional` |  | default = 1 |
+| 13 | `triple_kills` | `float` | `optional` |  | default = 1 |
+| 14 | `rampages` | `float` | `optional` |  | default = 1 |
 
 </details>
 
@@ -744,8 +744,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `rank_chunked_stats` | `.CMsgGCGetHeroTimedStatsResponse.RankChunkedStats` | `repeated` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `rank_chunked_stats` | `.CMsgGCGetHeroTimedStatsResponse.RankChunkedStats` | `repeated` |  |  |
 
 </details>
 
@@ -757,12 +757,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `time` | `uint32` | `optional` | `` |  |
-| 2 | `all_stats` | `.CMatchPlayerTimedStatAverages` | `optional` | `` |  |
-| 3 | `winning_stats` | `.CMatchPlayerTimedStatAverages` | `optional` | `` |  |
-| 4 | `losing_stats` | `.CMatchPlayerTimedStatAverages` | `optional` | `` |  |
-| 5 | `winning_stddevs` | `.CMatchPlayerTimedStatStdDeviations` | `optional` | `` |  |
-| 6 | `losing_stddevs` | `.CMatchPlayerTimedStatStdDeviations` | `optional` | `` |  |
+| 1 | `time` | `uint32` | `optional` |  |  |
+| 2 | `all_stats` | `.CMatchPlayerTimedStatAverages` | `optional` |  |  |
+| 3 | `winning_stats` | `.CMatchPlayerTimedStatAverages` | `optional` |  |  |
+| 4 | `losing_stats` | `.CMatchPlayerTimedStatAverages` | `optional` |  |  |
+| 5 | `winning_stddevs` | `.CMatchPlayerTimedStatStdDeviations` | `optional` |  |  |
+| 6 | `losing_stddevs` | `.CMatchPlayerTimedStatStdDeviations` | `optional` |  |  |
 
 </details>
 
@@ -774,8 +774,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `rank_chunk` | `uint32` | `optional` | `` |  |
-| 2 | `timed_stats` | `.CMsgGCGetHeroTimedStatsResponse.TimedStatsContainer` | `repeated` | `` |  |
+| 1 | `rank_chunk` | `uint32` | `optional` |  |  |
+| 2 | `timed_stats` | `.CMsgGCGetHeroTimedStatsResponse.TimedStatsContainer` | `repeated` |  |  |
 
 </details>
 
@@ -799,8 +799,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `def_index` | `uint32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
+| 1 | `def_index` | `uint32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -812,7 +812,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `reservations` | `.CMsgGCItemEditorReservation` | `repeated` | `` |  |
+| 1 | `reservations` | `.CMsgGCItemEditorReservation` | `repeated` |  |  |
 
 </details>
 
@@ -824,8 +824,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `def_index` | `uint32` | `optional` | `` |  |
-| 2 | `username` | `string` | `optional` | `` |  |
+| 1 | `def_index` | `uint32` | `optional` |  |  |
+| 2 | `username` | `string` | `optional` |  |  |
 
 </details>
 
@@ -837,9 +837,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `def_index` | `uint32` | `optional` | `` |  |
-| 2 | `username` | `string` | `optional` | `` |  |
-| 3 | `result` | `uint32` | `optional` | `` |  |
+| 1 | `def_index` | `uint32` | `optional` |  |  |
+| 2 | `username` | `string` | `optional` |  |  |
+| 3 | `result` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -851,8 +851,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `def_index` | `uint32` | `optional` | `` |  |
-| 2 | `username` | `string` | `optional` | `` |  |
+| 1 | `def_index` | `uint32` | `optional` |  |  |
+| 2 | `username` | `string` | `optional` |  |  |
 
 </details>
 
@@ -864,8 +864,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `def_index` | `uint32` | `optional` | `` |  |
-| 2 | `released` | `bool` | `optional` | `` |  |
+| 1 | `def_index` | `uint32` | `optional` |  |  |
+| 2 | `released` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -889,10 +889,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `channel_id` | `uint32` | `optional` | `` |  |
-| 2 | `country_code` | `string` | `optional` | `` |  |
-| 3 | `description` | `string` | `optional` | `` |  |
-| 4 | `language_code` | `string` | `optional` | `` |  |
+| 1 | `channel_id` | `uint32` | `optional` |  |  |
+| 2 | `country_code` | `string` | `optional` |  |  |
+| 3 | `description` | `string` | `optional` |  |  |
+| 4 | `language_code` | `string` | `optional` |  |  |
 
 </details>
 
@@ -904,8 +904,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 4 | `grant_item_gift_data` | `.CMsgDOTAClaimEventActionData.GrantItemGiftData` | `optional` | `` |  |
-| 5 | `grant_item_choice_item_def` | `uint64` | `optional` | `` |  |
+| 4 | `grant_item_gift_data` | `.CMsgDOTAClaimEventActionData.GrantItemGiftData` | `optional` |  |  |
+| 5 | `grant_item_choice_item_def` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -917,8 +917,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `give_to_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `gift_message` | `string` | `optional` | `` |  |
+| 1 | `give_to_account_id` | `uint32` | `optional` |  |  |
+| 2 | `gift_message` | `string` | `optional` |  |  |
 
 </details>
 
@@ -930,12 +930,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `action_id` | `uint32` | `optional` | `` |  |
-| 3 | `quantity` | `uint32` | `optional` | `` |  |
-| 4 | `data` | `.CMsgDOTAClaimEventActionData` | `optional` | `` |  |
-| 5 | `score_mode` | `.EEventActionScoreMode` | `optional` | `` | default = k_eEventActionScoreMode_Add |
-| 6 | `suppress_rewards` | `bool` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `action_id` | `uint32` | `optional` |  |  |
+| 3 | `quantity` | `uint32` | `optional` |  |  |
+| 4 | `data` | `.CMsgDOTAClaimEventActionData` | `optional` |  |  |
+| 5 | `score_mode` | `.EEventActionScoreMode` | `optional` |  | default = k_eEventActionScoreMode_Add |
+| 6 | `suppress_rewards` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -947,11 +947,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `action_id` | `uint32` | `optional` | `` |  |
-| 3 | `item_id` | `uint64` | `optional` | `` |  |
-| 4 | `quantity` | `uint32` | `optional` | `` |  |
-| 5 | `suppress_rewards` | `bool` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `action_id` | `uint32` | `optional` |  |  |
+| 3 | `item_id` | `uint64` | `optional` |  |  |
+| 4 | `quantity` | `uint32` | `optional` |  |  |
+| 5 | `suppress_rewards` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -963,7 +963,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `action_results` | `.CMsgDOTAClaimEventActionResponse` | `optional` | `` |  |
+| 1 | `action_results` | `.CMsgDOTAClaimEventActionResponse` | `optional` |  |  |
 
 </details>
 
@@ -975,8 +975,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `uint64` | `optional` | `` |  |
-| 2 | `action_results` | `.CMsgDOTAClaimEventActionResponse` | `optional` | `` |  |
+| 1 | `item_id` | `uint64` | `optional` |  |  |
+| 2 | `action_results` | `.CMsgDOTAClaimEventActionResponse` | `optional` |  |  |
 
 </details>
 
@@ -988,8 +988,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1001,16 +1001,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `total_points` | `uint32` | `optional` | `` |  |
-| 2 | `total_premium_points` | `uint32` | `optional` | `` |  |
-| 3 | `event_id` | `uint32` | `optional` | `` |  |
-| 4 | `points` | `uint32` | `optional` | `` |  |
-| 5 | `premium_points` | `uint32` | `optional` | `` |  |
-| 6 | `completed_actions` | `.CMsgDOTAGetEventPointsResponse.Action` | `repeated` | `` |  |
-| 7 | `account_id` | `uint32` | `optional` | `` |  |
-| 8 | `owned` | `bool` | `optional` | `` |  |
-| 9 | `audit_action` | `uint32` | `optional` | `` |  |
-| 10 | `active_season_id` | `uint32` | `optional` | `` |  |
+| 1 | `total_points` | `uint32` | `optional` |  |  |
+| 2 | `total_premium_points` | `uint32` | `optional` |  |  |
+| 3 | `event_id` | `uint32` | `optional` |  |  |
+| 4 | `points` | `uint32` | `optional` |  |  |
+| 5 | `premium_points` | `uint32` | `optional` |  |  |
+| 6 | `completed_actions` | `.CMsgDOTAGetEventPointsResponse.Action` | `repeated` |  |  |
+| 7 | `account_id` | `uint32` | `optional` |  |  |
+| 8 | `owned` | `bool` | `optional` |  |  |
+| 9 | `audit_action` | `uint32` | `optional` |  |  |
+| 10 | `active_season_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1022,8 +1022,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `action_id` | `uint32` | `optional` | `` |  |
-| 2 | `times_completed` | `uint32` | `optional` | `` | default = 1 |
+| 1 | `action_id` | `uint32` | `optional` |  |  |
+| 2 | `times_completed` | `uint32` | `optional` |  | default = 1 |
 
 </details>
 
@@ -1035,9 +1035,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `periodic_resource_id` | `uint32` | `optional` | `` |  |
-| 3 | `timestamp` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `periodic_resource_id` | `uint32` | `optional` |  |  |
+| 3 | `timestamp` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1049,8 +1049,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `periodic_resource_max` | `uint32` | `optional` | `` |  |
-| 2 | `periodic_resource_used` | `uint32` | `optional` | `` |  |
+| 1 | `periodic_resource_max` | `uint32` | `optional` |  |  |
+| 2 | `periodic_resource_used` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1062,8 +1062,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `periodic_resource_key` | `.CMsgDOTAGetPeriodicResource` | `optional` | `` |  |
-| 2 | `periodic_resource_value` | `.CMsgDOTAGetPeriodicResourceResponse` | `optional` | `` |  |
+| 1 | `periodic_resource_key` | `.CMsgDOTAGetPeriodicResource` | `optional` |  |  |
+| 2 | `periodic_resource_value` | `.CMsgDOTAGetPeriodicResourceResponse` | `optional` |  |  |
 
 </details>
 
@@ -1075,9 +1075,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `selection_index` | `uint32` | `optional` | `` |  |
-| 2 | `selection` | `uint32` | `optional` | `` |  |
-| 3 | `leagueid` | `uint32` | `optional` | `` |  |
+| 1 | `selection_index` | `uint32` | `optional` |  |  |
+| 2 | `selection` | `uint32` | `optional` |  |  |
+| 3 | `leagueid` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1089,7 +1089,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `eresult` | `uint32` | `optional` | `` | default = 2 |
+| 1 | `eresult` | `uint32` | `optional` |  | default = 2 |
 
 </details>
 
@@ -1101,7 +1101,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `leagueid` | `uint32` | `optional` | `` |  |
+| 1 | `leagueid` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1113,7 +1113,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `eresult` | `uint32` | `optional` | `` | default = 2 |
+| 1 | `eresult` | `uint32` | `optional` |  | default = 2 |
 
 </details>
 
@@ -1125,7 +1125,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `selections` | `.CMsgDOTACompendiumSelection` | `repeated` | `` |  |
+| 1 | `selections` | `.CMsgDOTACompendiumSelection` | `repeated` |  |  |
 
 </details>
 
@@ -1137,8 +1137,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `leagueid` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `leagueid` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1150,10 +1150,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `leagueid` | `uint32` | `optional` | `` |  |
-| 3 | `result` | `uint32` | `optional` | `` | default = 2 |
-| 4 | `compendium_data` | `.CMsgDOTACompendiumData` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `leagueid` | `uint32` | `optional` |  |  |
+| 3 | `result` | `uint32` | `optional` |  | default = 2 |
+| 4 | `compendium_data` | `.CMsgDOTACompendiumData` | `optional` |  |  |
 
 </details>
 
@@ -1165,14 +1165,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `start_at_match_id` | `uint64` | `optional` | `` |  |
-| 3 | `matches_requested` | `uint32` | `optional` | `` |  |
-| 4 | `hero_id` | `int32` | `optional` | `` |  |
-| 5 | `request_id` | `uint32` | `optional` | `` |  |
-| 7 | `include_practice_matches` | `bool` | `optional` | `` |  |
-| 8 | `include_custom_games` | `bool` | `optional` | `` |  |
-| 9 | `include_event_games` | `bool` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `start_at_match_id` | `uint64` | `optional` |  |  |
+| 3 | `matches_requested` | `uint32` | `optional` |  |  |
+| 4 | `hero_id` | `int32` | `optional` |  |  |
+| 5 | `request_id` | `uint32` | `optional` |  |  |
+| 7 | `include_practice_matches` | `bool` | `optional` |  |  |
+| 8 | `include_custom_games` | `bool` | `optional` |  |  |
+| 9 | `include_event_games` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1184,8 +1184,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `matches` | `.CMsgDOTAGetPlayerMatchHistoryResponse.Match` | `repeated` | `` |  |
-| 2 | `request_id` | `uint32` | `optional` | `` |  |
+| 1 | `matches` | `.CMsgDOTAGetPlayerMatchHistoryResponse.Match` | `repeated` |  |  |
+| 2 | `request_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1197,28 +1197,28 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `start_time` | `uint32` | `optional` | `` |  |
-| 3 | `hero_id` | `int32` | `optional` | `` |  |
-| 4 | `winner` | `bool` | `optional` | `` |  |
-| 5 | `game_mode` | `uint32` | `optional` | `` |  |
-| 6 | `rank_change` | `int32` | `optional` | `` |  |
-| 7 | `previous_rank` | `uint32` | `optional` | `` |  |
-| 8 | `lobby_type` | `uint32` | `optional` | `` |  |
-| 9 | `solo_rank` | `bool` | `optional` | `` |  |
-| 10 | `abandon` | `bool` | `optional` | `` |  |
-| 11 | `duration` | `uint32` | `optional` | `` |  |
-| 12 | `engine` | `uint32` | `optional` | `` |  |
-| 13 | `active_plus_subscription` | `bool` | `optional` | `` |  |
-| 14 | `seasonal_rank` | `bool` | `optional` | `` |  |
-| 15 | `tourney_id` | `uint32` | `optional` | `` |  |
-| 16 | `tourney_round` | `uint32` | `optional` | `` |  |
-| 17 | `tourney_tier` | `uint32` | `optional` | `` |  |
-| 18 | `tourney_division` | `uint32` | `optional` | `` |  |
-| 19 | `team_id` | `uint32` | `optional` | `` |  |
-| 20 | `team_name` | `string` | `optional` | `` |  |
-| 21 | `ugc_team_ui_logo` | `uint64` | `optional` | `` |  |
-| 22 | `selected_facet` | `uint32` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `start_time` | `uint32` | `optional` |  |  |
+| 3 | `hero_id` | `int32` | `optional` |  |  |
+| 4 | `winner` | `bool` | `optional` |  |  |
+| 5 | `game_mode` | `uint32` | `optional` |  |  |
+| 6 | `rank_change` | `int32` | `optional` |  |  |
+| 7 | `previous_rank` | `uint32` | `optional` |  |  |
+| 8 | `lobby_type` | `uint32` | `optional` |  |  |
+| 9 | `solo_rank` | `bool` | `optional` |  |  |
+| 10 | `abandon` | `bool` | `optional` |  |  |
+| 11 | `duration` | `uint32` | `optional` |  |  |
+| 12 | `engine` | `uint32` | `optional` |  |  |
+| 13 | `active_plus_subscription` | `bool` | `optional` |  |  |
+| 14 | `seasonal_rank` | `bool` | `optional` |  |  |
+| 15 | `tourney_id` | `uint32` | `optional` |  |  |
+| 16 | `tourney_round` | `uint32` | `optional` |  |  |
+| 17 | `tourney_tier` | `uint32` | `optional` |  |  |
+| 18 | `tourney_division` | `uint32` | `optional` |  |  |
+| 19 | `team_id` | `uint32` | `optional` |  |  |
+| 20 | `team_name` | `string` | `optional` |  |  |
+| 21 | `ugc_team_ui_logo` | `uint64` | `optional` |  |  |
+| 22 | `selected_facet` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1242,14 +1242,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `uint64` | `optional` | `` |  |
-| 2 | `type` | `uint32` | `optional` | `` |  |
-| 3 | `timestamp` | `uint32` | `optional` | `` |  |
-| 4 | `reference_a` | `uint32` | `optional` | `` |  |
-| 5 | `reference_b` | `uint32` | `optional` | `` |  |
-| 6 | `reference_c` | `uint32` | `optional` | `` |  |
-| 7 | `message` | `string` | `optional` | `` |  |
-| 8 | `unread` | `bool` | `optional` | `` |  |
+| 1 | `id` | `uint64` | `optional` |  |  |
+| 2 | `type` | `uint32` | `optional` |  |  |
+| 3 | `timestamp` | `uint32` | `optional` |  |  |
+| 4 | `reference_a` | `uint32` | `optional` |  |  |
+| 5 | `reference_b` | `uint32` | `optional` |  |  |
+| 6 | `reference_c` | `uint32` | `optional` |  |  |
+| 7 | `message` | `string` | `optional` |  |  |
+| 8 | `unread` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1261,8 +1261,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgGCNotificationsUpdate.EResult` | `optional` | `` | default = SUCCESS |
-| 2 | `notifications` | `.CMsgGCNotifications_Notification` | `repeated` | `` |  |
+| 1 | `result` | `.CMsgGCNotificationsUpdate.EResult` | `optional` |  | default = SUCCESS |
+| 2 | `notifications` | `.CMsgGCNotifications_Notification` | `repeated` |  |  |
 
 </details>
 
@@ -1274,7 +1274,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `update` | `.CMsgGCNotificationsUpdate` | `optional` | `` |  |
+| 1 | `update` | `.CMsgGCNotificationsUpdate` | `optional` |  |  |
 
 </details>
 
@@ -1298,14 +1298,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_name` | `string` | `optional` | `` |  |
-| 2 | `country_code` | `string` | `optional` | `` |  |
-| 3 | `fantasy_role` | `uint32` | `optional` | `` |  |
-| 4 | `team_id` | `uint32` | `optional` | `` |  |
-| 5 | `sponsor` | `string` | `optional` | `` |  |
-| 6 | `accepted_pro_agreement` | `bool` | `optional` | `` |  |
-| 7 | `registration_period` | `uint32` | `optional` | `` |  |
-| 8 | `real_name` | `string` | `optional` | `` |  |
+| 1 | `player_name` | `string` | `optional` |  |  |
+| 2 | `country_code` | `string` | `optional` |  |  |
+| 3 | `fantasy_role` | `uint32` | `optional` |  |  |
+| 4 | `team_id` | `uint32` | `optional` |  |  |
+| 5 | `sponsor` | `string` | `optional` |  |  |
+| 6 | `accepted_pro_agreement` | `bool` | `optional` |  |  |
+| 7 | `registration_period` | `uint32` | `optional` |  |  |
+| 8 | `real_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1317,7 +1317,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgGCPlayerInfoSubmitResponse.EResult` | `optional` | `` | default = SUCCESS |
+| 1 | `result` | `.CMsgGCPlayerInfoSubmitResponse.EResult` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -1329,8 +1329,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `unlocked_emoticons` | `bytes` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `unlocked_emoticons` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -1354,7 +1354,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `emoticon_access` | `.CMsgDOTAEmoticonAccessSDO` | `optional` | `` |  |
+| 1 | `emoticon_access` | `.CMsgDOTAEmoticonAccessSDO` | `optional` |  |  |
 
 </details>
 
@@ -1366,8 +1366,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def` | `uint32` | `optional` | `` |  |
-| 2 | `event_type` | `uint32` | `optional` | `` |  |
+| 1 | `item_def` | `uint32` | `optional` |  |  |
+| 2 | `event_type` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1391,7 +1391,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_ids` | `int32` | `repeated` | `` |  |
+| 1 | `hero_ids` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -1403,7 +1403,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1415,26 +1415,26 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `curr_hero_id` | `int32` | `optional` | `` |  |
-| 3 | `laps_completed` | `uint32` | `optional` | `` |  |
-| 4 | `curr_hero_games` | `uint32` | `optional` | `` |  |
-| 5 | `curr_lap_time_started` | `uint32` | `optional` | `` |  |
-| 6 | `curr_lap_games` | `uint32` | `optional` | `` |  |
-| 7 | `best_lap_games` | `uint32` | `optional` | `` |  |
-| 8 | `best_lap_time` | `uint32` | `optional` | `` |  |
-| 9 | `lap_heroes_completed` | `uint32` | `optional` | `` |  |
-| 10 | `lap_heroes_remaining` | `uint32` | `optional` | `` |  |
-| 11 | `next_hero_id` | `int32` | `optional` | `` |  |
-| 12 | `prev_hero_id` | `int32` | `optional` | `` |  |
-| 13 | `prev_hero_games` | `uint32` | `optional` | `` |  |
-| 14 | `prev_avg_tries` | `float` | `optional` | `` |  |
-| 15 | `curr_avg_tries` | `float` | `optional` | `` |  |
-| 16 | `next_avg_tries` | `float` | `optional` | `` |  |
-| 17 | `full_lap_avg_tries` | `float` | `optional` | `` |  |
-| 18 | `curr_lap_avg_tries` | `float` | `optional` | `` |  |
-| 19 | `profile_name` | `string` | `optional` | `` |  |
-| 20 | `start_hero_id` | `int32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `curr_hero_id` | `int32` | `optional` |  |  |
+| 3 | `laps_completed` | `uint32` | `optional` |  |  |
+| 4 | `curr_hero_games` | `uint32` | `optional` |  |  |
+| 5 | `curr_lap_time_started` | `uint32` | `optional` |  |  |
+| 6 | `curr_lap_games` | `uint32` | `optional` |  |  |
+| 7 | `best_lap_games` | `uint32` | `optional` |  |  |
+| 8 | `best_lap_time` | `uint32` | `optional` |  |  |
+| 9 | `lap_heroes_completed` | `uint32` | `optional` |  |  |
+| 10 | `lap_heroes_remaining` | `uint32` | `optional` |  |  |
+| 11 | `next_hero_id` | `int32` | `optional` |  |  |
+| 12 | `prev_hero_id` | `int32` | `optional` |  |  |
+| 13 | `prev_hero_games` | `uint32` | `optional` |  |  |
+| 14 | `prev_avg_tries` | `float` | `optional` |  |  |
+| 15 | `curr_avg_tries` | `float` | `optional` |  |  |
+| 16 | `next_avg_tries` | `float` | `optional` |  |  |
+| 17 | `full_lap_avg_tries` | `float` | `optional` |  |  |
+| 18 | `curr_lap_avg_tries` | `float` | `optional` |  |  |
+| 19 | `profile_name` | `string` | `optional` |  |  |
+| 20 | `start_hero_id` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1446,7 +1446,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1458,7 +1458,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `trophies` | `.CMsgClientToGCGetTrophyListResponse.Trophy` | `repeated` | `` |  |
+| 2 | `trophies` | `.CMsgClientToGCGetTrophyListResponse.Trophy` | `repeated` |  |  |
 
 </details>
 
@@ -1470,9 +1470,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `trophy_id` | `uint32` | `optional` | `` |  |
-| 2 | `trophy_score` | `uint32` | `optional` | `` |  |
-| 3 | `last_updated` | `uint32` | `optional` | `` |  |
+| 1 | `trophy_id` | `uint32` | `optional` |  |  |
+| 2 | `trophy_score` | `uint32` | `optional` |  |  |
+| 3 | `last_updated` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1484,10 +1484,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `trophy_id` | `uint32` | `optional` | `` |  |
-| 2 | `trophy_score` | `uint32` | `optional` | `` |  |
-| 3 | `trophy_old_score` | `uint32` | `optional` | `` |  |
-| 4 | `last_updated` | `uint32` | `optional` | `` |  |
+| 1 | `trophy_id` | `uint32` | `optional` |  |  |
+| 2 | `trophy_score` | `uint32` | `optional` |  |  |
+| 3 | `trophy_old_score` | `uint32` | `optional` |  |  |
+| 4 | `last_updated` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1499,7 +1499,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `rank_type` | `.ERankType` | `optional` | `` | default = k_ERankType_Invalid |
+| 1 | `rank_type` | `.ERankType` | `optional` |  | default = k_ERankType_Invalid |
 
 </details>
 
@@ -1511,11 +1511,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgGCToClientRankResponse.EResultCode` | `optional` | `` | default = k_Succeeded |
-| 2 | `rank_value` | `uint32` | `optional` | `` |  |
-| 3 | `rank_data1` | `uint32` | `optional` | `` |  |
-| 4 | `rank_data2` | `uint32` | `optional` | `` |  |
-| 5 | `rank_data3` | `uint32` | `optional` | `` |  |
+| 1 | `result` | `.CMsgGCToClientRankResponse.EResultCode` | `optional` |  | default = k_Succeeded |
+| 2 | `rank_value` | `uint32` | `optional` |  |  |
+| 3 | `rank_data1` | `uint32` | `optional` |  |  |
+| 4 | `rank_data2` | `uint32` | `optional` |  |  |
+| 5 | `rank_data3` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1527,8 +1527,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `rank_type` | `.ERankType` | `optional` | `` | default = k_ERankType_Invalid |
-| 2 | `rank_info` | `.CMsgGCToClientRankResponse` | `optional` | `` |  |
+| 1 | `rank_type` | `.ERankType` | `optional` |  | default = k_ERankType_Invalid |
+| 2 | `rank_info` | `.CMsgGCToClientRankResponse` | `optional` |  |  |
 
 </details>
 
@@ -1540,7 +1540,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1552,7 +1552,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `slots` | `.CMsgClientToGCSetProfileCardSlots.CardSlot` | `repeated` | `` |  |
+| 1 | `slots` | `.CMsgClientToGCSetProfileCardSlots.CardSlot` | `repeated` |  |  |
 
 </details>
 
@@ -1564,9 +1564,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `slot_id` | `uint32` | `optional` | `` |  |
-| 2 | `slot_type` | `.EProfileCardSlotType` | `optional` | `` | default = k_EProfileCardSlotType_Empty |
-| 3 | `slot_value` | `uint64` | `optional` | `` |  |
+| 1 | `slot_id` | `uint32` | `optional` |  |  |
+| 2 | `slot_type` | `.EProfileCardSlotType` | `optional` |  | default = k_EProfileCardSlotType_Empty |
+| 3 | `slot_value` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -1590,15 +1590,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `source_item_id` | `uint64` | `optional` | `` |  |
-| 3 | `hero_id` | `int32` | `optional` | `` |  |
-| 4 | `sequence_name` | `string` | `optional` | `` |  |
-| 5 | `cycle` | `float` | `optional` | `` |  |
-| 6 | `wearables` | `uint32` | `repeated` | `` |  |
-| 7 | `inscription` | `string` | `optional` | `` |  |
-| 8 | `styles` | `uint32` | `repeated` | `` |  |
-| 9 | `reforger_item_id` | `uint64` | `optional` | `` |  |
-| 10 | `tournament_drop` | `bool` | `optional` | `` |  |
+| 1 | `source_item_id` | `uint64` | `optional` |  |  |
+| 3 | `hero_id` | `int32` | `optional` |  |  |
+| 4 | `sequence_name` | `string` | `optional` |  |  |
+| 5 | `cycle` | `float` | `optional` |  |  |
+| 6 | `wearables` | `uint32` | `repeated` |  |  |
+| 7 | `inscription` | `string` | `optional` |  |  |
+| 8 | `styles` | `uint32` | `repeated` |  |  |
+| 9 | `reforger_item_id` | `uint64` | `optional` |  |  |
+| 10 | `tournament_drop` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1610,7 +1610,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `resulting_item_id` | `uint64` | `optional` | `` |  |
+| 1 | `resulting_item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -1622,7 +1622,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1634,29 +1634,29 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `player_stats` | `float` | `repeated` | `` |  |
-| 3 | `match_count` | `uint32` | `optional` | `` |  |
-| 4 | `mean_gpm` | `float` | `optional` | `` |  |
-| 5 | `mean_xppm` | `float` | `optional` | `` |  |
-| 6 | `mean_lasthits` | `float` | `optional` | `` |  |
-| 7 | `rampages` | `uint32` | `optional` | `` |  |
-| 8 | `triple_kills` | `uint32` | `optional` | `` |  |
-| 9 | `first_blood_claimed` | `uint32` | `optional` | `` |  |
-| 10 | `first_blood_given` | `uint32` | `optional` | `` |  |
-| 11 | `couriers_killed` | `uint32` | `optional` | `` |  |
-| 12 | `aegises_snatched` | `uint32` | `optional` | `` |  |
-| 13 | `cheeses_eaten` | `uint32` | `optional` | `` |  |
-| 14 | `creeps_stacked` | `uint32` | `optional` | `` |  |
-| 15 | `fight_score` | `float` | `optional` | `` |  |
-| 16 | `farm_score` | `float` | `optional` | `` |  |
-| 17 | `support_score` | `float` | `optional` | `` |  |
-| 18 | `push_score` | `float` | `optional` | `` |  |
-| 19 | `versatility_score` | `float` | `optional` | `` |  |
-| 20 | `mean_networth` | `float` | `optional` | `` |  |
-| 21 | `mean_damage` | `float` | `optional` | `` |  |
-| 22 | `mean_heals` | `float` | `optional` | `` |  |
-| 23 | `rapiers_purchased` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `player_stats` | `float` | `repeated` |  |  |
+| 3 | `match_count` | `uint32` | `optional` |  |  |
+| 4 | `mean_gpm` | `float` | `optional` |  |  |
+| 5 | `mean_xppm` | `float` | `optional` |  |  |
+| 6 | `mean_lasthits` | `float` | `optional` |  |  |
+| 7 | `rampages` | `uint32` | `optional` |  |  |
+| 8 | `triple_kills` | `uint32` | `optional` |  |  |
+| 9 | `first_blood_claimed` | `uint32` | `optional` |  |  |
+| 10 | `first_blood_given` | `uint32` | `optional` |  |  |
+| 11 | `couriers_killed` | `uint32` | `optional` |  |  |
+| 12 | `aegises_snatched` | `uint32` | `optional` |  |  |
+| 13 | `cheeses_eaten` | `uint32` | `optional` |  |  |
+| 14 | `creeps_stacked` | `uint32` | `optional` |  |  |
+| 15 | `fight_score` | `float` | `optional` |  |  |
+| 16 | `farm_score` | `float` | `optional` |  |  |
+| 17 | `support_score` | `float` | `optional` |  |  |
+| 18 | `push_score` | `float` | `optional` |  |  |
+| 19 | `versatility_score` | `float` | `optional` |  |  |
+| 20 | `mean_networth` | `float` | `optional` |  |  |
+| 21 | `mean_damage` | `float` | `optional` |  |  |
+| 22 | `mean_heals` | `float` | `optional` |  |  |
+| 23 | `rapiers_purchased` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1680,8 +1680,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `games` | `.CMsgGCToClientCustomGamesFriendsPlayedResponse.CustomGame` | `repeated` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `games` | `.CMsgGCToClientCustomGamesFriendsPlayedResponse.CustomGame` | `repeated` |  |  |
 
 </details>
 
@@ -1693,8 +1693,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `custom_game_id` | `uint64` | `optional` | `` |  |
-| 2 | `account_ids` | `uint32` | `repeated` | `` |  |
+| 1 | `custom_game_id` | `uint64` | `optional` |  |  |
+| 2 | `account_ids` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -1706,8 +1706,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint64` | `optional` | `` |  |
-| 2 | `comment` | `string` | `optional` | `` |  |
+| 1 | `event_id` | `uint64` | `optional` |  |  |
+| 2 | `comment` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1719,7 +1719,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `success` | `bool` | `optional` | `` |  |
+| 1 | `success` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1731,9 +1731,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `message` | `string` | `optional` | `` |  |
-| 2 | `match_id` | `uint64` | `optional` | `` |  |
-| 3 | `match_timestamp` | `uint32` | `optional` | `` |  |
+| 1 | `message` | `string` | `optional` |  |  |
+| 2 | `match_id` | `uint64` | `optional` |  |  |
+| 3 | `match_timestamp` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1745,7 +1745,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `success` | `bool` | `optional` | `` |  |
+| 1 | `success` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1757,7 +1757,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `custom_game_id` | `uint64` | `optional` | `` |  |
+| 1 | `custom_game_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -1769,8 +1769,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `custom_game_id` | `uint64` | `optional` | `` |  |
-| 2 | `account_ids` | `uint32` | `repeated` | `` |  |
+| 1 | `custom_game_id` | `uint64` | `optional` |  |  |
+| 2 | `account_ids` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -1782,15 +1782,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `party_id` | `fixed64` | `optional` | `` |  |
-| 2 | `party_state` | `.CSODOTAParty.State` | `optional` | `` | default = UI |
-| 3 | `open` | `bool` | `optional` | `` |  |
-| 4 | `members` | `.CMsgDOTAPartyRichPresence.Member` | `repeated` | `` |  |
-| 5 | `low_priority` | `bool` | `optional` | `` |  |
-| 6 | `weekend_tourney` | `.CMsgDOTAPartyRichPresence.WeekendTourney` | `optional` | `` |  |
-| 7 | `team_id` | `uint32` | `optional` | `` |  |
-| 8 | `team_name` | `string` | `optional` | `` |  |
-| 9 | `ugc_team_ui_logo` | `uint64` | `optional` | `` |  |
+| 1 | `party_id` | `fixed64` | `optional` |  |  |
+| 2 | `party_state` | `.CSODOTAParty.State` | `optional` |  | default = UI |
+| 3 | `open` | `bool` | `optional` |  |  |
+| 4 | `members` | `.CMsgDOTAPartyRichPresence.Member` | `repeated` |  |  |
+| 5 | `low_priority` | `bool` | `optional` |  |  |
+| 6 | `weekend_tourney` | `.CMsgDOTAPartyRichPresence.WeekendTourney` | `optional` |  |  |
+| 7 | `team_id` | `uint32` | `optional` |  |  |
+| 8 | `team_name` | `string` | `optional` |  |  |
+| 9 | `ugc_team_ui_logo` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -1802,8 +1802,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steam_id` | `fixed64` | `optional` | `` |  |
-| 2 | `coach` | `bool` | `optional` | `` |  |
+| 1 | `steam_id` | `fixed64` | `optional` |  |  |
+| 2 | `coach` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1815,13 +1815,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `division` | `uint32` | `optional` | `` |  |
-| 2 | `skill_level` | `uint32` | `optional` | `` |  |
-| 3 | `round` | `uint32` | `optional` | `` |  |
-| 4 | `tournament_id` | `uint32` | `optional` | `` |  |
-| 5 | `state_seq_num` | `uint32` | `optional` | `` |  |
-| 6 | `event` | `.EWeekendTourneyRichPresenceEvent` | `optional` | `` | default = k_EWeekendTourneyRichPresenceEvent_None |
-| 7 | `event_round` | `uint32` | `optional` | `` |  |
+| 1 | `division` | `uint32` | `optional` |  |  |
+| 2 | `skill_level` | `uint32` | `optional` |  |  |
+| 3 | `round` | `uint32` | `optional` |  |  |
+| 4 | `tournament_id` | `uint32` | `optional` |  |  |
+| 5 | `state_seq_num` | `uint32` | `optional` |  |  |
+| 6 | `event` | `.EWeekendTourneyRichPresenceEvent` | `optional` |  | default = k_EWeekendTourneyRichPresenceEvent_None |
+| 7 | `event_round` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1833,15 +1833,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `lobby_id` | `fixed64` | `optional` | `` |  |
-| 2 | `lobby_state` | `.CSODOTALobby.State` | `optional` | `` | default = UI |
-| 3 | `password` | `bool` | `optional` | `` |  |
-| 4 | `game_mode` | `.DOTA_GameMode` | `optional` | `` | default = DOTA_GAMEMODE_NONE |
-| 5 | `member_count` | `uint32` | `optional` | `` |  |
-| 6 | `max_member_count` | `uint32` | `optional` | `` |  |
-| 7 | `custom_game_id` | `fixed64` | `optional` | `` |  |
-| 8 | `name` | `string` | `optional` | `` |  |
-| 9 | `lobby_type` | `uint32` | `optional` | `` |  |
+| 1 | `lobby_id` | `fixed64` | `optional` |  |  |
+| 2 | `lobby_state` | `.CSODOTALobby.State` | `optional` |  | default = UI |
+| 3 | `password` | `bool` | `optional` |  |  |
+| 4 | `game_mode` | `.DOTA_GameMode` | `optional` |  | default = DOTA_GAMEMODE_NONE |
+| 5 | `member_count` | `uint32` | `optional` |  |  |
+| 6 | `max_member_count` | `uint32` | `optional` |  |  |
+| 7 | `custom_game_id` | `fixed64` | `optional` |  |  |
+| 8 | `name` | `string` | `optional` |  |  |
+| 9 | `lobby_type` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1853,10 +1853,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `lobby_id` | `fixed64` | `optional` | `` |  |
-| 2 | `custom_game_id` | `uint64` | `optional` | `` |  |
-| 3 | `lobby_members` | `uint32` | `repeated` | `` |  |
-| 4 | `start_time` | `uint32` | `optional` | `` |  |
+| 1 | `lobby_id` | `fixed64` | `optional` |  |  |
+| 2 | `custom_game_id` | `uint64` | `optional` |  |  |
+| 3 | `lobby_members` | `uint32` | `repeated` |  |  |
+| 4 | `start_time` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1868,12 +1868,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `lobby_id` | `fixed64` | `optional` | `` |  |
-| 2 | `loading_duration` | `uint32` | `optional` | `` |  |
-| 3 | `result_code` | `sint32` | `optional` | `` |  |
-| 4 | `result_string` | `string` | `optional` | `` |  |
-| 5 | `signon_states` | `uint32` | `optional` | `` |  |
-| 6 | `comment` | `string` | `optional` | `` |  |
+| 1 | `lobby_id` | `fixed64` | `optional` |  |  |
+| 2 | `loading_duration` | `uint32` | `optional` |  |  |
+| 3 | `result_code` | `sint32` | `optional` |  |  |
+| 4 | `result_string` | `string` | `optional` |  |  |
+| 5 | `signon_states` | `uint32` | `optional` |  |  |
+| 6 | `comment` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1885,8 +1885,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id_1` | `uint64` | `optional` | `` |  |
-| 2 | `item_id_2` | `uint64` | `optional` | `` |  |
+| 1 | `item_id_1` | `uint64` | `optional` |  |  |
+| 2 | `item_id_2` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -1910,7 +1910,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `quest_ids` | `uint32` | `repeated` | `` |  |
+| 1 | `quest_ids` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -1922,8 +1922,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `success` | `bool` | `optional` | `` |  |
-| 2 | `quests` | `.CMsgClientToGCGetQuestProgressResponse.Quest` | `repeated` | `` |  |
+| 1 | `success` | `bool` | `optional` |  |  |
+| 2 | `quests` | `.CMsgClientToGCGetQuestProgressResponse.Quest` | `repeated` |  |  |
 
 </details>
 
@@ -1935,12 +1935,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `challenge_id` | `uint32` | `optional` | `` |  |
-| 2 | `time_completed` | `uint32` | `optional` | `` |  |
-| 3 | `attempts` | `uint32` | `optional` | `` |  |
-| 4 | `hero_id` | `int32` | `optional` | `` |  |
-| 5 | `template_id` | `uint32` | `optional` | `` |  |
-| 6 | `quest_rank` | `uint32` | `optional` | `` |  |
+| 1 | `challenge_id` | `uint32` | `optional` |  |  |
+| 2 | `time_completed` | `uint32` | `optional` |  |  |
+| 3 | `attempts` | `uint32` | `optional` |  |  |
+| 4 | `hero_id` | `int32` | `optional` |  |  |
+| 5 | `template_id` | `uint32` | `optional` |  |  |
+| 6 | `quest_rank` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1952,8 +1952,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `quest_id` | `uint32` | `optional` | `` |  |
-| 2 | `completed_challenges` | `.CMsgClientToGCGetQuestProgressResponse.Challenge` | `repeated` | `` |  |
+| 1 | `quest_id` | `uint32` | `optional` |  |  |
+| 2 | `completed_challenges` | `.CMsgClientToGCGetQuestProgressResponse.Challenge` | `repeated` |  |  |
 
 </details>
 
@@ -1965,7 +1965,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -1977,7 +1977,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1989,9 +1989,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `records` | `.CMsgDOTASDOHeroStatsHistory` | `repeated` | `` |  |
-| 3 | `result` | `.CMsgGCGetHeroStatsHistoryResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `records` | `.CMsgDOTASDOHeroStatsHistory` | `repeated` |  |  |
+| 3 | `result` | `.CMsgGCGetHeroStatsHistoryResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -2015,23 +2015,23 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `match_id` | `uint64` | `optional` | `` |  |
-| 3 | `seq_num` | `uint32` | `optional` | `` |  |
-| 4 | `reasons` | `uint32` | `optional` | `` |  |
-| 5 | `matches_in_report` | `uint32` | `optional` | `` |  |
-| 6 | `matches_clean` | `uint32` | `optional` | `` |  |
-| 7 | `matches_reported` | `uint32` | `optional` | `` |  |
-| 8 | `matches_abandoned` | `uint32` | `optional` | `` |  |
-| 9 | `reports_count` | `uint32` | `optional` | `` |  |
-| 10 | `reports_parties` | `uint32` | `optional` | `` |  |
-| 11 | `commend_count` | `uint32` | `optional` | `` |  |
-| 14 | `date` | `uint32` | `optional` | `` |  |
-| 17 | `raw_behavior_score` | `uint32` | `optional` | `` |  |
-| 18 | `old_raw_behavior_score` | `uint32` | `optional` | `` |  |
-| 19 | `comms_reports` | `uint32` | `optional` | `` |  |
-| 20 | `comms_parties` | `uint32` | `optional` | `` |  |
-| 21 | `behavior_rating` | `.CMsgPlayerConductScorecard.EBehaviorRating` | `optional` | `` | default = k_eBehaviorGood |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `match_id` | `uint64` | `optional` |  |  |
+| 3 | `seq_num` | `uint32` | `optional` |  |  |
+| 4 | `reasons` | `uint32` | `optional` |  |  |
+| 5 | `matches_in_report` | `uint32` | `optional` |  |  |
+| 6 | `matches_clean` | `uint32` | `optional` |  |  |
+| 7 | `matches_reported` | `uint32` | `optional` |  |  |
+| 8 | `matches_abandoned` | `uint32` | `optional` |  |  |
+| 9 | `reports_count` | `uint32` | `optional` |  |  |
+| 10 | `reports_parties` | `uint32` | `optional` |  |  |
+| 11 | `commend_count` | `uint32` | `optional` |  |  |
+| 14 | `date` | `uint32` | `optional` |  |  |
+| 17 | `raw_behavior_score` | `uint32` | `optional` |  |  |
+| 18 | `old_raw_behavior_score` | `uint32` | `optional` |  |  |
+| 19 | `comms_reports` | `uint32` | `optional` |  |  |
+| 20 | `comms_parties` | `uint32` | `optional` |  |  |
+| 21 | `behavior_rating` | `.CMsgPlayerConductScorecard.EBehaviorRating` | `optional` |  | default = k_eBehaviorGood |
 
 </details>
 
@@ -2043,7 +2043,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2055,19 +2055,19 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `coins_remaining` | `uint32` | `optional` | `` |  |
-| 2 | `total_points_won` | `uint32` | `optional` | `` |  |
-| 3 | `total_points_wagered` | `uint32` | `optional` | `` |  |
-| 4 | `total_points_tipped` | `uint32` | `optional` | `` |  |
-| 5 | `success_rate` | `uint32` | `optional` | `` |  |
-| 6 | `total_games_wagered` | `uint32` | `optional` | `` |  |
-| 7 | `coins_max` | `uint32` | `optional` | `` |  |
-| 8 | `rank_wagers_remaining` | `uint32` | `optional` | `` |  |
-| 9 | `rank_wagers_max` | `uint32` | `optional` | `` |  |
-| 10 | `prediction_tokens_remaining` | `uint32` | `optional` | `` |  |
-| 11 | `prediction_tokens_max` | `uint32` | `optional` | `` |  |
-| 12 | `bounties_remaining` | `uint32` | `optional` | `` |  |
-| 13 | `bounties_max` | `uint32` | `optional` | `` |  |
+| 1 | `coins_remaining` | `uint32` | `optional` |  |  |
+| 2 | `total_points_won` | `uint32` | `optional` |  |  |
+| 3 | `total_points_wagered` | `uint32` | `optional` |  |  |
+| 4 | `total_points_tipped` | `uint32` | `optional` |  |  |
+| 5 | `success_rate` | `uint32` | `optional` |  |  |
+| 6 | `total_games_wagered` | `uint32` | `optional` |  |  |
+| 7 | `coins_max` | `uint32` | `optional` |  |  |
+| 8 | `rank_wagers_remaining` | `uint32` | `optional` |  |  |
+| 9 | `rank_wagers_max` | `uint32` | `optional` |  |  |
+| 10 | `prediction_tokens_remaining` | `uint32` | `optional` |  |  |
+| 11 | `prediction_tokens_max` | `uint32` | `optional` |  |  |
+| 12 | `bounties_remaining` | `uint32` | `optional` |  |  |
+| 13 | `bounties_max` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2079,8 +2079,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `wagering_info` | `.CMsgGCToClientWageringResponse` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `wagering_info` | `.CMsgGCToClientWageringResponse` | `optional` |  |  |
 
 </details>
 
@@ -2092,8 +2092,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `arcana_votes` | `.CMsgClientToGCRequestArcanaVotesRemainingResponse` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `arcana_votes` | `.CMsgClientToGCRequestArcanaVotesRemainingResponse` | `optional` |  |  |
 
 </details>
 
@@ -2105,7 +2105,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_ids` | `.EEvent` | `repeated` | `` |  |
+| 1 | `event_ids` | `.EEvent` | `repeated` |  |  |
 
 </details>
 
@@ -2117,7 +2117,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_goals` | `.CMsgEventGoals.EventGoal` | `repeated` | `` |  |
+| 1 | `event_goals` | `.CMsgEventGoals.EventGoal` | `repeated` |  |  |
 
 </details>
 
@@ -2129,9 +2129,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 2 | `goal_id` | `uint32` | `optional` | `` |  |
-| 3 | `value` | `uint64` | `optional` | `` |  |
+| 1 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 2 | `goal_id` | `uint32` | `optional` |  |  |
+| 3 | `value` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -2143,7 +2143,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2155,7 +2155,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `predictions` | `.CMsgPredictionRankings.Prediction` | `repeated` | `` |  |
+| 1 | `predictions` | `.CMsgPredictionRankings.Prediction` | `repeated` |  |  |
 
 </details>
 
@@ -2167,10 +2167,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `answer_id` | `uint32` | `optional` | `` |  |
-| 2 | `answer_name` | `string` | `optional` | `` |  |
-| 3 | `answer_logo` | `uint64` | `optional` | `` |  |
-| 4 | `answer_value` | `float` | `optional` | `` |  |
+| 1 | `answer_id` | `uint32` | `optional` |  |  |
+| 2 | `answer_name` | `string` | `optional` |  |  |
+| 3 | `answer_logo` | `uint64` | `optional` |  |  |
+| 4 | `answer_value` | `float` | `optional` |  |  |
 
 </details>
 
@@ -2182,8 +2182,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `selection_id` | `uint32` | `optional` | `` |  |
-| 2 | `prediction_lines` | `.CMsgPredictionRankings.PredictionLine` | `repeated` | `` |  |
+| 1 | `selection_id` | `uint32` | `optional` |  |  |
+| 2 | `prediction_lines` | `.CMsgPredictionRankings.PredictionLine` | `repeated` |  |  |
 
 </details>
 
@@ -2195,7 +2195,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `results` | `.CMsgPredictionResults.Result` | `repeated` | `` |  |
+| 1 | `results` | `.CMsgPredictionResults.Result` | `repeated` |  |  |
 
 </details>
 
@@ -2207,8 +2207,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `answer_selection` | `uint32` | `optional` | `` |  |
-| 3 | `answer_value` | `float` | `optional` | `` |  |
+| 2 | `answer_selection` | `uint32` | `optional` |  |  |
+| 3 | `answer_value` | `float` | `optional` |  |  |
 
 </details>
 
@@ -2220,8 +2220,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `selection_id` | `uint32` | `optional` | `` |  |
-| 2 | `result_breakdown` | `.CMsgPredictionResults.ResultBreakdown` | `repeated` | `` |  |
+| 1 | `selection_id` | `uint32` | `optional` |  |  |
+| 2 | `result_breakdown` | `.CMsgPredictionResults.ResultBreakdown` | `repeated` |  |  |
 
 </details>
 
@@ -2233,7 +2233,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -2245,7 +2245,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `bool` | `optional` | `` |  |
+| 1 | `result` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2257,8 +2257,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 3 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 3 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2270,7 +2270,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `bool` | `optional` | `` |  |
+| 1 | `result` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2282,7 +2282,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -2294,7 +2294,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `bool` | `optional` | `` |  |
+| 1 | `result` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2318,8 +2318,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `success` | `bool` | `optional` | `` |  |
-| 2 | `teammate_stats` | `.CMsgClientToGCTeammateStatsResponse.TeammateStat` | `repeated` | `` |  |
+| 1 | `success` | `bool` | `optional` |  |  |
+| 2 | `teammate_stats` | `.CMsgClientToGCTeammateStatsResponse.TeammateStat` | `repeated` |  |  |
 
 </details>
 
@@ -2331,12 +2331,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `games` | `uint32` | `optional` | `` |  |
-| 3 | `wins` | `uint32` | `optional` | `` |  |
-| 4 | `most_recent_game_timestamp` | `uint32` | `optional` | `` |  |
-| 5 | `most_recent_game_match_id` | `uint64` | `optional` | `` |  |
-| 100 | `performance` | `float` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `games` | `uint32` | `optional` |  |  |
+| 3 | `wins` | `uint32` | `optional` |  |  |
+| 4 | `most_recent_game_timestamp` | `uint32` | `optional` |  |  |
+| 5 | `most_recent_game_match_id` | `uint64` | `optional` |  |  |
+| 100 | `performance` | `float` | `optional` |  |  |
 
 </details>
 
@@ -2348,7 +2348,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `matches` | `.CMsgArcanaVoteMatchVotes` | `repeated` | `` |  |
+| 1 | `matches` | `.CMsgArcanaVoteMatchVotes` | `repeated` |  |  |
 
 </details>
 
@@ -2360,7 +2360,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCVoteForArcanaResponse.Result` | `optional` | `` | default = SUCCEEDED |
+| 1 | `result` | `.CMsgClientToGCVoteForArcanaResponse.Result` | `optional` |  | default = SUCCEEDED |
 
 </details>
 
@@ -2384,10 +2384,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `bool` | `optional` | `` |  |
-| 2 | `votes_remaining` | `uint32` | `optional` | `` |  |
-| 3 | `votes_total` | `uint32` | `optional` | `` |  |
-| 4 | `matches_previously_voted_for` | `.CMsgArcanaVoteMatchVotes` | `repeated` | `` |  |
+| 1 | `result` | `bool` | `optional` |  |  |
+| 2 | `votes_remaining` | `uint32` | `optional` |  |  |
+| 3 | `votes_total` | `uint32` | `optional` |  |  |
+| 4 | `matches_previously_voted_for` | `.CMsgArcanaVoteMatchVotes` | `repeated` |  |  |
 
 </details>
 
@@ -2399,7 +2399,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2411,9 +2411,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `bool` | `optional` | `` |  |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 3 | `log_entries` | `.CMsgClientToGCRequestEventPointLogResponseV2.LogEntry` | `repeated` | `` |  |
+| 1 | `result` | `bool` | `optional` |  |  |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 3 | `log_entries` | `.CMsgClientToGCRequestEventPointLogResponseV2.LogEntry` | `repeated` |  |  |
 
 </details>
 
@@ -2425,10 +2425,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `timestamp` | `uint32` | `optional` | `` |  |
-| 2 | `audit_action` | `uint32` | `optional` | `` |  |
-| 3 | `event_points` | `int32` | `optional` | `` |  |
-| 4 | `audit_data` | `uint64` | `optional` | `` |  |
+| 1 | `timestamp` | `uint32` | `optional` |  |  |
+| 2 | `audit_action` | `uint32` | `optional` |  |  |
+| 3 | `event_points` | `int32` | `optional` |  |  |
+| 4 | `audit_data` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -2440,8 +2440,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `user_stats_event` | `uint32` | `optional` | `` |  |
-| 2 | `reference_data` | `uint64` | `optional` | `` |  |
+| 1 | `user_stats_event` | `uint32` | `optional` |  |  |
+| 2 | `reference_data` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -2453,9 +2453,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 2 | `slot_chosen` | `uint32` | `optional` | `` |  |
-| 3 | `week` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 2 | `slot_chosen` | `uint32` | `optional` |  |  |
+| 3 | `week` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2467,8 +2467,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `points_won` | `uint32` | `optional` | `` |  |
-| 2 | `aura_won` | `bool` | `optional` | `` |  |
+| 1 | `points_won` | `uint32` | `optional` |  |  |
+| 2 | `aura_won` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2480,8 +2480,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `quest_id` | `uint32` | `optional` | `` |  |
-| 2 | `completed_challenges` | `.CMsgGCToClientQuestProgressUpdated.Challenge` | `repeated` | `` |  |
+| 1 | `quest_id` | `uint32` | `optional` |  |  |
+| 2 | `completed_challenges` | `.CMsgGCToClientQuestProgressUpdated.Challenge` | `repeated` |  |  |
 
 </details>
 
@@ -2493,13 +2493,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `challenge_id` | `uint32` | `optional` | `` |  |
-| 2 | `time_completed` | `uint32` | `optional` | `` |  |
-| 3 | `attempts` | `uint32` | `optional` | `` |  |
-| 4 | `hero_id` | `int32` | `optional` | `` |  |
-| 5 | `template_id` | `uint32` | `optional` | `` |  |
-| 6 | `quest_rank` | `uint32` | `optional` | `` |  |
-| 7 | `max_quest_rank` | `uint32` | `optional` | `` |  |
+| 1 | `challenge_id` | `uint32` | `optional` |  |  |
+| 2 | `time_completed` | `uint32` | `optional` |  |  |
+| 3 | `attempts` | `uint32` | `optional` |  |  |
+| 4 | `hero_id` | `int32` | `optional` |  |  |
+| 5 | `template_id` | `uint32` | `optional` |  |  |
+| 6 | `quest_rank` | `uint32` | `optional` |  |  |
+| 7 | `max_quest_rank` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2511,9 +2511,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `currency_id` | `uint64` | `optional` | `` |  |
-| 2 | `purchase_def` | `uint32` | `optional` | `` |  |
-| 3 | `claim_as_points` | `bool` | `optional` | `` |  |
+| 1 | `currency_id` | `uint64` | `optional` |  |  |
+| 2 | `purchase_def` | `uint32` | `optional` |  |  |
+| 3 | `claim_as_points` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2525,7 +2525,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgDOTARedeemItemResponse.EResultCode` | `optional` | `` | default = k_Succeeded |
+| 1 | `response` | `.CMsgDOTARedeemItemResponse.EResultCode` | `optional` |  | default = k_Succeeded |
 
 </details>
 
@@ -2537,9 +2537,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `predictions` | `.CMsgClientToGCSelectCompendiumInGamePrediction.Prediction` | `repeated` | `` |  |
-| 3 | `league_id` | `uint32` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `predictions` | `.CMsgClientToGCSelectCompendiumInGamePrediction.Prediction` | `repeated` |  |  |
+| 3 | `league_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2551,8 +2551,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `prediction_id` | `uint32` | `optional` | `` |  |
-| 2 | `prediction_value` | `uint32` | `optional` | `` |  |
+| 1 | `prediction_id` | `uint32` | `optional` |  |  |
+| 2 | `prediction_value` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2564,7 +2564,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCSelectCompendiumInGamePredictionResponse.EResult` | `optional` | `` | default = SUCCESS |
+| 1 | `result` | `.CMsgClientToGCSelectCompendiumInGamePredictionResponse.EResult` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -2576,10 +2576,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_card_pack_item_id` | `uint64` | `optional` | `` |  |
-| 2 | `team_id` | `uint32` | `optional` | `` |  |
-| 3 | `deprecated_league_id` | `uint32` | `optional` | `` |  |
-| 4 | `region` | `.ELeagueRegion` | `optional` | `` | default = LEAGUE_REGION_UNSET |
+| 1 | `player_card_pack_item_id` | `uint64` | `optional` |  |  |
+| 2 | `team_id` | `uint32` | `optional` |  |  |
+| 3 | `deprecated_league_id` | `uint32` | `optional` |  |  |
+| 4 | `region` | `.ELeagueRegion` | `optional` |  | default = LEAGUE_REGION_UNSET |
 
 </details>
 
@@ -2591,8 +2591,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCOpenPlayerCardPackResponse.Result` | `optional` | `` | default = SUCCESS |
-| 2 | `player_card_item_ids` | `uint64` | `repeated` | `` |  |
+| 1 | `result` | `.CMsgClientToGCOpenPlayerCardPackResponse.Result` | `optional` |  | default = SUCCESS |
+| 2 | `player_card_item_ids` | `uint64` | `repeated` |  |  |
 
 </details>
 
@@ -2604,8 +2604,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `event_id` | `uint32` | `optional` | `` |  |
-| 3 | `player_card_item_ids` | `uint64` | `repeated` | `` |  |
+| 2 | `event_id` | `uint32` | `optional` |  |  |
+| 3 | `player_card_item_ids` | `uint64` | `repeated` |  |  |
 
 </details>
 
@@ -2617,8 +2617,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCRecyclePlayerCardResponse.Result` | `optional` | `` | default = SUCCESS |
-| 2 | `dust_amount` | `uint32` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCRecyclePlayerCardResponse.Result` | `optional` |  | default = SUCCESS |
+| 2 | `dust_amount` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2630,9 +2630,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `card_dust_item_id` | `uint64` | `optional` | `` |  |
-| 2 | `event_id` | `uint32` | `optional` | `` |  |
-| 3 | `premium_pack` | `bool` | `optional` | `` |  |
+| 1 | `card_dust_item_id` | `uint64` | `optional` |  |  |
+| 2 | `event_id` | `uint32` | `optional` |  |  |
+| 3 | `premium_pack` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2644,7 +2644,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCCreatePlayerCardPackResponse.Result` | `optional` | `` | default = SUCCESS |
+| 1 | `result` | `.CMsgClientToGCCreatePlayerCardPackResponse.Result` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -2656,10 +2656,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `card_dust_item_id` | `uint64` | `optional` | `` |  |
-| 2 | `event_id` | `uint32` | `optional` | `` |  |
-| 3 | `premium_pack` | `bool` | `optional` | `` |  |
-| 4 | `team_id` | `uint32` | `optional` | `` |  |
+| 1 | `card_dust_item_id` | `uint64` | `optional` |  |  |
+| 2 | `event_id` | `uint32` | `optional` |  |  |
+| 3 | `premium_pack` | `bool` | `optional` |  |  |
+| 4 | `team_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2671,7 +2671,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCCreateTeamPlayerCardPackResponse.Result` | `optional` | `` | default = SUCCESS |
+| 1 | `result` | `.CMsgClientToGCCreateTeamPlayerCardPackResponse.Result` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -2683,15 +2683,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `battle_pass_level` | `uint32` | `optional` | `` |  |
-| 2 | `questlines` | `.CMsgGCToClientBattlePassRollup_International2016.Questlines` | `repeated` | `` |  |
-| 3 | `wagering` | `.CMsgGCToClientBattlePassRollup_International2016.Wagering` | `optional` | `` |  |
-| 4 | `achievements` | `.CMsgGCToClientBattlePassRollup_International2016.Achievements` | `optional` | `` |  |
-| 5 | `battle_cup` | `.CMsgGCToClientBattlePassRollup_International2016.BattleCup` | `optional` | `` |  |
-| 6 | `predictions` | `.CMsgGCToClientBattlePassRollup_International2016.Predictions` | `optional` | `` |  |
-| 7 | `bracket` | `.CMsgGCToClientBattlePassRollup_International2016.Bracket` | `optional` | `` |  |
-| 8 | `player_cards` | `.CMsgGCToClientBattlePassRollup_International2016.PlayerCard` | `repeated` | `` |  |
-| 9 | `fantasy_challenge` | `.CMsgGCToClientBattlePassRollup_International2016.FantasyChallenge` | `optional` | `` |  |
+| 1 | `battle_pass_level` | `uint32` | `optional` |  |  |
+| 2 | `questlines` | `.CMsgGCToClientBattlePassRollup_International2016.Questlines` | `repeated` |  |  |
+| 3 | `wagering` | `.CMsgGCToClientBattlePassRollup_International2016.Wagering` | `optional` |  |  |
+| 4 | `achievements` | `.CMsgGCToClientBattlePassRollup_International2016.Achievements` | `optional` |  |  |
+| 5 | `battle_cup` | `.CMsgGCToClientBattlePassRollup_International2016.BattleCup` | `optional` |  |  |
+| 6 | `predictions` | `.CMsgGCToClientBattlePassRollup_International2016.Predictions` | `optional` |  |  |
+| 7 | `bracket` | `.CMsgGCToClientBattlePassRollup_International2016.Bracket` | `optional` |  |  |
+| 8 | `player_cards` | `.CMsgGCToClientBattlePassRollup_International2016.PlayerCard` | `repeated` |  |  |
+| 9 | `fantasy_challenge` | `.CMsgGCToClientBattlePassRollup_International2016.FantasyChallenge` | `optional` |  |  |
 
 </details>
 
@@ -2703,11 +2703,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `onestar` | `uint32` | `optional` | `` |  |
-| 3 | `twostar` | `uint32` | `optional` | `` |  |
-| 4 | `threestar` | `uint32` | `optional` | `` |  |
-| 5 | `total` | `uint32` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `onestar` | `uint32` | `optional` |  |  |
+| 3 | `twostar` | `uint32` | `optional` |  |  |
+| 4 | `threestar` | `uint32` | `optional` |  |  |
+| 5 | `total` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2719,11 +2719,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `total_wagered` | `uint32` | `optional` | `` |  |
-| 2 | `total_won` | `uint32` | `optional` | `` |  |
-| 3 | `average_won` | `uint32` | `optional` | `` |  |
-| 4 | `success_rate` | `uint32` | `optional` | `` |  |
-| 5 | `total_tips` | `uint32` | `optional` | `` |  |
+| 1 | `total_wagered` | `uint32` | `optional` |  |  |
+| 2 | `total_won` | `uint32` | `optional` |  |  |
+| 3 | `average_won` | `uint32` | `optional` |  |  |
+| 4 | `success_rate` | `uint32` | `optional` |  |  |
+| 5 | `total_tips` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2735,9 +2735,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `completed` | `uint32` | `optional` | `` |  |
-| 2 | `total` | `uint32` | `optional` | `` |  |
-| 3 | `points` | `uint32` | `optional` | `` |  |
+| 1 | `completed` | `uint32` | `optional` |  |  |
+| 2 | `total` | `uint32` | `optional` |  |  |
+| 3 | `points` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2749,8 +2749,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `wins` | `uint32` | `optional` | `` |  |
-| 2 | `score` | `uint32` | `optional` | `` |  |
+| 1 | `wins` | `uint32` | `optional` |  |  |
+| 2 | `score` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2762,9 +2762,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `correct` | `uint32` | `optional` | `` |  |
-| 2 | `total` | `uint32` | `optional` | `` |  |
-| 3 | `points` | `uint32` | `optional` | `` |  |
+| 1 | `correct` | `uint32` | `optional` |  |  |
+| 2 | `total` | `uint32` | `optional` |  |  |
+| 3 | `points` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2776,8 +2776,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `correct` | `uint32` | `optional` | `` |  |
-| 2 | `points` | `uint32` | `optional` | `` |  |
+| 1 | `correct` | `uint32` | `optional` |  |  |
+| 2 | `points` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2789,8 +2789,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `quality` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `quality` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2802,8 +2802,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `total_score` | `float` | `optional` | `` |  |
-| 2 | `percentile` | `float` | `optional` | `` |  |
+| 1 | `total_score` | `float` | `optional` |  |  |
+| 2 | `percentile` | `float` | `optional` |  |  |
 
 </details>
 
@@ -2815,15 +2815,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `battle_pass_level` | `uint32` | `optional` | `` |  |
-| 2 | `questlines` | `.CMsgGCToClientBattlePassRollup_Fall2016.Questlines` | `repeated` | `` |  |
-| 3 | `wagering` | `.CMsgGCToClientBattlePassRollup_Fall2016.Wagering` | `optional` | `` |  |
-| 4 | `achievements` | `.CMsgGCToClientBattlePassRollup_Fall2016.Achievements` | `optional` | `` |  |
-| 5 | `battle_cup` | `.CMsgGCToClientBattlePassRollup_Fall2016.BattleCup` | `optional` | `` |  |
-| 6 | `predictions` | `.CMsgGCToClientBattlePassRollup_Fall2016.Predictions` | `optional` | `` |  |
-| 7 | `bracket` | `.CMsgGCToClientBattlePassRollup_Fall2016.Bracket` | `optional` | `` |  |
-| 8 | `player_cards` | `.CMsgGCToClientBattlePassRollup_Fall2016.PlayerCard` | `repeated` | `` |  |
-| 9 | `fantasy_challenge` | `.CMsgGCToClientBattlePassRollup_Fall2016.FantasyChallenge` | `optional` | `` |  |
+| 1 | `battle_pass_level` | `uint32` | `optional` |  |  |
+| 2 | `questlines` | `.CMsgGCToClientBattlePassRollup_Fall2016.Questlines` | `repeated` |  |  |
+| 3 | `wagering` | `.CMsgGCToClientBattlePassRollup_Fall2016.Wagering` | `optional` |  |  |
+| 4 | `achievements` | `.CMsgGCToClientBattlePassRollup_Fall2016.Achievements` | `optional` |  |  |
+| 5 | `battle_cup` | `.CMsgGCToClientBattlePassRollup_Fall2016.BattleCup` | `optional` |  |  |
+| 6 | `predictions` | `.CMsgGCToClientBattlePassRollup_Fall2016.Predictions` | `optional` |  |  |
+| 7 | `bracket` | `.CMsgGCToClientBattlePassRollup_Fall2016.Bracket` | `optional` |  |  |
+| 8 | `player_cards` | `.CMsgGCToClientBattlePassRollup_Fall2016.PlayerCard` | `repeated` |  |  |
+| 9 | `fantasy_challenge` | `.CMsgGCToClientBattlePassRollup_Fall2016.FantasyChallenge` | `optional` |  |  |
 
 </details>
 
@@ -2835,11 +2835,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `onestar` | `uint32` | `optional` | `` |  |
-| 3 | `twostar` | `uint32` | `optional` | `` |  |
-| 4 | `threestar` | `uint32` | `optional` | `` |  |
-| 5 | `total` | `uint32` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `onestar` | `uint32` | `optional` |  |  |
+| 3 | `twostar` | `uint32` | `optional` |  |  |
+| 4 | `threestar` | `uint32` | `optional` |  |  |
+| 5 | `total` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2851,11 +2851,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `total_wagered` | `uint32` | `optional` | `` |  |
-| 2 | `total_won` | `uint32` | `optional` | `` |  |
-| 3 | `average_won` | `uint32` | `optional` | `` |  |
-| 4 | `success_rate` | `uint32` | `optional` | `` |  |
-| 5 | `total_tips` | `uint32` | `optional` | `` |  |
+| 1 | `total_wagered` | `uint32` | `optional` |  |  |
+| 2 | `total_won` | `uint32` | `optional` |  |  |
+| 3 | `average_won` | `uint32` | `optional` |  |  |
+| 4 | `success_rate` | `uint32` | `optional` |  |  |
+| 5 | `total_tips` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2867,9 +2867,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `completed` | `uint32` | `optional` | `` |  |
-| 2 | `total` | `uint32` | `optional` | `` |  |
-| 3 | `points` | `uint32` | `optional` | `` |  |
+| 1 | `completed` | `uint32` | `optional` |  |  |
+| 2 | `total` | `uint32` | `optional` |  |  |
+| 3 | `points` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2881,8 +2881,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `wins` | `uint32` | `optional` | `` |  |
-| 2 | `score` | `uint32` | `optional` | `` |  |
+| 1 | `wins` | `uint32` | `optional` |  |  |
+| 2 | `score` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2894,9 +2894,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `correct` | `uint32` | `optional` | `` |  |
-| 2 | `total` | `uint32` | `optional` | `` |  |
-| 3 | `points` | `uint32` | `optional` | `` |  |
+| 1 | `correct` | `uint32` | `optional` |  |  |
+| 2 | `total` | `uint32` | `optional` |  |  |
+| 3 | `points` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2908,8 +2908,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `correct` | `uint32` | `optional` | `` |  |
-| 2 | `points` | `uint32` | `optional` | `` |  |
+| 1 | `correct` | `uint32` | `optional` |  |  |
+| 2 | `points` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2921,8 +2921,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `quality` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `quality` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2934,8 +2934,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `total_score` | `float` | `optional` | `` |  |
-| 2 | `percentile` | `float` | `optional` | `` |  |
+| 1 | `total_score` | `float` | `optional` |  |  |
+| 2 | `percentile` | `float` | `optional` |  |  |
 
 </details>
 
@@ -2947,15 +2947,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `battle_pass_level` | `uint32` | `optional` | `` |  |
-| 2 | `questlines` | `.CMsgGCToClientBattlePassRollup_Winter2017.Questlines` | `repeated` | `` |  |
-| 3 | `wagering` | `.CMsgGCToClientBattlePassRollup_Winter2017.Wagering` | `optional` | `` |  |
-| 4 | `achievements` | `.CMsgGCToClientBattlePassRollup_Winter2017.Achievements` | `optional` | `` |  |
-| 5 | `battle_cup` | `.CMsgGCToClientBattlePassRollup_Winter2017.BattleCup` | `optional` | `` |  |
-| 6 | `predictions` | `.CMsgGCToClientBattlePassRollup_Winter2017.Predictions` | `optional` | `` |  |
-| 7 | `bracket` | `.CMsgGCToClientBattlePassRollup_Winter2017.Bracket` | `optional` | `` |  |
-| 8 | `player_cards` | `.CMsgGCToClientBattlePassRollup_Winter2017.PlayerCard` | `repeated` | `` |  |
-| 9 | `fantasy_challenge` | `.CMsgGCToClientBattlePassRollup_Winter2017.FantasyChallenge` | `optional` | `` |  |
+| 1 | `battle_pass_level` | `uint32` | `optional` |  |  |
+| 2 | `questlines` | `.CMsgGCToClientBattlePassRollup_Winter2017.Questlines` | `repeated` |  |  |
+| 3 | `wagering` | `.CMsgGCToClientBattlePassRollup_Winter2017.Wagering` | `optional` |  |  |
+| 4 | `achievements` | `.CMsgGCToClientBattlePassRollup_Winter2017.Achievements` | `optional` |  |  |
+| 5 | `battle_cup` | `.CMsgGCToClientBattlePassRollup_Winter2017.BattleCup` | `optional` |  |  |
+| 6 | `predictions` | `.CMsgGCToClientBattlePassRollup_Winter2017.Predictions` | `optional` |  |  |
+| 7 | `bracket` | `.CMsgGCToClientBattlePassRollup_Winter2017.Bracket` | `optional` |  |  |
+| 8 | `player_cards` | `.CMsgGCToClientBattlePassRollup_Winter2017.PlayerCard` | `repeated` |  |  |
+| 9 | `fantasy_challenge` | `.CMsgGCToClientBattlePassRollup_Winter2017.FantasyChallenge` | `optional` |  |  |
 
 </details>
 
@@ -2967,11 +2967,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `onestar` | `uint32` | `optional` | `` |  |
-| 3 | `twostar` | `uint32` | `optional` | `` |  |
-| 4 | `threestar` | `uint32` | `optional` | `` |  |
-| 5 | `total` | `uint32` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `onestar` | `uint32` | `optional` |  |  |
+| 3 | `twostar` | `uint32` | `optional` |  |  |
+| 4 | `threestar` | `uint32` | `optional` |  |  |
+| 5 | `total` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2983,11 +2983,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `total_wagered` | `uint32` | `optional` | `` |  |
-| 2 | `total_won` | `uint32` | `optional` | `` |  |
-| 3 | `average_won` | `uint32` | `optional` | `` |  |
-| 4 | `success_rate` | `uint32` | `optional` | `` |  |
-| 5 | `total_tips` | `uint32` | `optional` | `` |  |
+| 1 | `total_wagered` | `uint32` | `optional` |  |  |
+| 2 | `total_won` | `uint32` | `optional` |  |  |
+| 3 | `average_won` | `uint32` | `optional` |  |  |
+| 4 | `success_rate` | `uint32` | `optional` |  |  |
+| 5 | `total_tips` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2999,9 +2999,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `completed` | `uint32` | `optional` | `` |  |
-| 2 | `total` | `uint32` | `optional` | `` |  |
-| 3 | `points` | `uint32` | `optional` | `` |  |
+| 1 | `completed` | `uint32` | `optional` |  |  |
+| 2 | `total` | `uint32` | `optional` |  |  |
+| 3 | `points` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3013,8 +3013,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `wins` | `uint32` | `optional` | `` |  |
-| 2 | `score` | `uint32` | `optional` | `` |  |
+| 1 | `wins` | `uint32` | `optional` |  |  |
+| 2 | `score` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3026,9 +3026,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `correct` | `uint32` | `optional` | `` |  |
-| 2 | `total` | `uint32` | `optional` | `` |  |
-| 3 | `points` | `uint32` | `optional` | `` |  |
+| 1 | `correct` | `uint32` | `optional` |  |  |
+| 2 | `total` | `uint32` | `optional` |  |  |
+| 3 | `points` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3040,8 +3040,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `correct` | `uint32` | `optional` | `` |  |
-| 2 | `points` | `uint32` | `optional` | `` |  |
+| 1 | `correct` | `uint32` | `optional` |  |  |
+| 2 | `points` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3053,8 +3053,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `quality` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `quality` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3066,8 +3066,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `total_score` | `float` | `optional` | `` |  |
-| 2 | `percentile` | `float` | `optional` | `` |  |
+| 1 | `total_score` | `float` | `optional` |  |  |
+| 2 | `percentile` | `float` | `optional` |  |  |
 
 </details>
 
@@ -3079,15 +3079,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `battle_pass_level` | `uint32` | `optional` | `` |  |
-| 2 | `questlines` | `.CMsgGCToClientBattlePassRollup_TI7.Questlines` | `repeated` | `` |  |
-| 3 | `wagering` | `.CMsgGCToClientBattlePassRollup_TI7.Wagering` | `optional` | `` |  |
-| 4 | `achievements` | `.CMsgGCToClientBattlePassRollup_TI7.Achievements` | `optional` | `` |  |
-| 5 | `battle_cup` | `.CMsgGCToClientBattlePassRollup_TI7.BattleCup` | `optional` | `` |  |
-| 6 | `predictions` | `.CMsgGCToClientBattlePassRollup_TI7.Predictions` | `optional` | `` |  |
-| 7 | `bracket` | `.CMsgGCToClientBattlePassRollup_TI7.Bracket` | `optional` | `` |  |
-| 8 | `player_cards` | `.CMsgGCToClientBattlePassRollup_TI7.PlayerCard` | `repeated` | `` |  |
-| 9 | `fantasy_challenge` | `.CMsgGCToClientBattlePassRollup_TI7.FantasyChallenge` | `optional` | `` |  |
+| 1 | `battle_pass_level` | `uint32` | `optional` |  |  |
+| 2 | `questlines` | `.CMsgGCToClientBattlePassRollup_TI7.Questlines` | `repeated` |  |  |
+| 3 | `wagering` | `.CMsgGCToClientBattlePassRollup_TI7.Wagering` | `optional` |  |  |
+| 4 | `achievements` | `.CMsgGCToClientBattlePassRollup_TI7.Achievements` | `optional` |  |  |
+| 5 | `battle_cup` | `.CMsgGCToClientBattlePassRollup_TI7.BattleCup` | `optional` |  |  |
+| 6 | `predictions` | `.CMsgGCToClientBattlePassRollup_TI7.Predictions` | `optional` |  |  |
+| 7 | `bracket` | `.CMsgGCToClientBattlePassRollup_TI7.Bracket` | `optional` |  |  |
+| 8 | `player_cards` | `.CMsgGCToClientBattlePassRollup_TI7.PlayerCard` | `repeated` |  |  |
+| 9 | `fantasy_challenge` | `.CMsgGCToClientBattlePassRollup_TI7.FantasyChallenge` | `optional` |  |  |
 
 </details>
 
@@ -3099,11 +3099,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `onestar` | `uint32` | `optional` | `` |  |
-| 3 | `twostar` | `uint32` | `optional` | `` |  |
-| 4 | `threestar` | `uint32` | `optional` | `` |  |
-| 5 | `total` | `uint32` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `onestar` | `uint32` | `optional` |  |  |
+| 3 | `twostar` | `uint32` | `optional` |  |  |
+| 4 | `threestar` | `uint32` | `optional` |  |  |
+| 5 | `total` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3115,11 +3115,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `total_wagered` | `uint32` | `optional` | `` |  |
-| 2 | `total_won` | `uint32` | `optional` | `` |  |
-| 3 | `average_won` | `uint32` | `optional` | `` |  |
-| 4 | `success_rate` | `uint32` | `optional` | `` |  |
-| 5 | `total_tips` | `uint32` | `optional` | `` |  |
+| 1 | `total_wagered` | `uint32` | `optional` |  |  |
+| 2 | `total_won` | `uint32` | `optional` |  |  |
+| 3 | `average_won` | `uint32` | `optional` |  |  |
+| 4 | `success_rate` | `uint32` | `optional` |  |  |
+| 5 | `total_tips` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3131,9 +3131,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `completed` | `uint32` | `optional` | `` |  |
-| 2 | `total` | `uint32` | `optional` | `` |  |
-| 3 | `points` | `uint32` | `optional` | `` |  |
+| 1 | `completed` | `uint32` | `optional` |  |  |
+| 2 | `total` | `uint32` | `optional` |  |  |
+| 3 | `points` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3145,8 +3145,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `wins` | `uint32` | `optional` | `` |  |
-| 2 | `score` | `uint32` | `optional` | `` |  |
+| 1 | `wins` | `uint32` | `optional` |  |  |
+| 2 | `score` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3158,9 +3158,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `correct` | `uint32` | `optional` | `` |  |
-| 2 | `total` | `uint32` | `optional` | `` |  |
-| 3 | `points` | `uint32` | `optional` | `` |  |
+| 1 | `correct` | `uint32` | `optional` |  |  |
+| 2 | `total` | `uint32` | `optional` |  |  |
+| 3 | `points` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3172,8 +3172,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `correct` | `uint32` | `optional` | `` |  |
-| 2 | `points` | `uint32` | `optional` | `` |  |
+| 1 | `correct` | `uint32` | `optional` |  |  |
+| 2 | `points` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3185,8 +3185,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `quality` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `quality` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3198,8 +3198,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `total_score` | `float` | `optional` | `` |  |
-| 2 | `percentile` | `float` | `optional` | `` |  |
+| 1 | `total_score` | `float` | `optional` |  |  |
+| 2 | `percentile` | `float` | `optional` |  |  |
 
 </details>
 
@@ -3211,14 +3211,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `battle_pass_level` | `uint32` | `optional` | `` |  |
-| 2 | `cavern_crawl` | `.CMsgGCToClientBattlePassRollup_TI8.CavernCrawl` | `optional` | `` |  |
-| 3 | `wagering` | `.CMsgGCToClientBattlePassRollup_TI8.Wagering` | `optional` | `` |  |
-| 4 | `achievements` | `.CMsgGCToClientBattlePassRollup_TI8.Achievements` | `optional` | `` |  |
-| 6 | `predictions` | `.CMsgGCToClientBattlePassRollup_TI8.Predictions` | `optional` | `` |  |
-| 7 | `bracket` | `.CMsgGCToClientBattlePassRollup_TI8.Bracket` | `optional` | `` |  |
-| 8 | `player_cards` | `.CMsgGCToClientBattlePassRollup_TI8.PlayerCard` | `repeated` | `` |  |
-| 9 | `fantasy_challenge` | `.CMsgGCToClientBattlePassRollup_TI8.FantasyChallenge` | `optional` | `` |  |
+| 1 | `battle_pass_level` | `uint32` | `optional` |  |  |
+| 2 | `cavern_crawl` | `.CMsgGCToClientBattlePassRollup_TI8.CavernCrawl` | `optional` |  |  |
+| 3 | `wagering` | `.CMsgGCToClientBattlePassRollup_TI8.Wagering` | `optional` |  |  |
+| 4 | `achievements` | `.CMsgGCToClientBattlePassRollup_TI8.Achievements` | `optional` |  |  |
+| 6 | `predictions` | `.CMsgGCToClientBattlePassRollup_TI8.Predictions` | `optional` |  |  |
+| 7 | `bracket` | `.CMsgGCToClientBattlePassRollup_TI8.Bracket` | `optional` |  |  |
+| 8 | `player_cards` | `.CMsgGCToClientBattlePassRollup_TI8.PlayerCard` | `repeated` |  |  |
+| 9 | `fantasy_challenge` | `.CMsgGCToClientBattlePassRollup_TI8.FantasyChallenge` | `optional` |  |  |
 
 </details>
 
@@ -3230,10 +3230,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `rooms_cleared` | `uint32` | `optional` | `` |  |
-| 2 | `carry_completed` | `bool` | `optional` | `` |  |
-| 3 | `support_completed` | `bool` | `optional` | `` |  |
-| 4 | `utility_completed` | `bool` | `optional` | `` |  |
+| 1 | `rooms_cleared` | `uint32` | `optional` |  |  |
+| 2 | `carry_completed` | `bool` | `optional` |  |  |
+| 3 | `support_completed` | `bool` | `optional` |  |  |
+| 4 | `utility_completed` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -3245,11 +3245,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `total_wagered` | `uint32` | `optional` | `` |  |
-| 2 | `total_won` | `uint32` | `optional` | `` |  |
-| 3 | `average_won` | `uint32` | `optional` | `` |  |
-| 4 | `success_rate` | `uint32` | `optional` | `` |  |
-| 5 | `total_tips` | `uint32` | `optional` | `` |  |
+| 1 | `total_wagered` | `uint32` | `optional` |  |  |
+| 2 | `total_won` | `uint32` | `optional` |  |  |
+| 3 | `average_won` | `uint32` | `optional` |  |  |
+| 4 | `success_rate` | `uint32` | `optional` |  |  |
+| 5 | `total_tips` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3261,9 +3261,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `completed` | `uint32` | `optional` | `` |  |
-| 2 | `total` | `uint32` | `optional` | `` |  |
-| 3 | `points` | `uint32` | `optional` | `` |  |
+| 1 | `completed` | `uint32` | `optional` |  |  |
+| 2 | `total` | `uint32` | `optional` |  |  |
+| 3 | `points` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3275,9 +3275,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `correct` | `uint32` | `optional` | `` |  |
-| 2 | `total` | `uint32` | `optional` | `` |  |
-| 3 | `points` | `uint32` | `optional` | `` |  |
+| 1 | `correct` | `uint32` | `optional` |  |  |
+| 2 | `total` | `uint32` | `optional` |  |  |
+| 3 | `points` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3289,8 +3289,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `correct` | `uint32` | `optional` | `` |  |
-| 2 | `points` | `uint32` | `optional` | `` |  |
+| 1 | `correct` | `uint32` | `optional` |  |  |
+| 2 | `points` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3302,8 +3302,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `quality` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `quality` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3315,8 +3315,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `total_score` | `float` | `optional` | `` |  |
-| 2 | `percentile` | `float` | `optional` | `` |  |
+| 1 | `total_score` | `float` | `optional` |  |  |
+| 2 | `percentile` | `float` | `optional` |  |  |
 
 </details>
 
@@ -3328,7 +3328,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `battle_pass_level` | `uint32` | `optional` | `` |  |
+| 1 | `battle_pass_level` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3340,7 +3340,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `battle_pass_level` | `uint32` | `optional` | `` |  |
+| 1 | `battle_pass_level` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3352,8 +3352,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3365,13 +3365,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_ti6` | `.CMsgGCToClientBattlePassRollup_International2016` | `optional` | `` |  |
-| 2 | `event_fall2016` | `.CMsgGCToClientBattlePassRollup_Fall2016` | `optional` | `` |  |
-| 3 | `event_winter2017` | `.CMsgGCToClientBattlePassRollup_Winter2017` | `optional` | `` |  |
-| 4 | `event_ti7` | `.CMsgGCToClientBattlePassRollup_TI7` | `optional` | `` |  |
-| 5 | `event_ti8` | `.CMsgGCToClientBattlePassRollup_TI8` | `optional` | `` |  |
-| 6 | `event_ti9` | `.CMsgGCToClientBattlePassRollup_TI9` | `optional` | `` |  |
-| 7 | `event_ti10` | `.CMsgGCToClientBattlePassRollup_TI10` | `optional` | `` |  |
+| 1 | `event_ti6` | `.CMsgGCToClientBattlePassRollup_International2016` | `optional` |  |  |
+| 2 | `event_fall2016` | `.CMsgGCToClientBattlePassRollup_Fall2016` | `optional` |  |  |
+| 3 | `event_winter2017` | `.CMsgGCToClientBattlePassRollup_Winter2017` | `optional` |  |  |
+| 4 | `event_ti7` | `.CMsgGCToClientBattlePassRollup_TI7` | `optional` |  |  |
+| 5 | `event_ti8` | `.CMsgGCToClientBattlePassRollup_TI8` | `optional` |  |  |
+| 6 | `event_ti9` | `.CMsgGCToClientBattlePassRollup_TI9` | `optional` |  |  |
+| 7 | `event_ti10` | `.CMsgGCToClientBattlePassRollup_TI10` | `optional` |  |  |
 
 </details>
 
@@ -3383,7 +3383,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3395,7 +3395,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_info` | `.CMsgGCToClientBattlePassRollupListResponse.EventInfo` | `repeated` | `` |  |
+| 1 | `event_info` | `.CMsgGCToClientBattlePassRollupListResponse.EventInfo` | `repeated` |  |  |
 
 </details>
 
@@ -3407,8 +3407,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `level` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `level` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3420,7 +3420,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `is_party` | `bool` | `optional` | `` |  |
+| 1 | `is_party` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -3432,7 +3432,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `success` | `bool` | `optional` | `` |  |
+| 1 | `success` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -3444,7 +3444,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `active` | `bool` | `optional` | `` |  |
+| 1 | `active` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -3456,7 +3456,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `client_version` | `uint32` | `optional` | `` |  |
+| 1 | `client_version` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3468,7 +3468,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `error` | `string` | `optional` | `` |  |
+| 1 | `error` | `string` | `optional` |  |  |
 
 </details>
 
@@ -3480,8 +3480,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_id` | `uint32` | `optional` | `` |  |
-| 2 | `event_id` | `uint32` | `optional` | `` |  |
+| 1 | `team_id` | `uint32` | `optional` |  |  |
+| 2 | `event_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3493,8 +3493,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `questions` | `.CMsgDOTATriviaQuestion` | `repeated` | `` |  |
-| 2 | `trivia_enabled` | `bool` | `optional` | `` |  |
+| 1 | `questions` | `.CMsgDOTATriviaQuestion` | `repeated` |  |  |
+| 2 | `trivia_enabled` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -3506,8 +3506,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `question_id` | `uint32` | `optional` | `` |  |
-| 2 | `answer_index` | `uint32` | `optional` | `` |  |
+| 1 | `question_id` | `uint32` | `optional` |  |  |
+| 2 | `answer_index` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3519,7 +3519,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.EDOTATriviaAnswerResult` | `optional` | `` | default = k_EDOTATriviaAnswerResult_Success |
+| 1 | `result` | `.EDOTATriviaAnswerResult` | `optional` |  | default = k_EDOTATriviaAnswerResult_Success |
 
 </details>
 
@@ -3543,8 +3543,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `trivia_enabled` | `bool` | `optional` | `` |  |
-| 2 | `current_timestamp` | `uint32` | `optional` | `` |  |
+| 1 | `trivia_enabled` | `bool` | `optional` |  |  |
+| 2 | `current_timestamp` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3568,7 +3568,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgDOTAAnchorPhoneNumberResponse.Result` | `optional` | `` | default = SUCCESS |
+| 1 | `result` | `.CMsgDOTAAnchorPhoneNumberResponse.Result` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -3592,7 +3592,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgDOTAUnanchorPhoneNumberResponse.Result` | `optional` | `` | default = SUCCESS |
+| 1 | `result` | `.CMsgDOTAUnanchorPhoneNumberResponse.Result` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -3604,10 +3604,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `commender_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `commender_name` | `string` | `optional` | `` |  |
-| 3 | `flags` | `uint32` | `optional` | `` |  |
-| 4 | `commender_hero_id` | `int32` | `optional` | `` |  |
+| 1 | `commender_account_id` | `uint32` | `optional` |  |  |
+| 2 | `commender_name` | `string` | `optional` |  |  |
+| 3 | `flags` | `uint32` | `optional` |  |  |
+| 4 | `commender_hero_id` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -3619,10 +3619,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `hero_id` | `int32` | `optional` | `` |  |
-| 3 | `item_id` | `int32` | `optional` | `` | default = -1 |
-| 4 | `league_id` | `uint32` | `optional` | `` |  |
+| 1 | `player_account_id` | `uint32` | `optional` |  |  |
+| 2 | `hero_id` | `int32` | `optional` |  |  |
+| 3 | `item_id` | `int32` | `optional` |  | default = -1 |
+| 4 | `league_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3634,13 +3634,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `original_request` | `.CMsgDOTAClientToGCQuickStatsRequest` | `optional` | `` |  |
-| 2 | `hero_stats` | `.CMsgDOTAClientToGCQuickStatsResponse.SimpleStats` | `optional` | `` |  |
-| 3 | `item_stats` | `.CMsgDOTAClientToGCQuickStatsResponse.SimpleStats` | `optional` | `` |  |
-| 4 | `item_hero_stats` | `.CMsgDOTAClientToGCQuickStatsResponse.SimpleStats` | `optional` | `` |  |
-| 5 | `item_player_stats` | `.CMsgDOTAClientToGCQuickStatsResponse.SimpleStats` | `optional` | `` |  |
-| 6 | `hero_player_stats` | `.CMsgDOTAClientToGCQuickStatsResponse.SimpleStats` | `optional` | `` |  |
-| 7 | `full_set_stats` | `.CMsgDOTAClientToGCQuickStatsResponse.SimpleStats` | `optional` | `` |  |
+| 1 | `original_request` | `.CMsgDOTAClientToGCQuickStatsRequest` | `optional` |  |  |
+| 2 | `hero_stats` | `.CMsgDOTAClientToGCQuickStatsResponse.SimpleStats` | `optional` |  |  |
+| 3 | `item_stats` | `.CMsgDOTAClientToGCQuickStatsResponse.SimpleStats` | `optional` |  |  |
+| 4 | `item_hero_stats` | `.CMsgDOTAClientToGCQuickStatsResponse.SimpleStats` | `optional` |  |  |
+| 5 | `item_player_stats` | `.CMsgDOTAClientToGCQuickStatsResponse.SimpleStats` | `optional` |  |  |
+| 6 | `hero_player_stats` | `.CMsgDOTAClientToGCQuickStatsResponse.SimpleStats` | `optional` |  |  |
+| 7 | `full_set_stats` | `.CMsgDOTAClientToGCQuickStatsResponse.SimpleStats` | `optional` |  |  |
 
 </details>
 
@@ -3652,10 +3652,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `win_percent` | `float` | `optional` | `` |  |
-| 2 | `pick_percent` | `float` | `optional` | `` |  |
-| 3 | `win_count` | `uint32` | `optional` | `` |  |
-| 4 | `pick_count` | `uint32` | `optional` | `` |  |
+| 1 | `win_percent` | `float` | `optional` |  |  |
+| 2 | `pick_percent` | `float` | `optional` |  |  |
+| 3 | `win_count` | `uint32` | `optional` |  |  |
+| 4 | `pick_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3667,7 +3667,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `choice` | `.DOTASelectionPriorityChoice` | `optional` | `` | default = k_DOTASelectionPriorityChoice_Invalid |
+| 1 | `choice` | `.DOTASelectionPriorityChoice` | `optional` |  | default = k_DOTASelectionPriorityChoice_Invalid |
 
 </details>
 
@@ -3679,7 +3679,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgDOTASelectionPriorityChoiceResponse.Result` | `optional` | `` | default = SUCCESS |
+| 1 | `result` | `.CMsgDOTASelectionPriorityChoiceResponse.Result` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -3691,7 +3691,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `badge_id` | `string` | `optional` | `` |  |
+| 1 | `badge_id` | `string` | `optional` |  |  |
 
 </details>
 
@@ -3703,7 +3703,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgDOTAGameAutographRewardResponse.Result` | `optional` | `` | default = SUCCESS |
+| 1 | `result` | `.CMsgDOTAGameAutographRewardResponse.Result` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -3727,7 +3727,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgDOTADestroyLobbyResponse.Result` | `optional` | `` | default = SUCCESS |
+| 1 | `result` | `.CMsgDOTADestroyLobbyResponse.Result` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -3751,7 +3751,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_ids` | `fixed32` | `repeated` | `` |  |
+| 1 | `account_ids` | `fixed32` | `repeated` |  |  |
 
 </details>
 
@@ -3763,10 +3763,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def` | `uint32` | `optional` | `` |  |
-| 2 | `quantity` | `uint32` | `optional` | `` |  |
-| 3 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 4 | `use_premium_points` | `bool` | `optional` | `` |  |
+| 1 | `item_def` | `uint32` | `optional` |  |  |
+| 2 | `quantity` | `uint32` | `optional` |  |  |
+| 3 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 4 | `use_premium_points` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -3778,7 +3778,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgPurchaseItemWithEventPointsResponse.Result` | `optional` | `` | default = SUCCESS |
+| 1 | `result` | `.CMsgPurchaseItemWithEventPointsResponse.Result` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -3790,8 +3790,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `relic_rarity` | `.EHeroRelicRarity` | `optional` | `` | default = HERO_RELIC_RARITY_INVALID |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `relic_rarity` | `.EHeroRelicRarity` | `optional` |  | default = HERO_RELIC_RARITY_INVALID |
 
 </details>
 
@@ -3803,8 +3803,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.EPurchaseHeroRelicResult` | `optional` | `` | default = k_EPurchaseHeroRelicResult_Success |
-| 2 | `kill_eater_type` | `uint32` | `optional` | `` |  |
+| 1 | `result` | `.EPurchaseHeroRelicResult` | `optional` |  | default = k_EPurchaseHeroRelicResult_Success |
+| 2 | `kill_eater_type` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3816,8 +3816,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 2 | `week` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 2 | `week` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3841,7 +3841,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3853,13 +3853,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `background_item` | `.CSOEconItem` | `optional` | `` |  |
-| 2 | `featured_heroes` | `.CMsgProfileResponse.FeaturedHero` | `repeated` | `` |  |
-| 3 | `recent_matches` | `.CMsgProfileResponse.MatchInfo` | `repeated` | `` |  |
-| 4 | `successful_heroes` | `.CMsgSuccessfulHero` | `repeated` | `` |  |
-| 5 | `recent_match_details` | `.CMsgRecentMatchInfo` | `optional` | `` |  |
-| 6 | `result` | `.CMsgProfileResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 7 | `stickerbook_page` | `.CMsgStickerbookPage` | `optional` | `` |  |
+| 1 | `background_item` | `.CSOEconItem` | `optional` |  |  |
+| 2 | `featured_heroes` | `.CMsgProfileResponse.FeaturedHero` | `repeated` |  |  |
+| 3 | `recent_matches` | `.CMsgProfileResponse.MatchInfo` | `repeated` |  |  |
+| 4 | `successful_heroes` | `.CMsgSuccessfulHero` | `repeated` |  |  |
+| 5 | `recent_match_details` | `.CMsgRecentMatchInfo` | `optional` |  |  |
+| 6 | `result` | `.CMsgProfileResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 7 | `stickerbook_page` | `.CMsgStickerbookPage` | `optional` |  |  |
 
 </details>
 
@@ -3871,11 +3871,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `equipped_econ_items` | `.CSOEconItem` | `repeated` | `` |  |
-| 3 | `manually_set` | `bool` | `optional` | `` |  |
-| 4 | `plus_hero_xp` | `uint32` | `optional` | `` |  |
-| 5 | `plus_hero_relics_item` | `.CSOEconItem` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `equipped_econ_items` | `.CSOEconItem` | `repeated` |  |  |
+| 3 | `manually_set` | `bool` | `optional` |  |  |
+| 4 | `plus_hero_xp` | `uint32` | `optional` |  |  |
+| 5 | `plus_hero_relics_item` | `.CSOEconItem` | `optional` |  |  |
 
 </details>
 
@@ -3887,11 +3887,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `match_timestamp` | `uint32` | `optional` | `` |  |
-| 3 | `performance_rating` | `sint32` | `optional` | `` |  |
-| 4 | `hero_id` | `int32` | `optional` | `` |  |
-| 5 | `won_match` | `bool` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `match_timestamp` | `uint32` | `optional` |  |  |
+| 3 | `performance_rating` | `sint32` | `optional` |  |  |
+| 4 | `hero_id` | `int32` | `optional` |  |  |
+| 5 | `won_match` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -3903,8 +3903,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `background_item_id` | `uint64` | `optional` | `` |  |
-| 2 | `featured_hero_ids` | `int32` | `repeated` | `` |  |
+| 1 | `background_item_id` | `uint64` | `optional` |  |  |
+| 2 | `featured_hero_ids` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -3916,7 +3916,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgProfileUpdateResponse.Result` | `optional` | `` | default = SUCCESS |
+| 1 | `result` | `.CMsgProfileUpdateResponse.Result` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -3928,10 +3928,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `last_run` | `uint32` | `optional` | `` |  |
-| 2 | `ability_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `game_count` | `uint32` | `optional` | `` |  |
-| 4 | `win_count` | `uint32` | `optional` | `` |  |
+| 1 | `last_run` | `uint32` | `optional` |  |  |
+| 2 | `ability_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `game_count` | `uint32` | `optional` |  |  |
+| 4 | `win_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3943,15 +3943,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `last_run` | `uint32` | `optional` | `` |  |
-| 3 | `avg_gold_per_min` | `uint32` | `optional` | `` |  |
-| 4 | `avg_xp_per_min` | `uint32` | `optional` | `` |  |
-| 5 | `avg_kills` | `uint32` | `optional` | `` |  |
-| 6 | `avg_deaths` | `uint32` | `optional` | `` |  |
-| 7 | `avg_assists` | `uint32` | `optional` | `` |  |
-| 8 | `avg_last_hits` | `uint32` | `optional` | `` |  |
-| 9 | `avg_denies` | `uint32` | `optional` | `` |  |
-| 10 | `avg_net_worth` | `uint32` | `optional` | `` |  |
+| 1 | `last_run` | `uint32` | `optional` |  |  |
+| 3 | `avg_gold_per_min` | `uint32` | `optional` |  |  |
+| 4 | `avg_xp_per_min` | `uint32` | `optional` |  |  |
+| 5 | `avg_kills` | `uint32` | `optional` |  |  |
+| 6 | `avg_deaths` | `uint32` | `optional` |  |  |
+| 7 | `avg_assists` | `uint32` | `optional` |  |  |
+| 8 | `avg_last_hits` | `uint32` | `optional` |  |  |
+| 9 | `avg_denies` | `uint32` | `optional` |  |  |
+| 10 | `avg_net_worth` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -3963,7 +3963,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -3975,8 +3975,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `hero_data_per_chunk` | `.CMsgHeroGlobalDataResponse.HeroDataPerRankChunk` | `repeated` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `hero_data_per_chunk` | `.CMsgHeroGlobalDataResponse.HeroDataPerRankChunk` | `repeated` |  |  |
 
 </details>
 
@@ -3988,10 +3988,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `day` | `uint32` | `optional` | `` |  |
-| 2 | `win_percent` | `float` | `optional` | `` |  |
-| 3 | `pick_percent` | `float` | `optional` | `` |  |
-| 4 | `ban_percent` | `float` | `optional` | `` |  |
+| 1 | `day` | `uint32` | `optional` |  |  |
+| 2 | `win_percent` | `float` | `optional` |  |  |
+| 3 | `pick_percent` | `float` | `optional` |  |  |
+| 4 | `ban_percent` | `float` | `optional` |  |  |
 
 </details>
 
@@ -4003,10 +4003,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `week` | `uint32` | `optional` | `` |  |
-| 2 | `win_percent` | `float` | `optional` | `` |  |
-| 3 | `pick_percent` | `float` | `optional` | `` |  |
-| 4 | `ban_percent` | `float` | `optional` | `` |  |
+| 1 | `week` | `uint32` | `optional` |  |  |
+| 2 | `win_percent` | `float` | `optional` |  |  |
+| 3 | `pick_percent` | `float` | `optional` |  |  |
+| 4 | `ban_percent` | `float` | `optional` |  |  |
 
 </details>
 
@@ -4018,11 +4018,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `rank_chunk` | `uint32` | `optional` | `` |  |
-| 2 | `talent_win_rates` | `.CMsgTalentWinRates` | `repeated` | `` |  |
-| 3 | `hero_averages` | `.CMsgGlobalHeroAverages` | `optional` | `` |  |
-| 4 | `graph_data` | `.CMsgHeroGlobalDataResponse.GraphData` | `repeated` | `` |  |
-| 5 | `week_data` | `.CMsgHeroGlobalDataResponse.WeekData` | `repeated` | `` |  |
+| 1 | `rank_chunk` | `uint32` | `optional` |  |  |
+| 2 | `talent_win_rates` | `.CMsgTalentWinRates` | `repeated` |  |  |
+| 3 | `hero_averages` | `.CMsgGlobalHeroAverages` | `optional` |  |  |
+| 4 | `graph_data` | `.CMsgHeroGlobalDataResponse.GraphData` | `repeated` |  |  |
+| 5 | `week_data` | `.CMsgHeroGlobalDataResponse.WeekData` | `repeated` |  |  |
 
 </details>
 
@@ -4034,7 +4034,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `heroes` | `.CMsgHeroGlobalDataResponse` | `repeated` | `` |  |
+| 1 | `heroes` | `.CMsgHeroGlobalDataResponse` | `repeated` |  |  |
 
 </details>
 
@@ -4046,7 +4046,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ranked_hero_data` | `.CMsgHeroGlobalDataHeroesAlliesAndEnemies.RankedHeroData` | `repeated` | `` |  |
+| 1 | `ranked_hero_data` | `.CMsgHeroGlobalDataHeroesAlliesAndEnemies.RankedHeroData` | `repeated` |  |  |
 
 </details>
 
@@ -4058,11 +4058,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `win_rate` | `uint32` | `optional` | `` |  |
-| 3 | `first_other_hero_id` | `int32` | `optional` | `` |  |
-| 5 | `ally_win_rate` | `uint32` | `repeated` | `` |  |
-| 6 | `enemy_win_rate` | `uint32` | `repeated` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `win_rate` | `uint32` | `optional` |  |  |
+| 3 | `first_other_hero_id` | `int32` | `optional` |  |  |
+| 5 | `ally_win_rate` | `uint32` | `repeated` |  |  |
+| 6 | `enemy_win_rate` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -4074,8 +4074,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `rank` | `uint32` | `optional` | `` |  |
-| 2 | `hero_data` | `.CMsgHeroGlobalDataHeroesAlliesAndEnemies.HeroData` | `repeated` | `` |  |
+| 1 | `rank` | `uint32` | `optional` |  |  |
+| 2 | `hero_data` | `.CMsgHeroGlobalDataHeroesAlliesAndEnemies.HeroData` | `repeated` |  |  |
 
 </details>
 
@@ -4087,7 +4087,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -4099,7 +4099,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `private_key` | `uint32` | `optional` | `` |  |
+| 1 | `private_key` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -4111,7 +4111,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgActivatePlusFreeTrialResponse.Result` | `optional` | `` | default = SUCCESS |
+| 1 | `result` | `.CMsgActivatePlusFreeTrialResponse.Result` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -4123,10 +4123,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `hero_id_completed` | `int32` | `optional` | `` |  |
-| 3 | `completed_paths` | `.CMsgGCToClientCavernCrawlMapPathCompleted.CompletedPathInfo` | `repeated` | `` |  |
-| 4 | `map_variant` | `uint32` | `optional` | `` | default = 255 |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `hero_id_completed` | `int32` | `optional` |  |  |
+| 3 | `completed_paths` | `.CMsgGCToClientCavernCrawlMapPathCompleted.CompletedPathInfo` | `repeated` |  |  |
+| 4 | `map_variant` | `uint32` | `optional` |  | default = 255 |
 
 </details>
 
@@ -4138,9 +4138,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `path_id_completed` | `uint32` | `optional` | `` | default = 255 |
-| 2 | `received_ultra_rare_reward` | `bool` | `optional` | `` |  |
-| 3 | `half_completed` | `bool` | `optional` | `` |  |
+| 1 | `path_id_completed` | `uint32` | `optional` |  | default = 255 |
+| 2 | `received_ultra_rare_reward` | `bool` | `optional` |  |  |
+| 3 | `half_completed` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -4152,7 +4152,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -4164,9 +4164,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `room_id` | `uint32` | `optional` | `` | default = 255 |
-| 3 | `map_variant` | `uint32` | `optional` | `` | default = 255 |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `room_id` | `uint32` | `optional` |  | default = 255 |
+| 3 | `map_variant` | `uint32` | `optional` |  | default = 255 |
 
 </details>
 
@@ -4178,7 +4178,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCCavernCrawlClaimRoomResponse.Result` | `optional` | `` | default = SUCCESS |
+| 1 | `result` | `.CMsgClientToGCCavernCrawlClaimRoomResponse.Result` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -4190,10 +4190,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `room_id` | `uint32` | `optional` | `` | default = 255 |
-| 3 | `item_type` | `uint32` | `optional` | `` |  |
-| 4 | `map_variant` | `uint32` | `optional` | `` | default = 255 |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `room_id` | `uint32` | `optional` |  | default = 255 |
+| 3 | `item_type` | `uint32` | `optional` |  |  |
+| 4 | `map_variant` | `uint32` | `optional` |  | default = 255 |
 
 </details>
 
@@ -4205,7 +4205,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCCavernCrawlUseItemOnRoomResponse.Result` | `optional` | `` | default = SUCCESS |
+| 1 | `result` | `.CMsgClientToGCCavernCrawlUseItemOnRoomResponse.Result` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -4217,10 +4217,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `path_id` | `uint32` | `optional` | `` | default = 255 |
-| 3 | `item_type` | `uint32` | `optional` | `` |  |
-| 4 | `map_variant` | `uint32` | `optional` | `` | default = 255 |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `path_id` | `uint32` | `optional` |  | default = 255 |
+| 3 | `item_type` | `uint32` | `optional` |  |  |
+| 4 | `map_variant` | `uint32` | `optional` |  | default = 255 |
 
 </details>
 
@@ -4232,7 +4232,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCCavernCrawlUseItemOnPathResponse.Result` | `optional` | `` | default = SUCCESS |
+| 1 | `result` | `.CMsgClientToGCCavernCrawlUseItemOnPathResponse.Result` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -4244,7 +4244,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -4256,10 +4256,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCCavernCrawlRequestMapStateResponse.Result` | `optional` | `` | default = SUCCESS |
-| 2 | `available_map_variants_mask` | `uint32` | `optional` | `` |  |
-| 3 | `inventory_item` | `.CMsgClientToGCCavernCrawlRequestMapStateResponse.InventoryItem` | `repeated` | `` |  |
-| 4 | `map_variants` | `.CMsgClientToGCCavernCrawlRequestMapStateResponse.MapVariant` | `repeated` | `` |  |
+| 1 | `result` | `.CMsgClientToGCCavernCrawlRequestMapStateResponse.Result` | `optional` |  | default = SUCCESS |
+| 2 | `available_map_variants_mask` | `uint32` | `optional` |  |  |
+| 3 | `inventory_item` | `.CMsgClientToGCCavernCrawlRequestMapStateResponse.InventoryItem` | `repeated` |  |  |
+| 4 | `map_variants` | `.CMsgClientToGCCavernCrawlRequestMapStateResponse.MapVariant` | `repeated` |  |  |
 
 </details>
 
@@ -4271,8 +4271,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `path_id_1` | `uint32` | `optional` | `` | default = 255 |
-| 2 | `path_id_2` | `uint32` | `optional` | `` | default = 255 |
+| 1 | `path_id_1` | `uint32` | `optional` |  | default = 255 |
+| 2 | `path_id_2` | `uint32` | `optional` |  | default = 255 |
 
 </details>
 
@@ -4284,8 +4284,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_type` | `uint32` | `optional` | `` |  |
-| 2 | `count` | `uint32` | `optional` | `` |  |
+| 1 | `item_type` | `uint32` | `optional` |  |  |
+| 2 | `count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -4297,8 +4297,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `map_room_id` | `uint32` | `optional` | `` | default = 255 |
-| 2 | `revealed_room_id` | `uint32` | `optional` | `` | default = 255 |
+| 1 | `map_room_id` | `uint32` | `optional` |  | default = 255 |
+| 2 | `revealed_room_id` | `uint32` | `optional` |  | default = 255 |
 
 </details>
 
@@ -4310,22 +4310,22 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `map_variant` | `uint32` | `optional` | `` | default = 255 |
-| 2 | `claimed_rooms_1` | `fixed64` | `optional` | `` |  |
-| 3 | `claimed_rooms_2` | `fixed64` | `optional` | `` |  |
-| 4 | `revealed_rooms_1` | `fixed64` | `optional` | `` |  |
-| 5 | `revealed_rooms_2` | `fixed64` | `optional` | `` |  |
-| 6 | `completed_paths_1` | `fixed64` | `optional` | `` |  |
-| 7 | `completed_paths_2` | `fixed64` | `optional` | `` |  |
-| 8 | `completed_paths_3` | `fixed64` | `optional` | `` |  |
-| 9 | `completed_paths_4` | `fixed64` | `optional` | `` |  |
-| 10 | `half_completed_paths_1` | `fixed64` | `optional` | `` |  |
-| 11 | `half_completed_paths_2` | `fixed64` | `optional` | `` |  |
-| 12 | `half_completed_paths_3` | `fixed64` | `optional` | `` |  |
-| 13 | `half_completed_paths_4` | `fixed64` | `optional` | `` |  |
-| 14 | `swapped_challenge` | `.CMsgClientToGCCavernCrawlRequestMapStateResponse.SwappedChallenge` | `repeated` | `` |  |
-| 15 | `ultra_rare_reward_room_number` | `uint32` | `optional` | `` | default = 255 |
-| 16 | `treasure_map` | `.CMsgClientToGCCavernCrawlRequestMapStateResponse.TreasureMap` | `repeated` | `` |  |
+| 1 | `map_variant` | `uint32` | `optional` |  | default = 255 |
+| 2 | `claimed_rooms_1` | `fixed64` | `optional` |  |  |
+| 3 | `claimed_rooms_2` | `fixed64` | `optional` |  |  |
+| 4 | `revealed_rooms_1` | `fixed64` | `optional` |  |  |
+| 5 | `revealed_rooms_2` | `fixed64` | `optional` |  |  |
+| 6 | `completed_paths_1` | `fixed64` | `optional` |  |  |
+| 7 | `completed_paths_2` | `fixed64` | `optional` |  |  |
+| 8 | `completed_paths_3` | `fixed64` | `optional` |  |  |
+| 9 | `completed_paths_4` | `fixed64` | `optional` |  |  |
+| 10 | `half_completed_paths_1` | `fixed64` | `optional` |  |  |
+| 11 | `half_completed_paths_2` | `fixed64` | `optional` |  |  |
+| 12 | `half_completed_paths_3` | `fixed64` | `optional` |  |  |
+| 13 | `half_completed_paths_4` | `fixed64` | `optional` |  |  |
+| 14 | `swapped_challenge` | `.CMsgClientToGCCavernCrawlRequestMapStateResponse.SwappedChallenge` | `repeated` |  |  |
+| 15 | `ultra_rare_reward_room_number` | `uint32` | `optional` |  | default = 255 |
+| 16 | `treasure_map` | `.CMsgClientToGCCavernCrawlRequestMapStateResponse.TreasureMap` | `repeated` |  |  |
 
 </details>
 
@@ -4337,7 +4337,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -4349,9 +4349,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCCavernCrawlGetClaimedRoomCountResponse.Result` | `optional` | `` | default = SUCCESS |
-| 2 | `map_variants` | `.CMsgClientToGCCavernCrawlGetClaimedRoomCountResponse.MapVariant` | `repeated` | `` |  |
-| 3 | `available_map_variants_mask` | `uint32` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCCavernCrawlGetClaimedRoomCountResponse.Result` | `optional` |  | default = SUCCESS |
+| 2 | `map_variants` | `.CMsgClientToGCCavernCrawlGetClaimedRoomCountResponse.MapVariant` | `repeated` |  |  |
+| 3 | `available_map_variants_mask` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -4363,8 +4363,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `map_variant` | `uint32` | `optional` | `` | default = 255 |
-| 2 | `count` | `uint32` | `optional` | `` |  |
+| 1 | `map_variant` | `uint32` | `optional` |  | default = 255 |
+| 2 | `count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -4376,7 +4376,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `mutations` | `.CMsgDOTAMutationList.Mutation` | `repeated` | `` |  |
+| 1 | `mutations` | `.CMsgDOTAMutationList.Mutation` | `repeated` |  |  |
 
 </details>
 
@@ -4388,9 +4388,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `uint32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `description` | `string` | `optional` | `` |  |
+| 1 | `id` | `uint32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `description` | `string` | `optional` |  |  |
 
 </details>
 
@@ -4402,8 +4402,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 2 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 2 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -4415,8 +4415,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `bool` | `optional` | `` |  |
-| 2 | `tips_received` | `.CMsgEventTipsSummaryResponse.Tipper` | `repeated` | `` |  |
+| 1 | `result` | `bool` | `optional` |  |  |
+| 2 | `tips_received` | `.CMsgEventTipsSummaryResponse.Tipper` | `repeated` |  |  |
 
 </details>
 
@@ -4428,8 +4428,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tipper_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `tip_count` | `uint32` | `optional` | `` | default = 1 |
+| 1 | `tipper_account_id` | `uint32` | `optional` |  |  |
+| 2 | `tip_count` | `uint32` | `optional` |  | default = 1 |
 
 </details>
 
@@ -4441,8 +4441,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `self_only` | `bool` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `self_only` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -4454,8 +4454,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgSocialFeedResponse.Result` | `optional` | `` | default = SUCCESS |
-| 2 | `feed_events` | `.CMsgSocialFeedResponse.FeedEvent` | `repeated` | `` |  |
+| 1 | `result` | `.CMsgSocialFeedResponse.Result` | `optional` |  | default = SUCCESS |
+| 2 | `feed_events` | `.CMsgSocialFeedResponse.FeedEvent` | `repeated` |  |  |
 
 </details>
 
@@ -4467,17 +4467,17 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `feed_event_id` | `uint64` | `optional` | `` |  |
-| 2 | `account_id` | `uint32` | `optional` | `` |  |
-| 3 | `timestamp` | `uint32` | `optional` | `` |  |
-| 4 | `comment_count` | `uint32` | `optional` | `` |  |
-| 5 | `event_type` | `uint32` | `optional` | `` |  |
-| 6 | `event_sub_type` | `uint32` | `optional` | `` |  |
-| 7 | `param_big_int_1` | `uint64` | `optional` | `` |  |
-| 8 | `param_int_1` | `uint32` | `optional` | `` |  |
-| 9 | `param_int_2` | `uint32` | `optional` | `` |  |
-| 10 | `param_int_3` | `uint32` | `optional` | `` |  |
-| 11 | `param_string` | `string` | `optional` | `` |  |
+| 1 | `feed_event_id` | `uint64` | `optional` |  |  |
+| 2 | `account_id` | `uint32` | `optional` |  |  |
+| 3 | `timestamp` | `uint32` | `optional` |  |  |
+| 4 | `comment_count` | `uint32` | `optional` |  |  |
+| 5 | `event_type` | `uint32` | `optional` |  |  |
+| 6 | `event_sub_type` | `uint32` | `optional` |  |  |
+| 7 | `param_big_int_1` | `uint64` | `optional` |  |  |
+| 8 | `param_int_1` | `uint32` | `optional` |  |  |
+| 9 | `param_int_2` | `uint32` | `optional` |  |  |
+| 10 | `param_int_3` | `uint32` | `optional` |  |  |
+| 11 | `param_string` | `string` | `optional` |  |  |
 
 </details>
 
@@ -4489,7 +4489,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `feed_event_id` | `uint64` | `optional` | `` |  |
+| 1 | `feed_event_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -4501,8 +4501,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgSocialFeedCommentsResponse.Result` | `optional` | `` | default = SUCCESS |
-| 3 | `feed_comments` | `.CMsgSocialFeedCommentsResponse.FeedComment` | `repeated` | `` |  |
+| 1 | `result` | `.CMsgSocialFeedCommentsResponse.Result` | `optional` |  | default = SUCCESS |
+| 3 | `feed_comments` | `.CMsgSocialFeedCommentsResponse.FeedComment` | `repeated` |  |  |
 
 </details>
 
@@ -4514,9 +4514,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `commenter_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `timestamp` | `uint32` | `optional` | `` |  |
-| 3 | `comment_text` | `string` | `optional` | `` |  |
+| 1 | `commenter_account_id` | `uint32` | `optional` |  |  |
+| 2 | `timestamp` | `uint32` | `optional` |  |  |
+| 3 | `comment_text` | `string` | `optional` |  |  |
 
 </details>
 
@@ -4528,9 +4528,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `event_id` | `uint32` | `optional` | `` |  |
-| 3 | `card_dust_item_id` | `uint64` | `optional` | `` |  |
+| 1 | `player_account_id` | `uint32` | `optional` |  |  |
+| 2 | `event_id` | `uint32` | `optional` |  |  |
+| 3 | `card_dust_item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -4542,8 +4542,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCPlayerCardSpecificPurchaseResponse.Result` | `optional` | `` | default = SUCCESS |
-| 2 | `item_id` | `uint64` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCPlayerCardSpecificPurchaseResponse.Result` | `optional` |  | default = SUCCESS |
+| 2 | `item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -4555,7 +4555,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `contest_id` | `uint32` | `optional` | `` |  |
+| 1 | `contest_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -4567,8 +4567,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCRequestContestVotesResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `votes` | `.CMsgClientToGCRequestContestVotesResponse.ItemVote` | `repeated` | `` |  |
+| 1 | `result` | `.CMsgClientToGCRequestContestVotesResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `votes` | `.CMsgClientToGCRequestContestVotesResponse.ItemVote` | `repeated` |  |  |
 
 </details>
 
@@ -4580,8 +4580,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `contest_item_id` | `uint64` | `optional` | `` |  |
-| 2 | `vote` | `int32` | `optional` | `` |  |
+| 1 | `contest_item_id` | `uint64` | `optional` |  |  |
+| 2 | `vote` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -4593,9 +4593,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `contest_id` | `uint32` | `optional` | `` |  |
-| 2 | `contest_item_id` | `uint64` | `optional` | `` |  |
-| 3 | `vote` | `int32` | `optional` | `` |  |
+| 1 | `contest_id` | `uint32` | `optional` |  |  |
+| 2 | `contest_item_id` | `uint64` | `optional` |  |  |
+| 3 | `vote` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -4607,7 +4607,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `eresult` | `.CMsgGCToClientRecordContestVoteResponse.EResult` | `optional` | `` | default = SUCCESS |
+| 1 | `eresult` | `.CMsgGCToClientRecordContestVoteResponse.EResult` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -4619,9 +4619,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 2 | `event_points` | `uint32` | `optional` | `` |  |
-| 3 | `premium_points` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 2 | `event_points` | `uint32` | `optional` |  |  |
+| 3 | `premium_points` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -4633,7 +4633,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.EDevEventRequestResult` | `optional` | `` | default = k_EDevEventRequestResult_Success |
+| 1 | `result` | `.EDevEventRequestResult` | `optional` |  | default = k_EDevEventRequestResult_Success |
 
 </details>
 
@@ -4645,9 +4645,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 2 | `action_id` | `uint32` | `optional` | `` |  |
-| 3 | `action_score` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 2 | `action_id` | `uint32` | `optional` |  |  |
+| 3 | `action_score` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -4659,7 +4659,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.EDevEventRequestResult` | `optional` | `` | default = k_EDevEventRequestResult_Success |
+| 1 | `result` | `.EDevEventRequestResult` | `optional` |  | default = k_EDevEventRequestResult_Success |
 
 </details>
 
@@ -4671,10 +4671,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 2 | `start_action_id` | `uint32` | `optional` | `` |  |
-| 3 | `end_action_id` | `uint32` | `optional` | `` |  |
-| 4 | `remove_audit` | `bool` | `optional` | `` |  |
+| 1 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 2 | `start_action_id` | `uint32` | `optional` |  |  |
+| 3 | `end_action_id` | `uint32` | `optional` |  |  |
+| 4 | `remove_audit` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -4686,7 +4686,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.EDevEventRequestResult` | `optional` | `` | default = k_EDevEventRequestResult_Success |
+| 1 | `result` | `.EDevEventRequestResult` | `optional` |  | default = k_EDevEventRequestResult_Success |
 
 </details>
 
@@ -4698,8 +4698,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 2 | `remove_audit` | `bool` | `optional` | `` |  |
+| 1 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 2 | `remove_audit` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -4711,7 +4711,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.EDevEventRequestResult` | `optional` | `` | default = k_EDevEventRequestResult_Success |
+| 1 | `result` | `.EDevEventRequestResult` | `optional` |  | default = k_EDevEventRequestResult_Success |
 
 </details>
 
@@ -4735,7 +4735,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.EDevEventRequestResult` | `optional` | `` | default = k_EDevEventRequestResult_Success |
+| 1 | `result` | `.EDevEventRequestResult` | `optional` |  | default = k_EDevEventRequestResult_Success |
 
 </details>
 
@@ -4747,7 +4747,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `uint64` | `optional` | `` |  |
+| 1 | `item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -4759,7 +4759,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.ESupportEventRequestResult` | `optional` | `` | default = k_ESupportEventRequestResult_Success |
+| 1 | `result` | `.ESupportEventRequestResult` | `optional` |  | default = k_ESupportEventRequestResult_Success |
 
 </details>
 
@@ -4783,11 +4783,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgGCToClientGetFilteredPlayersResponse.Result` | `optional` | `` | default = SUCCESS |
-| 2 | `filtered_players` | `.CMsgGCToClientGetFilteredPlayersResponse.CFilterEntry` | `repeated` | `` |  |
-| 3 | `base_slots` | `int32` | `optional` | `` |  |
-| 4 | `additional_slots` | `int32` | `optional` | `` |  |
-| 5 | `next_slot_cost` | `int32` | `optional` | `` |  |
+| 1 | `result` | `.CMsgGCToClientGetFilteredPlayersResponse.Result` | `optional` |  | default = SUCCESS |
+| 2 | `filtered_players` | `.CMsgGCToClientGetFilteredPlayersResponse.CFilterEntry` | `repeated` |  |  |
+| 3 | `base_slots` | `int32` | `optional` |  |  |
+| 4 | `additional_slots` | `int32` | `optional` |  |  |
+| 5 | `next_slot_cost` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -4799,10 +4799,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `fixed32` | `optional` | `` |  |
-| 2 | `time_added` | `fixed32` | `optional` | `` |  |
-| 3 | `time_expires` | `fixed32` | `optional` | `` |  |
-| 4 | `note` | `string` | `optional` | `` |  |
+| 1 | `account_id` | `fixed32` | `optional` |  |  |
+| 2 | `time_added` | `fixed32` | `optional` |  |  |
+| 3 | `time_expires` | `fixed32` | `optional` |  |  |
+| 4 | `note` | `string` | `optional` |  |  |
 
 </details>
 
@@ -4814,7 +4814,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id_to_remove` | `fixed32` | `optional` | `` |  |
+| 1 | `account_id_to_remove` | `fixed32` | `optional` |  |  |
 
 </details>
 
@@ -4826,7 +4826,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgGCToClientRemoveFilteredPlayerResponse.Result` | `optional` | `` | default = SUCCESS |
+| 1 | `result` | `.CMsgGCToClientRemoveFilteredPlayerResponse.Result` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -4838,7 +4838,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `additional_slots_current` | `int32` | `optional` | `` |  |
+| 1 | `additional_slots_current` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -4850,9 +4850,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgGCToClientPurchaseFilteredPlayerSlotResponse.Result` | `optional` | `` | default = SUCCESS |
-| 2 | `additional_slots` | `int32` | `optional` | `` |  |
-| 3 | `next_slot_cost` | `int32` | `optional` | `` |  |
+| 1 | `result` | `.CMsgGCToClientPurchaseFilteredPlayerSlotResponse.Result` | `optional` |  | default = SUCCESS |
+| 2 | `additional_slots` | `int32` | `optional` |  |  |
+| 3 | `next_slot_cost` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -4864,8 +4864,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_account_id` | `fixed32` | `optional` | `` |  |
-| 2 | `new_note` | `string` | `optional` | `` |  |
+| 1 | `target_account_id` | `fixed32` | `optional` |  |  |
+| 2 | `new_note` | `string` | `optional` |  |  |
 
 </details>
 
@@ -4877,7 +4877,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgGCToClientUpdateFilteredPlayerNoteResponse.Result` | `optional` | `` | default = SUCCESS |
+| 1 | `result` | `.CMsgGCToClientUpdateFilteredPlayerNoteResponse.Result` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -4889,9 +4889,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `fixed32` | `optional` | `` |  |
-| 2 | `match_id` | `fixed64` | `optional` | `` |  |
-| 3 | `creation_time` | `fixed32` | `optional` | `` |  |
+| 1 | `account_id` | `fixed32` | `optional` |  |  |
+| 2 | `match_id` | `fixed64` | `optional` |  |  |
+| 3 | `creation_time` | `fixed32` | `optional` |  |  |
 
 </details>
 
@@ -4903,7 +4903,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `num_active_beacons` | `int32` | `repeated` | `` |  |
+| 1 | `num_active_beacons` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -4915,9 +4915,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `beacon_added` | `bool` | `optional` | `` |  |
-| 2 | `beacon_type` | `int32` | `optional` | `` |  |
-| 3 | `account_id` | `fixed32` | `optional` | `` |  |
+| 1 | `beacon_added` | `bool` | `optional` |  |  |
+| 2 | `beacon_type` | `int32` | `optional` |  |  |
+| 3 | `account_id` | `fixed32` | `optional` |  |  |
 
 </details>
 
@@ -4929,7 +4929,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `action` | `.CMsgClientToGCUpdatePartyBeacon.Action` | `optional` | `` | default = ON |
+| 1 | `action` | `.CMsgClientToGCUpdatePartyBeacon.Action` | `optional` |  | default = ON |
 
 </details>
 
@@ -4953,8 +4953,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgGCToClientRequestActiveBeaconPartiesResponse.EResponse` | `optional` | `` | default = SUCCESS |
-| 2 | `active_parties` | `.CPartySearchClientParty` | `repeated` | `` |  |
+| 1 | `response` | `.CMsgGCToClientRequestActiveBeaconPartiesResponse.EResponse` | `optional` |  | default = SUCCESS |
+| 2 | `active_parties` | `.CPartySearchClientParty` | `repeated` |  |  |
 
 </details>
 
@@ -4966,9 +4966,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `party_id` | `fixed64` | `optional` | `` |  |
-| 2 | `account_id` | `fixed32` | `optional` | `` |  |
-| 3 | `beacon_type` | `int32` | `optional` | `` |  |
+| 1 | `party_id` | `fixed64` | `optional` |  |  |
+| 2 | `account_id` | `fixed32` | `optional` |  |  |
+| 3 | `beacon_type` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -4980,7 +4980,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgGCToClientJoinPartyFromBeaconResponse.EResponse` | `optional` | `` | default = SUCCESS |
+| 1 | `response` | `.CMsgGCToClientJoinPartyFromBeaconResponse.EResponse` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -4992,12 +4992,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `action` | `.CMsgClientToGCManageFavorites.Action` | `optional` | `` | default = ADD |
-| 2 | `account_id` | `fixed32` | `optional` | `` |  |
-| 3 | `favorite_name` | `string` | `optional` | `` |  |
-| 4 | `invite_response` | `bool` | `optional` | `` |  |
-| 5 | `from_friendlist` | `bool` | `optional` | `` |  |
-| 6 | `lobby_id` | `fixed64` | `optional` | `` |  |
+| 1 | `action` | `.CMsgClientToGCManageFavorites.Action` | `optional` |  | default = ADD |
+| 2 | `account_id` | `fixed32` | `optional` |  |  |
+| 3 | `favorite_name` | `string` | `optional` |  |  |
+| 4 | `invite_response` | `bool` | `optional` |  |  |
+| 5 | `from_friendlist` | `bool` | `optional` |  |  |
+| 6 | `lobby_id` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -5009,9 +5009,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgGCToClientManageFavoritesResponse.EResponse` | `optional` | `` | default = SUCCESS |
-| 2 | `debug_message` | `string` | `optional` | `` |  |
-| 3 | `player` | `.CMsgPartySearchPlayer` | `optional` | `` |  |
+| 1 | `response` | `.CMsgGCToClientManageFavoritesResponse.EResponse` | `optional` |  | default = SUCCESS |
+| 2 | `debug_message` | `string` | `optional` |  |  |
+| 3 | `player` | `.CMsgPartySearchPlayer` | `optional` |  |  |
 
 </details>
 
@@ -5023,8 +5023,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `pagination_key` | `uint64` | `optional` | `` |  |
-| 2 | `pagination_count` | `int32` | `optional` | `` |  |
+| 1 | `pagination_key` | `uint64` | `optional` |  |  |
+| 2 | `pagination_count` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -5036,9 +5036,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgGCToClientGetFavoritePlayersResponse.EResponse` | `optional` | `` | default = SUCCESS |
-| 2 | `players` | `.CMsgPartySearchPlayer` | `repeated` | `` |  |
-| 3 | `next_pagination_key` | `uint64` | `optional` | `` |  |
+| 1 | `response` | `.CMsgGCToClientGetFavoritePlayersResponse.EResponse` | `optional` |  | default = SUCCESS |
+| 2 | `players` | `.CMsgPartySearchPlayer` | `repeated` |  |  |
+| 3 | `next_pagination_key` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -5050,7 +5050,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `fixed32` | `optional` | `` |  |
+| 1 | `account_id` | `fixed32` | `optional` |  |  |
 
 </details>
 
@@ -5062,7 +5062,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_ids` | `fixed32` | `repeated` | `` |  |
+| 1 | `account_ids` | `fixed32` | `repeated` |  |  |
 
 </details>
 
@@ -5074,7 +5074,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `results` | `.CMsgGCToClientVerifyFavoritePlayersResponse.Result` | `repeated` | `` |  |
+| 1 | `results` | `.CMsgGCToClientVerifyFavoritePlayersResponse.Result` | `repeated` |  |  |
 
 </details>
 
@@ -5086,8 +5086,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player` | `.CMsgPartySearchPlayer` | `optional` | `` |  |
-| 2 | `is_favorite` | `bool` | `optional` | `` |  |
+| 1 | `player` | `.CMsgPartySearchPlayer` | `optional` |  |  |
+| 2 | `is_favorite` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -5099,7 +5099,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5111,8 +5111,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCRequestPlayerRecentAccomplishmentsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `player_accomplishments` | `.CMsgPlayerRecentAccomplishments` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCRequestPlayerRecentAccomplishmentsResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `player_accomplishments` | `.CMsgPlayerRecentAccomplishments` | `optional` |  |  |
 
 </details>
 
@@ -5124,8 +5124,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `hero_id` | `int32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `hero_id` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -5137,8 +5137,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCRequestPlayerHeroRecentAccomplishmentsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `hero_accomplishments` | `.CMsgPlayerHeroRecentAccomplishments` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCRequestPlayerHeroRecentAccomplishmentsResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `hero_accomplishments` | `.CMsgPlayerHeroRecentAccomplishments` | `optional` |  |  |
 
 </details>
 
@@ -5150,9 +5150,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 3 | `rating` | `sint32` | `optional` | `` |  |
-| 4 | `flags` | `uint32` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 3 | `rating` | `sint32` | `optional` |  |  |
+| 4 | `flags` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5164,8 +5164,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `eresult` | `.CMsgClientToGCSubmitPlayerMatchSurveyResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `eresult` | `.CMsgClientToGCSubmitPlayerMatchSurveyResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5189,8 +5189,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `event_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `event_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5202,10 +5202,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.EUnderDraftResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `account_id` | `uint32` | `optional` | `` |  |
-| 3 | `event_id` | `uint32` | `optional` | `` |  |
-| 4 | `draft_data` | `.CMsgUnderDraftData` | `optional` | `` |  |
+| 1 | `result` | `.EUnderDraftResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `account_id` | `uint32` | `optional` |  |  |
+| 3 | `event_id` | `uint32` | `optional` |  |  |
+| 4 | `draft_data` | `.CMsgUnderDraftData` | `optional` |  |  |
 
 </details>
 
@@ -5217,7 +5217,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5229,9 +5229,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.EUnderDraftResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `event_id` | `uint32` | `optional` | `` |  |
-| 3 | `draft_data` | `.CMsgUnderDraftData` | `optional` | `` |  |
+| 1 | `result` | `.EUnderDraftResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `event_id` | `uint32` | `optional` |  |  |
+| 3 | `draft_data` | `.CMsgUnderDraftData` | `optional` |  |  |
 
 </details>
 
@@ -5243,8 +5243,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `slot_id` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `slot_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5256,7 +5256,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5268,10 +5268,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.EUnderDraftResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `event_id` | `uint32` | `optional` | `` |  |
-| 3 | `slot_id` | `uint32` | `optional` | `` |  |
-| 4 | `draft_data` | `.CMsgUnderDraftData` | `optional` | `` |  |
+| 1 | `result` | `.EUnderDraftResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `event_id` | `uint32` | `optional` |  |  |
+| 3 | `slot_id` | `uint32` | `optional` |  |  |
+| 4 | `draft_data` | `.CMsgUnderDraftData` | `optional` |  |  |
 
 </details>
 
@@ -5283,7 +5283,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5295,9 +5295,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.EUnderDraftResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `event_id` | `uint32` | `optional` | `` |  |
-| 3 | `draft_data` | `.CMsgUnderDraftData` | `optional` | `` |  |
+| 1 | `result` | `.EUnderDraftResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `event_id` | `uint32` | `optional` |  |  |
+| 3 | `draft_data` | `.CMsgUnderDraftData` | `optional` |  |  |
 
 </details>
 
@@ -5309,8 +5309,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `slot_id` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `slot_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5322,10 +5322,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.EUnderDraftResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `event_id` | `uint32` | `optional` | `` |  |
-| 3 | `slot_id` | `uint32` | `optional` | `` |  |
-| 4 | `draft_data` | `.CMsgUnderDraftData` | `optional` | `` |  |
+| 1 | `result` | `.EUnderDraftResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `event_id` | `uint32` | `optional` |  |  |
+| 3 | `slot_id` | `uint32` | `optional` |  |  |
+| 4 | `draft_data` | `.CMsgUnderDraftData` | `optional` |  |  |
 
 </details>
 
@@ -5337,8 +5337,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `action_id` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `action_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5350,7 +5350,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.EUnderDraftResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.EUnderDraftResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -5362,9 +5362,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `chose_radiant_as_winner` | `bool` | `optional` | `` |  |
-| 2 | `event_id` | `uint32` | `optional` | `` |  |
-| 3 | `end_time` | `uint32` | `optional` | `` |  |
+| 1 | `chose_radiant_as_winner` | `bool` | `optional` |  |  |
+| 2 | `event_id` | `uint32` | `optional` |  |  |
+| 3 | `end_time` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5376,7 +5376,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.EDOTADraftTriviaAnswerResult` | `optional` | `` | default = k_EDOTADraftTriviaAnswerResult_Success |
+| 1 | `result` | `.EDOTADraftTriviaAnswerResult` | `optional` |  | default = k_EDOTADraftTriviaAnswerResult_Success |
 
 </details>
 
@@ -5388,9 +5388,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `total_votes` | `uint32` | `optional` | `` |  |
-| 2 | `radiant_votes` | `uint32` | `optional` | `` |  |
-| 3 | `dire_votes` | `uint32` | `optional` | `` |  |
+| 1 | `total_votes` | `uint32` | `optional` |  |  |
+| 2 | `radiant_votes` | `uint32` | `optional` |  |  |
+| 3 | `dire_votes` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5414,10 +5414,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `enum_result` | `.CMsgClientToGCRequestReporterUpdatesResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `updates` | `.CMsgClientToGCRequestReporterUpdatesResponse.ReporterUpdate` | `repeated` | `` |  |
-| 3 | `num_reported` | `int32` | `optional` | `` |  |
-| 4 | `num_no_action_taken` | `int32` | `optional` | `` |  |
+| 1 | `enum_result` | `.CMsgClientToGCRequestReporterUpdatesResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `updates` | `.CMsgClientToGCRequestReporterUpdatesResponse.ReporterUpdate` | `repeated` |  |  |
+| 3 | `num_reported` | `int32` | `optional` |  |  |
+| 4 | `num_no_action_taken` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -5429,10 +5429,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `hero_id` | `int32` | `optional` | `` |  |
-| 3 | `report_reason` | `uint32` | `optional` | `` |  |
-| 4 | `timestamp` | `uint32` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `hero_id` | `int32` | `optional` |  |  |
+| 3 | `report_reason` | `uint32` | `optional` |  |  |
+| 4 | `timestamp` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5444,7 +5444,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_ids` | `uint64` | `repeated` | `` |  |
+| 1 | `match_ids` | `uint64` | `repeated` |  |  |
 
 </details>
 
@@ -5468,7 +5468,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCRecalibrateMMRResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCRecalibrateMMRResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -5480,9 +5480,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `receiver_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `item_def_index` | `uint32` | `repeated` | `` |  |
-| 3 | `action_id` | `uint32` | `optional` | `` |  |
+| 1 | `receiver_account_id` | `uint32` | `optional` |  |  |
+| 2 | `item_def_index` | `uint32` | `repeated` |  |  |
+| 3 | `action_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5506,17 +5506,17 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCGetOWMatchDetailsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `overwatch_replay_id` | `uint64` | `optional` | `` |  |
-| 3 | `decryption_key` | `uint64` | `optional` | `` |  |
-| 4 | `cluster` | `uint32` | `optional` | `` |  |
-| 5 | `overwatch_salt` | `uint32` | `optional` | `` |  |
-| 6 | `target_player_slot` | `uint32` | `optional` | `` |  |
-| 7 | `markers` | `.CMsgClientToGCGetOWMatchDetailsResponse.Marker` | `repeated` | `` |  |
-| 8 | `report_reason` | `.EOverwatchReportReason` | `optional` | `` | default = k_EOverwatchReportReason_Unknown |
-| 9 | `target_hero_id` | `int32` | `optional` | `` |  |
-| 10 | `rank_tier` | `uint32` | `optional` | `` |  |
-| 11 | `lane_selection_flags` | `uint32` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCGetOWMatchDetailsResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `overwatch_replay_id` | `uint64` | `optional` |  |  |
+| 3 | `decryption_key` | `uint64` | `optional` |  |  |
+| 4 | `cluster` | `uint32` | `optional` |  |  |
+| 5 | `overwatch_salt` | `uint32` | `optional` |  |  |
+| 6 | `target_player_slot` | `uint32` | `optional` |  |  |
+| 7 | `markers` | `.CMsgClientToGCGetOWMatchDetailsResponse.Marker` | `repeated` |  |  |
+| 8 | `report_reason` | `.EOverwatchReportReason` | `optional` |  | default = k_EOverwatchReportReason_Unknown |
+| 9 | `target_hero_id` | `int32` | `optional` |  |  |
+| 10 | `rank_tier` | `uint32` | `optional` |  |  |
+| 11 | `lane_selection_flags` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5528,8 +5528,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `start_game_time_s` | `uint32` | `optional` | `` |  |
-| 2 | `end_game_time_s` | `uint32` | `optional` | `` |  |
+| 1 | `start_game_time_s` | `uint32` | `optional` |  |  |
+| 2 | `end_game_time_s` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5541,10 +5541,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `overwatch_replay_id` | `uint64` | `optional` | `` |  |
-| 2 | `target_player_slot` | `uint32` | `optional` | `` |  |
-| 3 | `cheating_conviction` | `.EOverwatchConviction` | `optional` | `` | default = k_EOverwatchConviction_None |
-| 4 | `griefing_conviction` | `.EOverwatchConviction` | `optional` | `` | default = k_EOverwatchConviction_None |
+| 1 | `overwatch_replay_id` | `uint64` | `optional` |  |  |
+| 2 | `target_player_slot` | `uint32` | `optional` |  |  |
+| 3 | `cheating_conviction` | `.EOverwatchConviction` | `optional` |  | default = k_EOverwatchConviction_None |
+| 4 | `griefing_conviction` | `.EOverwatchConviction` | `optional` |  | default = k_EOverwatchConviction_None |
 
 </details>
 
@@ -5556,8 +5556,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCSubmitOWConvictionResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `overwatch_replay_id` | `uint64` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCSubmitOWConvictionResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `overwatch_replay_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -5581,7 +5581,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `agreement_url` | `string` | `optional` | `` |  |
+| 1 | `agreement_url` | `string` | `optional` |  |  |
 
 </details>
 
@@ -5605,7 +5605,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `agreement_accepted` | `bool` | `optional` | `` |  |
+| 1 | `agreement_accepted` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -5617,7 +5617,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `expire_time` | `fixed32` | `optional` | `` |  |
+| 1 | `expire_time` | `fixed32` | `optional` |  |  |
 
 </details>
 
@@ -5629,8 +5629,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `overwatch_replay_id` | `uint64` | `optional` | `` |  |
-| 2 | `target_player_slot` | `uint32` | `optional` | `` |  |
+| 1 | `overwatch_replay_id` | `uint64` | `optional` |  |  |
+| 2 | `target_player_slot` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5642,8 +5642,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `overwatch_replay_id` | `uint64` | `optional` | `` |  |
-| 2 | `target_player_slot` | `uint32` | `optional` | `` |  |
+| 1 | `overwatch_replay_id` | `uint64` | `optional` |  |  |
+| 2 | `target_player_slot` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5655,7 +5655,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `overwatch_replay_id` | `uint64` | `optional` | `` |  |
+| 1 | `overwatch_replay_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -5679,8 +5679,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCGetDPCFavoritesResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `favorites` | `.CMsgClientToGCGetDPCFavoritesResponse.Favorite` | `repeated` | `` |  |
+| 1 | `result` | `.CMsgClientToGCGetDPCFavoritesResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `favorites` | `.CMsgClientToGCGetDPCFavoritesResponse.Favorite` | `repeated` |  |  |
 
 </details>
 
@@ -5692,8 +5692,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `favorite_type` | `.EDPCFavoriteType` | `optional` | `` | default = FAVORITE_TYPE_ALL |
-| 2 | `favorite_id` | `uint32` | `optional` | `` |  |
+| 1 | `favorite_type` | `.EDPCFavoriteType` | `optional` |  | default = FAVORITE_TYPE_ALL |
+| 2 | `favorite_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5705,9 +5705,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `favorite_type` | `.EDPCFavoriteType` | `optional` | `` | default = FAVORITE_TYPE_ALL |
-| 2 | `favorite_id` | `uint32` | `optional` | `` |  |
-| 3 | `enabled` | `bool` | `optional` | `` |  |
+| 1 | `favorite_type` | `.EDPCFavoriteType` | `optional` |  | default = FAVORITE_TYPE_ALL |
+| 2 | `favorite_id` | `uint32` | `optional` |  |  |
+| 3 | `enabled` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -5719,7 +5719,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCSetDPCFavoriteStateResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCSetDPCFavoriteStateResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -5731,8 +5731,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `active_season_id` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `active_season_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5744,7 +5744,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCSetEventActiveSeasonIDResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCSetEventActiveSeasonIDResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -5756,10 +5756,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 2 | `blessing_ids` | `int32` | `repeated` | `` |  |
-| 3 | `debug` | `bool` | `optional` | `` |  |
-| 4 | `debug_remove` | `bool` | `optional` | `` |  |
+| 1 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 2 | `blessing_ids` | `int32` | `repeated` |  |  |
+| 3 | `debug` | `bool` | `optional` |  |  |
+| 4 | `debug_remove` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -5771,7 +5771,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCPurchaseLabyrinthBlessingsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `result` | `.CMsgClientToGCPurchaseLabyrinthBlessingsResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -5783,7 +5783,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5795,8 +5795,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCGetStickerbookResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `stickerbook` | `.CMsgStickerbook` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCGetStickerbookResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `stickerbook` | `.CMsgStickerbook` | `optional` |  |  |
 
 </details>
 
@@ -5808,9 +5808,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_id` | `uint32` | `optional` | `` |  |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 3 | `page_type` | `.EStickerbookPageType` | `optional` | `` | default = STICKER_PAGE_GENERIC |
+| 1 | `team_id` | `uint32` | `optional` |  |  |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 3 | `page_type` | `.EStickerbookPageType` | `optional` |  | default = STICKER_PAGE_GENERIC |
 
 </details>
 
@@ -5822,8 +5822,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCCreateStickerbookPageResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `page_number` | `uint32` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCCreateStickerbookPageResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `page_number` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5835,9 +5835,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `page_num` | `uint32` | `optional` | `` |  |
-| 2 | `sticker_count` | `uint32` | `optional` | `` |  |
-| 3 | `sticker_max` | `uint32` | `optional` | `` |  |
+| 1 | `page_num` | `uint32` | `optional` |  |  |
+| 2 | `sticker_count` | `uint32` | `optional` |  |  |
+| 3 | `sticker_max` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5849,7 +5849,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCDeleteStickerbookPageResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCDeleteStickerbookPageResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -5861,7 +5861,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `sticker_items` | `.CMsgClientToGCPlaceStickersRequest.StickerItem` | `repeated` | `` |  |
+| 1 | `sticker_items` | `.CMsgClientToGCPlaceStickersRequest.StickerItem` | `repeated` |  |  |
 
 </details>
 
@@ -5873,8 +5873,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `page_num` | `uint32` | `optional` | `` |  |
-| 3 | `sticker` | `.CMsgStickerbookSticker` | `optional` | `` |  |
+| 2 | `page_num` | `uint32` | `optional` |  |  |
+| 3 | `sticker` | `.CMsgStickerbookSticker` | `optional` |  |  |
 
 </details>
 
@@ -5886,7 +5886,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCPlaceStickersResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCPlaceStickersResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -5898,7 +5898,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `slots` | `.CMsgClientToGCPlaceCollectionStickersRequest.Slot` | `repeated` | `` |  |
+| 1 | `slots` | `.CMsgClientToGCPlaceCollectionStickersRequest.Slot` | `repeated` |  |  |
 
 </details>
 
@@ -5910,11 +5910,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `page_num` | `uint32` | `optional` | `` |  |
-| 2 | `slot` | `uint32` | `optional` | `` |  |
-| 3 | `new_item_id` | `uint64` | `optional` | `` |  |
-| 4 | `old_item_def_id` | `uint32` | `optional` | `` |  |
-| 5 | `old_quality` | `uint32` | `optional` | `` |  |
+| 1 | `page_num` | `uint32` | `optional` |  |  |
+| 2 | `slot` | `uint32` | `optional` |  |  |
+| 3 | `new_item_id` | `uint64` | `optional` |  |  |
+| 4 | `old_item_def_id` | `uint32` | `optional` |  |  |
+| 5 | `old_quality` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -5926,7 +5926,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCPlaceCollectionStickersResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCPlaceCollectionStickersResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -5938,7 +5938,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `page_order_sequence` | `.CMsgStickerbookTeamPageOrderSequence` | `optional` | `` |  |
+| 1 | `page_order_sequence` | `.CMsgStickerbookTeamPageOrderSequence` | `optional` |  |  |
 
 </details>
 
@@ -5950,7 +5950,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCOrderStickerbookTeamPageResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCOrderStickerbookTeamPageResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -5962,9 +5962,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `new_item_id` | `uint64` | `optional` | `` |  |
-| 3 | `old_item_id` | `uint64` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `new_item_id` | `uint64` | `optional` |  |  |
+| 3 | `old_item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -5976,7 +5976,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCSetHeroStickerResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCSetHeroStickerResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -6000,8 +6000,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCGetHeroStickersResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `sticker_heroes` | `.CMsgStickerHeroes` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCGetHeroStickersResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `sticker_heroes` | `.CMsgStickerHeroes` | `optional` |  |  |
 
 </details>
 
@@ -6013,8 +6013,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `page_num` | `uint32` | `optional` | `` |  |
-| 2 | `clear` | `bool` | `optional` | `` |  |
+| 1 | `page_num` | `uint32` | `optional` |  |  |
+| 2 | `clear` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -6026,7 +6026,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCSetFavoritePageResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCSetFavoritePageResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -6038,9 +6038,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 2 | `action_id` | `uint32` | `optional` | `` |  |
-| 3 | `data` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 2 | `action_id` | `uint32` | `optional` |  |  |
+| 3 | `data` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -6052,7 +6052,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCClaimSwagResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCClaimSwagResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -6064,7 +6064,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `contest_id` | `uint32` | `optional` | `` |  |
+| 1 | `contest_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -6076,7 +6076,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `votes` | `.CMsgGCToClientCollectorsCacheAvailableDataResponse.Vote` | `repeated` | `` |  |
+| 1 | `votes` | `.CMsgGCToClientCollectorsCacheAvailableDataResponse.Vote` | `repeated` |  |  |
 
 </details>
 
@@ -6088,8 +6088,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def` | `uint32` | `optional` | `` |  |
-| 2 | `vote_type` | `.CMsgGCToClientCollectorsCacheAvailableDataResponse.Vote.EVoteType` | `optional` | `` | default = k_eUp |
+| 1 | `item_def` | `uint32` | `optional` |  |  |
+| 2 | `vote_type` | `.CMsgGCToClientCollectorsCacheAvailableDataResponse.Vote.EVoteType` | `optional` |  | default = k_eUp |
 
 </details>
 
@@ -6101,7 +6101,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_clip` | `.CMatchClip` | `optional` | `` |  |
+| 1 | `match_clip` | `.CMatchClip` | `optional` |  |  |
 
 </details>
 
@@ -6113,7 +6113,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgGCToClientUploadMatchClipResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgGCToClientUploadMatchClipResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -6137,9 +6137,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgGCToClientMapStatsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `personal_stats` | `.CMsgMapStatsSnapshot` | `optional` | `` |  |
-| 3 | `global_stats` | `.CMsgGlobalMapStats` | `optional` | `` |  |
+| 1 | `response` | `.CMsgGCToClientMapStatsResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `personal_stats` | `.CMsgMapStatsSnapshot` | `optional` |  |  |
+| 3 | `global_stats` | `.CMsgGlobalMapStats` | `optional` |  |  |
 
 </details>
 
@@ -6151,11 +6151,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `quest_id` | `uint32` | `optional` | `` |  |
-| 2 | `difficulty` | `uint32` | `optional` | `` |  |
-| 3 | `progress_flags` | `uint32` | `optional` | `` |  |
-| 4 | `half_credit_flags` | `uint32` | `optional` | `` |  |
-| 5 | `completed` | `bool` | `optional` | `` |  |
+| 1 | `quest_id` | `uint32` | `optional` |  |  |
+| 2 | `difficulty` | `uint32` | `optional` |  |  |
+| 3 | `progress_flags` | `uint32` | `optional` |  |  |
+| 4 | `half_credit_flags` | `uint32` | `optional` |  |  |
+| 5 | `completed` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -6167,7 +6167,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `quests` | `.CMsgRoadToTIAssignedQuest` | `repeated` | `` |  |
+| 1 | `quests` | `.CMsgRoadToTIAssignedQuest` | `repeated` |  |  |
 
 </details>
 
@@ -6179,7 +6179,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -6191,8 +6191,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCRoadToTIGetQuestsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `quest_data` | `.CMsgRoadToTIUserData` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCRoadToTIGetQuestsResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `quest_data` | `.CMsgRoadToTIUserData` | `optional` |  |  |
 
 </details>
 
@@ -6204,7 +6204,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -6216,8 +6216,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCRoadToTIGetActiveQuestResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `quest_data` | `.CMsgRoadToTIAssignedQuest` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCRoadToTIGetActiveQuestResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `quest_data` | `.CMsgRoadToTIAssignedQuest` | `optional` |  |  |
 
 </details>
 
@@ -6229,8 +6229,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `quest_data` | `.CMsgRoadToTIUserData` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `quest_data` | `.CMsgRoadToTIUserData` | `optional` |  |  |
 
 </details>
 
@@ -6242,9 +6242,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `item_type` | `uint32` | `optional` | `` |  |
-| 3 | `hero_index` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `item_type` | `uint32` | `optional` |  |  |
+| 3 | `hero_index` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -6256,7 +6256,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCRoadToTIUseItemResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCRoadToTIUseItemResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -6268,9 +6268,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `force_match_type` | `bool` | `optional` | `` |  |
-| 3 | `force_id` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `force_match_type` | `bool` | `optional` |  |  |
+| 3 | `force_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -6282,9 +6282,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `quest_data` | `.CMsgRoadToTIAssignedQuest` | `optional` | `` |  |
-| 2 | `quest_period` | `uint32` | `optional` | `` |  |
-| 3 | `quest_number` | `uint32` | `optional` | `` |  |
+| 1 | `quest_data` | `.CMsgRoadToTIAssignedQuest` | `optional` |  |  |
+| 2 | `quest_period` | `uint32` | `optional` |  |  |
+| 3 | `quest_number` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -6296,9 +6296,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `defindex` | `uint32` | `optional` | `` |  |
-| 2 | `lobby_id` | `uint64` | `optional` | `` |  |
-| 3 | `target_account_ids` | `uint32` | `repeated` | `` |  |
+| 1 | `defindex` | `uint32` | `optional` |  |  |
+| 2 | `lobby_id` | `uint64` | `optional` |  |  |
+| 3 | `target_account_ids` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -6310,8 +6310,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.ENewBloomGiftingResponse` | `optional` | `` | default = kENewBloomGifting_UnknownFailure |
-| 2 | `received_account_ids` | `uint32` | `repeated` | `` |  |
+| 1 | `result` | `.ENewBloomGiftingResponse` | `optional` |  | default = kENewBloomGifting_UnknownFailure |
+| 2 | `received_account_ids` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -6323,7 +6323,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `banned_hero_ids` | `int32` | `repeated` | `` |  |
+| 1 | `banned_hero_ids` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -6335,9 +6335,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `comic_id` | `uint32` | `optional` | `` |  |
-| 2 | `stats` | `.CMsgClientToGCUpdateComicBookStats.SingleStat` | `repeated` | `` |  |
-| 3 | `language_stats` | `.CMsgClientToGCUpdateComicBookStats.LanguageStats` | `optional` | `` |  |
+| 1 | `comic_id` | `uint32` | `optional` |  |  |
+| 2 | `stats` | `.CMsgClientToGCUpdateComicBookStats.SingleStat` | `repeated` |  |  |
+| 3 | `language_stats` | `.CMsgClientToGCUpdateComicBookStats.LanguageStats` | `optional` |  |  |
 
 </details>
 
@@ -6349,8 +6349,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `stat_type` | `.CMsgClientToGCUpdateComicBookStat_Type` | `optional` | `` | default = CMsgClientToGCUpdateComicBookStat_Type_HighestPageRead |
-| 2 | `stat_value` | `uint32` | `optional` | `` |  |
+| 1 | `stat_type` | `.CMsgClientToGCUpdateComicBookStat_Type` | `optional` |  | default = CMsgClientToGCUpdateComicBookStat_Type_HighestPageRead |
+| 2 | `stat_value` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -6362,9 +6362,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `comic_id` | `uint32` | `optional` | `` |  |
-| 2 | `client_language` | `uint32` | `optional` | `` |  |
-| 3 | `client_comic_language` | `uint32` | `optional` | `` |  |
+| 1 | `comic_id` | `uint32` | `optional` |  |  |
+| 2 | `client_language` | `uint32` | `optional` |  |  |
+| 3 | `client_comic_language` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -6376,7 +6376,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -6388,7 +6388,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgGCRankedPlayerInfoSubmitResponse.EResult` | `optional` | `` | default = SUCCESS |
+| 1 | `result` | `.CMsgGCRankedPlayerInfoSubmitResponse.EResult` | `optional` |  | default = SUCCESS |
 
 </details>
 
@@ -6400,7 +6400,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
+| 1 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
 
 </details>
 
@@ -6412,7 +6412,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgDOTAClaimGatedEventResponse.ResultCode` | `optional` | `` | default = Success |
+| 1 | `result` | `.CMsgDOTAClaimGatedEventResponse.ResultCode` | `optional` |  | default = Success |
 
 </details>
 
@@ -6424,8 +6424,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 2 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 2 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -6437,11 +6437,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 2 | `account_id` | `uint32` | `optional` | `` |  |
-| 3 | `score` | `float` | `optional` | `` |  |
-| 4 | `percentile` | `float` | `optional` | `` |  |
-| 5 | `final_rank_bucket` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 2 | `account_id` | `uint32` | `optional` |  |  |
+| 3 | `score` | `float` | `optional` |  |  |
+| 4 | `percentile` | `float` | `optional` |  |  |
+| 5 | `final_rank_bucket` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -6453,7 +6453,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
+| 1 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
 
 </details>
 
@@ -6465,9 +6465,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCGetEventCouponResponse.ResultCode` | `optional` | `` | default = Success |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 3 | `coupons` | `.CMsgClientToGCGetEventCouponResponse.Coupon` | `repeated` | `` |  |
+| 1 | `result` | `.CMsgClientToGCGetEventCouponResponse.ResultCode` | `optional` |  | default = Success |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 3 | `coupons` | `.CMsgClientToGCGetEventCouponResponse.Coupon` | `repeated` |  |  |
 
 </details>
 
@@ -6479,8 +6479,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `coupon_id` | `uint32` | `optional` | `` |  |
-| 2 | `coupon_code` | `string` | `optional` | `` |  |
+| 1 | `coupon_id` | `uint32` | `optional` |  |  |
+| 2 | `coupon_code` | `string` | `optional` |  |  |
 
 </details>
 
@@ -6492,10 +6492,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id_points_to_buy` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 2 | `event_id_points_to_spend` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 3 | `num_points_to_buy` | `uint32` | `optional` | `` |  |
-| 4 | `num_points_to_spend` | `uint32` | `optional` | `` |  |
+| 1 | `event_id_points_to_buy` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 2 | `event_id_points_to_spend` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 3 | `num_points_to_buy` | `uint32` | `optional` |  |  |
+| 4 | `num_points_to_spend` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -6507,7 +6507,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCConvertEventPointsResponse.ResultCode` | `optional` | `` | default = Success |
+| 1 | `result` | `.CMsgClientToGCConvertEventPointsResponse.ResultCode` | `optional` |  | default = Success |
 
 </details>
 
@@ -6519,8 +6519,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `server_id` | `fixed64` | `optional` | `` |  |
-| 2 | `invited_player_id` | `fixed64` | `optional` | `` |  |
+| 1 | `server_id` | `fixed64` | `optional` |  |  |
+| 2 | `invited_player_id` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -6532,9 +6532,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `server_id` | `fixed64` | `optional` | `` |  |
-| 2 | `from_player` | `fixed64` | `optional` | `` |  |
-| 3 | `party_invite` | `bool` | `optional` | `` |  |
+| 1 | `server_id` | `fixed64` | `optional` |  |  |
+| 2 | `from_player` | `fixed64` | `optional` |  |  |
+| 3 | `party_invite` | `bool` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-common-battle-report.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-common-battle-report.md
@@ -29,9 +29,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `timestamp` | `uint32` | `optional` | `` |  |
-| 3 | `duration` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `timestamp` | `uint32` | `optional` |  |  |
+| 3 | `duration` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -43,56 +43,56 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `kills` | `uint32` | `optional` | `` |  |
-| 3 | `deaths` | `uint32` | `optional` | `` |  |
-| 4 | `assists` | `uint32` | `optional` | `` |  |
-| 5 | `rank_change` | `int32` | `optional` | `` |  |
-| 6 | `last_hits` | `uint32` | `optional` | `` |  |
-| 7 | `gpm` | `uint32` | `optional` | `` |  |
-| 8 | `xpm` | `uint32` | `optional` | `` |  |
-| 9 | `role` | `.CMsgBattleReport_Role` | `optional` | `` | default = k_eUnknownRole |
-| 10 | `outcome` | `.CMsgBattleReport_EOutcome` | `optional` | `` | default = k_eWin |
-| 11 | `lane_outcome` | `.CMsgBattleReport_ELaneOutcome` | `optional` | `` | default = k_eUnknownLaneOutcome |
-| 12 | `ranked` | `bool` | `optional` | `` |  |
-| 13 | `match_id` | `uint64` | `optional` | `` |  |
-| 14 | `lane_selection_flags` | `uint32` | `optional` | `` |  |
-| 15 | `predicted_position` | `uint32` | `optional` | `` |  |
-| 16 | `seconds_dead` | `uint32` | `optional` | `` |  |
-| 17 | `winning_team` | `uint32` | `optional` | `` |  |
-| 19 | `party_game` | `bool` | `optional` | `` |  |
-| 20 | `start_time` | `uint32` | `optional` | `` |  |
-| 21 | `denies` | `uint32` | `optional` | `` |  |
-| 22 | `bounty_runes` | `uint32` | `optional` | `` |  |
-| 23 | `water_runes` | `uint32` | `optional` | `` |  |
-| 24 | `power_runes` | `uint32` | `optional` | `` |  |
-| 25 | `time_enemy_t1_tower_destroyed` | `uint32` | `optional` | `` |  |
-| 26 | `time_friendly_t1_tower_destroyed` | `uint32` | `optional` | `` |  |
-| 27 | `enemy_roshan_kills` | `uint32` | `optional` | `` |  |
-| 28 | `player_slot` | `uint32` | `optional` | `` |  |
-| 29 | `teleports_used` | `uint32` | `optional` | `` |  |
-| 30 | `dewards` | `uint32` | `optional` | `` |  |
-| 31 | `camps_stacked` | `uint32` | `optional` | `` |  |
-| 32 | `support_gold` | `uint32` | `optional` | `` |  |
-| 33 | `hero_damage` | `uint32` | `optional` | `` |  |
-| 34 | `hero_healing` | `uint32` | `optional` | `` |  |
-| 35 | `tower_damage` | `uint32` | `optional` | `` |  |
-| 36 | `successful_smokes` | `uint32` | `optional` | `` |  |
-| 37 | `stun_duration` | `uint32` | `optional` | `` |  |
-| 38 | `duration` | `uint32` | `optional` | `` |  |
-| 39 | `friendly_roshan_kills` | `uint32` | `optional` | `` |  |
-| 40 | `previous_rank` | `int32` | `optional` | `` |  |
-| 41 | `game_mode` | `uint32` | `optional` | `` |  |
-| 42 | `lobby_type` | `uint32` | `optional` | `` |  |
-| 43 | `time_purchased_shard` | `float` | `optional` | `` |  |
-| 44 | `time_purchased_scepter` | `float` | `optional` | `` |  |
-| 45 | `item0` | `int32` | `optional` | `` | default = -1 |
-| 46 | `item1` | `int32` | `optional` | `` | default = -1 |
-| 47 | `item2` | `int32` | `optional` | `` | default = -1 |
-| 48 | `item3` | `int32` | `optional` | `` | default = -1 |
-| 49 | `item4` | `int32` | `optional` | `` | default = -1 |
-| 50 | `item5` | `int32` | `optional` | `` | default = -1 |
-| 51 | `selected_facet` | `uint32` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `kills` | `uint32` | `optional` |  |  |
+| 3 | `deaths` | `uint32` | `optional` |  |  |
+| 4 | `assists` | `uint32` | `optional` |  |  |
+| 5 | `rank_change` | `int32` | `optional` |  |  |
+| 6 | `last_hits` | `uint32` | `optional` |  |  |
+| 7 | `gpm` | `uint32` | `optional` |  |  |
+| 8 | `xpm` | `uint32` | `optional` |  |  |
+| 9 | `role` | `.CMsgBattleReport_Role` | `optional` |  | default = k_eUnknownRole |
+| 10 | `outcome` | `.CMsgBattleReport_EOutcome` | `optional` |  | default = k_eWin |
+| 11 | `lane_outcome` | `.CMsgBattleReport_ELaneOutcome` | `optional` |  | default = k_eUnknownLaneOutcome |
+| 12 | `ranked` | `bool` | `optional` |  |  |
+| 13 | `match_id` | `uint64` | `optional` |  |  |
+| 14 | `lane_selection_flags` | `uint32` | `optional` |  |  |
+| 15 | `predicted_position` | `uint32` | `optional` |  |  |
+| 16 | `seconds_dead` | `uint32` | `optional` |  |  |
+| 17 | `winning_team` | `uint32` | `optional` |  |  |
+| 19 | `party_game` | `bool` | `optional` |  |  |
+| 20 | `start_time` | `uint32` | `optional` |  |  |
+| 21 | `denies` | `uint32` | `optional` |  |  |
+| 22 | `bounty_runes` | `uint32` | `optional` |  |  |
+| 23 | `water_runes` | `uint32` | `optional` |  |  |
+| 24 | `power_runes` | `uint32` | `optional` |  |  |
+| 25 | `time_enemy_t1_tower_destroyed` | `uint32` | `optional` |  |  |
+| 26 | `time_friendly_t1_tower_destroyed` | `uint32` | `optional` |  |  |
+| 27 | `enemy_roshan_kills` | `uint32` | `optional` |  |  |
+| 28 | `player_slot` | `uint32` | `optional` |  |  |
+| 29 | `teleports_used` | `uint32` | `optional` |  |  |
+| 30 | `dewards` | `uint32` | `optional` |  |  |
+| 31 | `camps_stacked` | `uint32` | `optional` |  |  |
+| 32 | `support_gold` | `uint32` | `optional` |  |  |
+| 33 | `hero_damage` | `uint32` | `optional` |  |  |
+| 34 | `hero_healing` | `uint32` | `optional` |  |  |
+| 35 | `tower_damage` | `uint32` | `optional` |  |  |
+| 36 | `successful_smokes` | `uint32` | `optional` |  |  |
+| 37 | `stun_duration` | `uint32` | `optional` |  |  |
+| 38 | `duration` | `uint32` | `optional` |  |  |
+| 39 | `friendly_roshan_kills` | `uint32` | `optional` |  |  |
+| 40 | `previous_rank` | `int32` | `optional` |  |  |
+| 41 | `game_mode` | `uint32` | `optional` |  |  |
+| 42 | `lobby_type` | `uint32` | `optional` |  |  |
+| 43 | `time_purchased_shard` | `float` | `optional` |  |  |
+| 44 | `time_purchased_scepter` | `float` | `optional` |  |  |
+| 45 | `item0` | `int32` | `optional` |  | default = -1 |
+| 46 | `item1` | `int32` | `optional` |  | default = -1 |
+| 47 | `item2` | `int32` | `optional` |  | default = -1 |
+| 48 | `item3` | `int32` | `optional` |  | default = -1 |
+| 49 | `item4` | `int32` | `optional` |  | default = -1 |
+| 50 | `item5` | `int32` | `optional` |  | default = -1 |
+| 51 | `selected_facet` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -104,7 +104,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `games` | `.CMsgBattleReport_Game` | `repeated` | `` |  |
+| 1 | `games` | `.CMsgBattleReport_Game` | `repeated` |  |  |
 
 </details>
 
@@ -116,8 +116,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `games` | `.CMsgBattleReport_Game` | `repeated` | `` |  |
-| 3 | `highlights` | `.CMsgBattleReportHighlights` | `optional` | `` |  |
+| 1 | `games` | `.CMsgBattleReport_Game` | `repeated` |  |  |
+| 3 | `highlights` | `.CMsgBattleReportHighlights` | `optional` |  |  |
 
 </details>
 
@@ -129,10 +129,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `win_loss_window` | `int32` | `optional` | `` |  |
-| 2 | `win_percent` | `float` | `optional` | `` |  |
-| 3 | `mmr_delta` | `int32` | `optional` | `` |  |
-| 4 | `highlight_score` | `float` | `optional` | `` |  |
+| 1 | `win_loss_window` | `int32` | `optional` |  |  |
+| 2 | `win_percent` | `float` | `optional` |  |  |
+| 3 | `mmr_delta` | `int32` | `optional` |  |  |
+| 4 | `highlight_score` | `float` | `optional` |  |  |
 
 </details>
 
@@ -144,16 +144,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `highlight_id` | `uint32` | `optional` | `` |  |
-| 2 | `category` | `.CMsgBattleReport_HighlightCategory` | `optional` | `` | default = k_eHighlightGeneral |
-| 3 | `tier` | `.CMsgBattleReport_HighlightTier` | `optional` | `` | default = k_eHighlightTierLow |
-| 4 | `rarity` | `.CMsgBattleReport_HighlightRarity` | `optional` | `` | default = k_eHighlightCommon |
-| 5 | `score` | `float` | `optional` | `` |  |
-| 6 | `confidence` | `float` | `optional` | `` |  |
-| 7 | `hero_id` | `int32` | `optional` | `` |  |
-| 8 | `role` | `.CMsgBattleReport_Role` | `optional` | `` | default = k_eUnknownRole |
-| 9 | `comparison_delta_value` | `float` | `optional` | `` |  |
-| 10 | `context` | `.CMsgBattleReport_CompareContext` | `optional` | `` | default = k_eCompareContextInvalid |
+| 1 | `highlight_id` | `uint32` | `optional` |  |  |
+| 2 | `category` | `.CMsgBattleReport_HighlightCategory` | `optional` |  | default = k_eHighlightGeneral |
+| 3 | `tier` | `.CMsgBattleReport_HighlightTier` | `optional` |  | default = k_eHighlightTierLow |
+| 4 | `rarity` | `.CMsgBattleReport_HighlightRarity` | `optional` |  | default = k_eHighlightCommon |
+| 5 | `score` | `float` | `optional` |  |  |
+| 6 | `confidence` | `float` | `optional` |  |  |
+| 7 | `hero_id` | `int32` | `optional` |  |  |
+| 8 | `role` | `.CMsgBattleReport_Role` | `optional` |  | default = k_eUnknownRole |
+| 9 | `comparison_delta_value` | `float` | `optional` |  |  |
+| 10 | `context` | `.CMsgBattleReport_CompareContext` | `optional` |  | default = k_eCompareContextInvalid |
 
 </details>
 
@@ -165,13 +165,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `timestamp` | `uint32` | `optional` | `` |  |
-| 2 | `duration` | `uint32` | `optional` | `` |  |
-| 3 | `acknowledged` | `bool` | `optional` | `` |  |
-| 4 | `featured_hero_id` | `int32` | `optional` | `` |  |
-| 5 | `featured_position` | `uint32` | `optional` | `` |  |
-| 6 | `games_played` | `uint32` | `optional` | `` |  |
-| 7 | `medal_counts` | `uint32` | `repeated` | `` |  |
+| 1 | `timestamp` | `uint32` | `optional` |  |  |
+| 2 | `duration` | `uint32` | `optional` |  |  |
+| 3 | `acknowledged` | `bool` | `optional` |  |  |
+| 4 | `featured_hero_id` | `int32` | `optional` |  |  |
+| 5 | `featured_position` | `uint32` | `optional` |  |  |
+| 6 | `games_played` | `uint32` | `optional` |  |  |
+| 7 | `medal_counts` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -183,7 +183,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `battle_report_info` | `.CMsgBattleReportInfo` | `repeated` | `` |  |
+| 1 | `battle_report_info` | `.CMsgBattleReportInfo` | `repeated` |  |  |
 
 </details>
 
@@ -195,7 +195,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `highlights` | `.CMsgBattleReport.Highlight` | `repeated` | `` |  |
+| 1 | `highlights` | `.CMsgBattleReport.Highlight` | `repeated` |  |  |
 
 </details>
 
@@ -207,7 +207,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgBattleReportAggregateStats.CMsgBattleReportAggregate` | `repeated` | `` |  |
+| 1 | `result` | `.CMsgBattleReportAggregateStats.CMsgBattleReportAggregate` | `repeated` |  |  |
 
 </details>
 
@@ -219,8 +219,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `mean` | `float` | `optional` | `` |  |
-| 2 | `stdev` | `float` | `optional` | `` |  |
+| 1 | `mean` | `float` | `optional` |  |  |
+| 2 | `stdev` | `float` | `optional` |  |  |
 
 </details>
 
@@ -232,37 +232,37 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `predicted_position` | `uint32` | `optional` | `` |  |
-| 3 | `game_count` | `uint32` | `optional` | `` |  |
-| 4 | `win_count` | `uint32` | `optional` | `` |  |
-| 5 | `lane_win_count` | `uint32` | `optional` | `` |  |
-| 6 | `kills` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 7 | `deaths` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 8 | `assists` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 9 | `rank_change` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 10 | `last_hits` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 11 | `denies` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 12 | `gpm` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 13 | `xpm` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 14 | `seconds_dead` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 15 | `bounty_runes` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 16 | `water_runes` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 17 | `power_runes` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 18 | `time_enemy_t1_tower_destroyed` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 19 | `time_friendly_t1_tower_destroyed` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 20 | `enemy_roshan_kills` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 21 | `teleports_used` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 22 | `dewards` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 23 | `camps_stacked` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 24 | `support_gold` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 25 | `hero_damage` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 26 | `hero_healing` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 27 | `tower_damage` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 28 | `successful_smokes` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 29 | `stun_duration` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 30 | `duration` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
-| 31 | `friendly_roshan_kills` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `predicted_position` | `uint32` | `optional` |  |  |
+| 3 | `game_count` | `uint32` | `optional` |  |  |
+| 4 | `win_count` | `uint32` | `optional` |  |  |
+| 5 | `lane_win_count` | `uint32` | `optional` |  |  |
+| 6 | `kills` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 7 | `deaths` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 8 | `assists` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 9 | `rank_change` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 10 | `last_hits` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 11 | `denies` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 12 | `gpm` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 13 | `xpm` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 14 | `seconds_dead` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 15 | `bounty_runes` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 16 | `water_runes` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 17 | `power_runes` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 18 | `time_enemy_t1_tower_destroyed` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 19 | `time_friendly_t1_tower_destroyed` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 20 | `enemy_roshan_kills` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 21 | `teleports_used` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 22 | `dewards` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 23 | `camps_stacked` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 24 | `support_gold` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 25 | `hero_damage` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 26 | `hero_healing` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 27 | `tower_damage` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 28 | `successful_smokes` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 29 | `stun_duration` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 30 | `duration` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
+| 31 | `friendly_roshan_kills` | `.CMsgBattleReportAggregateStats.CMsgBattleReportStat` | `optional` |  |  |
 
 </details>
 
@@ -286,10 +286,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `report` | `.CMsgBattleReport` | `optional` | `` |  |
-| 2 | `response` | `.CMsgClientToGCGetBattleReportResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 3 | `aggregate_stats` | `.CMsgBattleReportAggregateStats` | `optional` | `` |  |
-| 4 | `info` | `.CMsgBattleReportInfo` | `optional` | `` |  |
+| 1 | `report` | `.CMsgBattleReport` | `optional` |  |  |
+| 2 | `response` | `.CMsgClientToGCGetBattleReportResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 3 | `aggregate_stats` | `.CMsgBattleReportAggregateStats` | `optional` |  |  |
+| 4 | `info` | `.CMsgBattleReportInfo` | `optional` |  |  |
 
 </details>
 
@@ -301,10 +301,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `aggregate_keys` | `.CMsgClientToGCGetBattleReportAggregateStats.CMsgBattleReportAggregateKey` | `repeated` | `` |  |
-| 2 | `timestamp` | `uint32` | `optional` | `` |  |
-| 3 | `duration` | `uint32` | `optional` | `` |  |
-| 4 | `rank` | `uint32` | `optional` | `` |  |
+| 1 | `aggregate_keys` | `.CMsgClientToGCGetBattleReportAggregateStats.CMsgBattleReportAggregateKey` | `repeated` |  |  |
+| 2 | `timestamp` | `uint32` | `optional` |  |  |
+| 3 | `duration` | `uint32` | `optional` |  |  |
+| 4 | `rank` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -316,8 +316,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `predicted_position` | `uint32` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `predicted_position` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -329,8 +329,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `aggregate_stats` | `.CMsgBattleReportAggregateStats` | `optional` | `` |  |
-| 2 | `response` | `.CMsgClientToGCGetBattleReportAggregateStatsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `aggregate_stats` | `.CMsgBattleReportAggregateStats` | `optional` |  |  |
+| 2 | `response` | `.CMsgClientToGCGetBattleReportAggregateStatsResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -342,7 +342,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -354,8 +354,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `battle_report_info_list` | `.CMsgBattleReportInfoList` | `optional` | `` |  |
-| 2 | `response` | `.CMsgClientToGCGetBattleReportInfoResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `battle_report_info_list` | `.CMsgBattleReportInfoList` | `optional` |  |  |
+| 2 | `response` | `.CMsgClientToGCGetBattleReportInfoResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -367,9 +367,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `timestamp` | `uint32` | `optional` | `` |  |
-| 3 | `duration` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `timestamp` | `uint32` | `optional` |  |  |
+| 3 | `duration` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -381,8 +381,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCAcknowledgeBattleReportResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `shards_awarded` | `uint32` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCAcknowledgeBattleReportResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `shards_awarded` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -394,9 +394,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `timestamp` | `uint32` | `optional` | `` |  |
-| 3 | `duration` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `timestamp` | `uint32` | `optional` |  |  |
+| 3 | `duration` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -408,8 +408,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCGetBattleReportMatchHistoryResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `games` | `.CMsgBattleReport_GameList` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCGetBattleReportMatchHistoryResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `games` | `.CMsgBattleReport_GameList` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-common-bot-script.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-common-bot-script.md
@@ -23,29 +23,29 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_id` | `uint32` | `optional` | `` |  |
-| 2 | `game_time` | `float` | `optional` | `` |  |
-| 3 | `dota_time` | `float` | `optional` | `` |  |
-| 4 | `game_state` | `uint32` | `optional` | `` |  |
-| 5 | `hero_pick_state` | `uint32` | `optional` | `` |  |
-| 6 | `time_of_day` | `float` | `optional` | `` |  |
-| 7 | `glyph_cooldown` | `float` | `optional` | `` |  |
-| 8 | `glyph_cooldown_enemy` | `float` | `optional` | `` |  |
-| 10 | `players` | `.CMsgBotWorldState.Player` | `repeated` | `` | (valve_map_field) = true |
-| 11 | `units` | `.CMsgBotWorldState.Unit` | `repeated` | `` | (valve_map_field) = true |
-| 12 | `dropped_items` | `.CMsgBotWorldState.DroppedItem` | `repeated` | `` | (diff_encode_field) = 112 |
-| 13 | `rune_infos` | `.CMsgBotWorldState.RuneInfo` | `repeated` | `` | (diff_encode_field) = 113 |
-| 14 | `incoming_teleports` | `.CMsgBotWorldState.TeleportInfo` | `repeated` | `` |  |
-| 15 | `linear_projectiles` | `.CMsgBotWorldState.LinearProjectile` | `repeated` | `` | (valve_map_field) = true |
-| 16 | `avoidance_zones` | `.CMsgBotWorldState.AvoidanceZone` | `repeated` | `` |  |
-| 17 | `couriers` | `.CMsgBotWorldState.Courier` | `repeated` | `` | (valve_map_field) = true |
-| 20 | `ability_events` | `.CMsgBotWorldState.EventAbility` | `repeated` | `` |  |
-| 21 | `damage_events` | `.CMsgBotWorldState.EventDamage` | `repeated` | `` |  |
-| 22 | `courier_killed_events` | `.CMsgBotWorldState.EventCourierKilled` | `repeated` | `` |  |
-| 23 | `roshan_killed_events` | `.CMsgBotWorldState.EventRoshanKilled` | `repeated` | `` |  |
-| 24 | `tree_events` | `.CMsgBotWorldState.EventTree` | `repeated` | `` |  |
-| 112 | `dropped_items_deltas` | `int32` | `repeated` | `` |  |
-| 113 | `rune_infos_deltas` | `int32` | `repeated` | `` |  |
+| 1 | `team_id` | `uint32` | `optional` |  |  |
+| 2 | `game_time` | `float` | `optional` |  |  |
+| 3 | `dota_time` | `float` | `optional` |  |  |
+| 4 | `game_state` | `uint32` | `optional` |  |  |
+| 5 | `hero_pick_state` | `uint32` | `optional` |  |  |
+| 6 | `time_of_day` | `float` | `optional` |  |  |
+| 7 | `glyph_cooldown` | `float` | `optional` |  |  |
+| 8 | `glyph_cooldown_enemy` | `float` | `optional` |  |  |
+| 10 | `players` | `.CMsgBotWorldState.Player` | `repeated` |  | (valve_map_field) = true |
+| 11 | `units` | `.CMsgBotWorldState.Unit` | `repeated` |  | (valve_map_field) = true |
+| 12 | `dropped_items` | `.CMsgBotWorldState.DroppedItem` | `repeated` |  | (diff_encode_field) = 112 |
+| 13 | `rune_infos` | `.CMsgBotWorldState.RuneInfo` | `repeated` |  | (diff_encode_field) = 113 |
+| 14 | `incoming_teleports` | `.CMsgBotWorldState.TeleportInfo` | `repeated` |  |  |
+| 15 | `linear_projectiles` | `.CMsgBotWorldState.LinearProjectile` | `repeated` |  | (valve_map_field) = true |
+| 16 | `avoidance_zones` | `.CMsgBotWorldState.AvoidanceZone` | `repeated` |  |  |
+| 17 | `couriers` | `.CMsgBotWorldState.Courier` | `repeated` |  | (valve_map_field) = true |
+| 20 | `ability_events` | `.CMsgBotWorldState.EventAbility` | `repeated` |  |  |
+| 21 | `damage_events` | `.CMsgBotWorldState.EventDamage` | `repeated` |  |  |
+| 22 | `courier_killed_events` | `.CMsgBotWorldState.EventCourierKilled` | `repeated` |  |  |
+| 23 | `roshan_killed_events` | `.CMsgBotWorldState.EventRoshanKilled` | `repeated` |  |  |
+| 24 | `tree_events` | `.CMsgBotWorldState.EventTree` | `repeated` |  |  |
+| 112 | `dropped_items_deltas` | `int32` | `repeated` |  |  |
+| 113 | `rune_infos_deltas` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -57,9 +57,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `x` | `float` | `optional` | `` |  |
-| 2 | `y` | `float` | `optional` | `` |  |
-| 3 | `z` | `float` | `optional` | `` |  |
+| 1 | `x` | `float` | `optional` |  |  |
+| 2 | `y` | `float` | `optional` |  |  |
+| 3 | `z` | `float` | `optional` |  |  |
 
 </details>
 
@@ -71,17 +71,17 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | (valve_map_key) = true |
-| 2 | `hero_id` | `int32` | `optional` | `` |  |
-| 3 | `is_alive` | `bool` | `optional` | `` |  |
-| 4 | `respawn_time` | `float` | `optional` | `` |  |
-| 5 | `kills` | `uint32` | `optional` | `` |  |
-| 6 | `deaths` | `uint32` | `optional` | `` |  |
-| 7 | `assists` | `uint32` | `optional` | `` |  |
-| 8 | `team_id` | `uint32` | `optional` | `` |  |
-| 9 | `primary_unit_handle` | `uint32` | `optional` | `` | default = 4294967295 |
-| 10 | `mmr` | `int32` | `optional` | `` |  |
-| 11 | `location` | `.CMsgBotWorldState.Vector` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | (valve_map_key) = true |
+| 2 | `hero_id` | `int32` | `optional` |  |  |
+| 3 | `is_alive` | `bool` | `optional` |  |  |
+| 4 | `respawn_time` | `float` | `optional` |  |  |
+| 5 | `kills` | `uint32` | `optional` |  |  |
+| 6 | `deaths` | `uint32` | `optional` |  |  |
+| 7 | `assists` | `uint32` | `optional` |  |  |
+| 8 | `team_id` | `uint32` | `optional` |  |  |
+| 9 | `primary_unit_handle` | `uint32` | `optional` |  | default = 4294967295 |
+| 10 | `mmr` | `int32` | `optional` |  |  |
+| 11 | `location` | `.CMsgBotWorldState.Vector` | `optional` |  |  |
 
 </details>
 
@@ -93,24 +93,24 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `handle` | `uint32` | `optional` | `` | (valve_map_key) = true |
-| 2 | `ability_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `slot` | `uint32` | `optional` | `` |  |
-| 5 | `caster_handle` | `uint32` | `optional` | `` | default = 4294967295 |
-| 6 | `level` | `uint32` | `optional` | `` |  |
-| 10 | `cast_range` | `uint32` | `optional` | `` |  |
-| 11 | `channel_time` | `float` | `optional` | `` |  |
-| 12 | `cooldown_remaining` | `float` | `optional` | `` | default = 0 |
-| 20 | `is_activated` | `bool` | `optional` | `` |  |
-| 21 | `is_toggled` | `bool` | `optional` | `` |  |
-| 22 | `is_in_ability_phase` | `bool` | `optional` | `` |  |
-| 23 | `is_channeling` | `bool` | `optional` | `` |  |
-| 24 | `is_stolen` | `bool` | `optional` | `` |  |
-| 25 | `is_fully_castable` | `bool` | `optional` | `` |  |
-| 30 | `charges` | `uint32` | `optional` | `` |  |
-| 31 | `secondary_charges` | `uint32` | `optional` | `` |  |
-| 40 | `is_combined_locked` | `bool` | `optional` | `` |  |
-| 50 | `power_treads_stat` | `int32` | `optional` | `` | default = -1 |
+| 1 | `handle` | `uint32` | `optional` |  | (valve_map_key) = true |
+| 2 | `ability_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `slot` | `uint32` | `optional` |  |  |
+| 5 | `caster_handle` | `uint32` | `optional` |  | default = 4294967295 |
+| 6 | `level` | `uint32` | `optional` |  |  |
+| 10 | `cast_range` | `uint32` | `optional` |  |  |
+| 11 | `channel_time` | `float` | `optional` |  |  |
+| 12 | `cooldown_remaining` | `float` | `optional` |  | default = 0 |
+| 20 | `is_activated` | `bool` | `optional` |  |  |
+| 21 | `is_toggled` | `bool` | `optional` |  |  |
+| 22 | `is_in_ability_phase` | `bool` | `optional` |  |  |
+| 23 | `is_channeling` | `bool` | `optional` |  |  |
+| 24 | `is_stolen` | `bool` | `optional` |  |  |
+| 25 | `is_fully_castable` | `bool` | `optional` |  |  |
+| 30 | `charges` | `uint32` | `optional` |  |  |
+| 31 | `secondary_charges` | `uint32` | `optional` |  |  |
+| 40 | `is_combined_locked` | `bool` | `optional` |  |  |
+| 50 | `power_treads_stat` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -122,8 +122,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `location` | `.CMsgBotWorldState.Vector` | `optional` | `` |  |
+| 1 | `item_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `location` | `.CMsgBotWorldState.Vector` | `optional` |  |  |
 
 </details>
 
@@ -135,10 +135,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `type` | `int32` | `optional` | `` |  |
-| 2 | `location` | `.CMsgBotWorldState.Vector` | `optional` | `` |  |
-| 3 | `status` | `uint32` | `optional` | `` |  |
-| 4 | `time_since_seen` | `float` | `optional` | `` |  |
+| 1 | `type` | `int32` | `optional` |  |  |
+| 2 | `location` | `.CMsgBotWorldState.Vector` | `optional` |  |  |
+| 3 | `status` | `uint32` | `optional` |  |  |
+| 4 | `time_since_seen` | `float` | `optional` |  |  |
 
 </details>
 
@@ -150,9 +150,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` |  |
-| 2 | `location` | `.CMsgBotWorldState.Vector` | `optional` | `` |  |
-| 3 | `time_remaining` | `float` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  |  |
+| 2 | `location` | `.CMsgBotWorldState.Vector` | `optional` |  |  |
+| 3 | `time_remaining` | `float` | `optional` |  |  |
 
 </details>
 
@@ -164,13 +164,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `stack_count` | `uint32` | `optional` | `` |  |
-| 3 | `ability_handle` | `uint32` | `optional` | `` | default = 4294967295 |
-| 4 | `ability_id` | `int32` | `optional` | `` | default = -1 |
-| 5 | `remaining_duration` | `float` | `optional` | `` |  |
-| 6 | `auxiliary_units_handles` | `uint32` | `repeated` | `` |  |
-| 7 | `handle` | `uint32` | `optional` | `` | (valve_map_key) = true |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `stack_count` | `uint32` | `optional` |  |  |
+| 3 | `ability_handle` | `uint32` | `optional` |  | default = 4294967295 |
+| 4 | `ability_id` | `int32` | `optional` |  | default = -1 |
+| 5 | `remaining_duration` | `float` | `optional` |  |  |
+| 6 | `auxiliary_units_handles` | `uint32` | `repeated` |  |  |
+| 7 | `handle` | `uint32` | `optional` |  | (valve_map_key) = true |
 
 </details>
 
@@ -182,15 +182,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `handle` | `uint32` | `optional` | `` | (valve_map_key) = true |
-| 2 | `caster_handle` | `uint32` | `optional` | `` | default = 4294967295 |
-| 3 | `caster_player_id` | `int32` | `optional` | `` |  |
-| 4 | `ability_handle` | `uint32` | `optional` | `` | default = 4294967295 |
-| 5 | `ability_id` | `int32` | `optional` | `` | default = -1 |
-| 6 | `location` | `.CMsgBotWorldState.Vector` | `optional` | `` |  |
-| 7 | `velocity` | `.CMsgBotWorldState.Vector` | `optional` | `` |  |
-| 8 | `radius` | `uint32` | `optional` | `` |  |
-| 9 | `caster_unit_type` | `.CMsgBotWorldState.UnitType` | `optional` | `` | default = INVALID |
+| 1 | `handle` | `uint32` | `optional` |  | (valve_map_key) = true |
+| 2 | `caster_handle` | `uint32` | `optional` |  | default = 4294967295 |
+| 3 | `caster_player_id` | `int32` | `optional` |  |  |
+| 4 | `ability_handle` | `uint32` | `optional` |  | default = 4294967295 |
+| 5 | `ability_id` | `int32` | `optional` |  | default = -1 |
+| 6 | `location` | `.CMsgBotWorldState.Vector` | `optional` |  |  |
+| 7 | `velocity` | `.CMsgBotWorldState.Vector` | `optional` |  |  |
+| 8 | `radius` | `uint32` | `optional` |  |  |
+| 9 | `caster_unit_type` | `.CMsgBotWorldState.UnitType` | `optional` |  | default = INVALID |
 
 </details>
 
@@ -202,16 +202,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `caster_handle` | `uint32` | `optional` | `` | default = 4294967295 |
-| 2 | `caster_player_id` | `int32` | `optional` | `` |  |
-| 3 | `ability_handle` | `uint32` | `optional` | `` | default = 4294967295 |
-| 4 | `ability_id` | `int32` | `optional` | `` | default = -1 |
-| 5 | `location` | `.CMsgBotWorldState.Vector` | `optional` | `` |  |
-| 6 | `velocity` | `uint32` | `optional` | `` |  |
-| 7 | `is_dodgeable` | `bool` | `optional` | `` |  |
-| 8 | `is_attack` | `bool` | `optional` | `` |  |
-| 9 | `caster_unit_type` | `.CMsgBotWorldState.UnitType` | `optional` | `` | default = INVALID |
-| 10 | `handle` | `uint32` | `optional` | `` | (valve_map_key) = true |
+| 1 | `caster_handle` | `uint32` | `optional` |  | default = 4294967295 |
+| 2 | `caster_player_id` | `int32` | `optional` |  |  |
+| 3 | `ability_handle` | `uint32` | `optional` |  | default = 4294967295 |
+| 4 | `ability_id` | `int32` | `optional` |  | default = -1 |
+| 5 | `location` | `.CMsgBotWorldState.Vector` | `optional` |  |  |
+| 6 | `velocity` | `uint32` | `optional` |  |  |
+| 7 | `is_dodgeable` | `bool` | `optional` |  |  |
+| 8 | `is_attack` | `bool` | `optional` |  |  |
+| 9 | `caster_unit_type` | `.CMsgBotWorldState.UnitType` | `optional` |  | default = INVALID |
+| 10 | `handle` | `uint32` | `optional` |  | (valve_map_key) = true |
 
 </details>
 
@@ -223,13 +223,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `location` | `.CMsgBotWorldState.Vector` | `optional` | `` |  |
-| 2 | `caster_handle` | `uint32` | `optional` | `` | default = 4294967295 |
-| 3 | `caster_player_id` | `int32` | `optional` | `` |  |
-| 4 | `ability_handle` | `uint32` | `optional` | `` | default = 4294967295 |
-| 5 | `ability_id` | `int32` | `optional` | `` | default = -1 |
-| 6 | `radius` | `uint32` | `optional` | `` |  |
-| 7 | `caster_unit_type` | `.CMsgBotWorldState.UnitType` | `optional` | `` | default = INVALID |
+| 1 | `location` | `.CMsgBotWorldState.Vector` | `optional` |  |  |
+| 2 | `caster_handle` | `uint32` | `optional` |  | default = 4294967295 |
+| 3 | `caster_player_id` | `int32` | `optional` |  |  |
+| 4 | `ability_handle` | `uint32` | `optional` |  | default = 4294967295 |
+| 5 | `ability_id` | `int32` | `optional` |  | default = -1 |
+| 6 | `radius` | `uint32` | `optional` |  |  |
+| 7 | `caster_unit_type` | `.CMsgBotWorldState.UnitType` | `optional` |  | default = INVALID |
 
 </details>
 
@@ -241,9 +241,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `handle` | `uint32` | `optional` | `` | (valve_map_key) = true |
-| 2 | `state` | `.CMsgBotWorldState.CourierState` | `optional` | `` | default = COURIER_STATE_INIT |
-| 3 | `player_id` | `int32` | `optional` | `` |  |
+| 1 | `handle` | `uint32` | `optional` |  | (valve_map_key) = true |
+| 2 | `state` | `.CMsgBotWorldState.CourierState` | `optional` |  | default = COURIER_STATE_INIT |
+| 3 | `player_id` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -255,11 +255,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ability_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `player_id` | `int32` | `optional` | `` |  |
-| 3 | `unit_handle` | `uint32` | `optional` | `` | default = 4294967295 |
-| 4 | `location` | `.CMsgBotWorldState.Vector` | `optional` | `` |  |
-| 5 | `is_channel_start` | `bool` | `optional` | `` |  |
+| 1 | `ability_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `player_id` | `int32` | `optional` |  |  |
+| 3 | `unit_handle` | `uint32` | `optional` |  | default = 4294967295 |
+| 4 | `location` | `.CMsgBotWorldState.Vector` | `optional` |  |  |
+| 5 | `is_channel_start` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -271,12 +271,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `damage` | `uint32` | `optional` | `` |  |
-| 2 | `victim_player_id` | `int32` | `optional` | `` |  |
-| 3 | `victim_unit_handle` | `uint32` | `optional` | `` | default = 4294967295 |
-| 4 | `attacker_player_id` | `int32` | `optional` | `` |  |
-| 5 | `attacker_unit_handle` | `uint32` | `optional` | `` | default = 4294967295 |
-| 6 | `ability_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `damage` | `uint32` | `optional` |  |  |
+| 2 | `victim_player_id` | `int32` | `optional` |  |  |
+| 3 | `victim_unit_handle` | `uint32` | `optional` |  | default = 4294967295 |
+| 4 | `attacker_player_id` | `int32` | `optional` |  |  |
+| 5 | `attacker_unit_handle` | `uint32` | `optional` |  | default = 4294967295 |
+| 6 | `ability_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -288,10 +288,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_id` | `uint32` | `optional` | `` |  |
-| 2 | `courier_unit_handle` | `uint32` | `optional` | `` | default = 4294967295 |
-| 3 | `killer_player_id` | `int32` | `optional` | `` |  |
-| 4 | `killer_unit_handle` | `uint32` | `optional` | `` | default = 4294967295 |
+| 1 | `team_id` | `uint32` | `optional` |  |  |
+| 2 | `courier_unit_handle` | `uint32` | `optional` |  | default = 4294967295 |
+| 3 | `killer_player_id` | `int32` | `optional` |  |  |
+| 4 | `killer_unit_handle` | `uint32` | `optional` |  | default = 4294967295 |
 
 </details>
 
@@ -303,8 +303,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `killer_player_id` | `int32` | `optional` | `` |  |
-| 2 | `killer_unit_handle` | `uint32` | `optional` | `` | default = 4294967295 |
+| 1 | `killer_player_id` | `int32` | `optional` |  |  |
+| 2 | `killer_unit_handle` | `uint32` | `optional` |  | default = 4294967295 |
 
 </details>
 
@@ -316,11 +316,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tree_id` | `uint32` | `optional` | `` |  |
-| 2 | `destroyed` | `bool` | `optional` | `` |  |
-| 3 | `respawned` | `bool` | `optional` | `` |  |
-| 4 | `location` | `.CMsgBotWorldState.Vector` | `optional` | `` |  |
-| 5 | `delayed` | `bool` | `optional` | `` |  |
+| 1 | `tree_id` | `uint32` | `optional` |  |  |
+| 2 | `destroyed` | `bool` | `optional` |  |  |
+| 3 | `respawned` | `bool` | `optional` |  |  |
+| 4 | `location` | `.CMsgBotWorldState.Vector` | `optional` |  |  |
+| 5 | `delayed` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -332,97 +332,97 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `handle` | `uint32` | `optional` | `` | (valve_map_key) = true |
-| 2 | `unit_type` | `.CMsgBotWorldState.UnitType` | `optional` | `` | default = INVALID |
-| 3 | `name` | `string` | `optional` | `` |  |
-| 4 | `team_id` | `uint32` | `optional` | `` |  |
-| 5 | `level` | `uint32` | `optional` | `` |  |
-| 6 | `location` | `.CMsgBotWorldState.Vector` | `optional` | `` |  |
-| 7 | `is_alive` | `bool` | `optional` | `` |  |
-| 8 | `player_id` | `int32` | `optional` | `` |  |
-| 10 | `bounding_radius` | `int32` | `optional` | `` |  |
-| 11 | `facing` | `int32` | `optional` | `` |  |
-| 12 | `ground_height` | `uint32` | `optional` | `` |  |
-| 15 | `vision_range_daytime` | `uint32` | `optional` | `` |  |
-| 16 | `vision_range_nighttime` | `uint32` | `optional` | `` |  |
-| 20 | `health` | `int32` | `optional` | `` |  |
-| 21 | `health_max` | `int32` | `optional` | `` |  |
-| 22 | `health_regen` | `float` | `optional` | `` |  |
-| 25 | `mana` | `int32` | `optional` | `` |  |
-| 26 | `mana_max` | `int32` | `optional` | `` |  |
-| 27 | `mana_regen` | `float` | `optional` | `` |  |
-| 30 | `base_movement_speed` | `int32` | `optional` | `` |  |
-| 31 | `current_movement_speed` | `int32` | `optional` | `` |  |
-| 35 | `anim_activity` | `int32` | `optional` | `` |  |
-| 36 | `anim_cycle` | `float` | `optional` | `` |  |
-| 40 | `base_damage` | `int32` | `optional` | `` |  |
-| 41 | `base_damage_variance` | `int32` | `optional` | `` |  |
-| 42 | `bonus_damage` | `int32` | `optional` | `` |  |
-| 43 | `attack_damage` | `int32` | `optional` | `` |  |
-| 44 | `attack_range` | `int32` | `optional` | `` |  |
-| 45 | `attack_speed` | `float` | `optional` | `` |  |
-| 46 | `attack_anim_point` | `float` | `optional` | `` |  |
-| 47 | `attack_acquisition_range` | `int32` | `optional` | `` |  |
-| 48 | `attack_projectile_speed` | `int32` | `optional` | `` |  |
-| 49 | `attack_target_handle` | `uint32` | `optional` | `` | default = 4294967295 |
-| 50 | `attacks_per_second` | `int32` | `optional` | `` | default = -1 |
-| 51 | `last_attack_time` | `float` | `optional` | `` | default = -1 |
-| 52 | `attack_target_name` | `string` | `optional` | `` |  |
-| 60 | `bounty_xp` | `uint32` | `optional` | `` |  |
-| 61 | `bounty_gold_min` | `uint32` | `optional` | `` |  |
-| 62 | `bounty_gold_max` | `uint32` | `optional` | `` |  |
-| 65 | `is_channeling` | `bool` | `optional` | `` |  |
-| 66 | `active_ability_handle` | `uint32` | `optional` | `` | default = 4294967295 |
-| 70 | `is_attack_immune` | `bool` | `optional` | `` |  |
-| 71 | `is_blind` | `bool` | `optional` | `` |  |
-| 72 | `is_block_disabled` | `bool` | `optional` | `` |  |
-| 73 | `is_disarmed` | `bool` | `optional` | `` |  |
-| 74 | `is_dominated` | `bool` | `optional` | `` |  |
-| 75 | `is_evade_disabled` | `bool` | `optional` | `` |  |
-| 76 | `is_hexed` | `bool` | `optional` | `` |  |
-| 77 | `is_invisible` | `bool` | `optional` | `` |  |
-| 78 | `is_invulnerable` | `bool` | `optional` | `` |  |
-| 79 | `is_magic_immune` | `bool` | `optional` | `` |  |
-| 80 | `is_muted` | `bool` | `optional` | `` |  |
-| 82 | `is_nightmared` | `bool` | `optional` | `` |  |
-| 83 | `is_rooted` | `bool` | `optional` | `` |  |
-| 84 | `is_silenced` | `bool` | `optional` | `` |  |
-| 85 | `is_specially_deniable` | `bool` | `optional` | `` |  |
-| 86 | `is_stunned` | `bool` | `optional` | `` |  |
-| 87 | `is_unable_to_miss` | `bool` | `optional` | `` |  |
-| 88 | `has_scepter` | `bool` | `optional` | `` |  |
-| 90 | `abilities` | `.CMsgBotWorldState.Ability` | `repeated` | `` | (valve_map_field) = true |
-| 91 | `items` | `.CMsgBotWorldState.Ability` | `repeated` | `` | (valve_map_field) = true |
-| 92 | `modifiers` | `.CMsgBotWorldState.Modifier` | `repeated` | `` | (valve_map_field) = true |
-| 93 | `incoming_tracking_projectiles` | `.CMsgBotWorldState.TrackingProjectile` | `repeated` | `` | (valve_map_field) = true |
-| 94 | `is_specially_undeniable` | `bool` | `optional` | `` |  |
-| 100 | `action_type` | `uint32` | `optional` | `` |  |
-| 101 | `ability_target_handle` | `uint32` | `optional` | `` | default = 4294967295 |
-| 102 | `is_using_ability` | `bool` | `optional` | `` |  |
-| 103 | `ability_target_name` | `string` | `optional` | `` |  |
-| 110 | `primary_attribute` | `uint32` | `optional` | `` |  |
-| 111 | `is_illusion` | `bool` | `optional` | `` |  |
-| 112 | `respawn_time` | `float` | `optional` | `` |  |
-| 113 | `buyback_cost` | `uint32` | `optional` | `` |  |
-| 114 | `buyback_cooldown` | `float` | `optional` | `` |  |
-| 115 | `spell_amplification` | `float` | `optional` | `` |  |
-| 116 | `armor` | `float` | `optional` | `` |  |
-| 117 | `magic_resist` | `float` | `optional` | `` |  |
-| 118 | `evasion` | `float` | `optional` | `` |  |
-| 120 | `xp_needed_to_level` | `uint32` | `optional` | `` |  |
-| 121 | `ability_points` | `uint32` | `optional` | `` |  |
-| 122 | `reliable_gold` | `int32` | `optional` | `` | default = -1 |
-| 123 | `unreliable_gold` | `int32` | `optional` | `` | default = -1 |
-| 124 | `last_hits` | `uint32` | `optional` | `` |  |
-| 125 | `denies` | `uint32` | `optional` | `` |  |
-| 126 | `net_worth` | `uint32` | `optional` | `` |  |
-| 127 | `strength` | `uint32` | `optional` | `` |  |
-| 128 | `agility` | `uint32` | `optional` | `` |  |
-| 129 | `intelligence` | `uint32` | `optional` | `` |  |
-| 130 | `remaining_lifespan` | `float` | `optional` | `` |  |
-| 140 | `flying_courier` | `bool` | `optional` | `` |  |
-| 150 | `shrine_cooldown` | `float` | `optional` | `` |  |
-| 151 | `is_shrine_healing` | `bool` | `optional` | `` |  |
+| 1 | `handle` | `uint32` | `optional` |  | (valve_map_key) = true |
+| 2 | `unit_type` | `.CMsgBotWorldState.UnitType` | `optional` |  | default = INVALID |
+| 3 | `name` | `string` | `optional` |  |  |
+| 4 | `team_id` | `uint32` | `optional` |  |  |
+| 5 | `level` | `uint32` | `optional` |  |  |
+| 6 | `location` | `.CMsgBotWorldState.Vector` | `optional` |  |  |
+| 7 | `is_alive` | `bool` | `optional` |  |  |
+| 8 | `player_id` | `int32` | `optional` |  |  |
+| 10 | `bounding_radius` | `int32` | `optional` |  |  |
+| 11 | `facing` | `int32` | `optional` |  |  |
+| 12 | `ground_height` | `uint32` | `optional` |  |  |
+| 15 | `vision_range_daytime` | `uint32` | `optional` |  |  |
+| 16 | `vision_range_nighttime` | `uint32` | `optional` |  |  |
+| 20 | `health` | `int32` | `optional` |  |  |
+| 21 | `health_max` | `int32` | `optional` |  |  |
+| 22 | `health_regen` | `float` | `optional` |  |  |
+| 25 | `mana` | `int32` | `optional` |  |  |
+| 26 | `mana_max` | `int32` | `optional` |  |  |
+| 27 | `mana_regen` | `float` | `optional` |  |  |
+| 30 | `base_movement_speed` | `int32` | `optional` |  |  |
+| 31 | `current_movement_speed` | `int32` | `optional` |  |  |
+| 35 | `anim_activity` | `int32` | `optional` |  |  |
+| 36 | `anim_cycle` | `float` | `optional` |  |  |
+| 40 | `base_damage` | `int32` | `optional` |  |  |
+| 41 | `base_damage_variance` | `int32` | `optional` |  |  |
+| 42 | `bonus_damage` | `int32` | `optional` |  |  |
+| 43 | `attack_damage` | `int32` | `optional` |  |  |
+| 44 | `attack_range` | `int32` | `optional` |  |  |
+| 45 | `attack_speed` | `float` | `optional` |  |  |
+| 46 | `attack_anim_point` | `float` | `optional` |  |  |
+| 47 | `attack_acquisition_range` | `int32` | `optional` |  |  |
+| 48 | `attack_projectile_speed` | `int32` | `optional` |  |  |
+| 49 | `attack_target_handle` | `uint32` | `optional` |  | default = 4294967295 |
+| 50 | `attacks_per_second` | `int32` | `optional` |  | default = -1 |
+| 51 | `last_attack_time` | `float` | `optional` |  | default = -1 |
+| 52 | `attack_target_name` | `string` | `optional` |  |  |
+| 60 | `bounty_xp` | `uint32` | `optional` |  |  |
+| 61 | `bounty_gold_min` | `uint32` | `optional` |  |  |
+| 62 | `bounty_gold_max` | `uint32` | `optional` |  |  |
+| 65 | `is_channeling` | `bool` | `optional` |  |  |
+| 66 | `active_ability_handle` | `uint32` | `optional` |  | default = 4294967295 |
+| 70 | `is_attack_immune` | `bool` | `optional` |  |  |
+| 71 | `is_blind` | `bool` | `optional` |  |  |
+| 72 | `is_block_disabled` | `bool` | `optional` |  |  |
+| 73 | `is_disarmed` | `bool` | `optional` |  |  |
+| 74 | `is_dominated` | `bool` | `optional` |  |  |
+| 75 | `is_evade_disabled` | `bool` | `optional` |  |  |
+| 76 | `is_hexed` | `bool` | `optional` |  |  |
+| 77 | `is_invisible` | `bool` | `optional` |  |  |
+| 78 | `is_invulnerable` | `bool` | `optional` |  |  |
+| 79 | `is_magic_immune` | `bool` | `optional` |  |  |
+| 80 | `is_muted` | `bool` | `optional` |  |  |
+| 82 | `is_nightmared` | `bool` | `optional` |  |  |
+| 83 | `is_rooted` | `bool` | `optional` |  |  |
+| 84 | `is_silenced` | `bool` | `optional` |  |  |
+| 85 | `is_specially_deniable` | `bool` | `optional` |  |  |
+| 86 | `is_stunned` | `bool` | `optional` |  |  |
+| 87 | `is_unable_to_miss` | `bool` | `optional` |  |  |
+| 88 | `has_scepter` | `bool` | `optional` |  |  |
+| 90 | `abilities` | `.CMsgBotWorldState.Ability` | `repeated` |  | (valve_map_field) = true |
+| 91 | `items` | `.CMsgBotWorldState.Ability` | `repeated` |  | (valve_map_field) = true |
+| 92 | `modifiers` | `.CMsgBotWorldState.Modifier` | `repeated` |  | (valve_map_field) = true |
+| 93 | `incoming_tracking_projectiles` | `.CMsgBotWorldState.TrackingProjectile` | `repeated` |  | (valve_map_field) = true |
+| 94 | `is_specially_undeniable` | `bool` | `optional` |  |  |
+| 100 | `action_type` | `uint32` | `optional` |  |  |
+| 101 | `ability_target_handle` | `uint32` | `optional` |  | default = 4294967295 |
+| 102 | `is_using_ability` | `bool` | `optional` |  |  |
+| 103 | `ability_target_name` | `string` | `optional` |  |  |
+| 110 | `primary_attribute` | `uint32` | `optional` |  |  |
+| 111 | `is_illusion` | `bool` | `optional` |  |  |
+| 112 | `respawn_time` | `float` | `optional` |  |  |
+| 113 | `buyback_cost` | `uint32` | `optional` |  |  |
+| 114 | `buyback_cooldown` | `float` | `optional` |  |  |
+| 115 | `spell_amplification` | `float` | `optional` |  |  |
+| 116 | `armor` | `float` | `optional` |  |  |
+| 117 | `magic_resist` | `float` | `optional` |  |  |
+| 118 | `evasion` | `float` | `optional` |  |  |
+| 120 | `xp_needed_to_level` | `uint32` | `optional` |  |  |
+| 121 | `ability_points` | `uint32` | `optional` |  |  |
+| 122 | `reliable_gold` | `int32` | `optional` |  | default = -1 |
+| 123 | `unreliable_gold` | `int32` | `optional` |  | default = -1 |
+| 124 | `last_hits` | `uint32` | `optional` |  |  |
+| 125 | `denies` | `uint32` | `optional` |  |  |
+| 126 | `net_worth` | `uint32` | `optional` |  |  |
+| 127 | `strength` | `uint32` | `optional` |  |  |
+| 128 | `agility` | `uint32` | `optional` |  |  |
+| 129 | `intelligence` | `uint32` | `optional` |  |  |
+| 130 | `remaining_lifespan` | `float` | `optional` |  |  |
+| 140 | `flying_courier` | `bool` | `optional` |  |  |
+| 150 | `shrine_cooldown` | `float` | `optional` |  |  |
+| 151 | `is_shrine_healing` | `bool` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-common-craftworks.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-common-craftworks.md
@@ -25,7 +25,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `component_quantities` | `.CMsgCraftworksComponents.ComponentQuantitiesEntry` | `repeated` | `` |  |
+| 1 | `component_quantities` | `.CMsgCraftworksComponents.ComponentQuantitiesEntry` | `repeated` |  |  |
 
 </details>
 
@@ -37,8 +37,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `uint32` | `optional` | `` |  |
+| 1 | `key` | `uint32` | `optional` |  |  |
+| 2 | `value` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -50,9 +50,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `quest_id` | `uint32` | `optional` | `` |  |
-| 2 | `reward_components` | `.CMsgCraftworksComponents` | `optional` | `` |  |
-| 3 | `stat_value` | `uint32` | `optional` | `` |  |
+| 1 | `quest_id` | `uint32` | `optional` |  |  |
+| 2 | `reward_components` | `.CMsgCraftworksComponents` | `optional` |  |  |
+| 3 | `stat_value` | `uint32` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-common-fighting-game.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-common-fighting-game.md
@@ -26,7 +26,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `friend_account_id` | `uint32` | `optional` | `` |  |
+| 1 | `friend_account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -38,7 +38,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCFightingGameChallengeFriendResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCFightingGameChallengeFriendResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -50,7 +50,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `friend_account_id` | `uint32` | `optional` | `` |  |
+| 1 | `friend_account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -62,8 +62,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `challenger_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `accept` | `bool` | `optional` | `` |  |
+| 1 | `challenger_account_id` | `uint32` | `optional` |  |  |
+| 2 | `accept` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -75,7 +75,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCFightingGameAnswerChallengeResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCFightingGameAnswerChallengeResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -87,7 +87,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `challenger_account_id` | `uint32` | `optional` | `` |  |
+| 1 | `challenger_account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -99,8 +99,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `challenger_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `responder_account_id` | `uint32` | `optional` | `` |  |
+| 1 | `challenger_account_id` | `uint32` | `optional` |  |  |
+| 2 | `responder_account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -112,8 +112,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `challenger_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `responder_account_id` | `uint32` | `optional` | `` |  |
+| 1 | `challenger_account_id` | `uint32` | `optional` |  |  |
+| 2 | `responder_account_id` | `uint32` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-common-item-battler.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-common-item-battler.md
@@ -26,11 +26,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `rank` | `uint32` | `optional` | `` |  |
-| 3 | `run_count` | `uint32` | `optional` | `` |  |
-| 4 | `victory_count` | `uint32` | `optional` | `` |  |
-| 5 | `concede_count` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `rank` | `uint32` | `optional` |  |  |
+| 3 | `run_count` | `uint32` | `optional` |  |  |
+| 4 | `victory_count` | `uint32` | `optional` |  |  |
+| 5 | `concede_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -42,9 +42,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `type` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `float` | `optional` | `` |  |
-| 3 | `multiplicative` | `bool` | `optional` | `` |  |
+| 1 | `type` | `uint32` | `optional` |  |  |
+| 2 | `value` | `float` | `optional` |  |  |
+| 3 | `multiplicative` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -56,12 +56,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_definition_id` | `uint32` | `optional` | `` |  |
-| 2 | `item_instance_id` | `uint32` | `optional` | `` |  |
-| 3 | `item_container_id` | `uint32` | `optional` | `` |  |
-| 4 | `position_x` | `uint32` | `optional` | `` |  |
-| 5 | `position_y` | `uint32` | `optional` | `` |  |
-| 6 | `permanent_modifiers` | `.CMsgItemBattlerItemModifier` | `repeated` | `` |  |
+| 1 | `item_definition_id` | `uint32` | `optional` |  |  |
+| 2 | `item_instance_id` | `uint32` | `optional` |  |  |
+| 3 | `item_container_id` | `uint32` | `optional` |  |  |
+| 4 | `position_x` | `uint32` | `optional` |  |  |
+| 5 | `position_y` | `uint32` | `optional` |  |  |
+| 6 | `permanent_modifiers` | `.CMsgItemBattlerItemModifier` | `repeated` |  |  |
 
 </details>
 
@@ -73,11 +73,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_container_id` | `uint32` | `optional` | `` |  |
-| 2 | `item_slot_ids` | `uint32` | `repeated` | `` |  |
-| 3 | `width` | `int32` | `optional` | `` |  |
-| 4 | `height` | `int32` | `optional` | `` |  |
-| 5 | `is_shop` | `bool` | `optional` | `` |  |
+| 1 | `item_container_id` | `uint32` | `optional` |  |  |
+| 2 | `item_slot_ids` | `uint32` | `repeated` |  |  |
+| 3 | `width` | `int32` | `optional` |  |  |
+| 4 | `height` | `int32` | `optional` |  |  |
+| 5 | `is_shop` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -89,13 +89,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_instance_id` | `uint32` | `optional` | `` |  |
-| 2 | `item_target_instance_ids` | `uint32` | `repeated` | `` |  |
-| 3 | `tick` | `uint32` | `optional` | `` |  |
-| 4 | `effect` | `uint32` | `optional` | `` |  |
-| 5 | `value` | `int32` | `optional` | `` |  |
-| 6 | `critical` | `bool` | `optional` | `` |  |
-| 7 | `lifesteal_healing` | `uint32` | `optional` | `` |  |
+| 1 | `item_instance_id` | `uint32` | `optional` |  |  |
+| 2 | `item_target_instance_ids` | `uint32` | `repeated` |  |  |
+| 3 | `tick` | `uint32` | `optional` |  |  |
+| 4 | `effect` | `uint32` | `optional` |  |  |
+| 5 | `value` | `int32` | `optional` |  |  |
+| 6 | `critical` | `bool` | `optional` |  |  |
+| 7 | `lifesteal_healing` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -107,9 +107,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `win` | `bool` | `optional` | `` |  |
-| 2 | `events` | `.CMsgItemBattlerFightEvent` | `repeated` | `` |  |
-| 3 | `error` | `bool` | `optional` | `` |  |
+| 1 | `win` | `bool` | `optional` |  |  |
+| 2 | `events` | `.CMsgItemBattlerFightEvent` | `repeated` |  |  |
+| 3 | `error` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -121,21 +121,21 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `hero_id` | `uint32` | `optional` | `` |  |
-| 3 | `monster_id` | `uint32` | `optional` | `` |  |
-| 4 | `board` | `.CMsgItemBattlerItemContainer` | `optional` | `` |  |
-| 5 | `wins` | `int32` | `optional` | `` |  |
-| 6 | `losses` | `int32` | `optional` | `` |  |
-| 7 | `prestige` | `int32` | `optional` | `` |  |
-| 8 | `level` | `uint32` | `optional` | `` |  |
-| 9 | `experience` | `int32` | `optional` | `` |  |
-| 10 | `skills` | `uint32` | `repeated` | `` |  |
-| 11 | `income` | `int32` | `optional` | `` |  |
-| 12 | `gold` | `int32` | `optional` | `` |  |
-| 13 | `base_max_health` | `uint32` | `optional` | `` |  |
-| 14 | `bonus_max_health` | `uint32` | `optional` | `` |  |
-| 15 | `abilities` | `.CMsgItemBattlerItemContainer` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `hero_id` | `uint32` | `optional` |  |  |
+| 3 | `monster_id` | `uint32` | `optional` |  |  |
+| 4 | `board` | `.CMsgItemBattlerItemContainer` | `optional` |  |  |
+| 5 | `wins` | `int32` | `optional` |  |  |
+| 6 | `losses` | `int32` | `optional` |  |  |
+| 7 | `prestige` | `int32` | `optional` |  |  |
+| 8 | `level` | `uint32` | `optional` |  |  |
+| 9 | `experience` | `int32` | `optional` |  |  |
+| 10 | `skills` | `uint32` | `repeated` |  |  |
+| 11 | `income` | `int32` | `optional` |  |  |
+| 12 | `gold` | `int32` | `optional` |  |  |
+| 13 | `base_max_health` | `uint32` | `optional` |  |  |
+| 14 | `bonus_max_health` | `uint32` | `optional` |  |  |
+| 15 | `abilities` | `.CMsgItemBattlerItemContainer` | `optional` |  |  |
 
 </details>
 
@@ -147,9 +147,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `is_shop` | `bool` | `optional` | `` |  |
-| 2 | `encounter_id` | `uint32` | `optional` | `` |  |
-| 3 | `shop_items` | `.CMsgItemBattlerItemContainer` | `optional` | `` |  |
+| 1 | `is_shop` | `bool` | `optional` |  |  |
+| 2 | `encounter_id` | `uint32` | `optional` |  |  |
+| 3 | `shop_items` | `.CMsgItemBattlerItemContainer` | `optional` |  |  |
 
 </details>
 
@@ -161,10 +161,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_data` | `.CMsgItemBattlerPlayerData` | `optional` | `` |  |
-| 2 | `items` | `.CMsgItemBattlerGhostData.ItemsEntry` | `repeated` | `` |  |
-| 3 | `day` | `int32` | `optional` | `` |  |
-| 4 | `abilities` | `.CMsgItemBattlerGhostData.AbilitiesEntry` | `repeated` | `` |  |
+| 1 | `player_data` | `.CMsgItemBattlerPlayerData` | `optional` |  |  |
+| 2 | `items` | `.CMsgItemBattlerGhostData.ItemsEntry` | `repeated` |  |  |
+| 3 | `day` | `int32` | `optional` |  |  |
+| 4 | `abilities` | `.CMsgItemBattlerGhostData.AbilitiesEntry` | `repeated` |  |  |
 
 </details>
 
@@ -176,8 +176,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `.CMsgItemBattlerItem` | `optional` | `` |  |
+| 1 | `key` | `uint32` | `optional` |  |  |
+| 2 | `value` | `.CMsgItemBattlerItem` | `optional` |  |  |
 
 </details>
 
@@ -189,8 +189,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `.CMsgItemBattlerItem` | `optional` | `` |  |
+| 1 | `key` | `uint32` | `optional` |  |  |
+| 2 | `value` | `.CMsgItemBattlerItem` | `optional` |  |  |
 
 </details>
 
@@ -202,20 +202,20 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `run_active` | `bool` | `optional` | `` |  |
-| 2 | `run_id` | `uint32` | `optional` | `` |  |
-| 3 | `game_state` | `.EItemBattlerGameState` | `optional` | `` | default = k_eGameState_Invalid |
-| 4 | `player_data` | `.CMsgItemBattlerPlayerData` | `optional` | `` |  |
-| 5 | `opponent_data` | `.CMsgItemBattlerPlayerData` | `optional` | `` |  |
-| 6 | `stash` | `.CMsgItemBattlerItemContainer` | `optional` | `` |  |
-| 7 | `encounter` | `.CMsgItemBattlerEncounterData` | `optional` | `` |  |
-| 8 | `fight_result` | `.CMsgItemBattlerFightResult` | `optional` | `` |  |
-| 9 | `items` | `.CMsgItemBattlerWorldData.ItemsEntry` | `repeated` | `` |  |
-| 10 | `day` | `int32` | `optional` | `` |  |
-| 11 | `hour` | `int32` | `optional` | `` |  |
-| 12 | `encounter_choices` | `uint32` | `repeated` | `` |  |
-| 13 | `monster_choices` | `uint32` | `repeated` | `` |  |
-| 14 | `conceded` | `bool` | `optional` | `` |  |
+| 1 | `run_active` | `bool` | `optional` |  |  |
+| 2 | `run_id` | `uint32` | `optional` |  |  |
+| 3 | `game_state` | `.EItemBattlerGameState` | `optional` |  | default = k_eGameState_Invalid |
+| 4 | `player_data` | `.CMsgItemBattlerPlayerData` | `optional` |  |  |
+| 5 | `opponent_data` | `.CMsgItemBattlerPlayerData` | `optional` |  |  |
+| 6 | `stash` | `.CMsgItemBattlerItemContainer` | `optional` |  |  |
+| 7 | `encounter` | `.CMsgItemBattlerEncounterData` | `optional` |  |  |
+| 8 | `fight_result` | `.CMsgItemBattlerFightResult` | `optional` |  |  |
+| 9 | `items` | `.CMsgItemBattlerWorldData.ItemsEntry` | `repeated` |  |  |
+| 10 | `day` | `int32` | `optional` |  |  |
+| 11 | `hour` | `int32` | `optional` |  |  |
+| 12 | `encounter_choices` | `uint32` | `repeated` |  |  |
+| 13 | `monster_choices` | `uint32` | `repeated` |  |  |
+| 14 | `conceded` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -227,8 +227,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `.CMsgItemBattlerItem` | `optional` | `` |  |
+| 1 | `key` | `uint32` | `optional` |  |  |
+| 2 | `value` | `.CMsgItemBattlerItem` | `optional` |  |  |
 
 </details>
 
@@ -240,8 +240,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `seed` | `uint32` | `optional` | `` |  |
-| 2 | `world_data` | `.CMsgItemBattlerWorldData` | `optional` | `` |  |
+| 1 | `seed` | `uint32` | `optional` |  |  |
+| 2 | `world_data` | `.CMsgItemBattlerWorldData` | `optional` |  |  |
 
 </details>
 
@@ -265,8 +265,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCItemBattlerGetUserDataResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `world_data` | `.CMsgItemBattlerWorldData` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCItemBattlerGetUserDataResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `world_data` | `.CMsgItemBattlerWorldData` | `optional` |  |  |
 
 </details>
 
@@ -290,12 +290,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `action` | `.CMsgClientToGCItemBattlerGameAction.EAction` | `optional` | `` | default = k_eInvalid |
-| 2 | `choice_index` | `uint32` | `optional` | `` |  |
-| 3 | `item_instance_id` | `uint32` | `optional` | `` |  |
-| 4 | `item_container_id` | `uint32` | `optional` | `` |  |
-| 5 | `item_position_x` | `uint32` | `optional` | `` |  |
-| 6 | `item_position_y` | `uint32` | `optional` | `` |  |
+| 1 | `action` | `.CMsgClientToGCItemBattlerGameAction.EAction` | `optional` |  | default = k_eInvalid |
+| 2 | `choice_index` | `uint32` | `optional` |  |  |
+| 3 | `item_instance_id` | `uint32` | `optional` |  |  |
+| 4 | `item_container_id` | `uint32` | `optional` |  |  |
+| 5 | `item_position_x` | `uint32` | `optional` |  |  |
+| 6 | `item_position_y` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -307,8 +307,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCItemBattlerGameActionResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `updated_world_data` | `.CMsgItemBattlerWorldData` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCItemBattlerGameActionResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `updated_world_data` | `.CMsgItemBattlerWorldData` | `optional` |  |  |
 
 </details>
 
@@ -320,7 +320,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_definition_id` | `uint32` | `optional` | `` |  |
+| 1 | `item_definition_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -332,7 +332,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCItemBattlerDevGrantItemResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCItemBattlerDevGrantItemResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -344,7 +344,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `world_data` | `.CMsgItemBattlerWorldData` | `optional` | `` |  |
+| 1 | `world_data` | `.CMsgItemBattlerWorldData` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-common-league.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-common-league.md
@@ -23,26 +23,26 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `node_id` | `uint32` | `optional` | `` |  |
-| 3 | `node_group_id` | `uint32` | `optional` | `` |  |
-| 4 | `winning_node_id` | `uint32` | `optional` | `` |  |
-| 5 | `losing_node_id` | `uint32` | `optional` | `` |  |
-| 6 | `incoming_node_id_1` | `uint32` | `optional` | `` |  |
-| 7 | `incoming_node_id_2` | `uint32` | `optional` | `` |  |
-| 8 | `node_type` | `.ELeagueNodeType` | `optional` | `` | default = INVALID_NODE_TYPE |
-| 9 | `scheduled_time` | `uint32` | `optional` | `` |  |
-| 10 | `series_id` | `uint32` | `optional` | `` |  |
-| 11 | `team_id_1` | `uint32` | `optional` | `` |  |
-| 12 | `team_id_2` | `uint32` | `optional` | `` |  |
-| 13 | `matches` | `.CMsgDOTALeagueNode.MatchDetails` | `repeated` | `` |  |
-| 14 | `team_1_wins` | `uint32` | `optional` | `` |  |
-| 15 | `team_2_wins` | `uint32` | `optional` | `` |  |
-| 16 | `has_started` | `bool` | `optional` | `` |  |
-| 17 | `is_completed` | `bool` | `optional` | `` |  |
-| 18 | `stream_ids` | `uint32` | `repeated` | `` |  |
-| 19 | `actual_time` | `uint32` | `optional` | `` |  |
-| 20 | `vods` | `.CMsgDOTALeagueNode.VOD` | `repeated` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `node_id` | `uint32` | `optional` |  |  |
+| 3 | `node_group_id` | `uint32` | `optional` |  |  |
+| 4 | `winning_node_id` | `uint32` | `optional` |  |  |
+| 5 | `losing_node_id` | `uint32` | `optional` |  |  |
+| 6 | `incoming_node_id_1` | `uint32` | `optional` |  |  |
+| 7 | `incoming_node_id_2` | `uint32` | `optional` |  |  |
+| 8 | `node_type` | `.ELeagueNodeType` | `optional` |  | default = INVALID_NODE_TYPE |
+| 9 | `scheduled_time` | `uint32` | `optional` |  |  |
+| 10 | `series_id` | `uint32` | `optional` |  |  |
+| 11 | `team_id_1` | `uint32` | `optional` |  |  |
+| 12 | `team_id_2` | `uint32` | `optional` |  |  |
+| 13 | `matches` | `.CMsgDOTALeagueNode.MatchDetails` | `repeated` |  |  |
+| 14 | `team_1_wins` | `uint32` | `optional` |  |  |
+| 15 | `team_2_wins` | `uint32` | `optional` |  |  |
+| 16 | `has_started` | `bool` | `optional` |  |  |
+| 17 | `is_completed` | `bool` | `optional` |  |  |
+| 18 | `stream_ids` | `uint32` | `repeated` |  |  |
+| 19 | `actual_time` | `uint32` | `optional` |  |  |
+| 20 | `vods` | `.CMsgDOTALeagueNode.VOD` | `repeated` |  |  |
 
 </details>
 
@@ -54,8 +54,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `winning_team_id` | `uint32` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `winning_team_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -67,9 +67,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `series_game` | `uint32` | `optional` | `` |  |
-| 2 | `stream_id` | `uint32` | `optional` | `` |  |
-| 3 | `url` | `string` | `optional` | `` |  |
+| 1 | `series_game` | `uint32` | `optional` |  |  |
+| 2 | `stream_id` | `uint32` | `optional` |  |  |
+| 3 | `url` | `string` | `optional` |  |  |
 
 </details>
 
@@ -81,33 +81,33 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `node_group_id` | `uint32` | `optional` | `` |  |
-| 3 | `parent_node_group_id` | `uint32` | `optional` | `` |  |
-| 4 | `incoming_node_group_ids` | `uint32` | `repeated` | `` |  |
-| 5 | `advancing_node_group_id` | `uint32` | `optional` | `` |  |
-| 6 | `advancing_team_count` | `uint32` | `optional` | `` |  |
-| 7 | `team_count` | `uint32` | `optional` | `` |  |
-| 8 | `node_group_type` | `.ELeagueNodeGroupType` | `optional` | `` | default = INVALID_GROUP_TYPE |
-| 9 | `default_node_type` | `.ELeagueNodeType` | `optional` | `` | default = INVALID_NODE_TYPE |
-| 10 | `round` | `uint32` | `optional` | `` |  |
-| 11 | `max_rounds` | `uint32` | `optional` | `` |  |
-| 12 | `is_tiebreaker` | `bool` | `optional` | `` |  |
-| 13 | `is_final_group` | `bool` | `optional` | `` |  |
-| 14 | `is_completed` | `bool` | `optional` | `` |  |
-| 15 | `team_standings` | `.CMsgDOTALeagueNodeGroup.TeamStanding` | `repeated` | `` |  |
-| 16 | `nodes` | `.CMsgDOTALeagueNode` | `repeated` | `` |  |
-| 17 | `node_groups` | `.CMsgDOTALeagueNodeGroup` | `repeated` | `` |  |
-| 18 | `phase` | `.ELeaguePhase` | `optional` | `` | default = LEAGUE_PHASE_UNSET |
-| 19 | `region` | `.ELeagueRegion` | `optional` | `` | default = LEAGUE_REGION_UNSET |
-| 20 | `start_time` | `uint32` | `optional` | `` |  |
-| 21 | `end_time` | `uint32` | `optional` | `` |  |
-| 22 | `secondary_advancing_node_group_id` | `uint32` | `optional` | `` |  |
-| 23 | `secondary_advancing_team_count` | `uint32` | `optional` | `` |  |
-| 24 | `tertiary_advancing_node_group_id` | `uint32` | `optional` | `` |  |
-| 25 | `tertiary_advancing_team_count` | `uint32` | `optional` | `` |  |
-| 26 | `elimination_dpc_points` | `uint32` | `optional` | `` |  |
-| 27 | `win_loss_limit` | `uint32` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `node_group_id` | `uint32` | `optional` |  |  |
+| 3 | `parent_node_group_id` | `uint32` | `optional` |  |  |
+| 4 | `incoming_node_group_ids` | `uint32` | `repeated` |  |  |
+| 5 | `advancing_node_group_id` | `uint32` | `optional` |  |  |
+| 6 | `advancing_team_count` | `uint32` | `optional` |  |  |
+| 7 | `team_count` | `uint32` | `optional` |  |  |
+| 8 | `node_group_type` | `.ELeagueNodeGroupType` | `optional` |  | default = INVALID_GROUP_TYPE |
+| 9 | `default_node_type` | `.ELeagueNodeType` | `optional` |  | default = INVALID_NODE_TYPE |
+| 10 | `round` | `uint32` | `optional` |  |  |
+| 11 | `max_rounds` | `uint32` | `optional` |  |  |
+| 12 | `is_tiebreaker` | `bool` | `optional` |  |  |
+| 13 | `is_final_group` | `bool` | `optional` |  |  |
+| 14 | `is_completed` | `bool` | `optional` |  |  |
+| 15 | `team_standings` | `.CMsgDOTALeagueNodeGroup.TeamStanding` | `repeated` |  |  |
+| 16 | `nodes` | `.CMsgDOTALeagueNode` | `repeated` |  |  |
+| 17 | `node_groups` | `.CMsgDOTALeagueNodeGroup` | `repeated` |  |  |
+| 18 | `phase` | `.ELeaguePhase` | `optional` |  | default = LEAGUE_PHASE_UNSET |
+| 19 | `region` | `.ELeagueRegion` | `optional` |  | default = LEAGUE_REGION_UNSET |
+| 20 | `start_time` | `uint32` | `optional` |  |  |
+| 21 | `end_time` | `uint32` | `optional` |  |  |
+| 22 | `secondary_advancing_node_group_id` | `uint32` | `optional` |  |  |
+| 23 | `secondary_advancing_team_count` | `uint32` | `optional` |  |  |
+| 24 | `tertiary_advancing_node_group_id` | `uint32` | `optional` |  |  |
+| 25 | `tertiary_advancing_team_count` | `uint32` | `optional` |  |  |
+| 26 | `elimination_dpc_points` | `uint32` | `optional` |  |  |
+| 27 | `win_loss_limit` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -119,21 +119,21 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `standing` | `uint32` | `optional` | `` |  |
-| 2 | `team_id` | `uint32` | `optional` | `` |  |
-| 3 | `team_name` | `string` | `optional` | `` |  |
-| 4 | `team_tag` | `string` | `optional` | `` |  |
-| 5 | `team_logo` | `uint64` | `optional` | `` |  |
-| 6 | `team_logo_url` | `string` | `optional` | `` |  |
-| 7 | `wins` | `uint32` | `optional` | `` |  |
-| 8 | `losses` | `uint32` | `optional` | `` |  |
-| 9 | `score` | `int64` | `optional` | `` |  |
-| 10 | `team_abbreviation` | `string` | `optional` | `` |  |
-| 14 | `is_pro` | `bool` | `optional` | `` |  |
-| 15 | `tiebreak_game_win_pct` | `uint32` | `optional` | `` |  |
-| 16 | `tiebreak_opponent_match_wins` | `uint32` | `optional` | `` |  |
-| 17 | `tiebreak_opponent_game_win_pct` | `uint32` | `optional` | `` |  |
-| 18 | `tiebreak_coinflip` | `uint32` | `optional` | `` |  |
+| 1 | `standing` | `uint32` | `optional` |  |  |
+| 2 | `team_id` | `uint32` | `optional` |  |  |
+| 3 | `team_name` | `string` | `optional` |  |  |
+| 4 | `team_tag` | `string` | `optional` |  |  |
+| 5 | `team_logo` | `uint64` | `optional` |  |  |
+| 6 | `team_logo_url` | `string` | `optional` |  |  |
+| 7 | `wins` | `uint32` | `optional` |  |  |
+| 8 | `losses` | `uint32` | `optional` |  |  |
+| 9 | `score` | `int64` | `optional` |  |  |
+| 10 | `team_abbreviation` | `string` | `optional` |  |  |
+| 14 | `is_pro` | `bool` | `optional` |  |  |
+| 15 | `tiebreak_game_win_pct` | `uint32` | `optional` |  |  |
+| 16 | `tiebreak_opponent_match_wins` | `uint32` | `optional` |  |  |
+| 17 | `tiebreak_opponent_game_win_pct` | `uint32` | `optional` |  |  |
+| 18 | `tiebreak_coinflip` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -145,13 +145,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `info` | `.CMsgDOTALeague.Info` | `optional` | `` |  |
-| 2 | `prize_pool` | `.CMsgDOTALeague.PrizePool` | `optional` | `` |  |
-| 3 | `admins` | `.CMsgDOTALeague.Admin` | `repeated` | `` |  |
-| 4 | `streams` | `.CMsgDOTALeague.Stream` | `repeated` | `` |  |
-| 5 | `node_groups` | `.CMsgDOTALeagueNodeGroup` | `repeated` | `` |  |
-| 6 | `series_infos` | `.CMsgDOTALeague.SeriesInfo` | `repeated` | `` |  |
-| 7 | `registered_players` | `.CMsgDOTALeague.Player` | `repeated` | `` |  |
+| 1 | `info` | `.CMsgDOTALeague.Info` | `optional` |  |  |
+| 2 | `prize_pool` | `.CMsgDOTALeague.PrizePool` | `optional` |  |  |
+| 3 | `admins` | `.CMsgDOTALeague.Admin` | `repeated` |  |  |
+| 4 | `streams` | `.CMsgDOTALeague.Stream` | `repeated` |  |  |
+| 5 | `node_groups` | `.CMsgDOTALeagueNodeGroup` | `repeated` |  |  |
+| 6 | `series_infos` | `.CMsgDOTALeague.SeriesInfo` | `repeated` |  |  |
+| 7 | `registered_players` | `.CMsgDOTALeague.Player` | `repeated` |  |  |
 
 </details>
 
@@ -163,20 +163,20 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `tier` | `.ELeagueTier` | `optional` | `` | default = LEAGUE_TIER_UNSET |
-| 4 | `region` | `.ELeagueRegion` | `optional` | `` | default = LEAGUE_REGION_UNSET |
-| 5 | `url` | `string` | `optional` | `` |  |
-| 6 | `description` | `string` | `optional` | `` |  |
-| 7 | `notes` | `string` | `optional` | `` |  |
-| 8 | `start_timestamp` | `uint32` | `optional` | `` |  |
-| 9 | `end_timestamp` | `uint32` | `optional` | `` |  |
-| 10 | `pro_circuit_points` | `uint32` | `optional` | `` |  |
-| 11 | `image_bits` | `uint32` | `optional` | `` |  |
-| 12 | `status` | `.ELeagueStatus` | `optional` | `` | default = LEAGUE_STATUS_UNSET |
-| 13 | `most_recent_activity` | `uint32` | `optional` | `` |  |
-| 14 | `registration_period` | `uint32` | `optional` | `` |  |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `tier` | `.ELeagueTier` | `optional` |  | default = LEAGUE_TIER_UNSET |
+| 4 | `region` | `.ELeagueRegion` | `optional` |  | default = LEAGUE_REGION_UNSET |
+| 5 | `url` | `string` | `optional` |  |  |
+| 6 | `description` | `string` | `optional` |  |  |
+| 7 | `notes` | `string` | `optional` |  |  |
+| 8 | `start_timestamp` | `uint32` | `optional` |  |  |
+| 9 | `end_timestamp` | `uint32` | `optional` |  |  |
+| 10 | `pro_circuit_points` | `uint32` | `optional` |  |  |
+| 11 | `image_bits` | `uint32` | `optional` |  |  |
+| 12 | `status` | `.ELeagueStatus` | `optional` |  | default = LEAGUE_STATUS_UNSET |
+| 13 | `most_recent_activity` | `uint32` | `optional` |  |  |
+| 14 | `registration_period` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -188,9 +188,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `is_primary` | `bool` | `optional` | `` |  |
-| 3 | `email_address` | `string` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `is_primary` | `bool` | `optional` |  |  |
+| 3 | `email_address` | `string` | `optional` |  |  |
 
 </details>
 
@@ -202,10 +202,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def` | `uint32` | `optional` | `` |  |
-| 2 | `sales_stop_timestamp` | `uint32` | `optional` | `` |  |
-| 3 | `revenue_pct` | `uint32` | `optional` | `` |  |
-| 4 | `revenue_cents_per_sale` | `uint32` | `optional` | `` |  |
+| 1 | `item_def` | `uint32` | `optional` |  |  |
+| 2 | `sales_stop_timestamp` | `uint32` | `optional` |  |  |
+| 3 | `revenue_pct` | `uint32` | `optional` |  |  |
+| 4 | `revenue_cents_per_sale` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -217,10 +217,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `base_prize_pool` | `uint32` | `optional` | `` |  |
-| 2 | `total_prize_pool` | `uint32` | `optional` | `` |  |
-| 3 | `prize_split_pct_x100` | `uint32` | `repeated` | `` |  |
-| 4 | `prize_pool_items` | `.CMsgDOTALeague.PrizePoolItem` | `repeated` | `` |  |
+| 1 | `base_prize_pool` | `uint32` | `optional` |  |  |
+| 2 | `total_prize_pool` | `uint32` | `optional` |  |  |
+| 3 | `prize_split_pct_x100` | `uint32` | `repeated` |  |  |
+| 4 | `prize_pool_items` | `.CMsgDOTALeague.PrizePoolItem` | `repeated` |  |  |
 
 </details>
 
@@ -232,12 +232,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `stream_id` | `uint32` | `optional` | `` |  |
-| 2 | `language` | `uint32` | `optional` | `` |  |
-| 3 | `name` | `string` | `optional` | `` |  |
-| 4 | `broadcast_provider` | `.ELeagueBroadcastProvider` | `optional` | `` | default = LEAGUE_BROADCAST_UNKNOWN |
-| 5 | `stream_url` | `string` | `optional` | `` |  |
-| 6 | `vod_url` | `string` | `optional` | `` |  |
+| 1 | `stream_id` | `uint32` | `optional` |  |  |
+| 2 | `language` | `uint32` | `optional` |  |  |
+| 3 | `name` | `string` | `optional` |  |  |
+| 4 | `broadcast_provider` | `.ELeagueBroadcastProvider` | `optional` |  | default = LEAGUE_BROADCAST_UNKNOWN |
+| 5 | `stream_url` | `string` | `optional` |  |  |
+| 6 | `vod_url` | `string` | `optional` |  |  |
 
 </details>
 
@@ -249,12 +249,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `series_id` | `uint32` | `optional` | `` |  |
-| 2 | `series_type` | `uint32` | `optional` | `` |  |
-| 3 | `start_time` | `uint32` | `optional` | `` |  |
-| 4 | `match_ids` | `uint64` | `repeated` | `` |  |
-| 5 | `team_id_1` | `uint32` | `optional` | `` |  |
-| 6 | `team_id_2` | `uint32` | `optional` | `` |  |
+| 1 | `series_id` | `uint32` | `optional` |  |  |
+| 2 | `series_type` | `uint32` | `optional` |  |  |
+| 3 | `start_time` | `uint32` | `optional` |  |  |
+| 4 | `match_ids` | `uint64` | `repeated` |  |  |
+| 5 | `team_id_1` | `uint32` | `optional` |  |  |
+| 6 | `team_id_2` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -266,9 +266,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `team_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `team_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -280,7 +280,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `leagues` | `.CMsgDOTALeague` | `repeated` | `` |  |
+| 1 | `leagues` | `.CMsgDOTALeague` | `repeated` |  |  |
 
 </details>
 
@@ -292,15 +292,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `tier` | `.ELeagueTier` | `optional` | `` | default = LEAGUE_TIER_UNSET |
-| 4 | `region` | `.ELeagueRegion` | `optional` | `` | default = LEAGUE_REGION_UNSET |
-| 5 | `most_recent_activity` | `uint32` | `optional` | `` |  |
-| 6 | `total_prize_pool` | `uint32` | `optional` | `` |  |
-| 7 | `start_timestamp` | `uint32` | `optional` | `` |  |
-| 8 | `end_timestamp` | `uint32` | `optional` | `` |  |
-| 9 | `status` | `uint32` | `optional` | `` |  |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `tier` | `.ELeagueTier` | `optional` |  | default = LEAGUE_TIER_UNSET |
+| 4 | `region` | `.ELeagueRegion` | `optional` |  | default = LEAGUE_REGION_UNSET |
+| 5 | `most_recent_activity` | `uint32` | `optional` |  |  |
+| 6 | `total_prize_pool` | `uint32` | `optional` |  |  |
+| 7 | `start_timestamp` | `uint32` | `optional` |  |  |
+| 8 | `end_timestamp` | `uint32` | `optional` |  |  |
+| 9 | `status` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -312,7 +312,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `infos` | `.CMsgDOTALeagueInfo` | `repeated` | `` |  |
+| 1 | `infos` | `.CMsgDOTALeagueInfo` | `repeated` |  |  |
 
 </details>
 
@@ -324,7 +324,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `games` | `.CMsgDOTALeagueLiveGames.LiveGame` | `repeated` | `` |  |
+| 1 | `games` | `.CMsgDOTALeagueLiveGames.LiveGame` | `repeated` |  |  |
 
 </details>
 
@@ -336,19 +336,19 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 2 | `server_steam_id` | `uint64` | `optional` | `` |  |
-| 3 | `radiant_name` | `string` | `optional` | `` |  |
-| 4 | `radiant_logo` | `uint64` | `optional` | `` |  |
-| 5 | `dire_name` | `string` | `optional` | `` |  |
-| 6 | `dire_logo` | `uint64` | `optional` | `` |  |
-| 7 | `time` | `uint32` | `optional` | `` |  |
-| 8 | `spectators` | `uint32` | `optional` | `` |  |
-| 9 | `radiant_team_id` | `uint32` | `optional` | `` |  |
-| 10 | `dire_team_id` | `uint32` | `optional` | `` |  |
-| 11 | `league_node_id` | `uint32` | `optional` | `` |  |
-| 12 | `series_id` | `uint32` | `optional` | `` |  |
-| 13 | `match_id` | `uint64` | `optional` | `` |  |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 2 | `server_steam_id` | `uint64` | `optional` |  |  |
+| 3 | `radiant_name` | `string` | `optional` |  |  |
+| 4 | `radiant_logo` | `uint64` | `optional` |  |  |
+| 5 | `dire_name` | `string` | `optional` |  |  |
+| 6 | `dire_logo` | `uint64` | `optional` |  |  |
+| 7 | `time` | `uint32` | `optional` |  |  |
+| 8 | `spectators` | `uint32` | `optional` |  |  |
+| 9 | `radiant_team_id` | `uint32` | `optional` |  |  |
+| 10 | `dire_team_id` | `uint32` | `optional` |  |  |
+| 11 | `league_node_id` | `uint32` | `optional` |  |  |
+| 12 | `series_id` | `uint32` | `optional` |  |  |
+| 13 | `match_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -360,7 +360,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `messages` | `.CMsgDOTALeagueMessages.Message` | `repeated` | `` |  |
+| 1 | `messages` | `.CMsgDOTALeagueMessages.Message` | `repeated` |  |  |
 
 </details>
 
@@ -372,9 +372,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `author_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `timestamp` | `uint32` | `optional` | `` |  |
-| 3 | `message` | `string` | `optional` | `` |  |
+| 1 | `author_account_id` | `uint32` | `optional` |  |  |
+| 2 | `timestamp` | `uint32` | `optional` |  |  |
+| 3 | `message` | `string` | `optional` |  |  |
 
 </details>
 
@@ -386,8 +386,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `prize_pool` | `uint32` | `optional` | `` |  |
-| 2 | `increment_per_second` | `float` | `optional` | `` |  |
+| 1 | `prize_pool` | `uint32` | `optional` |  |  |
+| 2 | `increment_per_second` | `float` | `optional` |  |  |
 
 </details>
 
@@ -411,7 +411,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -423,7 +423,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `node_infos` | `.CMsgDOTALeagueAvailableLobbyNodes.NodeInfo` | `repeated` | `` |  |
+| 1 | `node_infos` | `.CMsgDOTALeagueAvailableLobbyNodes.NodeInfo` | `repeated` |  |  |
 
 </details>
 
@@ -435,11 +435,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `node_id` | `uint32` | `optional` | `` |  |
-| 2 | `node_name` | `string` | `optional` | `` |  |
-| 3 | `node_group_name` | `string` | `optional` | `` |  |
-| 4 | `team_id_1` | `uint32` | `optional` | `` |  |
-| 5 | `team_id_2` | `uint32` | `optional` | `` |  |
+| 1 | `node_id` | `uint32` | `optional` |  |  |
+| 2 | `node_name` | `string` | `optional` |  |  |
+| 3 | `node_group_name` | `string` | `optional` |  |  |
+| 4 | `team_id_1` | `uint32` | `optional` |  |  |
+| 5 | `team_id_2` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -451,7 +451,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `node_results` | `.CMsgDOTALeagueNodeResults.Result` | `repeated` | `` |  |
+| 1 | `node_results` | `.CMsgDOTALeagueNodeResults.Result` | `repeated` |  |  |
 
 </details>
 
@@ -463,23 +463,23 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `node_id` | `uint32` | `optional` | `` |  |
-| 2 | `winning_node_id` | `uint32` | `optional` | `` |  |
-| 3 | `losing_node_id` | `uint32` | `optional` | `` |  |
-| 4 | `incoming_node_id_1` | `uint32` | `optional` | `` |  |
-| 5 | `incoming_node_id_2` | `uint32` | `optional` | `` |  |
-| 6 | `team_id_1` | `uint32` | `optional` | `` |  |
-| 7 | `team_id_2` | `uint32` | `optional` | `` |  |
-| 8 | `team_1_name` | `string` | `optional` | `` |  |
-| 9 | `team_2_name` | `string` | `optional` | `` |  |
-| 10 | `team_1_wins` | `uint32` | `optional` | `` |  |
-| 11 | `team_2_wins` | `uint32` | `optional` | `` |  |
-| 12 | `winning_team_id` | `uint32` | `optional` | `` |  |
-| 13 | `losing_team_id` | `uint32` | `optional` | `` |  |
-| 14 | `has_started` | `bool` | `optional` | `` |  |
-| 15 | `is_completed` | `bool` | `optional` | `` |  |
-| 16 | `scheduled_time` | `uint32` | `optional` | `` |  |
-| 17 | `match_ids` | `uint64` | `repeated` | `` |  |
+| 1 | `node_id` | `uint32` | `optional` |  |  |
+| 2 | `winning_node_id` | `uint32` | `optional` |  |  |
+| 3 | `losing_node_id` | `uint32` | `optional` |  |  |
+| 4 | `incoming_node_id_1` | `uint32` | `optional` |  |  |
+| 5 | `incoming_node_id_2` | `uint32` | `optional` |  |  |
+| 6 | `team_id_1` | `uint32` | `optional` |  |  |
+| 7 | `team_id_2` | `uint32` | `optional` |  |  |
+| 8 | `team_1_name` | `string` | `optional` |  |  |
+| 9 | `team_2_name` | `string` | `optional` |  |  |
+| 10 | `team_1_wins` | `uint32` | `optional` |  |  |
+| 11 | `team_2_wins` | `uint32` | `optional` |  |  |
+| 12 | `winning_team_id` | `uint32` | `optional` |  |  |
+| 13 | `losing_team_id` | `uint32` | `optional` |  |  |
+| 14 | `has_started` | `bool` | `optional` |  |  |
+| 15 | `is_completed` | `bool` | `optional` |  |  |
+| 16 | `scheduled_time` | `uint32` | `optional` |  |  |
+| 17 | `match_ids` | `uint64` | `repeated` |  |  |
 
 </details>
 
@@ -491,9 +491,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `results` | `.CMsgDOTADPCLeagueResults.Result` | `repeated` | `` |  |
-| 2 | `points` | `uint32` | `repeated` | `` |  |
-| 3 | `dollars` | `uint32` | `repeated` | `` |  |
+| 1 | `results` | `.CMsgDOTADPCLeagueResults.Result` | `repeated` |  |  |
+| 2 | `points` | `uint32` | `repeated` |  |  |
+| 3 | `dollars` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -505,16 +505,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `standing` | `uint32` | `optional` | `` |  |
-| 2 | `team_id` | `uint32` | `optional` | `` |  |
-| 3 | `team_name` | `string` | `optional` | `` |  |
-| 4 | `team_logo` | `uint64` | `optional` | `` |  |
-| 5 | `team_logo_url` | `string` | `optional` | `` |  |
-| 6 | `points` | `uint32` | `optional` | `` |  |
-| 7 | `earnings` | `uint32` | `optional` | `` |  |
-| 8 | `timestamp` | `uint32` | `optional` | `` |  |
-| 9 | `phase` | `.ELeaguePhase` | `optional` | `` | default = LEAGUE_PHASE_UNSET |
-| 10 | `team_abbreviation` | `string` | `optional` | `` |  |
+| 1 | `standing` | `uint32` | `optional` |  |  |
+| 2 | `team_id` | `uint32` | `optional` |  |  |
+| 3 | `team_name` | `string` | `optional` |  |  |
+| 4 | `team_logo` | `uint64` | `optional` |  |  |
+| 5 | `team_logo_url` | `string` | `optional` |  |  |
+| 6 | `points` | `uint32` | `optional` |  |  |
+| 7 | `earnings` | `uint32` | `optional` |  |  |
+| 8 | `timestamp` | `uint32` | `optional` |  |  |
+| 9 | `phase` | `.ELeaguePhase` | `optional` |  | default = LEAGUE_PHASE_UNSET |
+| 10 | `team_abbreviation` | `string` | `optional` |  |  |
 
 </details>
 
@@ -526,7 +526,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `results` | `.CMsgDOTADPCTeamResults.Result` | `repeated` | `` |  |
+| 1 | `results` | `.CMsgDOTADPCTeamResults.Result` | `repeated` |  |  |
 
 </details>
 
@@ -538,11 +538,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 2 | `standing` | `uint32` | `optional` | `` |  |
-| 3 | `points` | `uint32` | `optional` | `` |  |
-| 4 | `earnings` | `uint32` | `optional` | `` |  |
-| 5 | `timestamp` | `uint32` | `optional` | `` |  |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 2 | `standing` | `uint32` | `optional` |  |  |
+| 3 | `points` | `uint32` | `optional` |  |  |
+| 4 | `earnings` | `uint32` | `optional` |  |  |
+| 5 | `timestamp` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -554,11 +554,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `results` | `.CMsgDOTADPCSeasonResults.TeamResult` | `repeated` | `` |  |
-| 2 | `standings` | `.CMsgDOTADPCSeasonResults.Standing` | `repeated` | `` |  |
-| 3 | `major_wildcard_standings` | `.CMsgDOTADPCSeasonResults.StandingEntry` | `repeated` | `` |  |
-| 4 | `major_group_standings` | `.CMsgDOTADPCSeasonResults.StandingEntry` | `repeated` | `` |  |
-| 5 | `major_playoff_standings` | `.CMsgDOTADPCSeasonResults.StandingEntry` | `repeated` | `` |  |
+| 1 | `results` | `.CMsgDOTADPCSeasonResults.TeamResult` | `repeated` |  |  |
+| 2 | `standings` | `.CMsgDOTADPCSeasonResults.Standing` | `repeated` |  |  |
+| 3 | `major_wildcard_standings` | `.CMsgDOTADPCSeasonResults.StandingEntry` | `repeated` |  |  |
+| 4 | `major_group_standings` | `.CMsgDOTADPCSeasonResults.StandingEntry` | `repeated` |  |  |
+| 5 | `major_playoff_standings` | `.CMsgDOTADPCSeasonResults.StandingEntry` | `repeated` |  |  |
 
 </details>
 
@@ -570,13 +570,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `timestamp` | `uint32` | `optional` | `` |  |
-| 2 | `league_id` | `uint32` | `optional` | `` |  |
-| 3 | `standing` | `uint32` | `optional` | `` |  |
-| 4 | `points` | `uint32` | `optional` | `` |  |
-| 5 | `earnings` | `uint32` | `optional` | `` |  |
-| 6 | `audit_action` | `uint32` | `optional` | `` |  |
-| 7 | `audit_data` | `uint32` | `optional` | `` |  |
+| 1 | `timestamp` | `uint32` | `optional` |  |  |
+| 2 | `league_id` | `uint32` | `optional` |  |  |
+| 3 | `standing` | `uint32` | `optional` |  |  |
+| 4 | `points` | `uint32` | `optional` |  |  |
+| 5 | `earnings` | `uint32` | `optional` |  |  |
+| 6 | `audit_action` | `uint32` | `optional` |  |  |
+| 7 | `audit_data` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -588,14 +588,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_id` | `uint32` | `optional` | `` |  |
-| 2 | `team_name` | `string` | `optional` | `` |  |
-| 3 | `team_logo` | `uint64` | `optional` | `` |  |
-| 4 | `team_logo_url` | `string` | `optional` | `` |  |
-| 5 | `total_points` | `uint32` | `optional` | `` |  |
-| 6 | `total_earnings` | `uint32` | `optional` | `` |  |
-| 7 | `league_results` | `.CMsgDOTADPCSeasonResults.TeamLeagueResult` | `repeated` | `` |  |
-| 8 | `team_abbreviation` | `string` | `optional` | `` |  |
+| 1 | `team_id` | `uint32` | `optional` |  |  |
+| 2 | `team_name` | `string` | `optional` |  |  |
+| 3 | `team_logo` | `uint64` | `optional` |  |  |
+| 4 | `team_logo_url` | `string` | `optional` |  |  |
+| 5 | `total_points` | `uint32` | `optional` |  |  |
+| 6 | `total_earnings` | `uint32` | `optional` |  |  |
+| 7 | `league_results` | `.CMsgDOTADPCSeasonResults.TeamLeagueResult` | `repeated` |  |  |
+| 8 | `team_abbreviation` | `string` | `optional` |  |  |
 
 </details>
 
@@ -607,12 +607,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_id` | `uint32` | `optional` | `` |  |
-| 2 | `wins` | `uint32` | `optional` | `` |  |
-| 3 | `losses` | `uint32` | `optional` | `` |  |
-| 4 | `team_url` | `string` | `optional` | `` |  |
-| 5 | `team_name` | `string` | `optional` | `` |  |
-| 6 | `team_abbreviation` | `string` | `optional` | `` |  |
+| 1 | `team_id` | `uint32` | `optional` |  |  |
+| 2 | `wins` | `uint32` | `optional` |  |  |
+| 3 | `losses` | `uint32` | `optional` |  |  |
+| 4 | `team_url` | `string` | `optional` |  |  |
+| 5 | `team_name` | `string` | `optional` |  |  |
+| 6 | `team_abbreviation` | `string` | `optional` |  |  |
 
 </details>
 
@@ -624,9 +624,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `region` | `.ELeagueRegion` | `optional` | `` | default = LEAGUE_REGION_UNSET |
-| 2 | `division` | `.ELeagueDivision` | `optional` | `` | default = LEAGUE_DIVISION_UNSET |
-| 3 | `entries` | `.CMsgDOTADPCSeasonResults.StandingEntry` | `repeated` | `` |  |
+| 1 | `region` | `.ELeagueRegion` | `optional` |  | default = LEAGUE_REGION_UNSET |
+| 2 | `division` | `.ELeagueDivision` | `optional` |  | default = LEAGUE_DIVISION_UNSET |
+| 3 | `entries` | `.CMsgDOTADPCSeasonResults.StandingEntry` | `repeated` |  |  |
 
 </details>
 
@@ -638,8 +638,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `time_last_updated` | `uint32` | `optional` | `` |  |
-| 2 | `saved_results` | `.CMsgDOTADPCSeasonResults` | `optional` | `` |  |
+| 1 | `time_last_updated` | `uint32` | `optional` |  |  |
+| 2 | `saved_results` | `.CMsgDOTADPCSeasonResults` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-common-lobby.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-common-lobby.md
@@ -25,9 +25,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `coach_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `player_account_id` | `uint32` | `optional` | `` |  |
-| 3 | `request_state` | `.ELobbyMemberCoachRequestState` | `optional` | `` | default = k_eLobbyMemberCoachRequestState_None |
+| 1 | `coach_account_id` | `uint32` | `optional` |  |  |
+| 2 | `player_account_id` | `uint32` | `optional` |  |  |
+| 3 | `request_state` | `.ELobbyMemberCoachRequestState` | `optional` |  | default = k_eLobbyMemberCoachRequestState_None |
 
 </details>
 
@@ -39,7 +39,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_badges` | `.CMsgLobbyPlayerPlusSubscriptionData.HeroBadge` | `repeated` | `` |  |
+| 1 | `hero_badges` | `.CMsgLobbyPlayerPlusSubscriptionData.HeroBadge` | `repeated` |  |  |
 
 </details>
 
@@ -51,8 +51,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `hero_badge_xp` | `uint32` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `hero_badge_xp` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -64,8 +64,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `action_id` | `uint32` | `optional` | `` |  |
-| 2 | `action_score` | `uint32` | `optional` | `` |  |
+| 1 | `action_id` | `uint32` | `optional` |  |  |
+| 2 | `action_score` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -77,9 +77,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `periodic_resource_id` | `uint32` | `optional` | `` |  |
-| 2 | `remaining` | `uint32` | `optional` | `` |  |
-| 3 | `max` | `uint32` | `optional` | `` |  |
+| 1 | `periodic_resource_id` | `uint32` | `optional` |  |  |
+| 2 | `remaining` | `uint32` | `optional` |  |  |
+| 3 | `max` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -91,8 +91,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `account_points` | `.CMsgLobbyEventPoints.AccountPoints` | `repeated` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `account_points` | `.CMsgLobbyEventPoints.AccountPoints` | `repeated` |  |  |
 
 </details>
 
@@ -104,20 +104,20 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `normal_points` | `uint32` | `optional` | `` |  |
-| 3 | `premium_points` | `uint32` | `optional` | `` |  |
-| 4 | `owned` | `bool` | `optional` | `` |  |
-| 7 | `event_level` | `uint32` | `optional` | `` |  |
-| 12 | `active_effects_mask` | `uint64` | `optional` | `` |  |
-| 23 | `wager_streak` | `uint32` | `optional` | `` |  |
-| 25 | `event_game_custom_actions` | `.CMsgEventActionData` | `repeated` | `` |  |
-| 26 | `tip_amount_index` | `uint32` | `optional` | `` |  |
-| 27 | `active_event_season_id` | `uint32` | `optional` | `` |  |
-| 28 | `teleport_fx_level` | `uint32` | `optional` | `` |  |
-| 30 | `networked_event_actions` | `.CMsgEventActionData` | `repeated` | `` |  |
-| 31 | `periodic_resources` | `.CMsgPeriodicResourceData` | `repeated` | `` |  |
-| 32 | `extra_event_messages` | `.CExtraMsgBlock` | `repeated` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `normal_points` | `uint32` | `optional` |  |  |
+| 3 | `premium_points` | `uint32` | `optional` |  |  |
+| 4 | `owned` | `bool` | `optional` |  |  |
+| 7 | `event_level` | `uint32` | `optional` |  |  |
+| 12 | `active_effects_mask` | `uint64` | `optional` |  |  |
+| 23 | `wager_streak` | `uint32` | `optional` |  |  |
+| 25 | `event_game_custom_actions` | `.CMsgEventActionData` | `repeated` |  |  |
+| 26 | `tip_amount_index` | `uint32` | `optional` |  |  |
+| 27 | `active_event_season_id` | `uint32` | `optional` |  |  |
+| 28 | `teleport_fx_level` | `uint32` | `optional` |  |  |
+| 30 | `networked_event_actions` | `.CMsgEventActionData` | `repeated` |  |  |
+| 31 | `periodic_resources` | `.CMsgPeriodicResourceData` | `repeated` |  |  |
+| 32 | `extra_event_messages` | `.CExtraMsgBlock` | `repeated` |  |  |
 
 </details>
 
@@ -129,8 +129,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `game_seed` | `uint32` | `optional` | `` |  |
-| 2 | `event_window_start_time` | `uint32` | `optional` | `` |  |
+| 1 | `game_seed` | `uint32` | `optional` |  |  |
+| 2 | `event_window_start_time` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -142,14 +142,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `group_id` | `uint64` | `optional` | `` | (key_field) = true |
-| 2 | `sender_id` | `fixed64` | `optional` | `` |  |
-| 3 | `sender_name` | `string` | `optional` | `` |  |
-| 4 | `members` | `.CSODOTALobbyInvite.LobbyMember` | `repeated` | `` |  |
-| 5 | `custom_game_id` | `uint64` | `optional` | `` |  |
-| 6 | `invite_gid` | `fixed64` | `optional` | `` |  |
-| 7 | `custom_game_crc` | `fixed64` | `optional` | `` |  |
-| 8 | `custom_game_timestamp` | `fixed32` | `optional` | `` |  |
+| 1 | `group_id` | `uint64` | `optional` |  | (key_field) = true |
+| 2 | `sender_id` | `fixed64` | `optional` |  |  |
+| 3 | `sender_name` | `string` | `optional` |  |  |
+| 4 | `members` | `.CSODOTALobbyInvite.LobbyMember` | `repeated` |  |  |
+| 5 | `custom_game_id` | `uint64` | `optional` |  |  |
+| 6 | `invite_gid` | `fixed64` | `optional` |  |  |
+| 7 | `custom_game_crc` | `fixed64` | `optional` |  |  |
+| 8 | `custom_game_timestamp` | `fixed32` | `optional` |  |  |
 
 </details>
 
@@ -161,8 +161,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `steam_id` | `fixed64` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `steam_id` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -174,20 +174,20 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `fixed64` | `optional` | `` | (key_field) = true |
-| 2 | `hero_id` | `int32` | `optional` | `` |  |
-| 3 | `team` | `.DOTA_GC_TEAM` | `optional` | `` | default = DOTA_GC_TEAM_GOOD_GUYS |
-| 7 | `slot` | `uint32` | `optional` | `` |  |
-| 16 | `leaver_status` | `.DOTALeaverStatus_t` | `optional` | `` | default = DOTA_LEAVER_NONE |
-| 23 | `coach_team` | `.DOTA_GC_TEAM` | `optional` | `` | default = DOTA_GC_TEAM_NOTEAM |
-| 28 | `leaver_actions` | `uint32` | `optional` | `` |  |
-| 31 | `custom_game_product_ids` | `uint32` | `repeated` | `` |  |
-| 40 | `live_spectator_team` | `.DOTA_GC_TEAM` | `optional` | `` | default = DOTA_GC_TEAM_NOTEAM |
-| 44 | `pending_awards` | `.CMsgPendingEventAward` | `repeated` | `` |  |
-| 45 | `pending_awards_on_victory` | `.CMsgPendingEventAward` | `repeated` | `` |  |
-| 52 | `reports_available` | `uint32` | `optional` | `` |  |
-| 55 | `live_spectator_account_id` | `uint32` | `optional` | `` |  |
-| 56 | `comms_reports_available` | `uint32` | `optional` | `` |  |
+| 1 | `id` | `fixed64` | `optional` |  | (key_field) = true |
+| 2 | `hero_id` | `int32` | `optional` |  |  |
+| 3 | `team` | `.DOTA_GC_TEAM` | `optional` |  | default = DOTA_GC_TEAM_GOOD_GUYS |
+| 7 | `slot` | `uint32` | `optional` |  |  |
+| 16 | `leaver_status` | `.DOTALeaverStatus_t` | `optional` |  | default = DOTA_LEAVER_NONE |
+| 23 | `coach_team` | `.DOTA_GC_TEAM` | `optional` |  | default = DOTA_GC_TEAM_NOTEAM |
+| 28 | `leaver_actions` | `uint32` | `optional` |  |  |
+| 31 | `custom_game_product_ids` | `uint32` | `repeated` |  |  |
+| 40 | `live_spectator_team` | `.DOTA_GC_TEAM` | `optional` |  | default = DOTA_GC_TEAM_NOTEAM |
+| 44 | `pending_awards` | `.CMsgPendingEventAward` | `repeated` |  |  |
+| 45 | `pending_awards_on_victory` | `.CMsgPendingEventAward` | `repeated` |  |  |
+| 52 | `reports_available` | `uint32` | `optional` |  |  |
+| 55 | `live_spectator_account_id` | `uint32` | `optional` |  |  |
+| 56 | `comms_reports_available` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -211,10 +211,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `party_id` | `uint64` | `optional` | `` |  |
-| 3 | `channel` | `uint32` | `optional` | `` | default = 6 |
-| 4 | `cameraman` | `bool` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `party_id` | `uint64` | `optional` |  |  |
+| 3 | `channel` | `uint32` | `optional` |  | default = 6 |
+| 4 | `cameraman` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -226,24 +226,24 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steam_id` | `fixed64` | `optional` | `` |  |
-| 3 | `rank_tier` | `int32` | `optional` | `` |  |
-| 4 | `leaderboard_rank` | `int32` | `optional` | `` | default = -1 |
-| 5 | `lane_selection_flags` | `int32` | `optional` | `` |  |
-| 6 | `rank_mmr_boost_type` | `.EDOTAMMRBoostType` | `optional` | `` | default = k_EDOTAMMRBoostType_None |
-| 7 | `coach_rating` | `int32` | `optional` | `` |  |
-| 8 | `coached_account_ids` | `uint32` | `repeated` | `` |  |
-| 9 | `was_mvp_last_game` | `bool` | `optional` | `` |  |
-| 10 | `can_earn_rewards` | `bool` | `optional` | `` |  |
-| 11 | `is_plus_subscriber` | `bool` | `optional` | `` |  |
-| 12 | `favorite_team_packed` | `uint64` | `optional` | `` |  |
-| 13 | `is_steam_china` | `bool` | `optional` | `` |  |
-| 14 | `title` | `uint32` | `optional` | `` |  |
-| 15 | `guild_id` | `uint32` | `optional` | `` |  |
-| 16 | `disabled_random_hero_bits` | `fixed32` | `repeated` | `` |  |
-| 17 | `disabled_hero_id` | `int32` | `repeated` | `` |  |
-| 18 | `enabled_hero_id` | `int32` | `repeated` | `` |  |
-| 19 | `banned_hero_ids` | `int32` | `repeated` | `` |  |
+| 1 | `steam_id` | `fixed64` | `optional` |  |  |
+| 3 | `rank_tier` | `int32` | `optional` |  |  |
+| 4 | `leaderboard_rank` | `int32` | `optional` |  | default = -1 |
+| 5 | `lane_selection_flags` | `int32` | `optional` |  |  |
+| 6 | `rank_mmr_boost_type` | `.EDOTAMMRBoostType` | `optional` |  | default = k_EDOTAMMRBoostType_None |
+| 7 | `coach_rating` | `int32` | `optional` |  |  |
+| 8 | `coached_account_ids` | `uint32` | `repeated` |  |  |
+| 9 | `was_mvp_last_game` | `bool` | `optional` |  |  |
+| 10 | `can_earn_rewards` | `bool` | `optional` |  |  |
+| 11 | `is_plus_subscriber` | `bool` | `optional` |  |  |
+| 12 | `favorite_team_packed` | `uint64` | `optional` |  |  |
+| 13 | `is_steam_china` | `bool` | `optional` |  |  |
+| 14 | `title` | `uint32` | `optional` |  |  |
+| 15 | `guild_id` | `uint32` | `optional` |  |  |
+| 16 | `disabled_random_hero_bits` | `fixed32` | `repeated` |  |  |
+| 17 | `disabled_hero_id` | `int32` | `repeated` |  |  |
+| 18 | `enabled_hero_id` | `int32` | `repeated` |  |  |
+| 19 | `banned_hero_ids` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -255,20 +255,20 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_name` | `string` | `optional` | `` |  |
-| 3 | `team_tag` | `string` | `optional` | `` |  |
-| 4 | `team_id` | `uint32` | `optional` | `` |  |
-| 5 | `team_logo` | `uint64` | `optional` | `` |  |
-| 6 | `team_base_logo` | `uint64` | `optional` | `` |  |
-| 7 | `team_banner_logo` | `uint64` | `optional` | `` |  |
-| 8 | `team_complete` | `bool` | `optional` | `` |  |
-| 15 | `rank` | `uint32` | `optional` | `` |  |
-| 16 | `rank_change` | `sint32` | `optional` | `` |  |
-| 17 | `is_home_team` | `bool` | `optional` | `` |  |
-| 18 | `is_challenge_match` | `bool` | `optional` | `` |  |
-| 19 | `challenge_match_token_account` | `uint64` | `optional` | `` |  |
-| 20 | `team_logo_url` | `string` | `optional` | `` |  |
-| 21 | `team_abbreviation` | `string` | `optional` | `` |  |
+| 1 | `team_name` | `string` | `optional` |  |  |
+| 3 | `team_tag` | `string` | `optional` |  |  |
+| 4 | `team_id` | `uint32` | `optional` |  |  |
+| 5 | `team_logo` | `uint64` | `optional` |  |  |
+| 6 | `team_base_logo` | `uint64` | `optional` |  |  |
+| 7 | `team_banner_logo` | `uint64` | `optional` |  |  |
+| 8 | `team_complete` | `bool` | `optional` |  |  |
+| 15 | `rank` | `uint32` | `optional` |  |  |
+| 16 | `rank_change` | `sint32` | `optional` |  |  |
+| 17 | `is_home_team` | `bool` | `optional` |  |  |
+| 18 | `is_challenge_match` | `bool` | `optional` |  |  |
+| 19 | `challenge_match_token_account` | `uint64` | `optional` |  |  |
+| 20 | `team_logo_url` | `string` | `optional` |  |  |
+| 21 | `team_abbreviation` | `string` | `optional` |  |  |
 
 </details>
 
@@ -280,17 +280,17 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `guild_primary_color` | `uint32` | `optional` | `` |  |
-| 3 | `guild_secondary_color` | `uint32` | `optional` | `` |  |
-| 4 | `guild_pattern` | `uint32` | `optional` | `` |  |
-| 5 | `guild_logo` | `uint64` | `optional` | `` |  |
-| 6 | `guild_points` | `uint32` | `optional` | `` |  |
-| 7 | `guild_event` | `uint32` | `optional` | `` |  |
-| 8 | `guild_flags` | `uint32` | `optional` | `` |  |
-| 9 | `team_for_guild` | `.DOTA_GC_TEAM` | `optional` | `` | default = DOTA_GC_TEAM_GOOD_GUYS |
-| 10 | `guild_tag` | `string` | `optional` | `` |  |
-| 11 | `guild_weekly_percentile` | `uint32` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `guild_primary_color` | `uint32` | `optional` |  |  |
+| 3 | `guild_secondary_color` | `uint32` | `optional` |  |  |
+| 4 | `guild_pattern` | `uint32` | `optional` |  |  |
+| 5 | `guild_logo` | `uint64` | `optional` |  |  |
+| 6 | `guild_points` | `uint32` | `optional` |  |  |
+| 7 | `guild_event` | `uint32` | `optional` |  |  |
+| 8 | `guild_flags` | `uint32` | `optional` |  |  |
+| 9 | `team_for_guild` | `.DOTA_GC_TEAM` | `optional` |  | default = DOTA_GC_TEAM_GOOD_GUYS |
+| 10 | `guild_tag` | `string` | `optional` |  |  |
+| 11 | `guild_weekly_percentile` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -302,11 +302,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `item_def_index` | `uint32` | `optional` | `` |  |
-| 3 | `is_supply_crate` | `bool` | `optional` | `` |  |
-| 4 | `is_timed_drop` | `bool` | `optional` | `` |  |
-| 5 | `account_id` | `uint32` | `optional` | `` |  |
-| 6 | `origin` | `uint32` | `optional` | `` |  |
+| 2 | `item_def_index` | `uint32` | `optional` |  |  |
+| 3 | `is_supply_crate` | `bool` | `optional` |  |  |
+| 4 | `is_timed_drop` | `bool` | `optional` |  |  |
+| 5 | `account_id` | `uint32` | `optional` |  |  |
+| 6 | `origin` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -318,10 +318,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `channel_id` | `uint32` | `optional` | `` |  |
-| 2 | `country_code` | `string` | `optional` | `` |  |
-| 3 | `description` | `string` | `optional` | `` |  |
-| 4 | `language_code` | `string` | `optional` | `` |  |
+| 1 | `channel_id` | `uint32` | `optional` |  |  |
+| 2 | `country_code` | `string` | `optional` |  |  |
+| 3 | `description` | `string` | `optional` |  |  |
+| 4 | `language_code` | `string` | `optional` |  |  |
 
 </details>
 
@@ -333,14 +333,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 3 | `challenge_instance_id` | `uint32` | `optional` | `` |  |
-| 4 | `challenge_parameter` | `uint32` | `optional` | `` |  |
-| 5 | `challenge_timestamp` | `uint32` | `optional` | `` |  |
-| 6 | `challenge_period_serial` | `uint32` | `optional` | `` |  |
-| 7 | `challenge_progress_at_start` | `uint32` | `optional` | `` |  |
-| 8 | `eligible_account_ids` | `uint32` | `repeated` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 3 | `challenge_instance_id` | `uint32` | `optional` |  |  |
+| 4 | `challenge_parameter` | `uint32` | `optional` |  |  |
+| 5 | `challenge_timestamp` | `uint32` | `optional` |  |  |
+| 6 | `challenge_period_serial` | `uint32` | `optional` |  |  |
+| 7 | `challenge_progress_at_start` | `uint32` | `optional` |  |  |
+| 8 | `eligible_account_ids` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -352,10 +352,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `overall_quality` | `uint32` | `optional` | `` |  |
-| 2 | `team_balance` | `uint32` | `optional` | `` |  |
-| 3 | `match_skill_range` | `uint32` | `optional` | `` |  |
-| 4 | `match_behavior` | `uint32` | `optional` | `` |  |
+| 1 | `overall_quality` | `uint32` | `optional` |  |  |
+| 2 | `team_balance` | `uint32` | `optional` |  |  |
+| 3 | `match_skill_range` | `uint32` | `optional` |  |  |
+| 4 | `match_behavior` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -367,97 +367,97 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `lobby_id` | `uint64` | `optional` | `` | (key_field) = true |
-| 3 | `game_mode` | `uint32` | `optional` | `` |  |
-| 4 | `state` | `.CSODOTALobby.State` | `optional` | `` | default = UI |
-| 5 | `connect` | `string` | `optional` | `` |  |
-| 6 | `server_id` | `fixed64` | `optional` | `` | default = 0 |
-| 10 | `pending_invites` | `fixed64` | `repeated` | `` |  |
-| 11 | `leader_id` | `fixed64` | `optional` | `` |  |
-| 12 | `lobby_type` | `.CSODOTALobby.LobbyType` | `optional` | `` | default = INVALID |
-| 13 | `allow_cheats` | `bool` | `optional` | `` |  |
-| 14 | `fill_with_bots` | `bool` | `optional` | `` |  |
-| 16 | `game_name` | `string` | `optional` | `` |  |
-| 17 | `team_details` | `.CLobbyTeamDetails` | `repeated` | `` |  |
-| 19 | `tournament_id` | `uint32` | `optional` | `` |  |
-| 20 | `tournament_game_id` | `uint32` | `optional` | `` |  |
-| 21 | `server_region` | `uint32` | `optional` | `` | default = 0 |
-| 22 | `game_state` | `.DOTA_GameState` | `optional` | `` | default = DOTA_GAMERULES_STATE_INIT |
-| 23 | `num_spectators` | `uint32` | `optional` | `` |  |
-| 25 | `matchgroup` | `uint32` | `optional` | `` |  |
-| 28 | `cm_pick` | `.DOTA_CM_PICK` | `optional` | `` | default = DOTA_CM_RANDOM |
-| 30 | `match_id` | `uint64` | `optional` | `` |  |
-| 31 | `allow_spectating` | `bool` | `optional` | `` | default = true |
-| 36 | `bot_difficulty_radiant` | `.DOTABotDifficulty` | `optional` | `` | default = BOT_DIFFICULTY_HARD |
-| 39 | `pass_key` | `string` | `optional` | `` |  |
-| 42 | `leagueid` | `uint32` | `optional` | `` |  |
-| 43 | `penalty_level_radiant` | `uint32` | `optional` | `` | default = 0 |
-| 44 | `penalty_level_dire` | `uint32` | `optional` | `` | default = 0 |
-| 46 | `series_type` | `uint32` | `optional` | `` |  |
-| 47 | `radiant_series_wins` | `uint32` | `optional` | `` |  |
-| 48 | `dire_series_wins` | `uint32` | `optional` | `` |  |
-| 51 | `allchat` | `bool` | `optional` | `` | default = false |
-| 53 | `dota_tv_delay` | `.LobbyDotaTVDelay` | `optional` | `` | default = LobbyDotaTV_10 |
-| 54 | `custom_game_mode` | `string` | `optional` | `` |  |
-| 55 | `custom_map_name` | `string` | `optional` | `` |  |
-| 56 | `custom_difficulty` | `uint32` | `optional` | `` |  |
-| 57 | `lan` | `bool` | `optional` | `` |  |
-| 58 | `broadcast_channel_info` | `.CLobbyBroadcastChannelInfo` | `repeated` | `` |  |
-| 59 | `first_leaver_accountid` | `uint32` | `optional` | `` |  |
-| 60 | `series_id` | `uint32` | `optional` | `` |  |
-| 61 | `low_priority` | `bool` | `optional` | `` |  |
-| 62 | `extra_messages` | `.CSODOTALobby.CExtraMsg` | `repeated` | `` |  |
-| 65 | `first_blood_happened` | `bool` | `optional` | `` |  |
-| 67 | `mass_disconnect` | `bool` | `optional` | `` |  |
-| 68 | `custom_game_id` | `uint64` | `optional` | `` |  |
-| 70 | `match_outcome` | `.EMatchOutcome` | `optional` | `` | default = k_EMatchOutcome_Unknown |
-| 71 | `custom_min_players` | `uint32` | `optional` | `` |  |
-| 72 | `custom_max_players` | `uint32` | `optional` | `` |  |
-| 75 | `visibility` | `.DOTALobbyVisibility` | `optional` | `` | default = DOTALobbyVisibility_Public |
-| 76 | `custom_game_crc` | `fixed64` | `optional` | `` |  |
-| 77 | `custom_game_auto_created_lobby` | `bool` | `optional` | `` |  |
-| 80 | `custom_game_timestamp` | `fixed32` | `optional` | `` |  |
-| 81 | `previous_series_matches` | `uint64` | `repeated` | `` |  |
-| 82 | `previous_match_override` | `uint64` | `optional` | `` |  |
-| 87 | `game_start_time` | `uint32` | `optional` | `` |  |
-| 88 | `pause_setting` | `.LobbyDotaPauseSetting` | `optional` | `` | default = LobbyDotaPauseSetting_Unlimited |
-| 90 | `weekend_tourney_division_id` | `uint32` | `optional` | `` |  |
-| 91 | `weekend_tourney_skill_level` | `uint32` | `optional` | `` |  |
-| 92 | `weekend_tourney_bracket_round` | `uint32` | `optional` | `` |  |
-| 93 | `bot_difficulty_dire` | `.DOTABotDifficulty` | `optional` | `` | default = BOT_DIFFICULTY_HARD |
-| 94 | `bot_radiant` | `uint64` | `optional` | `` |  |
-| 95 | `bot_dire` | `uint64` | `optional` | `` |  |
-| 96 | `event_progression_enabled` | `.EEvent` | `repeated` | `` |  |
-| 97 | `selection_priority_rules` | `.DOTASelectionPriorityRules` | `optional` | `` | default = k_DOTASelectionPriorityRules_Manual |
-| 98 | `series_previous_selection_priority_team_id` | `uint32` | `optional` | `` |  |
-| 99 | `series_current_selection_priority_team_id` | `uint32` | `optional` | `` |  |
-| 100 | `series_current_priority_team_choice` | `.DOTASelectionPriorityChoice` | `optional` | `` | default = k_DOTASelectionPriorityChoice_Invalid |
-| 101 | `series_current_non_priority_team_choice` | `.DOTASelectionPriorityChoice` | `optional` | `` | default = k_DOTASelectionPriorityChoice_Invalid |
-| 102 | `series_current_selection_priority_used_coin_toss` | `bool` | `optional` | `` |  |
-| 103 | `current_primary_event` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 104 | `current_primary_event_for_display` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 105 | `emergency_disabled_hero_ids` | `int32` | `repeated` | `` |  |
-| 106 | `custom_game_private_key` | `fixed64` | `optional` | `` |  |
-| 107 | `custom_game_penalties` | `bool` | `optional` | `` |  |
-| 109 | `lan_host_ping_location` | `string` | `optional` | `` |  |
-| 110 | `league_node_id` | `uint32` | `optional` | `` |  |
-| 111 | `match_duration` | `uint32` | `optional` | `` |  |
-| 113 | `league_phase` | `uint32` | `optional` | `` |  |
-| 116 | `experimental_gameplay_enabled` | `bool` | `optional` | `` |  |
-| 117 | `guild_challenges` | `.CLobbyGuildChallenge` | `repeated` | `` |  |
-| 118 | `guild_details` | `.CLobbyGuildDetails` | `repeated` | `` |  |
-| 120 | `all_members` | `.CSODOTALobbyMember` | `repeated` | `` |  |
-| 121 | `member_indices` | `uint32` | `repeated` | `` |  |
-| 122 | `left_member_indices` | `uint32` | `repeated` | `` |  |
-| 123 | `free_member_indices` | `uint32` | `repeated` | `` |  |
-| 124 | `requested_hero_ids` | `int32` | `repeated` | `` |  |
-| 125 | `coach_friend_requests` | `.CMsgLobbyCoachFriendRequest` | `repeated` | `` |  |
-| 126 | `is_in_steam_china` | `bool` | `optional` | `` |  |
-| 127 | `with_scenario_save` | `bool` | `optional` | `` |  |
-| 128 | `lobby_creation_time` | `uint32` | `optional` | `` |  |
-| 129 | `event_game_definition` | `string` | `optional` | `` |  |
-| 131 | `match_quality_data` | `.CDOTALobbyMatchQualityData` | `optional` | `` |  |
-| 132 | `requested_hero_teams` | `int32` | `repeated` | `` |  |
+| 1 | `lobby_id` | `uint64` | `optional` |  | (key_field) = true |
+| 3 | `game_mode` | `uint32` | `optional` |  |  |
+| 4 | `state` | `.CSODOTALobby.State` | `optional` |  | default = UI |
+| 5 | `connect` | `string` | `optional` |  |  |
+| 6 | `server_id` | `fixed64` | `optional` |  | default = 0 |
+| 10 | `pending_invites` | `fixed64` | `repeated` |  |  |
+| 11 | `leader_id` | `fixed64` | `optional` |  |  |
+| 12 | `lobby_type` | `.CSODOTALobby.LobbyType` | `optional` |  | default = INVALID |
+| 13 | `allow_cheats` | `bool` | `optional` |  |  |
+| 14 | `fill_with_bots` | `bool` | `optional` |  |  |
+| 16 | `game_name` | `string` | `optional` |  |  |
+| 17 | `team_details` | `.CLobbyTeamDetails` | `repeated` |  |  |
+| 19 | `tournament_id` | `uint32` | `optional` |  |  |
+| 20 | `tournament_game_id` | `uint32` | `optional` |  |  |
+| 21 | `server_region` | `uint32` | `optional` |  | default = 0 |
+| 22 | `game_state` | `.DOTA_GameState` | `optional` |  | default = DOTA_GAMERULES_STATE_INIT |
+| 23 | `num_spectators` | `uint32` | `optional` |  |  |
+| 25 | `matchgroup` | `uint32` | `optional` |  |  |
+| 28 | `cm_pick` | `.DOTA_CM_PICK` | `optional` |  | default = DOTA_CM_RANDOM |
+| 30 | `match_id` | `uint64` | `optional` |  |  |
+| 31 | `allow_spectating` | `bool` | `optional` |  | default = true |
+| 36 | `bot_difficulty_radiant` | `.DOTABotDifficulty` | `optional` |  | default = BOT_DIFFICULTY_HARD |
+| 39 | `pass_key` | `string` | `optional` |  |  |
+| 42 | `leagueid` | `uint32` | `optional` |  |  |
+| 43 | `penalty_level_radiant` | `uint32` | `optional` |  | default = 0 |
+| 44 | `penalty_level_dire` | `uint32` | `optional` |  | default = 0 |
+| 46 | `series_type` | `uint32` | `optional` |  |  |
+| 47 | `radiant_series_wins` | `uint32` | `optional` |  |  |
+| 48 | `dire_series_wins` | `uint32` | `optional` |  |  |
+| 51 | `allchat` | `bool` | `optional` |  | default = false |
+| 53 | `dota_tv_delay` | `.LobbyDotaTVDelay` | `optional` |  | default = LobbyDotaTV_10 |
+| 54 | `custom_game_mode` | `string` | `optional` |  |  |
+| 55 | `custom_map_name` | `string` | `optional` |  |  |
+| 56 | `custom_difficulty` | `uint32` | `optional` |  |  |
+| 57 | `lan` | `bool` | `optional` |  |  |
+| 58 | `broadcast_channel_info` | `.CLobbyBroadcastChannelInfo` | `repeated` |  |  |
+| 59 | `first_leaver_accountid` | `uint32` | `optional` |  |  |
+| 60 | `series_id` | `uint32` | `optional` |  |  |
+| 61 | `low_priority` | `bool` | `optional` |  |  |
+| 62 | `extra_messages` | `.CSODOTALobby.CExtraMsg` | `repeated` |  |  |
+| 65 | `first_blood_happened` | `bool` | `optional` |  |  |
+| 67 | `mass_disconnect` | `bool` | `optional` |  |  |
+| 68 | `custom_game_id` | `uint64` | `optional` |  |  |
+| 70 | `match_outcome` | `.EMatchOutcome` | `optional` |  | default = k_EMatchOutcome_Unknown |
+| 71 | `custom_min_players` | `uint32` | `optional` |  |  |
+| 72 | `custom_max_players` | `uint32` | `optional` |  |  |
+| 75 | `visibility` | `.DOTALobbyVisibility` | `optional` |  | default = DOTALobbyVisibility_Public |
+| 76 | `custom_game_crc` | `fixed64` | `optional` |  |  |
+| 77 | `custom_game_auto_created_lobby` | `bool` | `optional` |  |  |
+| 80 | `custom_game_timestamp` | `fixed32` | `optional` |  |  |
+| 81 | `previous_series_matches` | `uint64` | `repeated` |  |  |
+| 82 | `previous_match_override` | `uint64` | `optional` |  |  |
+| 87 | `game_start_time` | `uint32` | `optional` |  |  |
+| 88 | `pause_setting` | `.LobbyDotaPauseSetting` | `optional` |  | default = LobbyDotaPauseSetting_Unlimited |
+| 90 | `weekend_tourney_division_id` | `uint32` | `optional` |  |  |
+| 91 | `weekend_tourney_skill_level` | `uint32` | `optional` |  |  |
+| 92 | `weekend_tourney_bracket_round` | `uint32` | `optional` |  |  |
+| 93 | `bot_difficulty_dire` | `.DOTABotDifficulty` | `optional` |  | default = BOT_DIFFICULTY_HARD |
+| 94 | `bot_radiant` | `uint64` | `optional` |  |  |
+| 95 | `bot_dire` | `uint64` | `optional` |  |  |
+| 96 | `event_progression_enabled` | `.EEvent` | `repeated` |  |  |
+| 97 | `selection_priority_rules` | `.DOTASelectionPriorityRules` | `optional` |  | default = k_DOTASelectionPriorityRules_Manual |
+| 98 | `series_previous_selection_priority_team_id` | `uint32` | `optional` |  |  |
+| 99 | `series_current_selection_priority_team_id` | `uint32` | `optional` |  |  |
+| 100 | `series_current_priority_team_choice` | `.DOTASelectionPriorityChoice` | `optional` |  | default = k_DOTASelectionPriorityChoice_Invalid |
+| 101 | `series_current_non_priority_team_choice` | `.DOTASelectionPriorityChoice` | `optional` |  | default = k_DOTASelectionPriorityChoice_Invalid |
+| 102 | `series_current_selection_priority_used_coin_toss` | `bool` | `optional` |  |  |
+| 103 | `current_primary_event` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 104 | `current_primary_event_for_display` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 105 | `emergency_disabled_hero_ids` | `int32` | `repeated` |  |  |
+| 106 | `custom_game_private_key` | `fixed64` | `optional` |  |  |
+| 107 | `custom_game_penalties` | `bool` | `optional` |  |  |
+| 109 | `lan_host_ping_location` | `string` | `optional` |  |  |
+| 110 | `league_node_id` | `uint32` | `optional` |  |  |
+| 111 | `match_duration` | `uint32` | `optional` |  |  |
+| 113 | `league_phase` | `uint32` | `optional` |  |  |
+| 116 | `experimental_gameplay_enabled` | `bool` | `optional` |  |  |
+| 117 | `guild_challenges` | `.CLobbyGuildChallenge` | `repeated` |  |  |
+| 118 | `guild_details` | `.CLobbyGuildDetails` | `repeated` |  |  |
+| 120 | `all_members` | `.CSODOTALobbyMember` | `repeated` |  |  |
+| 121 | `member_indices` | `uint32` | `repeated` |  |  |
+| 122 | `left_member_indices` | `uint32` | `repeated` |  |  |
+| 123 | `free_member_indices` | `uint32` | `repeated` |  |  |
+| 124 | `requested_hero_ids` | `int32` | `repeated` |  |  |
+| 125 | `coach_friend_requests` | `.CMsgLobbyCoachFriendRequest` | `repeated` |  |  |
+| 126 | `is_in_steam_china` | `bool` | `optional` |  |  |
+| 127 | `with_scenario_save` | `bool` | `optional` |  |  |
+| 128 | `lobby_creation_time` | `uint32` | `optional` |  |  |
+| 129 | `event_game_definition` | `string` | `optional` |  |  |
+| 131 | `match_quality_data` | `.CDOTALobbyMatchQualityData` | `optional` |  |  |
+| 132 | `requested_hero_teams` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -469,8 +469,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `uint32` | `optional` | `` |  |
-| 2 | `contents` | `bytes` | `optional` | `` |  |
+| 1 | `id` | `uint32` | `optional` |  |  |
+| 2 | `contents` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -482,9 +482,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `all_members` | `.CSODOTAServerLobbyMember` | `repeated` | `` |  |
-| 2 | `extra_startup_messages` | `.CSODOTALobby.CExtraMsg` | `repeated` | `` |  |
-| 3 | `broadcast_active` | `bool` | `optional` | `` |  |
+| 1 | `all_members` | `.CSODOTAServerLobbyMember` | `repeated` |  |  |
+| 2 | `extra_startup_messages` | `.CSODOTALobby.CExtraMsg` | `repeated` |  |  |
+| 3 | `broadcast_active` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -496,9 +496,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `all_members` | `.CSODOTAStaticLobbyMember` | `repeated` | `` |  |
-| 2 | `is_player_draft` | `bool` | `optional` | `` |  |
-| 3 | `is_last_match_in_series` | `bool` | `optional` | `` |  |
+| 1 | `all_members` | `.CSODOTAStaticLobbyMember` | `repeated` |  |  |
+| 2 | `is_player_draft` | `bool` | `optional` |  |  |
+| 3 | `is_last_match_in_series` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -510,10 +510,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `all_members` | `.CSODOTAServerStaticLobbyMember` | `repeated` | `` |  |
-| 2 | `post_patch_strategy_time_buffer` | `float` | `optional` | `` |  |
-| 3 | `lobby_event_points` | `.CMsgLobbyEventPoints` | `repeated` | `` |  |
-| 4 | `broadcast_url` | `string` | `optional` | `` |  |
+| 1 | `all_members` | `.CSODOTAServerStaticLobbyMember` | `repeated` |  |  |
+| 2 | `post_patch_strategy_time_buffer` | `float` | `optional` |  |  |
+| 3 | `lobby_event_points` | `.CMsgLobbyEventPoints` | `repeated` |  |  |
+| 4 | `broadcast_url` | `string` | `optional` |  |  |
 
 </details>
 
@@ -525,10 +525,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `plus_data` | `.CMsgLobbyPlayerPlusSubscriptionData` | `optional` | `` |  |
-| 3 | `unlocked_chat_wheel_message_ranges` | `.CMsgAdditionalLobbyStartupAccountData.ChatWheelMessageRange` | `repeated` | `` |  |
-| 4 | `unlocked_ping_wheel_message_ranges` | `.CMsgAdditionalLobbyStartupAccountData.PingWheelMessageRange` | `repeated` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `plus_data` | `.CMsgLobbyPlayerPlusSubscriptionData` | `optional` |  |  |
+| 3 | `unlocked_chat_wheel_message_ranges` | `.CMsgAdditionalLobbyStartupAccountData.ChatWheelMessageRange` | `repeated` |  |  |
+| 4 | `unlocked_ping_wheel_message_ranges` | `.CMsgAdditionalLobbyStartupAccountData.PingWheelMessageRange` | `repeated` |  |  |
 
 </details>
 
@@ -540,8 +540,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `message_id_start` | `uint32` | `optional` | `` | default = 4294967295 |
-| 2 | `message_id_end` | `uint32` | `optional` | `` | default = 4294967295 |
+| 1 | `message_id_start` | `uint32` | `optional` |  | default = 4294967295 |
+| 2 | `message_id_end` | `uint32` | `optional` |  | default = 4294967295 |
 
 </details>
 
@@ -553,8 +553,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `message_id_start` | `uint32` | `optional` | `` | default = 4294967295 |
-| 2 | `message_id_end` | `uint32` | `optional` | `` | default = 4294967295 |
+| 1 | `message_id_start` | `uint32` | `optional` |  | default = 4294967295 |
+| 2 | `message_id_end` | `uint32` | `optional` |  | default = 4294967295 |
 
 </details>
 
@@ -578,7 +578,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `json` | `string` | `optional` | `` |  |
+| 1 | `json` | `string` | `optional` |  |  |
 
 </details>
 
@@ -590,15 +590,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 3 | `guild_points` | `uint32` | `optional` | `` |  |
-| 4 | `guild_logo` | `uint64` | `optional` | `` |  |
-| 5 | `guild_primary_color` | `uint32` | `optional` | `` |  |
-| 6 | `guild_secondary_color` | `uint32` | `optional` | `` |  |
-| 7 | `guild_pattern` | `uint32` | `optional` | `` |  |
-| 8 | `guild_flags` | `uint32` | `optional` | `` |  |
-| 9 | `guild_weekly_percentile` | `uint32` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 3 | `guild_points` | `uint32` | `optional` |  |  |
+| 4 | `guild_logo` | `uint64` | `optional` |  |  |
+| 5 | `guild_primary_color` | `uint32` | `optional` |  |  |
+| 6 | `guild_secondary_color` | `uint32` | `optional` |  |  |
+| 7 | `guild_pattern` | `uint32` | `optional` |  |  |
+| 8 | `guild_flags` | `uint32` | `optional` |  |  |
+| 9 | `guild_weekly_percentile` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -610,15 +610,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `event_points` | `.CMsgLobbyEventPoints` | `repeated` | `` |  |
-| 3 | `is_plus_subscriber` | `bool` | `optional` | `` |  |
-| 4 | `primary_event_id` | `uint32` | `optional` | `` |  |
-| 5 | `favorite_team` | `uint32` | `optional` | `` |  |
-| 6 | `favorite_team_quality` | `uint32` | `optional` | `` |  |
-| 7 | `guild_info` | `.CMsgLocalServerGuildData` | `optional` | `` |  |
-| 8 | `teleport_fx_level` | `uint32` | `optional` | `` |  |
-| 9 | `additional_data` | `.CMsgAdditionalLobbyStartupAccountData` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `event_points` | `.CMsgLobbyEventPoints` | `repeated` |  |  |
+| 3 | `is_plus_subscriber` | `bool` | `optional` |  |  |
+| 4 | `primary_event_id` | `uint32` | `optional` |  |  |
+| 5 | `favorite_team` | `uint32` | `optional` |  |  |
+| 6 | `favorite_team_quality` | `uint32` | `optional` |  |  |
+| 7 | `guild_info` | `.CMsgLocalServerGuildData` | `optional` |  |  |
+| 8 | `teleport_fx_level` | `uint32` | `optional` |  |  |
+| 9 | `additional_data` | `.CMsgAdditionalLobbyStartupAccountData` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-common-match-management.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-common-match-management.md
@@ -25,21 +25,21 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `is_coach` | `bool` | `optional` | `` |  |
-| 4 | `region_ping_codes` | `uint32` | `repeated` | `` | packed = true |
-| 5 | `region_ping_times` | `uint32` | `repeated` | `` | packed = true |
-| 6 | `region_ping_failed_bitmask` | `uint32` | `optional` | `` |  |
-| 7 | `tourney_skill_level` | `uint32` | `optional` | `` |  |
-| 8 | `tourney_buyin` | `uint32` | `optional` | `` |  |
-| 9 | `tourney_prevent_until` | `uint32` | `optional` | `` |  |
-| 10 | `is_plus_subscriber` | `bool` | `optional` | `` |  |
-| 11 | `lane_selection_flags` | `uint32` | `optional` | `` |  |
-| 12 | `joined_from_partyfinder` | `bool` | `optional` | `` |  |
-| 13 | `mm_data_valid` | `bool` | `optional` | `` |  |
-| 14 | `high_priority_disabled` | `bool` | `optional` | `` |  |
-| 15 | `has_hp_resource` | `bool` | `optional` | `` |  |
-| 16 | `is_steam_china` | `bool` | `optional` | `` |  |
-| 17 | `banned_hero_ids` | `int32` | `repeated` | `` |  |
+| 2 | `is_coach` | `bool` | `optional` |  |  |
+| 4 | `region_ping_codes` | `uint32` | `repeated` |  | packed = true |
+| 5 | `region_ping_times` | `uint32` | `repeated` |  | packed = true |
+| 6 | `region_ping_failed_bitmask` | `uint32` | `optional` |  |  |
+| 7 | `tourney_skill_level` | `uint32` | `optional` |  |  |
+| 8 | `tourney_buyin` | `uint32` | `optional` |  |  |
+| 9 | `tourney_prevent_until` | `uint32` | `optional` |  |  |
+| 10 | `is_plus_subscriber` | `bool` | `optional` |  |  |
+| 11 | `lane_selection_flags` | `uint32` | `optional` |  |  |
+| 12 | `joined_from_partyfinder` | `bool` | `optional` |  |  |
+| 13 | `mm_data_valid` | `bool` | `optional` |  |  |
+| 14 | `high_priority_disabled` | `bool` | `optional` |  |  |
+| 15 | `has_hp_resource` | `bool` | `optional` |  |  |
+| 16 | `is_steam_china` | `bool` | `optional` |  |  |
+| 17 | `banned_hero_ids` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -51,62 +51,62 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `party_id` | `uint64` | `optional` | `` | (key_field) = true |
-| 2 | `leader_id` | `fixed64` | `optional` | `` |  |
-| 3 | `member_ids` | `fixed64` | `repeated` | `` |  |
-| 4 | `game_modes` | `uint32` | `optional` | `` |  |
-| 6 | `state` | `.CSODOTAParty.State` | `optional` | `` | default = UI |
-| 7 | `effective_started_matchmaking_time` | `uint32` | `optional` | `` |  |
-| 11 | `matchgroups` | `uint32` | `optional` | `` |  |
-| 19 | `low_priority_account_id` | `uint32` | `optional` | `` |  |
-| 21 | `match_type` | `.MatchType` | `optional` | `` | default = MATCH_TYPE_CASUAL |
-| 23 | `team_id` | `uint32` | `optional` | `` |  |
-| 24 | `match_disabled_until_date` | `uint32` | `optional` | `` |  |
-| 25 | `match_disabled_account_id` | `uint32` | `optional` | `` |  |
-| 26 | `matchmaking_max_range_minutes` | `uint32` | `optional` | `` |  |
-| 27 | `matchlanguages` | `uint32` | `optional` | `` |  |
-| 29 | `members` | `.CSODOTAPartyMember` | `repeated` | `` |  |
-| 32 | `raw_started_matchmaking_time` | `uint32` | `optional` | `` |  |
-| 33 | `attempt_start_time` | `uint32` | `optional` | `` |  |
-| 34 | `attempt_num` | `uint32` | `optional` | `` |  |
-| 35 | `low_priority_games_remaining` | `uint32` | `optional` | `` |  |
-| 40 | `open_for_join_requests` | `bool` | `optional` | `` |  |
-| 41 | `sent_invites` | `.CSODOTAPartyInvite` | `repeated` | `` |  |
-| 42 | `recv_invites` | `.CSODOTAPartyInvite` | `repeated` | `` |  |
-| 43 | `account_flags` | `uint32` | `optional` | `` |  |
-| 44 | `region_select_flags` | `uint32` | `optional` | `` |  |
-| 45 | `exclusive_tournament_id` | `uint32` | `optional` | `` |  |
-| 47 | `tourney_division_id` | `uint32` | `optional` | `` |  |
-| 48 | `tourney_schedule_time` | `uint32` | `optional` | `` |  |
-| 49 | `tourney_skill_level` | `uint32` | `optional` | `` |  |
-| 50 | `tourney_bracket_round` | `uint32` | `optional` | `` |  |
-| 51 | `team_name` | `string` | `optional` | `` |  |
-| 52 | `team_ui_logo` | `uint64` | `optional` | `` |  |
-| 53 | `team_base_logo` | `uint64` | `optional` | `` |  |
-| 54 | `tourney_queue_deadline_time` | `uint32` | `optional` | `` |  |
-| 55 | `tourney_queue_deadline_state` | `.ETourneyQueueDeadlineState` | `optional` | `` | default = k_ETourneyQueueDeadlineState_Normal |
-| 56 | `party_builder_slots_to_fill` | `uint32` | `optional` | `` |  |
-| 57 | `party_builder_match_groups` | `uint32` | `optional` | `` |  |
-| 58 | `party_builder_start_time` | `uint32` | `optional` | `` |  |
-| 59 | `solo_queue` | `bool` | `optional` | `` |  |
-| 61 | `steam_clan_account_id` | `uint32` | `optional` | `` |  |
-| 62 | `ready_check` | `.CMsgReadyCheckStatus` | `optional` | `` |  |
-| 63 | `custom_game_disabled_until_date` | `uint32` | `optional` | `` |  |
-| 64 | `custom_game_disabled_account_id` | `uint32` | `optional` | `` |  |
-| 65 | `is_challenge_match` | `bool` | `optional` | `` |  |
-| 66 | `party_search_beacon_active` | `bool` | `optional` | `` |  |
-| 67 | `matchmaking_flags` | `uint32` | `optional` | `` |  |
-| 68 | `high_priority_state` | `.EHighPriorityMMState` | `optional` | `` | default = k_EHighPriorityMM_Unknown |
-| 69 | `lane_selections_enabled` | `bool` | `optional` | `` |  |
-| 70 | `custom_game_difficulty_mask` | `uint32` | `optional` | `` |  |
-| 71 | `is_steam_china` | `bool` | `optional` | `` |  |
-| 72 | `bot_difficulty_mask` | `uint32` | `optional` | `` |  |
-| 73 | `bot_script_index_mask` | `uint32` | `optional` | `` |  |
-| 74 | `restricted_from_ranked` | `bool` | `optional` | `` |  |
-| 75 | `restricted_from_ranked_account_id` | `uint32` | `optional` | `` |  |
-| 76 | `rank_spread_likert_scale` | `uint32` | `optional` | `` |  |
-| 77 | `behavior_score_likert_scale` | `uint32` | `optional` | `` |  |
-| 78 | `contains_required_playtester` | `bool` | `optional` | `` |  |
+| 1 | `party_id` | `uint64` | `optional` |  | (key_field) = true |
+| 2 | `leader_id` | `fixed64` | `optional` |  |  |
+| 3 | `member_ids` | `fixed64` | `repeated` |  |  |
+| 4 | `game_modes` | `uint32` | `optional` |  |  |
+| 6 | `state` | `.CSODOTAParty.State` | `optional` |  | default = UI |
+| 7 | `effective_started_matchmaking_time` | `uint32` | `optional` |  |  |
+| 11 | `matchgroups` | `uint32` | `optional` |  |  |
+| 19 | `low_priority_account_id` | `uint32` | `optional` |  |  |
+| 21 | `match_type` | `.MatchType` | `optional` |  | default = MATCH_TYPE_CASUAL |
+| 23 | `team_id` | `uint32` | `optional` |  |  |
+| 24 | `match_disabled_until_date` | `uint32` | `optional` |  |  |
+| 25 | `match_disabled_account_id` | `uint32` | `optional` |  |  |
+| 26 | `matchmaking_max_range_minutes` | `uint32` | `optional` |  |  |
+| 27 | `matchlanguages` | `uint32` | `optional` |  |  |
+| 29 | `members` | `.CSODOTAPartyMember` | `repeated` |  |  |
+| 32 | `raw_started_matchmaking_time` | `uint32` | `optional` |  |  |
+| 33 | `attempt_start_time` | `uint32` | `optional` |  |  |
+| 34 | `attempt_num` | `uint32` | `optional` |  |  |
+| 35 | `low_priority_games_remaining` | `uint32` | `optional` |  |  |
+| 40 | `open_for_join_requests` | `bool` | `optional` |  |  |
+| 41 | `sent_invites` | `.CSODOTAPartyInvite` | `repeated` |  |  |
+| 42 | `recv_invites` | `.CSODOTAPartyInvite` | `repeated` |  |  |
+| 43 | `account_flags` | `uint32` | `optional` |  |  |
+| 44 | `region_select_flags` | `uint32` | `optional` |  |  |
+| 45 | `exclusive_tournament_id` | `uint32` | `optional` |  |  |
+| 47 | `tourney_division_id` | `uint32` | `optional` |  |  |
+| 48 | `tourney_schedule_time` | `uint32` | `optional` |  |  |
+| 49 | `tourney_skill_level` | `uint32` | `optional` |  |  |
+| 50 | `tourney_bracket_round` | `uint32` | `optional` |  |  |
+| 51 | `team_name` | `string` | `optional` |  |  |
+| 52 | `team_ui_logo` | `uint64` | `optional` |  |  |
+| 53 | `team_base_logo` | `uint64` | `optional` |  |  |
+| 54 | `tourney_queue_deadline_time` | `uint32` | `optional` |  |  |
+| 55 | `tourney_queue_deadline_state` | `.ETourneyQueueDeadlineState` | `optional` |  | default = k_ETourneyQueueDeadlineState_Normal |
+| 56 | `party_builder_slots_to_fill` | `uint32` | `optional` |  |  |
+| 57 | `party_builder_match_groups` | `uint32` | `optional` |  |  |
+| 58 | `party_builder_start_time` | `uint32` | `optional` |  |  |
+| 59 | `solo_queue` | `bool` | `optional` |  |  |
+| 61 | `steam_clan_account_id` | `uint32` | `optional` |  |  |
+| 62 | `ready_check` | `.CMsgReadyCheckStatus` | `optional` |  |  |
+| 63 | `custom_game_disabled_until_date` | `uint32` | `optional` |  |  |
+| 64 | `custom_game_disabled_account_id` | `uint32` | `optional` |  |  |
+| 65 | `is_challenge_match` | `bool` | `optional` |  |  |
+| 66 | `party_search_beacon_active` | `bool` | `optional` |  |  |
+| 67 | `matchmaking_flags` | `uint32` | `optional` |  |  |
+| 68 | `high_priority_state` | `.EHighPriorityMMState` | `optional` |  | default = k_EHighPriorityMM_Unknown |
+| 69 | `lane_selections_enabled` | `bool` | `optional` |  |  |
+| 70 | `custom_game_difficulty_mask` | `uint32` | `optional` |  |  |
+| 71 | `is_steam_china` | `bool` | `optional` |  |  |
+| 72 | `bot_difficulty_mask` | `uint32` | `optional` |  |  |
+| 73 | `bot_script_index_mask` | `uint32` | `optional` |  |  |
+| 74 | `restricted_from_ranked` | `bool` | `optional` |  |  |
+| 75 | `restricted_from_ranked_account_id` | `uint32` | `optional` |  |  |
+| 76 | `rank_spread_likert_scale` | `uint32` | `optional` |  |  |
+| 77 | `behavior_score_likert_scale` | `uint32` | `optional` |  |  |
+| 78 | `contains_required_playtester` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -118,14 +118,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `group_id` | `uint64` | `optional` | `` | (key_field) = true |
-| 2 | `sender_id` | `fixed64` | `optional` | `` |  |
-| 3 | `sender_name` | `string` | `optional` | `` |  |
-| 4 | `members` | `.CSODOTAPartyInvite.PartyMember` | `repeated` | `` |  |
-| 5 | `team_id` | `uint32` | `optional` | `` |  |
-| 6 | `low_priority_status` | `bool` | `optional` | `` |  |
-| 7 | `as_coach` | `bool` | `optional` | `` |  |
-| 8 | `invite_gid` | `fixed64` | `optional` | `` |  |
+| 1 | `group_id` | `uint64` | `optional` |  | (key_field) = true |
+| 2 | `sender_id` | `fixed64` | `optional` |  |  |
+| 3 | `sender_name` | `string` | `optional` |  |  |
+| 4 | `members` | `.CSODOTAPartyInvite.PartyMember` | `repeated` |  |  |
+| 5 | `team_id` | `uint32` | `optional` |  |  |
+| 6 | `low_priority_status` | `bool` | `optional` |  |  |
+| 7 | `as_coach` | `bool` | `optional` |  |  |
+| 8 | `invite_gid` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -137,9 +137,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `steam_id` | `fixed64` | `optional` | `` |  |
-| 4 | `is_coach` | `bool` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `steam_id` | `fixed64` | `optional` |  |  |
+| 4 | `is_coach` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -151,12 +151,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `lobby_state` | `uint32` | `optional` | `` |  |
-| 2 | `game_state` | `.DOTA_GameState` | `optional` | `` | default = DOTA_GAMERULES_STATE_INIT |
-| 3 | `leaver_detected` | `bool` | `optional` | `` |  |
-| 4 | `first_blood_happened` | `bool` | `optional` | `` |  |
-| 5 | `discard_match_results` | `bool` | `optional` | `` |  |
-| 6 | `mass_disconnect` | `bool` | `optional` | `` |  |
+| 1 | `lobby_state` | `uint32` | `optional` |  |  |
+| 2 | `game_state` | `.DOTA_GameState` | `optional` |  | default = DOTA_GAMERULES_STATE_INIT |
+| 3 | `leaver_detected` | `bool` | `optional` |  |  |
+| 4 | `first_blood_happened` | `bool` | `optional` |  |  |
+| 5 | `discard_match_results` | `bool` | `optional` |  |  |
+| 6 | `mass_disconnect` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -168,10 +168,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `start_timestamp` | `uint32` | `optional` | `` |  |
-| 2 | `finish_timestamp` | `uint32` | `optional` | `` |  |
-| 3 | `initiator_account_id` | `uint32` | `optional` | `` |  |
-| 4 | `ready_members` | `.CMsgReadyCheckStatus.ReadyMember` | `repeated` | `` |  |
+| 1 | `start_timestamp` | `uint32` | `optional` |  |  |
+| 2 | `finish_timestamp` | `uint32` | `optional` |  |  |
+| 3 | `initiator_account_id` | `uint32` | `optional` |  |  |
+| 4 | `ready_members` | `.CMsgReadyCheckStatus.ReadyMember` | `repeated` |  |  |
 
 </details>
 
@@ -183,8 +183,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `ready_status` | `.EReadyCheckStatus` | `optional` | `` | default = k_EReadyCheckStatus_Unknown |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `ready_status` | `.EReadyCheckStatus` | `optional` |  | default = k_EReadyCheckStatus_Unknown |
 
 </details>
 
@@ -208,7 +208,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.EReadyCheckRequestResult` | `optional` | `` | default = k_EReadyCheckRequestResult_Success |
+| 1 | `result` | `.EReadyCheckRequestResult` | `optional` |  | default = k_EReadyCheckRequestResult_Success |
 
 </details>
 
@@ -220,7 +220,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ready_status` | `.EReadyCheckStatus` | `optional` | `` | default = k_EReadyCheckStatus_Unknown |
+| 1 | `ready_status` | `.EReadyCheckStatus` | `optional` |  | default = k_EReadyCheckStatus_Unknown |
 
 </details>
 
@@ -232,7 +232,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `kv_data` | `bytes` | `optional` | `` |  |
+| 1 | `kv_data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -244,9 +244,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `average_queue_time` | `uint32` | `optional` | `` |  |
-| 2 | `maximum_queue_time` | `uint32` | `optional` | `` |  |
-| 3 | `behavior_score_variance` | `.EMatchBehaviorScoreVariance` | `optional` | `` | default = k_EMatchBehaviorScoreVariance_Invalid |
+| 1 | `average_queue_time` | `uint32` | `optional` |  |  |
+| 2 | `maximum_queue_time` | `uint32` | `optional` |  |  |
+| 3 | `behavior_score_variance` | `.EMatchBehaviorScoreVariance` | `optional` |  | default = k_EMatchBehaviorScoreVariance_Invalid |
 
 </details>
 
@@ -258,8 +258,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `mvps` | `.CMvpData.MvpDatum` | `repeated` | `` |  |
-| 2 | `event_mvps` | `.CMvpData.MvpDatum` | `repeated` | `` |  |
+| 1 | `mvps` | `.CMvpData.MvpDatum` | `repeated` |  |  |
+| 2 | `event_mvps` | `.CMvpData.MvpDatum` | `repeated` |  |  |
 
 </details>
 
@@ -271,8 +271,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_slot` | `uint32` | `optional` | `` |  |
-| 2 | `accolades` | `.CMvpData.MvpDatum.MvpAccolade` | `repeated` | `` |  |
+| 1 | `player_slot` | `uint32` | `optional` |  |  |
+| 2 | `accolades` | `.CMvpData.MvpDatum.MvpAccolade` | `repeated` |  |  |
 
 </details>
 
@@ -284,8 +284,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `type` | `.CMvpData.MvpDatum.MvpAccolade.MvpAccoladeType` | `optional` | `` | default = kills |
-| 2 | `detail_value` | `float` | `optional` | `` |  |
+| 1 | `type` | `.CMvpData.MvpDatum.MvpAccolade.MvpAccoladeType` | `optional` |  | default = kills |
+| 2 | `detail_value` | `float` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-common-monster-hunter.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-common-monster-hunter.md
@@ -26,8 +26,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `material_id` | `uint32` | `optional` | `` |  |
-| 2 | `material_count` | `uint32` | `optional` | `` |  |
+| 1 | `material_id` | `uint32` | `optional` |  |  |
+| 2 | `material_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -39,8 +39,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `stats` | `uint32` | `repeated` | `` |  |
-| 2 | `unlocked` | `bool` | `optional` | `` |  |
+| 1 | `stats` | `uint32` | `repeated` |  |  |
+| 2 | `unlocked` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -52,9 +52,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `material_inventory` | `.CMsgMonsterHunterMaterialQuantity` | `optional` | `` |  |
-| 2 | `hero_codex` | `.CMsgMonsterHunterUserData.HeroCodexEntry` | `repeated` | `` |  |
-| 3 | `unlocked_count` | `int32` | `optional` | `` |  |
+| 1 | `material_inventory` | `.CMsgMonsterHunterMaterialQuantity` | `optional` |  |  |
+| 2 | `hero_codex` | `.CMsgMonsterHunterUserData.HeroCodexEntry` | `repeated` |  |  |
+| 3 | `unlocked_count` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -66,8 +66,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key` | `int32` | `optional` | `` |  |
-| 2 | `value` | `.CMsgMonsterHunterHeroCodexEntry` | `optional` | `` |  |
+| 1 | `key` | `int32` | `optional` |  |  |
+| 2 | `value` | `.CMsgMonsterHunterHeroCodexEntry` | `optional` |  |  |
 
 </details>
 
@@ -79,7 +79,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `players` | `.CMsgMonsterHunterMatchRewards.Player` | `repeated` | `` |  |
+| 1 | `players` | `.CMsgMonsterHunterMatchRewards.Player` | `repeated` |  |  |
 
 </details>
 
@@ -91,12 +91,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_slot` | `uint32` | `optional` | `` |  |
-| 2 | `possible_match_reward_materials` | `.CMsgMonsterHunterMaterialQuantity` | `optional` | `` |  |
-| 3 | `actual_match_reward_materials` | `.CMsgMonsterHunterMaterialQuantity` | `optional` | `` |  |
-| 4 | `hunt_reward` | `.CMsgMonsterHunterMatchRewards.Player.HuntReward` | `optional` | `` |  |
-| 5 | `denial_rewards` | `.CMsgMonsterHunterMatchRewards.Player.HuntReward` | `repeated` | `` |  |
-| 6 | `hunter_duel` | `bool` | `optional` | `` |  |
+| 1 | `player_slot` | `uint32` | `optional` |  |  |
+| 2 | `possible_match_reward_materials` | `.CMsgMonsterHunterMaterialQuantity` | `optional` |  |  |
+| 3 | `actual_match_reward_materials` | `.CMsgMonsterHunterMaterialQuantity` | `optional` |  |  |
+| 4 | `hunt_reward` | `.CMsgMonsterHunterMatchRewards.Player.HuntReward` | `optional` |  |  |
+| 5 | `denial_rewards` | `.CMsgMonsterHunterMatchRewards.Player.HuntReward` | `repeated` |  |  |
+| 6 | `hunter_duel` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -108,9 +108,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `materials` | `.CMsgMonsterHunterMaterialQuantity` | `optional` | `` |  |
-| 3 | `success` | `bool` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `materials` | `.CMsgMonsterHunterMaterialQuantity` | `optional` |  |  |
+| 3 | `success` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -134,8 +134,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCMonsterHunterGetUserDataResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `user_data` | `.CMsgMonsterHunterUserData` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCMonsterHunterGetUserDataResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `user_data` | `.CMsgMonsterHunterUserData` | `optional` |  |  |
 
 </details>
 
@@ -147,7 +147,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `user_data` | `.CMsgMonsterHunterUserData` | `optional` | `` |  |
+| 1 | `user_data` | `.CMsgMonsterHunterUserData` | `optional` |  |  |
 
 </details>
 
@@ -172,9 +172,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCMonsterHunterClaimRewardResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `claim_response` | `.CMsgDOTAClaimEventActionResponse` | `optional` | `` |  |
-| 3 | `materials_received` | `.CMsgMonsterHunterMaterialQuantity` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCMonsterHunterClaimRewardResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `claim_response` | `.CMsgDOTAClaimEventActionResponse` | `optional` |  |  |
+| 3 | `materials_received` | `.CMsgMonsterHunterMaterialQuantity` | `optional` |  |  |
 
 </details>
 
@@ -186,8 +186,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `econ_item_id` | `uint32` | `optional` | `` |  |
-| 2 | `set_index` | `uint32` | `optional` | `` |  |
+| 1 | `econ_item_id` | `uint32` | `optional` |  |  |
+| 2 | `set_index` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -199,7 +199,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_sets` | `.CMsgMonsterHunterItemSet` | `repeated` | `` |  |
+| 1 | `item_sets` | `.CMsgMonsterHunterItemSet` | `repeated` |  |  |
 
 </details>
 
@@ -211,8 +211,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCMonsterHunterClaimSetRewardResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `claim_responses` | `.CMsgDOTAClaimEventActionResponse` | `repeated` | `` |  |
+| 1 | `response` | `.CMsgClientToGCMonsterHunterClaimSetRewardResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `claim_responses` | `.CMsgDOTAClaimEventActionResponse` | `repeated` |  |  |
 
 </details>
 
@@ -224,9 +224,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `material_offer` | `.CMsgMonsterHunterMaterialQuantity` | `optional` | `` |  |
-| 2 | `material_request` | `.CMsgMonsterHunterMaterialQuantity` | `optional` | `` |  |
-| 3 | `recipe_id` | `uint32` | `optional` | `` |  |
+| 1 | `material_offer` | `.CMsgMonsterHunterMaterialQuantity` | `optional` |  |  |
+| 2 | `material_request` | `.CMsgMonsterHunterMaterialQuantity` | `optional` |  |  |
+| 3 | `recipe_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -238,8 +238,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCMonsterHunterTradeMaterialsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `materials_received` | `.CMsgMonsterHunterMaterialQuantity` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCMonsterHunterTradeMaterialsResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `materials_received` | `.CMsgMonsterHunterMaterialQuantity` | `optional` |  |  |
 
 </details>
 
@@ -251,9 +251,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `token_gift` | `.CMsgMonsterHunterMaterialCount` | `optional` | `` |  |
-| 2 | `recipient_account_id` | `uint32` | `optional` | `` |  |
-| 3 | `periodic_resource_id` | `uint32` | `optional` | `` |  |
+| 1 | `token_gift` | `.CMsgMonsterHunterMaterialCount` | `optional` |  |  |
+| 2 | `recipient_account_id` | `uint32` | `optional` |  |  |
+| 3 | `periodic_resource_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -265,7 +265,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCMonsterHunterGiftMaterialsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCMonsterHunterGiftMaterialsResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -277,7 +277,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `friend_account_id` | `uint32` | `optional` | `` |  |
+| 1 | `friend_account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -289,8 +289,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCMonsterHunterRequestMaterialsNeededByFriendResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `token_quantity` | `.CMsgMonsterHunterMaterialQuantity` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCMonsterHunterRequestMaterialsNeededByFriendResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `token_quantity` | `.CMsgMonsterHunterMaterialQuantity` | `optional` |  |  |
 
 </details>
 
@@ -302,7 +302,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `reset_codex_only` | `bool` | `optional` | `` |  |
+| 1 | `reset_codex_only` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -314,7 +314,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCMonsterHunterDevResetAllResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCMonsterHunterDevResetAllResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -326,7 +326,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `material_quantity` | `.CMsgMonsterHunterMaterialQuantity` | `optional` | `` |  |
+| 1 | `material_quantity` | `.CMsgMonsterHunterMaterialQuantity` | `optional` |  |  |
 
 </details>
 
@@ -338,7 +338,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCMonsterHunterDevGrantMaterialsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCMonsterHunterDevGrantMaterialsResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -362,7 +362,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCMonsterHunterDevClearInventoryResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCMonsterHunterDevClearInventoryResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -374,8 +374,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `investigation_game_state` | `.CMsgMonsterHunterInvestigationGameState` | `optional` | `` |  |
-| 2 | `win` | `bool` | `optional` | `` |  |
+| 1 | `investigation_game_state` | `.CMsgMonsterHunterInvestigationGameState` | `optional` |  |  |
+| 2 | `win` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -387,7 +387,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCMonsterHunterDevClaimInvestigationRewardsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCMonsterHunterDevClaimInvestigationRewardsResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -399,8 +399,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `codex_id` | `uint32` | `optional` | `` |  |
-| 2 | `reward` | `uint32` | `optional` | `` |  |
+| 1 | `codex_id` | `uint32` | `optional` |  |  |
+| 2 | `reward` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -412,8 +412,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCMonsterHunterClaimCodexRewardResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `claim_response` | `.CMsgDOTAClaimEventActionResponse` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCMonsterHunterClaimCodexRewardResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `claim_response` | `.CMsgDOTAClaimEventActionResponse` | `optional` |  |  |
 
 </details>
 
@@ -425,9 +425,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `codex_id` | `uint32` | `optional` | `` |  |
-| 2 | `stat_type` | `.EHeroCodexEntryStatType` | `optional` | `` | default = k_eHeroCodexEntryStatType_Killed |
-| 3 | `action` | `.CMsgDevModifyCodexAction.EAction` | `optional` | `` | default = k_eClear |
+| 1 | `codex_id` | `uint32` | `optional` |  |  |
+| 2 | `stat_type` | `.EHeroCodexEntryStatType` | `optional` |  | default = k_eHeroCodexEntryStatType_Killed |
+| 3 | `action` | `.CMsgDevModifyCodexAction.EAction` | `optional` |  | default = k_eClear |
 
 </details>
 
@@ -439,7 +439,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `actions` | `.CMsgDevModifyCodexAction` | `repeated` | `` |  |
+| 1 | `actions` | `.CMsgDevModifyCodexAction` | `repeated` |  |  |
 
 </details>
 
@@ -451,7 +451,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCMonsterHunterDevModifyHeroCodexResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCMonsterHunterDevModifyHeroCodexResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -463,8 +463,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `language` | `uint32` | `optional` | `` |  |
-| 2 | `feedback` | `string` | `optional` | `` |  |
+| 1 | `language` | `uint32` | `optional` |  |  |
+| 2 | `feedback` | `string` | `optional` |  |  |
 
 </details>
 
@@ -476,7 +476,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCMonsterHunterFeedbackResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCMonsterHunterFeedbackResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-common-overworld.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-common-overworld.md
@@ -27,8 +27,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `token_id` | `uint32` | `optional` | `` |  |
-| 2 | `token_count` | `uint32` | `optional` | `` |  |
+| 1 | `token_id` | `uint32` | `optional` |  |  |
+| 2 | `token_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -40,7 +40,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `token_counts` | `.CMsgOverworldTokenCount` | `repeated` | `` |  |
+| 1 | `token_counts` | `.CMsgOverworldTokenCount` | `repeated` |  |  |
 
 </details>
 
@@ -52,7 +52,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `reward_options` | `.CMsgOverworldEncounterTokenTreasureData.RewardOption` | `repeated` | `` |  |
+| 1 | `reward_options` | `.CMsgOverworldEncounterTokenTreasureData.RewardOption` | `repeated` |  |  |
 
 </details>
 
@@ -64,9 +64,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `reward_data` | `uint32` | `optional` | `` |  |
-| 2 | `token_cost` | `.CMsgOverworldTokenQuantity` | `optional` | `` |  |
-| 3 | `token_reward` | `.CMsgOverworldTokenQuantity` | `optional` | `` |  |
+| 1 | `reward_data` | `uint32` | `optional` |  |  |
+| 2 | `token_cost` | `.CMsgOverworldTokenQuantity` | `optional` |  |  |
+| 3 | `token_reward` | `.CMsgOverworldTokenQuantity` | `optional` |  |  |
 
 </details>
 
@@ -78,7 +78,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `quests` | `.CMsgOverworldEncounterTokenQuestData.Quest` | `repeated` | `` |  |
+| 1 | `quests` | `.CMsgOverworldEncounterTokenQuestData.Quest` | `repeated` |  |  |
 
 </details>
 
@@ -90,9 +90,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `reward_data` | `uint32` | `optional` | `` |  |
-| 2 | `token_cost` | `.CMsgOverworldTokenQuantity` | `optional` | `` |  |
-| 3 | `token_reward` | `.CMsgOverworldTokenQuantity` | `optional` | `` |  |
+| 1 | `reward_data` | `uint32` | `optional` |  |  |
+| 2 | `token_cost` | `.CMsgOverworldTokenQuantity` | `optional` |  |  |
+| 3 | `token_reward` | `.CMsgOverworldTokenQuantity` | `optional` |  |  |
 
 </details>
 
@@ -104,7 +104,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_ids` | `int32` | `repeated` | `` |  |
+| 1 | `hero_ids` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -116,8 +116,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_list` | `.CMsgOverworldHeroList` | `optional` | `` |  |
-| 2 | `additive` | `bool` | `optional` | `` |  |
+| 1 | `hero_list` | `.CMsgOverworldHeroList` | `optional` |  |  |
+| 2 | `additive` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -129,10 +129,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `choice` | `int32` | `optional` | `` |  |
-| 2 | `progress` | `int32` | `optional` | `` |  |
-| 3 | `max_progress` | `int32` | `optional` | `` |  |
-| 4 | `visited` | `bool` | `optional` | `` |  |
+| 1 | `choice` | `int32` | `optional` |  |  |
+| 2 | `progress` | `int32` | `optional` |  |  |
+| 3 | `max_progress` | `int32` | `optional` |  |  |
+| 4 | `visited` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -144,7 +144,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `extra_encounter_data` | `.CExtraMsgBlock` | `repeated` | `` |  |
+| 1 | `extra_encounter_data` | `.CExtraMsgBlock` | `repeated` |  |  |
 
 </details>
 
@@ -156,9 +156,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `node_id` | `uint32` | `optional` | `` |  |
-| 2 | `node_state` | `.EOverworldNodeState` | `optional` | `` | default = k_eOverworldNodeState_Invalid |
-| 3 | `node_encounter_data` | `.CMsgOverworldEncounterData` | `optional` | `` |  |
+| 1 | `node_id` | `uint32` | `optional` |  |  |
+| 2 | `node_state` | `.EOverworldNodeState` | `optional` |  | default = k_eOverworldNodeState_Invalid |
+| 3 | `node_encounter_data` | `.CMsgOverworldEncounterData` | `optional` |  |  |
 
 </details>
 
@@ -170,9 +170,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `path_id` | `uint32` | `optional` | `` |  |
-| 2 | `path_cost` | `.CMsgOverworldTokenQuantity` | `optional` | `` |  |
-| 3 | `path_state` | `.EOverworldPathState` | `optional` | `` | default = k_eOverworldPathState_Invalid |
+| 1 | `path_id` | `uint32` | `optional` |  |  |
+| 2 | `path_cost` | `.CMsgOverworldTokenQuantity` | `optional` |  |  |
+| 3 | `path_state` | `.EOverworldPathState` | `optional` |  | default = k_eOverworldPathState_Invalid |
 
 </details>
 
@@ -196,9 +196,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `node_id` | `uint32` | `optional` | `` |  |
-| 2 | `currency_amount` | `uint32` | `optional` | `` |  |
-| 3 | `custom_data` | `.CMsgOverworldMinigameCustomData` | `optional` | `` |  |
+| 1 | `node_id` | `uint32` | `optional` |  |  |
+| 2 | `currency_amount` | `uint32` | `optional` |  |  |
+| 3 | `custom_data` | `.CMsgOverworldMinigameCustomData` | `optional` |  |  |
 
 </details>
 
@@ -210,10 +210,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `fortune1` | `uint32` | `optional` | `` |  |
-| 2 | `fortune2` | `uint32` | `optional` | `` |  |
-| 3 | `fortune3` | `uint32` | `optional` | `` |  |
-| 4 | `timestamp` | `uint32` | `optional` | `` |  |
+| 1 | `fortune1` | `uint32` | `optional` |  |  |
+| 2 | `fortune2` | `uint32` | `optional` |  |  |
+| 3 | `fortune3` | `uint32` | `optional` |  |  |
+| 4 | `timestamp` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -225,12 +225,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `token_inventory` | `.CMsgOverworldTokenQuantity` | `optional` | `` |  |
-| 2 | `overworld_nodes` | `.CMsgOverworldNode` | `repeated` | `` |  |
-| 3 | `overworld_paths` | `.CMsgOverworldPath` | `repeated` | `` |  |
-| 4 | `current_node_id` | `uint32` | `optional` | `` |  |
-| 5 | `minigame_data` | `.CMsgOverworldUserData.MinigameDataEntry` | `repeated` | `` |  |
-| 6 | `current_fortune` | `.CMsgOverworldFortune` | `optional` | `` |  |
+| 1 | `token_inventory` | `.CMsgOverworldTokenQuantity` | `optional` |  |  |
+| 2 | `overworld_nodes` | `.CMsgOverworldNode` | `repeated` |  |  |
+| 3 | `overworld_paths` | `.CMsgOverworldPath` | `repeated` |  |  |
+| 4 | `current_node_id` | `uint32` | `optional` |  |  |
+| 5 | `minigame_data` | `.CMsgOverworldUserData.MinigameDataEntry` | `repeated` |  |  |
+| 6 | `current_fortune` | `.CMsgOverworldFortune` | `optional` |  |  |
 
 </details>
 
@@ -242,8 +242,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `.CMsgOverworldMinigameUserData` | `optional` | `` |  |
+| 1 | `key` | `uint32` | `optional` |  |  |
+| 2 | `value` | `.CMsgOverworldMinigameUserData` | `optional` |  |  |
 
 </details>
 
@@ -255,7 +255,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `players` | `.CMsgOverworldMatchRewards.Player` | `repeated` | `` |  |
+| 1 | `players` | `.CMsgOverworldMatchRewards.Player` | `repeated` |  |  |
 
 </details>
 
@@ -267,9 +267,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_slot` | `uint32` | `optional` | `` |  |
-| 2 | `tokens` | `.CMsgOverworldTokenQuantity` | `optional` | `` |  |
-| 3 | `overworld_id` | `uint32` | `optional` | `` |  |
+| 1 | `player_slot` | `uint32` | `optional` |  |  |
+| 2 | `tokens` | `.CMsgOverworldTokenQuantity` | `optional` |  |  |
+| 3 | `overworld_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -281,7 +281,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `overworld_id` | `uint32` | `optional` | `` |  |
+| 1 | `overworld_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -293,8 +293,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCOverworldGetUserDataResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `user_data` | `.CMsgOverworldUserData` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCOverworldGetUserDataResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `user_data` | `.CMsgOverworldUserData` | `optional` |  |  |
 
 </details>
 
@@ -306,8 +306,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `overworld_id` | `uint32` | `optional` | `` |  |
-| 2 | `user_data` | `.CMsgOverworldUserData` | `optional` | `` |  |
+| 1 | `overworld_id` | `uint32` | `optional` |  |  |
+| 2 | `user_data` | `.CMsgOverworldUserData` | `optional` |  |  |
 
 </details>
 
@@ -319,8 +319,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `overworld_id` | `uint32` | `optional` | `` |  |
-| 2 | `path_id` | `uint32` | `optional` | `` |  |
+| 1 | `overworld_id` | `uint32` | `optional` |  |  |
+| 2 | `path_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -332,8 +332,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCOverworldCompletePathResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `claim_response` | `.CMsgDOTAClaimEventActionResponse` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCOverworldCompletePathResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `claim_response` | `.CMsgDOTAClaimEventActionResponse` | `optional` |  |  |
 
 </details>
 
@@ -345,8 +345,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `token_id` | `uint32` | `optional` | `` |  |
-| 2 | `choice` | `uint32` | `optional` | `` |  |
+| 1 | `token_id` | `uint32` | `optional` |  |  |
+| 2 | `choice` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -358,14 +358,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `overworld_id` | `uint32` | `optional` | `` |  |
-| 2 | `node_id` | `uint32` | `optional` | `` |  |
-| 3 | `reward_data` | `uint32` | `optional` | `` |  |
-| 4 | `periodic_resource_id` | `uint32` | `optional` | `` |  |
-| 5 | `extra_reward_data` | `.CMsgOverworldEncounterData` | `optional` | `` |  |
-| 6 | `leaderboard_data` | `uint32` | `optional` | `` |  |
-| 7 | `leaderboard_index` | `uint32` | `optional` | `` |  |
-| 8 | `should_claim_reward` | `bool` | `optional` | `` |  |
+| 1 | `overworld_id` | `uint32` | `optional` |  |  |
+| 2 | `node_id` | `uint32` | `optional` |  |  |
+| 3 | `reward_data` | `uint32` | `optional` |  |  |
+| 4 | `periodic_resource_id` | `uint32` | `optional` |  |  |
+| 5 | `extra_reward_data` | `.CMsgOverworldEncounterData` | `optional` |  |  |
+| 6 | `leaderboard_data` | `uint32` | `optional` |  |  |
+| 7 | `leaderboard_index` | `uint32` | `optional` |  |  |
+| 8 | `should_claim_reward` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -377,9 +377,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCOverworldClaimEncounterRewardResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `claim_response` | `.CMsgDOTAClaimEventActionResponse` | `optional` | `` |  |
-| 3 | `tokens_received` | `.CMsgOverworldTokenQuantity` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCOverworldClaimEncounterRewardResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `claim_response` | `.CMsgDOTAClaimEventActionResponse` | `optional` |  |  |
+| 3 | `tokens_received` | `.CMsgOverworldTokenQuantity` | `optional` |  |  |
 
 </details>
 
@@ -391,8 +391,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `overworld_id` | `uint32` | `optional` | `` |  |
-| 2 | `node_id` | `uint32` | `optional` | `` |  |
+| 1 | `overworld_id` | `uint32` | `optional` |  |  |
+| 2 | `node_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -404,7 +404,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCOverworldVisitEncounterResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCOverworldVisitEncounterResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -416,8 +416,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `overworld_id` | `uint32` | `optional` | `` |  |
-| 2 | `node_id` | `uint32` | `optional` | `` |  |
+| 1 | `overworld_id` | `uint32` | `optional` |  |  |
+| 2 | `node_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -429,7 +429,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCOverworldMoveToNodeResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCOverworldMoveToNodeResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -441,11 +441,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `overworld_id` | `uint32` | `optional` | `` |  |
-| 2 | `token_offer` | `.CMsgOverworldTokenQuantity` | `optional` | `` |  |
-| 3 | `token_request` | `.CMsgOverworldTokenQuantity` | `optional` | `` |  |
-| 4 | `recipe` | `uint32` | `optional` | `` |  |
-| 5 | `encounter_id` | `uint32` | `optional` | `` |  |
+| 1 | `overworld_id` | `uint32` | `optional` |  |  |
+| 2 | `token_offer` | `.CMsgOverworldTokenQuantity` | `optional` |  |  |
+| 3 | `token_request` | `.CMsgOverworldTokenQuantity` | `optional` |  |  |
+| 4 | `recipe` | `uint32` | `optional` |  |  |
+| 5 | `encounter_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -457,8 +457,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCOverworldTradeTokensResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `tokens_received` | `.CMsgOverworldTokenQuantity` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCOverworldTradeTokensResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `tokens_received` | `.CMsgOverworldTokenQuantity` | `optional` |  |  |
 
 </details>
 
@@ -470,10 +470,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `overworld_id` | `uint32` | `optional` | `` |  |
-| 2 | `token_gift` | `.CMsgOverworldTokenCount` | `optional` | `` |  |
-| 3 | `recipient_account_id` | `uint32` | `optional` | `` |  |
-| 4 | `periodic_resource_id` | `uint32` | `optional` | `` |  |
+| 1 | `overworld_id` | `uint32` | `optional` |  |  |
+| 2 | `token_gift` | `.CMsgOverworldTokenCount` | `optional` |  |  |
+| 3 | `recipient_account_id` | `uint32` | `optional` |  |  |
+| 4 | `periodic_resource_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -485,7 +485,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCOverworldGiftTokensResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCOverworldGiftTokensResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -497,8 +497,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `friend_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `overworld_id` | `uint32` | `optional` | `` |  |
+| 1 | `friend_account_id` | `uint32` | `optional` |  |  |
+| 2 | `overworld_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -510,8 +510,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCOverworldRequestTokensNeededByFriendResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `token_quantity` | `.CMsgOverworldTokenQuantity` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCOverworldRequestTokensNeededByFriendResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `token_quantity` | `.CMsgOverworldTokenQuantity` | `optional` |  |  |
 
 </details>
 
@@ -523,7 +523,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `overworld_id` | `uint32` | `optional` | `` |  |
+| 1 | `overworld_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -535,7 +535,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCOverworldDevResetAllResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCOverworldDevResetAllResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -547,8 +547,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `overworld_id` | `uint32` | `optional` | `` |  |
-| 2 | `node_id` | `uint32` | `optional` | `` |  |
+| 1 | `overworld_id` | `uint32` | `optional` |  |  |
+| 2 | `node_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -560,7 +560,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCOverworldDevResetNodeResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCOverworldDevResetNodeResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -572,8 +572,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `overworld_id` | `uint32` | `optional` | `` |  |
-| 2 | `token_quantity` | `.CMsgOverworldTokenQuantity` | `optional` | `` |  |
+| 1 | `overworld_id` | `uint32` | `optional` |  |  |
+| 2 | `token_quantity` | `.CMsgOverworldTokenQuantity` | `optional` |  |  |
 
 </details>
 
@@ -585,7 +585,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCOverworldDevGrantTokensResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCOverworldDevGrantTokensResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -597,7 +597,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `overworld_id` | `uint32` | `optional` | `` |  |
+| 1 | `overworld_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -609,7 +609,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCOverworldDevClearInventoryResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCOverworldDevClearInventoryResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -621,8 +621,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `overworld_id` | `uint32` | `optional` | `` |  |
-| 2 | `fortune_id` | `uint32` | `optional` | `` |  |
+| 1 | `overworld_id` | `uint32` | `optional` |  |  |
+| 2 | `fortune_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -634,7 +634,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCOverworldDevSetFortuneResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCOverworldDevSetFortuneResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -646,8 +646,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `overworld_id` | `uint32` | `optional` | `` |  |
-| 2 | `fortune_id` | `uint32` | `optional` | `` |  |
+| 1 | `overworld_id` | `uint32` | `optional` |  |  |
+| 2 | `fortune_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -659,7 +659,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCOverworldDevClearFortuneResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCOverworldDevClearFortuneResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -671,7 +671,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `overworld_id` | `uint32` | `optional` | `` |  |
+| 1 | `overworld_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -683,7 +683,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCOverworldRequestFortuneResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCOverworldRequestFortuneResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -695,9 +695,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `language` | `uint32` | `optional` | `` |  |
-| 2 | `overworld_id` | `uint32` | `optional` | `` |  |
-| 3 | `feedback` | `string` | `optional` | `` |  |
+| 1 | `language` | `uint32` | `optional` |  |  |
+| 2 | `overworld_id` | `uint32` | `optional` |  |  |
+| 3 | `feedback` | `string` | `optional` |  |  |
 
 </details>
 
@@ -709,7 +709,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCOverworldFeedbackResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCOverworldFeedbackResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -721,9 +721,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `magic` | `uint32` | `optional` | `` |  |
-| 2 | `image_id` | `uint32` | `optional` | `` |  |
-| 3 | `language` | `uint32` | `optional` | `` |  |
+| 1 | `magic` | `uint32` | `optional` |  |  |
+| 2 | `image_id` | `uint32` | `optional` |  |  |
+| 3 | `language` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -735,8 +735,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `image_id` | `uint32` | `optional` | `` |  |
-| 2 | `images` | `.CMsgClientToGCOverworldGetDynamicImageResponse.Image` | `repeated` | `` |  |
+| 1 | `image_id` | `uint32` | `optional` |  |  |
+| 2 | `images` | `.CMsgClientToGCOverworldGetDynamicImageResponse.Image` | `repeated` |  |  |
 
 </details>
 
@@ -748,10 +748,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `width` | `uint32` | `optional` | `` |  |
-| 2 | `height` | `uint32` | `optional` | `` |  |
-| 3 | `format` | `.CMsgClientToGCOverworldGetDynamicImageResponse.EDynamicImageFormat` | `optional` | `` | default = k_eUnknown |
-| 4 | `image_bytes` | `bytes` | `optional` | `` |  |
+| 1 | `width` | `uint32` | `optional` |  |  |
+| 2 | `height` | `uint32` | `optional` |  |  |
+| 3 | `format` | `.CMsgClientToGCOverworldGetDynamicImageResponse.EDynamicImageFormat` | `optional` |  | default = k_eUnknown |
+| 4 | `image_bytes` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -763,12 +763,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `overworld_id` | `uint32` | `optional` | `` |  |
-| 2 | `node_id` | `uint32` | `optional` | `` |  |
-| 3 | `action` | `.EOverworldMinigameAction` | `optional` | `` | default = k_eOverworldMinigameAction_Invalid |
-| 4 | `selection` | `uint32` | `optional` | `` |  |
-| 5 | `option_value` | `uint32` | `optional` | `` |  |
-| 6 | `currency_amount` | `uint32` | `optional` | `` |  |
+| 1 | `overworld_id` | `uint32` | `optional` |  |  |
+| 2 | `node_id` | `uint32` | `optional` |  |  |
+| 3 | `action` | `.EOverworldMinigameAction` | `optional` |  | default = k_eOverworldMinigameAction_Invalid |
+| 4 | `selection` | `uint32` | `optional` |  |  |
+| 5 | `option_value` | `uint32` | `optional` |  |  |
+| 6 | `currency_amount` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -780,7 +780,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCOverworldMinigameActionResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCOverworldMinigameActionResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-common-survivors.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-common-survivors.md
@@ -26,8 +26,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `attribute_levels` | `.CMsgSurvivorsUserData.AttributeLevelsEntry` | `repeated` | `` |  |
-| 2 | `unlocked_difficulty` | `uint32` | `optional` | `` |  |
+| 1 | `attribute_levels` | `.CMsgSurvivorsUserData.AttributeLevelsEntry` | `repeated` |  |  |
+| 2 | `unlocked_difficulty` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -39,8 +39,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key` | `int32` | `optional` | `` |  |
-| 2 | `value` | `uint32` | `optional` | `` |  |
+| 1 | `key` | `int32` | `optional` |  |  |
+| 2 | `value` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -52,13 +52,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `powerup_id` | `uint32` | `optional` | `` |  |
-| 2 | `level` | `uint32` | `optional` | `` |  |
-| 3 | `time_received` | `uint32` | `optional` | `` |  |
-| 4 | `time_held` | `uint32` | `optional` | `` |  |
-| 5 | `total_damage` | `uint64` | `optional` | `` |  |
-| 6 | `dps` | `uint32` | `optional` | `` |  |
-| 7 | `has_scepter` | `uint32` | `optional` | `` |  |
+| 1 | `powerup_id` | `uint32` | `optional` |  |  |
+| 2 | `level` | `uint32` | `optional` |  |  |
+| 3 | `time_received` | `uint32` | `optional` |  |  |
+| 4 | `time_held` | `uint32` | `optional` |  |  |
+| 5 | `total_damage` | `uint64` | `optional` |  |  |
+| 6 | `dps` | `uint32` | `optional` |  |  |
+| 7 | `has_scepter` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -70,13 +70,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `time_survived` | `uint32` | `optional` | `` |  |
-| 2 | `player_level` | `uint32` | `optional` | `` |  |
-| 3 | `game_result` | `uint32` | `optional` | `` |  |
-| 4 | `gold_earned` | `uint32` | `optional` | `` |  |
-| 5 | `powerups` | `.CMsgClientToGCSurvivorsPowerUpTelemetryData` | `repeated` | `` |  |
-| 6 | `difficulty` | `uint32` | `optional` | `` |  |
-| 7 | `metaprogression_level` | `uint32` | `optional` | `` |  |
+| 1 | `time_survived` | `uint32` | `optional` |  |  |
+| 2 | `player_level` | `uint32` | `optional` |  |  |
+| 3 | `game_result` | `uint32` | `optional` |  |  |
+| 4 | `gold_earned` | `uint32` | `optional` |  |  |
+| 5 | `powerups` | `.CMsgClientToGCSurvivorsPowerUpTelemetryData` | `repeated` |  |  |
+| 6 | `difficulty` | `uint32` | `optional` |  |  |
+| 7 | `metaprogression_level` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -88,7 +88,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCSurvivorsGameTelemetryDataResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCSurvivorsGameTelemetryDataResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-common.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-common.md
@@ -26,62 +26,62 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` | (key_field) = true |
-| 3 | `wins` | `uint32` | `optional` | `` |  |
-| 4 | `losses` | `uint32` | `optional` | `` |  |
-| 12 | `xp` | `uint32` | `optional` | `` |  |
-| 13 | `level` | `uint32` | `optional` | `` |  |
-| 14 | `initial_skill` | `uint32` | `optional` | `` |  |
-| 15 | `leaver_count` | `uint32` | `optional` | `` |  |
-| 18 | `low_priority_until_date` | `uint32` | `optional` | `` |  |
-| 20 | `prevent_text_chat_until_date` | `uint32` | `optional` | `` |  |
-| 21 | `prevent_voice_until_date` | `uint32` | `optional` | `` |  |
-| 22 | `last_abandoned_game_date` | `uint32` | `optional` | `` |  |
-| 23 | `leaver_penalty_count` | `uint32` | `optional` | `` |  |
-| 24 | `completed_game_streak` | `uint32` | `optional` | `` |  |
-| 38 | `account_disabled_until_date` | `uint32` | `optional` | `` |  |
-| 39 | `account_disabled_count` | `uint32` | `optional` | `` |  |
-| 41 | `match_disabled_until_date` | `uint32` | `optional` | `` |  |
-| 42 | `match_disabled_count` | `uint32` | `optional` | `` |  |
-| 47 | `shutdownlawterminatetimestamp` | `uint32` | `optional` | `` |  |
-| 48 | `low_priority_games_remaining` | `uint32` | `optional` | `` |  |
-| 55 | `recruitment_level` | `uint32` | `optional` | `` |  |
-| 56 | `has_new_notifications` | `bool` | `optional` | `` |  |
-| 57 | `is_league_admin` | `bool` | `optional` | `` |  |
-| 58 | `secondary_leaver_count` | `uint32` | `optional` | `` |  |
-| 59 | `last_secondary_abandoned_game_date` | `uint32` | `optional` | `` |  |
-| 60 | `casual_games_played` | `uint32` | `optional` | `` |  |
-| 61 | `solo_competitive_games_played` | `uint32` | `optional` | `` |  |
-| 62 | `party_competitive_games_played` | `uint32` | `optional` | `` |  |
-| 65 | `casual_1v1_games_played` | `uint32` | `optional` | `` |  |
-| 67 | `curr_all_hero_challenge_id` | `int32` | `optional` | `` |  |
-| 68 | `play_time_points` | `uint32` | `optional` | `` |  |
-| 69 | `account_flags` | `uint32` | `optional` | `` |  |
-| 70 | `play_time_level` | `uint32` | `optional` | `` |  |
-| 71 | `player_behavior_seq_num_last_report` | `uint32` | `optional` | `` |  |
-| 72 | `player_behavior_score_last_report` | `uint32` | `optional` | `` |  |
-| 73 | `player_behavior_report_old_data` | `bool` | `optional` | `` |  |
-| 74 | `tourney_skill_level` | `uint32` | `optional` | `` |  |
-| 85 | `tourney_recent_participation_date` | `uint32` | `optional` | `` |  |
-| 86 | `prevent_public_text_chat_until_date` | `uint32` | `optional` | `` |  |
-| 88 | `anchored_phone_number_id` | `uint64` | `optional` | `` |  |
-| 89 | `ranked_matchmaking_ban_until_date` | `uint32` | `optional` | `` |  |
-| 90 | `recent_game_time_1` | `uint32` | `optional` | `` |  |
-| 91 | `recent_game_time_2` | `uint32` | `optional` | `` |  |
-| 92 | `recent_game_time_3` | `uint32` | `optional` | `` |  |
-| 103 | `favorite_team_packed` | `uint64` | `optional` | `` |  |
-| 104 | `recent_report_time` | `uint32` | `optional` | `` |  |
-| 105 | `custom_game_disabled_until_date` | `uint32` | `optional` | `` |  |
-| 106 | `recent_win_time_1` | `uint32` | `optional` | `` |  |
-| 107 | `recent_win_time_2` | `uint32` | `optional` | `` |  |
-| 108 | `recent_win_time_3` | `uint32` | `optional` | `` |  |
-| 109 | `coach_rating` | `uint32` | `optional` | `` |  |
-| 114 | `queue_points` | `uint32` | `optional` | `` |  |
-| 115 | `role_handicaps` | `.CSODOTAGameAccountClient.RoleHandicap` | `repeated` | `` |  |
-| 120 | `event_mode_recent_time` | `uint32` | `optional` | `` |  |
-| 121 | `mmr_recalibration_time` | `uint32` | `optional` | `` |  |
-| 122 | `prevent_new_player_chat_until_date` | `uint32` | `optional` | `` |  |
-| 123 | `banned_hero_ids` | `int32` | `repeated` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  | (key_field) = true |
+| 3 | `wins` | `uint32` | `optional` |  |  |
+| 4 | `losses` | `uint32` | `optional` |  |  |
+| 12 | `xp` | `uint32` | `optional` |  |  |
+| 13 | `level` | `uint32` | `optional` |  |  |
+| 14 | `initial_skill` | `uint32` | `optional` |  |  |
+| 15 | `leaver_count` | `uint32` | `optional` |  |  |
+| 18 | `low_priority_until_date` | `uint32` | `optional` |  |  |
+| 20 | `prevent_text_chat_until_date` | `uint32` | `optional` |  |  |
+| 21 | `prevent_voice_until_date` | `uint32` | `optional` |  |  |
+| 22 | `last_abandoned_game_date` | `uint32` | `optional` |  |  |
+| 23 | `leaver_penalty_count` | `uint32` | `optional` |  |  |
+| 24 | `completed_game_streak` | `uint32` | `optional` |  |  |
+| 38 | `account_disabled_until_date` | `uint32` | `optional` |  |  |
+| 39 | `account_disabled_count` | `uint32` | `optional` |  |  |
+| 41 | `match_disabled_until_date` | `uint32` | `optional` |  |  |
+| 42 | `match_disabled_count` | `uint32` | `optional` |  |  |
+| 47 | `shutdownlawterminatetimestamp` | `uint32` | `optional` |  |  |
+| 48 | `low_priority_games_remaining` | `uint32` | `optional` |  |  |
+| 55 | `recruitment_level` | `uint32` | `optional` |  |  |
+| 56 | `has_new_notifications` | `bool` | `optional` |  |  |
+| 57 | `is_league_admin` | `bool` | `optional` |  |  |
+| 58 | `secondary_leaver_count` | `uint32` | `optional` |  |  |
+| 59 | `last_secondary_abandoned_game_date` | `uint32` | `optional` |  |  |
+| 60 | `casual_games_played` | `uint32` | `optional` |  |  |
+| 61 | `solo_competitive_games_played` | `uint32` | `optional` |  |  |
+| 62 | `party_competitive_games_played` | `uint32` | `optional` |  |  |
+| 65 | `casual_1v1_games_played` | `uint32` | `optional` |  |  |
+| 67 | `curr_all_hero_challenge_id` | `int32` | `optional` |  |  |
+| 68 | `play_time_points` | `uint32` | `optional` |  |  |
+| 69 | `account_flags` | `uint32` | `optional` |  |  |
+| 70 | `play_time_level` | `uint32` | `optional` |  |  |
+| 71 | `player_behavior_seq_num_last_report` | `uint32` | `optional` |  |  |
+| 72 | `player_behavior_score_last_report` | `uint32` | `optional` |  |  |
+| 73 | `player_behavior_report_old_data` | `bool` | `optional` |  |  |
+| 74 | `tourney_skill_level` | `uint32` | `optional` |  |  |
+| 85 | `tourney_recent_participation_date` | `uint32` | `optional` |  |  |
+| 86 | `prevent_public_text_chat_until_date` | `uint32` | `optional` |  |  |
+| 88 | `anchored_phone_number_id` | `uint64` | `optional` |  |  |
+| 89 | `ranked_matchmaking_ban_until_date` | `uint32` | `optional` |  |  |
+| 90 | `recent_game_time_1` | `uint32` | `optional` |  |  |
+| 91 | `recent_game_time_2` | `uint32` | `optional` |  |  |
+| 92 | `recent_game_time_3` | `uint32` | `optional` |  |  |
+| 103 | `favorite_team_packed` | `uint64` | `optional` |  |  |
+| 104 | `recent_report_time` | `uint32` | `optional` |  |  |
+| 105 | `custom_game_disabled_until_date` | `uint32` | `optional` |  |  |
+| 106 | `recent_win_time_1` | `uint32` | `optional` |  |  |
+| 107 | `recent_win_time_2` | `uint32` | `optional` |  |  |
+| 108 | `recent_win_time_3` | `uint32` | `optional` |  |  |
+| 109 | `coach_rating` | `uint32` | `optional` |  |  |
+| 114 | `queue_points` | `uint32` | `optional` |  |  |
+| 115 | `role_handicaps` | `.CSODOTAGameAccountClient.RoleHandicap` | `repeated` |  |  |
+| 120 | `event_mode_recent_time` | `uint32` | `optional` |  |  |
+| 121 | `mmr_recalibration_time` | `uint32` | `optional` |  |  |
+| 122 | `prevent_new_player_chat_until_date` | `uint32` | `optional` |  |  |
+| 123 | `banned_hero_ids` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -93,8 +93,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `role` | `uint32` | `optional` | `` |  |
-| 2 | `handicap` | `float` | `optional` | `` |  |
+| 1 | `role` | `uint32` | `optional` |  |  |
+| 2 | `handicap` | `float` | `optional` |  |  |
 
 </details>
 
@@ -106,14 +106,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` | (key_field) = true |
-| 2 | `original_start_date` | `uint32` | `optional` | `` |  |
-| 3 | `plus_flags` | `uint32` | `optional` | `` |  |
-| 4 | `plus_status` | `uint32` | `optional` | `` |  |
-| 5 | `prepaid_time_start` | `uint32` | `optional` | `` |  |
-| 6 | `prepaid_time_balance` | `uint32` | `optional` | `` |  |
-| 7 | `next_payment_date` | `fixed32` | `optional` | `` |  |
-| 8 | `steam_agreement_id` | `fixed64` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  | (key_field) = true |
+| 2 | `original_start_date` | `uint32` | `optional` |  |  |
+| 3 | `plus_flags` | `uint32` | `optional` |  |  |
+| 4 | `plus_status` | `uint32` | `optional` |  |  |
+| 5 | `prepaid_time_start` | `uint32` | `optional` |  |  |
+| 6 | `prepaid_time_balance` | `uint32` | `optional` |  |  |
+| 7 | `next_payment_date` | `fixed32` | `optional` |  |  |
+| 8 | `steam_agreement_id` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -125,7 +125,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `message_id` | `uint32` | `optional` | `` | default = 4294967295, (key_field) = true |
+| 1 | `message_id` | `uint32` | `optional` |  | default = 4294967295, (key_field) = true |
 
 </details>
 
@@ -137,7 +137,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `accounts` | `.CMsgLobbyFeaturedGamemodeProgress.AccountProgress` | `repeated` | `` |  |
+| 1 | `accounts` | `.CMsgLobbyFeaturedGamemodeProgress.AccountProgress` | `repeated` |  |  |
 
 </details>
 
@@ -149,9 +149,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `current_value` | `uint32` | `optional` | `` |  |
-| 3 | `max_value` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `current_value` | `uint32` | `optional` |  |  |
+| 3 | `max_value` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -163,15 +163,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `win_date` | `uint32` | `optional` | `` |  |
-| 3 | `valid_until` | `uint32` | `optional` | `` |  |
-| 4 | `skill_level` | `uint32` | `optional` | `` |  |
-| 5 | `tournament_id` | `uint32` | `optional` | `` |  |
-| 6 | `division_id` | `uint32` | `optional` | `` |  |
-| 7 | `team_id` | `uint32` | `optional` | `` |  |
-| 8 | `streak` | `uint32` | `optional` | `` |  |
-| 9 | `trophy_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `win_date` | `uint32` | `optional` |  |  |
+| 3 | `valid_until` | `uint32` | `optional` |  |  |
+| 4 | `skill_level` | `uint32` | `optional` |  |  |
+| 5 | `tournament_id` | `uint32` | `optional` |  |  |
+| 6 | `division_id` | `uint32` | `optional` |  |  |
+| 7 | `team_id` | `uint32` | `optional` |  |  |
+| 8 | `streak` | `uint32` | `optional` |  |  |
+| 9 | `trophy_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -183,7 +183,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `winners` | `.CMsgBattleCupVictory` | `repeated` | `` |  |
+| 1 | `winners` | `.CMsgBattleCupVictory` | `repeated` |  |  |
 
 </details>
 
@@ -195,7 +195,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `message` | `string` | `optional` | `` |  |
+| 1 | `message` | `string` | `optional` |  |  |
 
 </details>
 
@@ -207,14 +207,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `status_effect_index` | `uint32` | `optional` | `` |  |
-| 3 | `sequence_name` | `string` | `optional` | `` |  |
-| 4 | `cycle` | `float` | `optional` | `` |  |
-| 5 | `wearable` | `uint32` | `repeated` | `` |  |
-| 6 | `inscription` | `string` | `optional` | `` |  |
-| 7 | `style` | `uint32` | `repeated` | `` |  |
-| 8 | `tournament_drop` | `bool` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `status_effect_index` | `uint32` | `optional` |  |  |
+| 3 | `sequence_name` | `string` | `optional` |  |  |
+| 4 | `cycle` | `float` | `optional` |  |  |
+| 5 | `wearable` | `uint32` | `repeated` |  |  |
+| 6 | `inscription` | `string` | `optional` |  |  |
+| 7 | `style` | `uint32` | `repeated` |  |  |
+| 8 | `tournament_drop` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -226,8 +226,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ability` | `int32` | `optional` | `` | default = -1 |
-| 2 | `time` | `uint32` | `optional` | `` |  |
+| 1 | `ability` | `int32` | `optional` |  | default = -1 |
+| 2 | `time` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -239,8 +239,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `stat` | `.EDOTAMatchPlayerTimeCustomStat` | `optional` | `` | default = k_EDOTA_MatchPlayerTimeCustomStat_HPRegenUnderT1Towers |
-| 3 | `value` | `float` | `optional` | `` |  |
+| 2 | `stat` | `.EDOTAMatchPlayerTimeCustomStat` | `optional` |  | default = k_EDOTA_MatchPlayerTimeCustomStat_HPRegenUnderT1Towers |
+| 3 | `value` | `float` | `optional` |  |  |
 
 </details>
 
@@ -252,43 +252,43 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `time` | `uint32` | `optional` | `` |  |
-| 2 | `kills` | `uint32` | `optional` | `` |  |
-| 3 | `deaths` | `uint32` | `optional` | `` |  |
-| 4 | `assists` | `uint32` | `optional` | `` |  |
-| 5 | `net_worth` | `uint32` | `optional` | `` |  |
-| 6 | `xp` | `uint32` | `optional` | `` |  |
-| 7 | `last_hits` | `uint32` | `optional` | `` |  |
-| 8 | `denies` | `uint32` | `optional` | `` |  |
-| 9 | `bounty_rune_gold` | `uint32` | `optional` | `` |  |
-| 10 | `range_creep_upgrade_gold` | `uint32` | `optional` | `` |  |
-| 11 | `observer_wards_dewarded` | `uint32` | `optional` | `` |  |
-| 12 | `reliable_gold_earned` | `uint32` | `optional` | `` |  |
-| 13 | `gold_loss_prevented` | `uint32` | `optional` | `` |  |
-| 14 | `hero_kill_gold` | `uint32` | `optional` | `` |  |
-| 15 | `creep_kill_gold` | `uint32` | `optional` | `` |  |
-| 16 | `building_gold` | `uint32` | `optional` | `` |  |
-| 17 | `other_gold` | `uint32` | `optional` | `` |  |
-| 18 | `comeback_gold` | `uint32` | `optional` | `` |  |
-| 19 | `experimental_gold` | `uint32` | `optional` | `` |  |
-| 20 | `experimental2_gold` | `uint32` | `optional` | `` |  |
-| 21 | `creep_deny_gold` | `uint32` | `optional` | `` |  |
-| 22 | `tp_scrolls_purchased_1` | `uint32` | `optional` | `` |  |
-| 23 | `tp_scrolls_purchased_2` | `uint32` | `optional` | `` |  |
-| 24 | `tp_scrolls_purchased_3` | `uint32` | `optional` | `` |  |
-| 25 | `tp_scrolls_purchased_4` | `uint32` | `optional` | `` |  |
-| 26 | `tp_scrolls_purchased_5` | `uint32` | `optional` | `` |  |
-| 27 | `neutral_gold` | `uint32` | `optional` | `` |  |
-| 28 | `courier_gold` | `uint32` | `optional` | `` |  |
-| 29 | `roshan_gold` | `uint32` | `optional` | `` |  |
-| 30 | `income_gold` | `uint32` | `optional` | `` |  |
-| 36 | `item_value` | `uint32` | `optional` | `` |  |
-| 37 | `support_gold_spent` | `uint32` | `optional` | `` |  |
-| 38 | `camps_stacked` | `uint32` | `optional` | `` |  |
-| 39 | `wards_placed` | `uint32` | `optional` | `` |  |
-| 40 | `triple_kills` | `uint32` | `optional` | `` |  |
-| 41 | `rampages` | `uint32` | `optional` | `` |  |
-| 42 | `custom_stats` | `.CMatchPlayerTimedCustomStat` | `repeated` | `` |  |
+| 1 | `time` | `uint32` | `optional` |  |  |
+| 2 | `kills` | `uint32` | `optional` |  |  |
+| 3 | `deaths` | `uint32` | `optional` |  |  |
+| 4 | `assists` | `uint32` | `optional` |  |  |
+| 5 | `net_worth` | `uint32` | `optional` |  |  |
+| 6 | `xp` | `uint32` | `optional` |  |  |
+| 7 | `last_hits` | `uint32` | `optional` |  |  |
+| 8 | `denies` | `uint32` | `optional` |  |  |
+| 9 | `bounty_rune_gold` | `uint32` | `optional` |  |  |
+| 10 | `range_creep_upgrade_gold` | `uint32` | `optional` |  |  |
+| 11 | `observer_wards_dewarded` | `uint32` | `optional` |  |  |
+| 12 | `reliable_gold_earned` | `uint32` | `optional` |  |  |
+| 13 | `gold_loss_prevented` | `uint32` | `optional` |  |  |
+| 14 | `hero_kill_gold` | `uint32` | `optional` |  |  |
+| 15 | `creep_kill_gold` | `uint32` | `optional` |  |  |
+| 16 | `building_gold` | `uint32` | `optional` |  |  |
+| 17 | `other_gold` | `uint32` | `optional` |  |  |
+| 18 | `comeback_gold` | `uint32` | `optional` |  |  |
+| 19 | `experimental_gold` | `uint32` | `optional` |  |  |
+| 20 | `experimental2_gold` | `uint32` | `optional` |  |  |
+| 21 | `creep_deny_gold` | `uint32` | `optional` |  |  |
+| 22 | `tp_scrolls_purchased_1` | `uint32` | `optional` |  |  |
+| 23 | `tp_scrolls_purchased_2` | `uint32` | `optional` |  |  |
+| 24 | `tp_scrolls_purchased_3` | `uint32` | `optional` |  |  |
+| 25 | `tp_scrolls_purchased_4` | `uint32` | `optional` |  |  |
+| 26 | `tp_scrolls_purchased_5` | `uint32` | `optional` |  |  |
+| 27 | `neutral_gold` | `uint32` | `optional` |  |  |
+| 28 | `courier_gold` | `uint32` | `optional` |  |  |
+| 29 | `roshan_gold` | `uint32` | `optional` |  |  |
+| 30 | `income_gold` | `uint32` | `optional` |  |  |
+| 36 | `item_value` | `uint32` | `optional` |  |  |
+| 37 | `support_gold_spent` | `uint32` | `optional` |  |  |
+| 38 | `camps_stacked` | `uint32` | `optional` |  |  |
+| 39 | `wards_placed` | `uint32` | `optional` |  |  |
+| 40 | `triple_kills` | `uint32` | `optional` |  |  |
+| 41 | `rampages` | `uint32` | `optional` |  |  |
+| 42 | `custom_stats` | `.CMatchPlayerTimedCustomStat` | `repeated` |  |  |
 
 </details>
 
@@ -300,11 +300,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `time` | `uint32` | `optional` | `` |  |
-| 2 | `enemy_towers_killed` | `uint32` | `optional` | `` |  |
-| 3 | `enemy_barracks_killed` | `uint32` | `optional` | `` |  |
-| 4 | `enemy_towers_status` | `uint32` | `optional` | `` |  |
-| 5 | `enemy_barracks_status` | `uint32` | `optional` | `` |  |
+| 1 | `time` | `uint32` | `optional` |  |  |
+| 2 | `enemy_towers_killed` | `uint32` | `optional` |  |  |
+| 3 | `enemy_barracks_killed` | `uint32` | `optional` |  |  |
+| 4 | `enemy_towers_status` | `uint32` | `optional` |  |  |
+| 5 | `enemy_barracks_status` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -316,8 +316,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `unit_name` | `string` | `optional` | `` |  |
-| 2 | `items` | `int32` | `repeated` | `` |  |
+| 1 | `unit_name` | `string` | `optional` |  |  |
+| 2 | `items` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -329,9 +329,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `permanent_buff` | `uint32` | `optional` | `` |  |
-| 2 | `stack_count` | `uint32` | `optional` | `` |  |
-| 3 | `grant_time` | `uint32` | `optional` | `` |  |
+| 1 | `permanent_buff` | `uint32` | `optional` |  |  |
+| 2 | `stack_count` | `uint32` | `optional` |  |  |
+| 3 | `grant_time` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -343,9 +343,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `is_pick` | `bool` | `optional` | `` |  |
-| 2 | `team` | `uint32` | `optional` | `` |  |
-| 3 | `hero_id` | `int32` | `optional` | `` |  |
+| 1 | `is_pick` | `bool` | `optional` |  |  |
+| 2 | `team` | `uint32` | `optional` |  |  |
+| 3 | `hero_id` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -357,15 +357,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `player_account_id` | `uint32` | `optional` | `` |  |
-| 3 | `game_time_seconds` | `uint32` | `optional` | `` |  |
-| 4 | `duration_seconds` | `uint32` | `optional` | `` |  |
-| 5 | `player_id` | `uint32` | `optional` | `` |  |
-| 6 | `hero_id` | `int32` | `optional` | `` |  |
-| 7 | `ability_id` | `int32` | `optional` | `` | default = -1 |
-| 8 | `camera_mode` | `uint32` | `optional` | `` |  |
-| 9 | `comment` | `string` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `player_account_id` | `uint32` | `optional` |  |  |
+| 3 | `game_time_seconds` | `uint32` | `optional` |  |  |
+| 4 | `duration_seconds` | `uint32` | `optional` |  |  |
+| 5 | `player_id` | `uint32` | `optional` |  |  |
+| 6 | `hero_id` | `int32` | `optional` |  |  |
+| 7 | `ability_id` | `int32` | `optional` |  | default = -1 |
+| 8 | `camera_mode` | `uint32` | `optional` |  |  |
+| 9 | `comment` | `string` | `optional` |  |  |
 
 </details>
 
@@ -377,9 +377,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `party_id` | `fixed64` | `optional` | `` |  |
-| 2 | `beacon_type` | `int32` | `optional` | `` |  |
-| 3 | `party_members` | `fixed32` | `repeated` | `` |  |
+| 1 | `party_id` | `fixed64` | `optional` |  |  |
+| 2 | `beacon_type` | `int32` | `optional` |  |  |
+| 3 | `party_members` | `fixed32` | `repeated` |  |  |
 
 </details>
 
@@ -391,8 +391,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `item_id` | `uint64` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -404,7 +404,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `has_item` | `bool` | `optional` | `` |  |
+| 1 | `has_item` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -416,9 +416,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `player_card_item_ids` | `uint64` | `repeated` | `` |  |
-| 3 | `all_for_event` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `player_card_item_ids` | `uint64` | `repeated` |  |  |
+| 3 | `all_for_event` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -430,7 +430,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_card_infos` | `.CMsgGCGetPlayerCardItemInfoResponse.PlayerCardInfo` | `repeated` | `` |  |
+| 1 | `player_card_infos` | `.CMsgGCGetPlayerCardItemInfoResponse.PlayerCardInfo` | `repeated` |  |  |
 
 </details>
 
@@ -442,9 +442,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_card_item_id` | `uint64` | `optional` | `` |  |
-| 2 | `account_id` | `uint32` | `optional` | `` |  |
-| 3 | `packed_bonuses` | `uint64` | `optional` | `` |  |
+| 1 | `player_card_item_id` | `uint64` | `optional` |  |  |
+| 2 | `account_id` | `uint32` | `optional` |  |  |
+| 3 | `packed_bonuses` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -456,9 +456,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` | (key_field) = true |
-| 2 | `location_id` | `int32` | `optional` | `` | (key_field) = true |
-| 3 | `completed` | `bool` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  | (key_field) = true |
+| 2 | `location_id` | `int32` | `optional` |  | (key_field) = true |
+| 3 | `completed` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -470,7 +470,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_ids` | `uint32` | `repeated` | `` |  |
+| 1 | `account_ids` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -482,21 +482,21 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 3 | `slots` | `.CMsgDOTAProfileCard.Slot` | `repeated` | `` |  |
-| 4 | `badge_points` | `uint32` | `optional` | `` |  |
-| 6 | `event_id` | `uint32` | `optional` | `` |  |
-| 7 | `recent_battle_cup_victory` | `.CMsgBattleCupVictory` | `optional` | `` |  |
-| 8 | `rank_tier` | `uint32` | `optional` | `` |  |
-| 9 | `leaderboard_rank` | `uint32` | `optional` | `` |  |
-| 10 | `is_plus_subscriber` | `bool` | `optional` | `` |  |
-| 11 | `plus_original_start_date` | `uint32` | `optional` | `` |  |
-| 12 | `rank_tier_score` | `uint32` | `optional` | `` |  |
-| 17 | `leaderboard_rank_core` | `uint32` | `optional` | `` |  |
-| 23 | `title` | `uint32` | `optional` | `` |  |
-| 24 | `favorite_team_packed` | `uint64` | `optional` | `` |  |
-| 25 | `lifetime_games` | `uint32` | `optional` | `` |  |
-| 26 | `event_level` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 3 | `slots` | `.CMsgDOTAProfileCard.Slot` | `repeated` |  |  |
+| 4 | `badge_points` | `uint32` | `optional` |  |  |
+| 6 | `event_id` | `uint32` | `optional` |  |  |
+| 7 | `recent_battle_cup_victory` | `.CMsgBattleCupVictory` | `optional` |  |  |
+| 8 | `rank_tier` | `uint32` | `optional` |  |  |
+| 9 | `leaderboard_rank` | `uint32` | `optional` |  |  |
+| 10 | `is_plus_subscriber` | `bool` | `optional` |  |  |
+| 11 | `plus_original_start_date` | `uint32` | `optional` |  |  |
+| 12 | `rank_tier_score` | `uint32` | `optional` |  |  |
+| 17 | `leaderboard_rank_core` | `uint32` | `optional` |  |  |
+| 23 | `title` | `uint32` | `optional` |  |  |
+| 24 | `favorite_team_packed` | `uint64` | `optional` |  |  |
+| 25 | `lifetime_games` | `uint32` | `optional` |  |  |
+| 26 | `event_level` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -508,13 +508,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `slot_id` | `uint32` | `optional` | `` |  |
-| 2 | `trophy` | `.CMsgDOTAProfileCard.Slot.Trophy` | `optional` | `` |  |
-| 3 | `stat` | `.CMsgDOTAProfileCard.Slot.Stat` | `optional` | `` |  |
-| 4 | `item` | `.CMsgDOTAProfileCard.Slot.Item` | `optional` | `` |  |
-| 5 | `hero` | `.CMsgDOTAProfileCard.Slot.Hero` | `optional` | `` |  |
-| 6 | `emoticon` | `.CMsgDOTAProfileCard.Slot.Emoticon` | `optional` | `` |  |
-| 7 | `team` | `.CMsgDOTAProfileCard.Slot.Team` | `optional` | `` |  |
+| 1 | `slot_id` | `uint32` | `optional` |  |  |
+| 2 | `trophy` | `.CMsgDOTAProfileCard.Slot.Trophy` | `optional` |  |  |
+| 3 | `stat` | `.CMsgDOTAProfileCard.Slot.Stat` | `optional` |  |  |
+| 4 | `item` | `.CMsgDOTAProfileCard.Slot.Item` | `optional` |  |  |
+| 5 | `hero` | `.CMsgDOTAProfileCard.Slot.Hero` | `optional` |  |  |
+| 6 | `emoticon` | `.CMsgDOTAProfileCard.Slot.Emoticon` | `optional` |  |  |
+| 7 | `team` | `.CMsgDOTAProfileCard.Slot.Team` | `optional` |  |  |
 
 </details>
 
@@ -526,8 +526,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `trophy_id` | `uint32` | `optional` | `` |  |
-| 2 | `trophy_score` | `uint32` | `optional` | `` |  |
+| 1 | `trophy_id` | `uint32` | `optional` |  |  |
+| 2 | `trophy_score` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -539,8 +539,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `stat_id` | `.CMsgDOTAProfileCard.EStatID` | `optional` | `` | default = k_eStat_Wins |
-| 2 | `stat_score` | `uint32` | `optional` | `` |  |
+| 1 | `stat_id` | `.CMsgDOTAProfileCard.EStatID` | `optional` |  | default = k_eStat_Wins |
+| 2 | `stat_score` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -552,8 +552,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `serialized_item` | `bytes` | `optional` | `` |  |
-| 2 | `item_id` | `uint64` | `optional` | `` |  |
+| 1 | `serialized_item` | `bytes` | `optional` |  |  |
+| 2 | `item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -565,9 +565,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `hero_wins` | `uint32` | `optional` | `` |  |
-| 3 | `hero_losses` | `uint32` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `hero_wins` | `uint32` | `optional` |  |  |
+| 3 | `hero_losses` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -579,7 +579,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `emoticon_id` | `uint32` | `optional` | `` |  |
+| 1 | `emoticon_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -591,7 +591,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_id` | `uint32` | `optional` | `` |  |
+| 1 | `team_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -603,23 +603,23 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` | (key_field) = true |
-| 2 | `event_id` | `uint32` | `optional` | `` | (key_field) = true |
-| 3 | `slot_id` | `uint32` | `optional` | `` | (key_field) = true |
-| 5 | `int_param_0` | `uint32` | `optional` | `` |  |
-| 6 | `int_param_1` | `uint32` | `optional` | `` |  |
-| 7 | `created_time` | `uint32` | `optional` | `` |  |
-| 8 | `completed` | `uint32` | `optional` | `` |  |
-| 9 | `sequence_id` | `uint32` | `optional` | `` |  |
-| 10 | `challenge_tier` | `uint32` | `optional` | `` |  |
-| 11 | `flags` | `uint32` | `optional` | `` |  |
-| 12 | `attempts` | `uint32` | `optional` | `` |  |
-| 13 | `complete_limit` | `uint32` | `optional` | `` |  |
-| 14 | `quest_rank` | `uint32` | `optional` | `` |  |
-| 15 | `max_quest_rank` | `uint32` | `optional` | `` |  |
-| 16 | `instance_id` | `uint32` | `optional` | `` |  |
-| 17 | `hero_id` | `int32` | `optional` | `` |  |
-| 18 | `template_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  | (key_field) = true |
+| 2 | `event_id` | `uint32` | `optional` |  | (key_field) = true |
+| 3 | `slot_id` | `uint32` | `optional` |  | (key_field) = true |
+| 5 | `int_param_0` | `uint32` | `optional` |  |  |
+| 6 | `int_param_1` | `uint32` | `optional` |  |  |
+| 7 | `created_time` | `uint32` | `optional` |  |  |
+| 8 | `completed` | `uint32` | `optional` |  |  |
+| 9 | `sequence_id` | `uint32` | `optional` |  |  |
+| 10 | `challenge_tier` | `uint32` | `optional` |  |  |
+| 11 | `flags` | `uint32` | `optional` |  |  |
+| 12 | `attempts` | `uint32` | `optional` |  |  |
+| 13 | `complete_limit` | `uint32` | `optional` |  |  |
+| 14 | `quest_rank` | `uint32` | `optional` |  |  |
+| 15 | `max_quest_rank` | `uint32` | `optional` |  |  |
+| 16 | `instance_id` | `uint32` | `optional` |  |  |
+| 17 | `hero_id` | `int32` | `optional` |  |  |
+| 18 | `template_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -631,9 +631,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 3 | `sequence_id` | `uint32` | `optional` | `` |  |
-| 4 | `hero_id` | `int32` | `optional` | `` |  |
+| 1 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 3 | `sequence_id` | `uint32` | `optional` |  |  |
+| 4 | `hero_id` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -645,7 +645,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgGCRerollPlayerChallengeResponse.EResult` | `optional` | `` | default = eResult_Success |
+| 1 | `result` | `.CMsgGCRerollPlayerChallengeResponse.EResult` | `optional` |  | default = eResult_Success |
 
 </details>
 
@@ -657,8 +657,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `top_custom_games` | `uint64` | `repeated` | `` |  |
-| 2 | `game_of_the_day` | `uint64` | `optional` | `` |  |
+| 1 | `top_custom_games` | `uint64` | `repeated` |  |  |
+| 2 | `game_of_the_day` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -670,11 +670,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match` | `.CMsgDOTARealtimeGameStats.MatchDetails` | `optional` | `` |  |
-| 2 | `teams` | `.CMsgDOTARealtimeGameStats.TeamDetails` | `repeated` | `` |  |
-| 3 | `buildings` | `.CMsgDOTARealtimeGameStats.BuildingDetails` | `repeated` | `` |  |
-| 4 | `graph_data` | `.CMsgDOTARealtimeGameStats.GraphData` | `optional` | `` |  |
-| 5 | `delta_frame` | `bool` | `optional` | `` |  |
+| 1 | `match` | `.CMsgDOTARealtimeGameStats.MatchDetails` | `optional` |  |  |
+| 2 | `teams` | `.CMsgDOTARealtimeGameStats.TeamDetails` | `repeated` |  |  |
+| 3 | `buildings` | `.CMsgDOTARealtimeGameStats.BuildingDetails` | `repeated` |  |  |
+| 4 | `graph_data` | `.CMsgDOTARealtimeGameStats.GraphData` | `optional` |  |  |
+| 5 | `delta_frame` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -686,17 +686,17 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_number` | `uint32` | `optional` | `` |  |
-| 2 | `team_id` | `uint32` | `optional` | `` |  |
-| 3 | `team_name` | `string` | `optional` | `` |  |
-| 4 | `team_logo` | `fixed64` | `optional` | `` |  |
-| 5 | `score` | `uint32` | `optional` | `` |  |
-| 6 | `players` | `.CMsgDOTARealtimeGameStats.PlayerDetails` | `repeated` | `` |  |
-| 7 | `only_team` | `bool` | `optional` | `` |  |
-| 8 | `cheers` | `uint32` | `optional` | `` |  |
-| 9 | `net_worth` | `uint32` | `optional` | `` |  |
-| 10 | `team_tag` | `string` | `optional` | `` |  |
-| 11 | `team_logo_url` | `string` | `optional` | `` |  |
+| 1 | `team_number` | `uint32` | `optional` |  |  |
+| 2 | `team_id` | `uint32` | `optional` |  |  |
+| 3 | `team_name` | `string` | `optional` |  |  |
+| 4 | `team_logo` | `fixed64` | `optional` |  |  |
+| 5 | `score` | `uint32` | `optional` |  |  |
+| 6 | `players` | `.CMsgDOTARealtimeGameStats.PlayerDetails` | `repeated` |  |  |
+| 7 | `only_team` | `bool` | `optional` |  |  |
+| 8 | `cheers` | `uint32` | `optional` |  |  |
+| 9 | `net_worth` | `uint32` | `optional` |  |  |
+| 10 | `team_tag` | `string` | `optional` |  |  |
+| 11 | `team_logo_url` | `string` | `optional` |  |  |
 
 </details>
 
@@ -708,11 +708,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `time` | `int32` | `optional` | `` |  |
-| 4 | `sold` | `bool` | `optional` | `` |  |
-| 5 | `stackcount` | `uint32` | `optional` | `` |  |
+| 1 | `item_ability_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `time` | `int32` | `optional` |  |  |
+| 4 | `sold` | `bool` | `optional` |  |  |
+| 5 | `stackcount` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -724,11 +724,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `level` | `uint32` | `optional` | `` |  |
-| 4 | `cooldown` | `float` | `optional` | `` |  |
-| 5 | `cooldown_max` | `float` | `optional` | `` |  |
+| 1 | `id` | `int32` | `optional` |  | default = -1 |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `level` | `uint32` | `optional` |  |  |
+| 4 | `cooldown` | `float` | `optional` |  |  |
+| 5 | `cooldown_max` | `float` | `optional` |  |  |
 
 </details>
 
@@ -740,9 +740,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `victimid` | `int32` | `optional` | `` | default = -1 |
-| 2 | `kills` | `uint32` | `optional` | `` |  |
-| 3 | `assists` | `uint32` | `optional` | `` |  |
+| 1 | `victimid` | `int32` | `optional` |  | default = -1 |
+| 2 | `kills` | `uint32` | `optional` |  |  |
+| 3 | `assists` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -754,7 +754,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `int32` | `repeated` | `` |  |
+| 1 | `id` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -766,56 +766,56 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `accountid` | `uint32` | `optional` | `` |  |
-| 2 | `playerid` | `int32` | `optional` | `` | default = -1 |
-| 3 | `name` | `string` | `optional` | `` |  |
-| 4 | `team` | `uint32` | `optional` | `` |  |
-| 5 | `heroid` | `int32` | `optional` | `` |  |
-| 6 | `healthpoints` | `uint32` | `optional` | `` |  |
-| 7 | `maxhealthpoints` | `uint32` | `optional` | `` |  |
-| 8 | `healthregenrate` | `float` | `optional` | `` |  |
-| 9 | `manapoints` | `uint32` | `optional` | `` |  |
-| 10 | `maxmanapoints` | `uint32` | `optional` | `` |  |
-| 11 | `manaregenrate` | `float` | `optional` | `` |  |
-| 12 | `base_strength` | `uint32` | `optional` | `` |  |
-| 13 | `base_agility` | `uint32` | `optional` | `` |  |
-| 14 | `base_intelligence` | `uint32` | `optional` | `` |  |
-| 15 | `base_armor` | `int32` | `optional` | `` |  |
-| 16 | `base_movespeed` | `uint32` | `optional` | `` |  |
-| 17 | `base_damage` | `uint32` | `optional` | `` |  |
-| 18 | `strength` | `uint32` | `optional` | `` |  |
-| 19 | `agility` | `uint32` | `optional` | `` |  |
-| 20 | `intelligence` | `uint32` | `optional` | `` |  |
-| 21 | `armor` | `int32` | `optional` | `` |  |
-| 22 | `movespeed` | `uint32` | `optional` | `` |  |
-| 23 | `damage` | `uint32` | `optional` | `` |  |
-| 24 | `hero_damage` | `uint32` | `optional` | `` |  |
-| 25 | `tower_damage` | `uint32` | `optional` | `` |  |
-| 26 | `abilities` | `.CMsgDOTARealtimeGameStats.AbilityDetails` | `repeated` | `` |  |
-| 27 | `level` | `uint32` | `optional` | `` |  |
-| 28 | `kill_count` | `uint32` | `optional` | `` |  |
-| 29 | `death_count` | `uint32` | `optional` | `` |  |
-| 30 | `assists_count` | `uint32` | `optional` | `` |  |
-| 31 | `denies_count` | `uint32` | `optional` | `` |  |
-| 32 | `lh_count` | `uint32` | `optional` | `` |  |
-| 33 | `hero_healing` | `uint32` | `optional` | `` |  |
-| 34 | `gold_per_min` | `uint32` | `optional` | `` |  |
-| 35 | `xp_per_min` | `uint32` | `optional` | `` |  |
-| 36 | `net_gold` | `uint32` | `optional` | `` |  |
-| 37 | `gold` | `uint32` | `optional` | `` |  |
-| 38 | `x` | `float` | `optional` | `` |  |
-| 39 | `y` | `float` | `optional` | `` |  |
-| 40 | `respawn_time` | `int32` | `optional` | `` |  |
-| 41 | `ultimate_cooldown` | `uint32` | `optional` | `` |  |
-| 42 | `has_buyback` | `bool` | `optional` | `` |  |
-| 43 | `items` | `.CMsgDOTARealtimeGameStats.ItemDetails` | `repeated` | `` |  |
-| 44 | `stashitems` | `.CMsgDOTARealtimeGameStats.ItemDetails` | `repeated` | `` |  |
-| 45 | `itemshoppinglist` | `.CMsgDOTARealtimeGameStats.ItemDetails` | `repeated` | `` |  |
-| 46 | `levelpoints` | `.CMsgDOTARealtimeGameStats.AbilityList` | `repeated` | `` |  |
-| 47 | `hero_to_hero_stats` | `.CMsgDOTARealtimeGameStats.HeroToHeroStats` | `repeated` | `` |  |
-| 48 | `has_ultimate` | `bool` | `optional` | `` |  |
-| 49 | `has_ultimate_mana` | `bool` | `optional` | `` |  |
-| 50 | `team_slot` | `uint32` | `optional` | `` |  |
+| 1 | `accountid` | `uint32` | `optional` |  |  |
+| 2 | `playerid` | `int32` | `optional` |  | default = -1 |
+| 3 | `name` | `string` | `optional` |  |  |
+| 4 | `team` | `uint32` | `optional` |  |  |
+| 5 | `heroid` | `int32` | `optional` |  |  |
+| 6 | `healthpoints` | `uint32` | `optional` |  |  |
+| 7 | `maxhealthpoints` | `uint32` | `optional` |  |  |
+| 8 | `healthregenrate` | `float` | `optional` |  |  |
+| 9 | `manapoints` | `uint32` | `optional` |  |  |
+| 10 | `maxmanapoints` | `uint32` | `optional` |  |  |
+| 11 | `manaregenrate` | `float` | `optional` |  |  |
+| 12 | `base_strength` | `uint32` | `optional` |  |  |
+| 13 | `base_agility` | `uint32` | `optional` |  |  |
+| 14 | `base_intelligence` | `uint32` | `optional` |  |  |
+| 15 | `base_armor` | `int32` | `optional` |  |  |
+| 16 | `base_movespeed` | `uint32` | `optional` |  |  |
+| 17 | `base_damage` | `uint32` | `optional` |  |  |
+| 18 | `strength` | `uint32` | `optional` |  |  |
+| 19 | `agility` | `uint32` | `optional` |  |  |
+| 20 | `intelligence` | `uint32` | `optional` |  |  |
+| 21 | `armor` | `int32` | `optional` |  |  |
+| 22 | `movespeed` | `uint32` | `optional` |  |  |
+| 23 | `damage` | `uint32` | `optional` |  |  |
+| 24 | `hero_damage` | `uint32` | `optional` |  |  |
+| 25 | `tower_damage` | `uint32` | `optional` |  |  |
+| 26 | `abilities` | `.CMsgDOTARealtimeGameStats.AbilityDetails` | `repeated` |  |  |
+| 27 | `level` | `uint32` | `optional` |  |  |
+| 28 | `kill_count` | `uint32` | `optional` |  |  |
+| 29 | `death_count` | `uint32` | `optional` |  |  |
+| 30 | `assists_count` | `uint32` | `optional` |  |  |
+| 31 | `denies_count` | `uint32` | `optional` |  |  |
+| 32 | `lh_count` | `uint32` | `optional` |  |  |
+| 33 | `hero_healing` | `uint32` | `optional` |  |  |
+| 34 | `gold_per_min` | `uint32` | `optional` |  |  |
+| 35 | `xp_per_min` | `uint32` | `optional` |  |  |
+| 36 | `net_gold` | `uint32` | `optional` |  |  |
+| 37 | `gold` | `uint32` | `optional` |  |  |
+| 38 | `x` | `float` | `optional` |  |  |
+| 39 | `y` | `float` | `optional` |  |  |
+| 40 | `respawn_time` | `int32` | `optional` |  |  |
+| 41 | `ultimate_cooldown` | `uint32` | `optional` |  |  |
+| 42 | `has_buyback` | `bool` | `optional` |  |  |
+| 43 | `items` | `.CMsgDOTARealtimeGameStats.ItemDetails` | `repeated` |  |  |
+| 44 | `stashitems` | `.CMsgDOTARealtimeGameStats.ItemDetails` | `repeated` |  |  |
+| 45 | `itemshoppinglist` | `.CMsgDOTARealtimeGameStats.ItemDetails` | `repeated` |  |  |
+| 46 | `levelpoints` | `.CMsgDOTARealtimeGameStats.AbilityList` | `repeated` |  |  |
+| 47 | `hero_to_hero_stats` | `.CMsgDOTARealtimeGameStats.HeroToHeroStats` | `repeated` |  |  |
+| 48 | `has_ultimate` | `bool` | `optional` |  |  |
+| 49 | `has_ultimate_mana` | `bool` | `optional` |  |  |
+| 50 | `team_slot` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -827,14 +827,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `team` | `uint32` | `optional` | `` |  |
-| 3 | `heading` | `float` | `optional` | `` |  |
-| 4 | `lane` | `uint32` | `optional` | `` |  |
-| 5 | `tier` | `uint32` | `optional` | `` |  |
-| 6 | `type` | `uint32` | `optional` | `` |  |
-| 7 | `x` | `float` | `optional` | `` |  |
-| 8 | `y` | `float` | `optional` | `` |  |
-| 9 | `destroyed` | `bool` | `optional` | `` |  |
+| 2 | `team` | `uint32` | `optional` |  |  |
+| 3 | `heading` | `float` | `optional` |  |  |
+| 4 | `lane` | `uint32` | `optional` |  |  |
+| 5 | `tier` | `uint32` | `optional` |  |  |
+| 6 | `type` | `uint32` | `optional` |  |  |
+| 7 | `x` | `float` | `optional` |  |  |
+| 8 | `y` | `float` | `optional` |  |  |
+| 9 | `destroyed` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -846,9 +846,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `death_time` | `int32` | `optional` | `` |  |
-| 3 | `killer_player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `death_time` | `int32` | `optional` |  |  |
+| 3 | `killer_player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -860,7 +860,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -872,8 +872,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero` | `int32` | `optional` | `` |  |
-| 2 | `team` | `uint32` | `optional` | `` |  |
+| 1 | `hero` | `int32` | `optional` |  |  |
+| 2 | `team` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -885,27 +885,27 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `server_steam_id` | `fixed64` | `optional` | `` |  |
-| 2 | `match_id` | `uint64` | `optional` | `` |  |
-| 3 | `timestamp` | `uint32` | `optional` | `` |  |
-| 4 | `time_of_day` | `float` | `optional` | `` |  |
-| 5 | `is_nightstalker_night` | `bool` | `optional` | `` |  |
-| 6 | `game_time` | `int32` | `optional` | `` |  |
-| 8 | `teamid_radiant` | `uint32` | `optional` | `` |  |
-| 9 | `teamid_dire` | `uint32` | `optional` | `` |  |
-| 10 | `picks` | `.CMsgDOTARealtimeGameStats.PickBanDetails` | `repeated` | `` |  |
-| 11 | `bans` | `.CMsgDOTARealtimeGameStats.PickBanDetails` | `repeated` | `` |  |
-| 12 | `kills` | `.CMsgDOTARealtimeGameStats.KillDetails` | `repeated` | `` |  |
-| 13 | `broadcasters` | `.CMsgDOTARealtimeGameStats.BroadcasterDetails` | `repeated` | `` |  |
-| 14 | `game_mode` | `uint32` | `optional` | `` |  |
-| 15 | `league_id` | `uint32` | `optional` | `` |  |
-| 16 | `single_team` | `bool` | `optional` | `` |  |
-| 17 | `cheers_peak` | `uint32` | `optional` | `` |  |
-| 18 | `league_node_id` | `uint32` | `optional` | `` |  |
-| 19 | `game_state` | `uint32` | `optional` | `` |  |
-| 20 | `lobby_type` | `uint32` | `optional` | `` |  |
-| 21 | `start_timestamp` | `uint32` | `optional` | `` |  |
-| 22 | `is_player_draft` | `bool` | `optional` | `` |  |
+| 1 | `server_steam_id` | `fixed64` | `optional` |  |  |
+| 2 | `match_id` | `uint64` | `optional` |  |  |
+| 3 | `timestamp` | `uint32` | `optional` |  |  |
+| 4 | `time_of_day` | `float` | `optional` |  |  |
+| 5 | `is_nightstalker_night` | `bool` | `optional` |  |  |
+| 6 | `game_time` | `int32` | `optional` |  |  |
+| 8 | `teamid_radiant` | `uint32` | `optional` |  |  |
+| 9 | `teamid_dire` | `uint32` | `optional` |  |  |
+| 10 | `picks` | `.CMsgDOTARealtimeGameStats.PickBanDetails` | `repeated` |  |  |
+| 11 | `bans` | `.CMsgDOTARealtimeGameStats.PickBanDetails` | `repeated` |  |  |
+| 12 | `kills` | `.CMsgDOTARealtimeGameStats.KillDetails` | `repeated` |  |  |
+| 13 | `broadcasters` | `.CMsgDOTARealtimeGameStats.BroadcasterDetails` | `repeated` |  |  |
+| 14 | `game_mode` | `uint32` | `optional` |  |  |
+| 15 | `league_id` | `uint32` | `optional` |  |  |
+| 16 | `single_team` | `bool` | `optional` |  |  |
+| 17 | `cheers_peak` | `uint32` | `optional` |  |  |
+| 18 | `league_node_id` | `uint32` | `optional` |  |  |
+| 19 | `game_state` | `uint32` | `optional` |  |  |
+| 20 | `lobby_type` | `uint32` | `optional` |  |  |
+| 21 | `start_timestamp` | `uint32` | `optional` |  |  |
+| 22 | `is_player_draft` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -917,12 +917,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `graph_gold` | `int32` | `repeated` | `` |  |
-| 2 | `graph_xp` | `int32` | `repeated` | `` |  |
-| 3 | `graph_kill` | `int32` | `repeated` | `` |  |
-| 4 | `graph_tower` | `int32` | `repeated` | `` |  |
-| 5 | `graph_rax` | `int32` | `repeated` | `` |  |
-| 6 | `team_loc_stats` | `.CMsgDOTARealtimeGameStats.GraphData.TeamLocationStats` | `repeated` | `` |  |
+| 1 | `graph_gold` | `int32` | `repeated` |  |  |
+| 2 | `graph_xp` | `int32` | `repeated` |  |  |
+| 3 | `graph_kill` | `int32` | `repeated` |  |  |
+| 4 | `graph_tower` | `int32` | `repeated` |  |  |
+| 5 | `graph_rax` | `int32` | `repeated` |  |  |
+| 6 | `team_loc_stats` | `.CMsgDOTARealtimeGameStats.GraphData.TeamLocationStats` | `repeated` |  |  |
 
 </details>
 
@@ -934,7 +934,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `stats` | `int32` | `repeated` | `` |  |
+| 1 | `stats` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -946,7 +946,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `loc_stats` | `.CMsgDOTARealtimeGameStats.GraphData.LocationStats` | `repeated` | `` |  |
+| 1 | `loc_stats` | `.CMsgDOTARealtimeGameStats.GraphData.LocationStats` | `repeated` |  |  |
 
 </details>
 
@@ -958,11 +958,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match` | `.CMsgDOTARealtimeGameStatsTerse.MatchDetails` | `optional` | `` |  |
-| 2 | `teams` | `.CMsgDOTARealtimeGameStatsTerse.TeamDetails` | `repeated` | `` |  |
-| 3 | `buildings` | `.CMsgDOTARealtimeGameStatsTerse.BuildingDetails` | `repeated` | `` |  |
-| 4 | `graph_data` | `.CMsgDOTARealtimeGameStatsTerse.GraphData` | `optional` | `` |  |
-| 5 | `delta_frame` | `bool` | `optional` | `` |  |
+| 1 | `match` | `.CMsgDOTARealtimeGameStatsTerse.MatchDetails` | `optional` |  |  |
+| 2 | `teams` | `.CMsgDOTARealtimeGameStatsTerse.TeamDetails` | `repeated` |  |  |
+| 3 | `buildings` | `.CMsgDOTARealtimeGameStatsTerse.BuildingDetails` | `repeated` |  |  |
+| 4 | `graph_data` | `.CMsgDOTARealtimeGameStatsTerse.GraphData` | `optional` |  |  |
+| 5 | `delta_frame` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -974,15 +974,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_number` | `uint32` | `optional` | `` |  |
-| 2 | `team_id` | `uint32` | `optional` | `` |  |
-| 3 | `team_name` | `string` | `optional` | `` |  |
-| 4 | `team_logo` | `fixed64` | `optional` | `` |  |
-| 5 | `score` | `uint32` | `optional` | `` |  |
-| 6 | `players` | `.CMsgDOTARealtimeGameStatsTerse.PlayerDetails` | `repeated` | `` |  |
-| 7 | `net_worth` | `uint32` | `optional` | `` |  |
-| 8 | `team_tag` | `string` | `optional` | `` |  |
-| 9 | `team_logo_url` | `string` | `optional` | `` |  |
+| 1 | `team_number` | `uint32` | `optional` |  |  |
+| 2 | `team_id` | `uint32` | `optional` |  |  |
+| 3 | `team_name` | `string` | `optional` |  |  |
+| 4 | `team_logo` | `fixed64` | `optional` |  |  |
+| 5 | `score` | `uint32` | `optional` |  |  |
+| 6 | `players` | `.CMsgDOTARealtimeGameStatsTerse.PlayerDetails` | `repeated` |  |  |
+| 7 | `net_worth` | `uint32` | `optional` |  |  |
+| 8 | `team_tag` | `string` | `optional` |  |  |
+| 9 | `team_logo_url` | `string` | `optional` |  |  |
 
 </details>
 
@@ -994,24 +994,24 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `accountid` | `uint32` | `optional` | `` |  |
-| 2 | `playerid` | `int32` | `optional` | `` | default = -1 |
-| 3 | `name` | `string` | `optional` | `` |  |
-| 4 | `team` | `uint32` | `optional` | `` |  |
-| 5 | `heroid` | `int32` | `optional` | `` |  |
-| 6 | `level` | `uint32` | `optional` | `` |  |
-| 7 | `kill_count` | `uint32` | `optional` | `` |  |
-| 8 | `death_count` | `uint32` | `optional` | `` |  |
-| 9 | `assists_count` | `uint32` | `optional` | `` |  |
-| 10 | `denies_count` | `uint32` | `optional` | `` |  |
-| 11 | `lh_count` | `uint32` | `optional` | `` |  |
-| 12 | `gold` | `uint32` | `optional` | `` |  |
-| 13 | `x` | `float` | `optional` | `` |  |
-| 14 | `y` | `float` | `optional` | `` |  |
-| 15 | `net_worth` | `uint32` | `optional` | `` |  |
-| 16 | `abilities` | `int32` | `repeated` | `` |  |
-| 17 | `items` | `int32` | `repeated` | `` |  |
-| 18 | `team_slot` | `uint32` | `optional` | `` |  |
+| 1 | `accountid` | `uint32` | `optional` |  |  |
+| 2 | `playerid` | `int32` | `optional` |  | default = -1 |
+| 3 | `name` | `string` | `optional` |  |  |
+| 4 | `team` | `uint32` | `optional` |  |  |
+| 5 | `heroid` | `int32` | `optional` |  |  |
+| 6 | `level` | `uint32` | `optional` |  |  |
+| 7 | `kill_count` | `uint32` | `optional` |  |  |
+| 8 | `death_count` | `uint32` | `optional` |  |  |
+| 9 | `assists_count` | `uint32` | `optional` |  |  |
+| 10 | `denies_count` | `uint32` | `optional` |  |  |
+| 11 | `lh_count` | `uint32` | `optional` |  |  |
+| 12 | `gold` | `uint32` | `optional` |  |  |
+| 13 | `x` | `float` | `optional` |  |  |
+| 14 | `y` | `float` | `optional` |  |  |
+| 15 | `net_worth` | `uint32` | `optional` |  |  |
+| 16 | `abilities` | `int32` | `repeated` |  |  |
+| 17 | `items` | `int32` | `repeated` |  |  |
+| 18 | `team_slot` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1023,14 +1023,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team` | `uint32` | `optional` | `` |  |
-| 2 | `heading` | `float` | `optional` | `` |  |
-| 3 | `type` | `uint32` | `optional` | `` |  |
-| 4 | `lane` | `uint32` | `optional` | `` |  |
-| 5 | `tier` | `uint32` | `optional` | `` |  |
-| 6 | `x` | `float` | `optional` | `` |  |
-| 7 | `y` | `float` | `optional` | `` |  |
-| 8 | `destroyed` | `bool` | `optional` | `` |  |
+| 1 | `team` | `uint32` | `optional` |  |  |
+| 2 | `heading` | `float` | `optional` |  |  |
+| 3 | `type` | `uint32` | `optional` |  |  |
+| 4 | `lane` | `uint32` | `optional` |  |  |
+| 5 | `tier` | `uint32` | `optional` |  |  |
+| 6 | `x` | `float` | `optional` |  |  |
+| 7 | `y` | `float` | `optional` |  |  |
+| 8 | `destroyed` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1042,8 +1042,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero` | `int32` | `optional` | `` |  |
-| 2 | `team` | `uint32` | `optional` | `` |  |
+| 1 | `hero` | `int32` | `optional` |  |  |
+| 2 | `team` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1055,20 +1055,20 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `server_steam_id` | `fixed64` | `optional` | `` |  |
-| 2 | `match_id` | `uint64` | `optional` | `` |  |
-| 3 | `timestamp` | `uint32` | `optional` | `` |  |
-| 4 | `game_time` | `int32` | `optional` | `` |  |
-| 6 | `steam_broadcaster_account_ids` | `uint32` | `repeated` | `` |  |
-| 7 | `game_mode` | `uint32` | `optional` | `` |  |
-| 8 | `league_id` | `uint32` | `optional` | `` |  |
-| 9 | `league_node_id` | `uint32` | `optional` | `` |  |
-| 10 | `game_state` | `uint32` | `optional` | `` |  |
-| 11 | `picks` | `.CMsgDOTARealtimeGameStatsTerse.PickBanDetails` | `repeated` | `` |  |
-| 12 | `bans` | `.CMsgDOTARealtimeGameStatsTerse.PickBanDetails` | `repeated` | `` |  |
-| 13 | `lobby_type` | `uint32` | `optional` | `` |  |
-| 14 | `start_timestamp` | `uint32` | `optional` | `` |  |
-| 15 | `is_player_draft` | `bool` | `optional` | `` |  |
+| 1 | `server_steam_id` | `fixed64` | `optional` |  |  |
+| 2 | `match_id` | `uint64` | `optional` |  |  |
+| 3 | `timestamp` | `uint32` | `optional` |  |  |
+| 4 | `game_time` | `int32` | `optional` |  |  |
+| 6 | `steam_broadcaster_account_ids` | `uint32` | `repeated` |  |  |
+| 7 | `game_mode` | `uint32` | `optional` |  |  |
+| 8 | `league_id` | `uint32` | `optional` |  |  |
+| 9 | `league_node_id` | `uint32` | `optional` |  |  |
+| 10 | `game_state` | `uint32` | `optional` |  |  |
+| 11 | `picks` | `.CMsgDOTARealtimeGameStatsTerse.PickBanDetails` | `repeated` |  |  |
+| 12 | `bans` | `.CMsgDOTARealtimeGameStatsTerse.PickBanDetails` | `repeated` |  |  |
+| 13 | `lobby_type` | `uint32` | `optional` |  |  |
+| 14 | `start_timestamp` | `uint32` | `optional` |  |  |
+| 15 | `is_player_draft` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1080,7 +1080,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `graph_gold` | `int32` | `repeated` | `` |  |
+| 1 | `graph_gold` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -1092,10 +1092,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event` | `.EBroadcastTimelineEvent` | `optional` | `` | default = EBroadcastTimelineEvent_MatchStarted |
-| 2 | `timestamp` | `fixed32` | `optional` | `` |  |
-| 3 | `data` | `uint32` | `optional` | `` |  |
-| 4 | `string_data` | `string` | `optional` | `` |  |
+| 1 | `event` | `.EBroadcastTimelineEvent` | `optional` |  | default = EBroadcastTimelineEvent_MatchStarted |
+| 2 | `timestamp` | `fixed32` | `optional` |  |  |
+| 3 | `data` | `uint32` | `optional` |  |  |
+| 4 | `string_data` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1107,7 +1107,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `matchgroups_version` | `uint32` | `optional` | `` |  |
+| 1 | `matchgroups_version` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1119,16 +1119,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `game_mode` | `uint32` | `optional` | `` |  |
-| 3 | `lobby_type` | `uint32` | `optional` | `` |  |
-| 4 | `start_time` | `uint32` | `optional` | `` |  |
-| 5 | `won` | `bool` | `optional` | `` |  |
-| 6 | `gpm` | `uint32` | `optional` | `` |  |
-| 7 | `xpm` | `uint32` | `optional` | `` |  |
-| 8 | `kills` | `uint32` | `optional` | `` |  |
-| 9 | `deaths` | `uint32` | `optional` | `` |  |
-| 10 | `assists` | `uint32` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `game_mode` | `uint32` | `optional` |  |  |
+| 3 | `lobby_type` | `uint32` | `optional` |  |  |
+| 4 | `start_time` | `uint32` | `optional` |  |  |
+| 5 | `won` | `bool` | `optional` |  |  |
+| 6 | `gpm` | `uint32` | `optional` |  |  |
+| 7 | `xpm` | `uint32` | `optional` |  |  |
+| 8 | `kills` | `uint32` | `optional` |  |  |
+| 9 | `deaths` | `uint32` | `optional` |  |  |
+| 10 | `assists` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1140,10 +1140,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `value` | `uint32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `min_raw_value` | `uint32` | `optional` | `` |  |
-| 4 | `max_raw_value` | `uint32` | `optional` | `` |  |
+| 1 | `value` | `uint32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `min_raw_value` | `uint32` | `optional` |  |  |
+| 4 | `max_raw_value` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1155,20 +1155,20 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `uint32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `type` | `.CMsgInGamePrediction.EPredictionType` | `optional` | `` | default = Generic |
-| 4 | `group` | `.CMsgInGamePrediction.ERandomSelectionGroup_t` | `optional` | `` | default = EarlyGame |
-| 5 | `question` | `string` | `optional` | `` |  |
-| 6 | `choices` | `.CMsgPredictionChoice` | `repeated` | `` |  |
-| 7 | `required_heroes` | `string` | `repeated` | `` |  |
-| 8 | `query_name` | `string` | `optional` | `` |  |
-| 9 | `query_values` | `.CMsgInGamePrediction.QueryKeyValues` | `repeated` | `` |  |
-| 10 | `answer_resolution_type` | `.CMsgInGamePrediction.EResolutionType_t` | `optional` | `` | default = InvalidQuery |
-| 11 | `points_to_grant` | `uint32` | `optional` | `` |  |
-| 12 | `reward_action` | `uint32` | `optional` | `` |  |
-| 13 | `debug_force_selection` | `uint32` | `optional` | `` |  |
-| 14 | `raw_value_type` | `.CMsgInGamePrediction.ERawValueType_t` | `optional` | `` | default = Number |
+| 1 | `id` | `uint32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `type` | `.CMsgInGamePrediction.EPredictionType` | `optional` |  | default = Generic |
+| 4 | `group` | `.CMsgInGamePrediction.ERandomSelectionGroup_t` | `optional` |  | default = EarlyGame |
+| 5 | `question` | `string` | `optional` |  |  |
+| 6 | `choices` | `.CMsgPredictionChoice` | `repeated` |  |  |
+| 7 | `required_heroes` | `string` | `repeated` |  |  |
+| 8 | `query_name` | `string` | `optional` |  |  |
+| 9 | `query_values` | `.CMsgInGamePrediction.QueryKeyValues` | `repeated` |  |  |
+| 10 | `answer_resolution_type` | `.CMsgInGamePrediction.EResolutionType_t` | `optional` |  | default = InvalidQuery |
+| 11 | `points_to_grant` | `uint32` | `optional` |  |  |
+| 12 | `reward_action` | `uint32` | `optional` |  |  |
+| 13 | `debug_force_selection` | `uint32` | `optional` |  |  |
+| 14 | `raw_value_type` | `.CMsgInGamePrediction.ERawValueType_t` | `optional` |  | default = Number |
 
 </details>
 
@@ -1180,8 +1180,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `value` | `string` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `value` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1193,10 +1193,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `predictions` | `.CMsgDOTASeasonPredictions.Prediction` | `repeated` | `` |  |
-| 2 | `in_game_predictions` | `.CMsgInGamePrediction` | `repeated` | `` |  |
-| 3 | `in_game_prediction_count_per_game` | `uint32` | `optional` | `` |  |
-| 4 | `in_game_prediction_voting_period_minutes` | `uint32` | `optional` | `` |  |
+| 1 | `predictions` | `.CMsgDOTASeasonPredictions.Prediction` | `repeated` |  |  |
+| 2 | `in_game_predictions` | `.CMsgInGamePrediction` | `repeated` |  |  |
+| 3 | `in_game_prediction_count_per_game` | `uint32` | `optional` |  |  |
+| 4 | `in_game_prediction_voting_period_minutes` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1208,26 +1208,26 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `type` | `.CMsgDOTASeasonPredictions.Prediction.EPredictionType` | `optional` | `` | default = Generic |
-| 2 | `question` | `string` | `optional` | `` |  |
-| 3 | `choices` | `.CMsgPredictionChoice` | `repeated` | `` |  |
-| 4 | `selection_id` | `uint32` | `optional` | `` |  |
-| 5 | `start_date` | `uint32` | `optional` | `` |  |
-| 6 | `lock_date` | `uint32` | `optional` | `` |  |
-| 7 | `reward` | `uint32` | `optional` | `` |  |
-| 8 | `answer_type` | `.CMsgDOTASeasonPredictions.Prediction.EAnswerType` | `optional` | `` | default = SingleInt |
-| 9 | `answer_id` | `uint32` | `optional` | `` |  |
-| 10 | `answers` | `.CMsgDOTASeasonPredictions.Prediction.Answers` | `repeated` | `` |  |
-| 11 | `query_name` | `string` | `optional` | `` |  |
-| 13 | `lock_on_selection_id` | `uint32` | `optional` | `` |  |
-| 14 | `lock_on_selection_value` | `uint32` | `optional` | `` |  |
-| 15 | `lock_on_selection_set` | `bool` | `optional` | `` |  |
-| 16 | `use_answer_value_ranges` | `bool` | `optional` | `` |  |
-| 17 | `region` | `.ELeagueRegion` | `optional` | `` | default = LEAGUE_REGION_UNSET |
-| 18 | `phases` | `.ELeaguePhase` | `repeated` | `` |  |
-| 19 | `reward_event` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 20 | `league_node_id` | `uint32` | `optional` | `` |  |
-| 21 | `reward_event_action` | `string` | `optional` | `` |  |
+| 1 | `type` | `.CMsgDOTASeasonPredictions.Prediction.EPredictionType` | `optional` |  | default = Generic |
+| 2 | `question` | `string` | `optional` |  |  |
+| 3 | `choices` | `.CMsgPredictionChoice` | `repeated` |  |  |
+| 4 | `selection_id` | `uint32` | `optional` |  |  |
+| 5 | `start_date` | `uint32` | `optional` |  |  |
+| 6 | `lock_date` | `uint32` | `optional` |  |  |
+| 7 | `reward` | `uint32` | `optional` |  |  |
+| 8 | `answer_type` | `.CMsgDOTASeasonPredictions.Prediction.EAnswerType` | `optional` |  | default = SingleInt |
+| 9 | `answer_id` | `uint32` | `optional` |  |  |
+| 10 | `answers` | `.CMsgDOTASeasonPredictions.Prediction.Answers` | `repeated` |  |  |
+| 11 | `query_name` | `string` | `optional` |  |  |
+| 13 | `lock_on_selection_id` | `uint32` | `optional` |  |  |
+| 14 | `lock_on_selection_value` | `uint32` | `optional` |  |  |
+| 15 | `lock_on_selection_set` | `bool` | `optional` |  |  |
+| 16 | `use_answer_value_ranges` | `bool` | `optional` |  |  |
+| 17 | `region` | `.ELeagueRegion` | `optional` |  | default = LEAGUE_REGION_UNSET |
+| 18 | `phases` | `.ELeaguePhase` | `repeated` |  |  |
+| 19 | `reward_event` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 20 | `league_node_id` | `uint32` | `optional` |  |  |
+| 21 | `reward_event_action` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1239,7 +1239,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `answer_id` | `uint32` | `optional` | `` |  |
+| 1 | `answer_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1251,7 +1251,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_predictions` | `.CMsgAvailablePredictions.MatchPrediction` | `repeated` | `` |  |
+| 1 | `match_predictions` | `.CMsgAvailablePredictions.MatchPrediction` | `repeated` |  |  |
 
 </details>
 
@@ -1263,8 +1263,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `predictions` | `.CMsgInGamePrediction` | `repeated` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `predictions` | `.CMsgInGamePrediction` | `repeated` |  |  |
 
 </details>
 
@@ -1276,7 +1276,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `leagues` | `.CMsgLeagueWatchedGames.League` | `repeated` | `` |  |
+| 1 | `leagues` | `.CMsgLeagueWatchedGames.League` | `repeated` |  |  |
 
 </details>
 
@@ -1288,8 +1288,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `node_id` | `uint32` | `optional` | `` |  |
-| 2 | `game` | `uint32` | `repeated` | `` |  |
+| 1 | `node_id` | `uint32` | `optional` |  |  |
+| 2 | `game` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -1301,8 +1301,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 2 | `series` | `.CMsgLeagueWatchedGames.Series` | `repeated` | `` |  |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 2 | `series` | `.CMsgLeagueWatchedGames.Series` | `repeated` |  |  |
 
 </details>
 
@@ -1314,54 +1314,54 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 3 | `duration` | `uint32` | `optional` | `` |  |
-| 4 | `starttime` | `fixed32` | `optional` | `` |  |
-| 5 | `players` | `.CMsgDOTAMatch.Player` | `repeated` | `` |  |
-| 6 | `match_id` | `uint64` | `optional` | `` |  |
-| 8 | `tower_status` | `uint32` | `repeated` | `` |  |
-| 9 | `barracks_status` | `uint32` | `repeated` | `` |  |
-| 10 | `cluster` | `uint32` | `optional` | `` |  |
-| 12 | `first_blood_time` | `uint32` | `optional` | `` |  |
-| 13 | `replay_salt` | `fixed32` | `optional` | `` |  |
-| 14 | `server_ip` | `fixed32` | `optional` | `` |  |
-| 15 | `server_port` | `uint32` | `optional` | `` |  |
-| 16 | `lobby_type` | `uint32` | `optional` | `` |  |
-| 17 | `human_players` | `uint32` | `optional` | `` |  |
-| 18 | `average_skill` | `uint32` | `optional` | `` |  |
-| 19 | `game_balance` | `float` | `optional` | `` |  |
-| 20 | `radiant_team_id` | `uint32` | `optional` | `` |  |
-| 21 | `dire_team_id` | `uint32` | `optional` | `` |  |
-| 22 | `leagueid` | `uint32` | `optional` | `` |  |
-| 23 | `radiant_team_name` | `string` | `optional` | `` |  |
-| 24 | `dire_team_name` | `string` | `optional` | `` |  |
-| 25 | `radiant_team_logo` | `uint64` | `optional` | `` |  |
-| 26 | `dire_team_logo` | `uint64` | `optional` | `` |  |
-| 27 | `radiant_team_complete` | `uint32` | `optional` | `` |  |
-| 28 | `dire_team_complete` | `uint32` | `optional` | `` |  |
-| 31 | `game_mode` | `.DOTA_GameMode` | `optional` | `` | default = DOTA_GAMEMODE_NONE |
-| 32 | `picks_bans` | `.CMatchHeroSelectEvent` | `repeated` | `` |  |
-| 33 | `match_seq_num` | `uint64` | `optional` | `` |  |
-| 34 | `replay_state` | `.CMsgDOTAMatch.ReplayState` | `optional` | `` | default = REPLAY_AVAILABLE |
-| 35 | `radiant_guild_id` | `uint32` | `optional` | `` |  |
-| 36 | `dire_guild_id` | `uint32` | `optional` | `` |  |
-| 37 | `radiant_team_tag` | `string` | `optional` | `` |  |
-| 38 | `dire_team_tag` | `string` | `optional` | `` |  |
-| 39 | `series_id` | `uint32` | `optional` | `` |  |
-| 40 | `series_type` | `uint32` | `optional` | `` |  |
-| 43 | `broadcaster_channels` | `.CMsgDOTAMatch.BroadcasterChannel` | `repeated` | `` |  |
-| 44 | `engine` | `uint32` | `optional` | `` |  |
-| 45 | `custom_game_data` | `.CMsgDOTAMatch.CustomGameData` | `optional` | `` |  |
-| 46 | `match_flags` | `uint32` | `optional` | `` |  |
-| 47 | `private_metadata_key` | `fixed32` | `optional` | `` |  |
-| 48 | `radiant_team_score` | `uint32` | `optional` | `` |  |
-| 49 | `dire_team_score` | `uint32` | `optional` | `` |  |
-| 50 | `match_outcome` | `.EMatchOutcome` | `optional` | `` | default = k_EMatchOutcome_Unknown |
-| 51 | `tournament_id` | `uint32` | `optional` | `` |  |
-| 52 | `tournament_round` | `uint32` | `optional` | `` |  |
-| 53 | `pre_game_duration` | `uint32` | `optional` | `` |  |
-| 54 | `radiant_team_logo_url` | `string` | `optional` | `` |  |
-| 55 | `dire_team_logo_url` | `string` | `optional` | `` |  |
-| 57 | `coaches` | `.CMsgDOTAMatch.Coach` | `repeated` | `` |  |
+| 3 | `duration` | `uint32` | `optional` |  |  |
+| 4 | `starttime` | `fixed32` | `optional` |  |  |
+| 5 | `players` | `.CMsgDOTAMatch.Player` | `repeated` |  |  |
+| 6 | `match_id` | `uint64` | `optional` |  |  |
+| 8 | `tower_status` | `uint32` | `repeated` |  |  |
+| 9 | `barracks_status` | `uint32` | `repeated` |  |  |
+| 10 | `cluster` | `uint32` | `optional` |  |  |
+| 12 | `first_blood_time` | `uint32` | `optional` |  |  |
+| 13 | `replay_salt` | `fixed32` | `optional` |  |  |
+| 14 | `server_ip` | `fixed32` | `optional` |  |  |
+| 15 | `server_port` | `uint32` | `optional` |  |  |
+| 16 | `lobby_type` | `uint32` | `optional` |  |  |
+| 17 | `human_players` | `uint32` | `optional` |  |  |
+| 18 | `average_skill` | `uint32` | `optional` |  |  |
+| 19 | `game_balance` | `float` | `optional` |  |  |
+| 20 | `radiant_team_id` | `uint32` | `optional` |  |  |
+| 21 | `dire_team_id` | `uint32` | `optional` |  |  |
+| 22 | `leagueid` | `uint32` | `optional` |  |  |
+| 23 | `radiant_team_name` | `string` | `optional` |  |  |
+| 24 | `dire_team_name` | `string` | `optional` |  |  |
+| 25 | `radiant_team_logo` | `uint64` | `optional` |  |  |
+| 26 | `dire_team_logo` | `uint64` | `optional` |  |  |
+| 27 | `radiant_team_complete` | `uint32` | `optional` |  |  |
+| 28 | `dire_team_complete` | `uint32` | `optional` |  |  |
+| 31 | `game_mode` | `.DOTA_GameMode` | `optional` |  | default = DOTA_GAMEMODE_NONE |
+| 32 | `picks_bans` | `.CMatchHeroSelectEvent` | `repeated` |  |  |
+| 33 | `match_seq_num` | `uint64` | `optional` |  |  |
+| 34 | `replay_state` | `.CMsgDOTAMatch.ReplayState` | `optional` |  | default = REPLAY_AVAILABLE |
+| 35 | `radiant_guild_id` | `uint32` | `optional` |  |  |
+| 36 | `dire_guild_id` | `uint32` | `optional` |  |  |
+| 37 | `radiant_team_tag` | `string` | `optional` |  |  |
+| 38 | `dire_team_tag` | `string` | `optional` |  |  |
+| 39 | `series_id` | `uint32` | `optional` |  |  |
+| 40 | `series_type` | `uint32` | `optional` |  |  |
+| 43 | `broadcaster_channels` | `.CMsgDOTAMatch.BroadcasterChannel` | `repeated` |  |  |
+| 44 | `engine` | `uint32` | `optional` |  |  |
+| 45 | `custom_game_data` | `.CMsgDOTAMatch.CustomGameData` | `optional` |  |  |
+| 46 | `match_flags` | `uint32` | `optional` |  |  |
+| 47 | `private_metadata_key` | `fixed32` | `optional` |  |  |
+| 48 | `radiant_team_score` | `uint32` | `optional` |  |  |
+| 49 | `dire_team_score` | `uint32` | `optional` |  |  |
+| 50 | `match_outcome` | `.EMatchOutcome` | `optional` |  | default = k_EMatchOutcome_Unknown |
+| 51 | `tournament_id` | `uint32` | `optional` |  |  |
+| 52 | `tournament_round` | `uint32` | `optional` |  |  |
+| 53 | `pre_game_duration` | `uint32` | `optional` |  |  |
+| 54 | `radiant_team_logo_url` | `string` | `optional` |  |  |
+| 55 | `dire_team_logo_url` | `string` | `optional` |  |  |
+| 57 | `coaches` | `.CMsgDOTAMatch.Coach` | `repeated` |  |  |
 
 </details>
 
@@ -1373,83 +1373,83 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `player_slot` | `uint32` | `optional` | `` |  |
-| 3 | `hero_id` | `int32` | `optional` | `` |  |
-| 4 | `item_0` | `int32` | `optional` | `` | default = -1 |
-| 5 | `item_1` | `int32` | `optional` | `` | default = -1 |
-| 6 | `item_2` | `int32` | `optional` | `` | default = -1 |
-| 7 | `item_3` | `int32` | `optional` | `` | default = -1 |
-| 8 | `item_4` | `int32` | `optional` | `` | default = -1 |
-| 9 | `item_5` | `int32` | `optional` | `` | default = -1 |
-| 10 | `expected_team_contribution` | `float` | `optional` | `` |  |
-| 11 | `scaled_metric` | `float` | `optional` | `` |  |
-| 12 | `previous_rank` | `uint32` | `optional` | `` |  |
-| 13 | `rank_change` | `sint32` | `optional` | `` |  |
-| 14 | `kills` | `uint32` | `optional` | `` |  |
-| 15 | `deaths` | `uint32` | `optional` | `` |  |
-| 16 | `assists` | `uint32` | `optional` | `` |  |
-| 17 | `leaver_status` | `uint32` | `optional` | `` |  |
-| 18 | `gold` | `uint32` | `optional` | `` |  |
-| 19 | `last_hits` | `uint32` | `optional` | `` |  |
-| 20 | `denies` | `uint32` | `optional` | `` |  |
-| 21 | `gold_per_min` | `uint32` | `optional` | `` |  |
-| 22 | `xp_per_min` | `uint32` | `optional` | `` |  |
-| 23 | `gold_spent` | `uint32` | `optional` | `` |  |
-| 24 | `hero_damage` | `uint32` | `optional` | `` |  |
-| 25 | `tower_damage` | `uint32` | `optional` | `` |  |
-| 26 | `hero_healing` | `uint32` | `optional` | `` |  |
-| 27 | `level` | `uint32` | `optional` | `` |  |
-| 28 | `time_last_seen` | `uint32` | `optional` | `` |  |
-| 29 | `player_name` | `string` | `optional` | `` |  |
-| 30 | `support_ability_value` | `uint32` | `optional` | `` |  |
-| 32 | `feeding_detected` | `bool` | `optional` | `` |  |
-| 34 | `search_rank` | `uint32` | `optional` | `` |  |
-| 35 | `search_rank_uncertainty` | `uint32` | `optional` | `` |  |
-| 36 | `rank_uncertainty_change` | `int32` | `optional` | `` |  |
-| 37 | `hero_play_count` | `uint32` | `optional` | `` |  |
-| 38 | `party_id` | `fixed64` | `optional` | `` |  |
-| 39 | `scaled_kills` | `float` | `optional` | `` |  |
-| 40 | `scaled_deaths` | `float` | `optional` | `` |  |
-| 41 | `scaled_assists` | `float` | `optional` | `` |  |
-| 42 | `claimed_farm_gold` | `uint32` | `optional` | `` |  |
-| 43 | `support_gold` | `uint32` | `optional` | `` |  |
-| 44 | `claimed_denies` | `uint32` | `optional` | `` |  |
-| 45 | `claimed_misses` | `uint32` | `optional` | `` |  |
-| 46 | `misses` | `uint32` | `optional` | `` |  |
-| 47 | `ability_upgrades` | `.CMatchPlayerAbilityUpgrade` | `repeated` | `` |  |
-| 48 | `additional_units_inventory` | `.CMatchAdditionalUnitInventory` | `repeated` | `` |  |
-| 50 | `custom_game_data` | `.CMsgDOTAMatch.Player.CustomGameData` | `optional` | `` |  |
-| 51 | `active_plus_subscription` | `bool` | `optional` | `` |  |
-| 52 | `net_worth` | `uint32` | `optional` | `` |  |
-| 54 | `scaled_hero_damage` | `uint32` | `optional` | `` |  |
-| 55 | `scaled_tower_damage` | `uint32` | `optional` | `` |  |
-| 56 | `scaled_hero_healing` | `uint32` | `optional` | `` |  |
-| 57 | `permanent_buffs` | `.CMatchPlayerPermanentBuff` | `repeated` | `` |  |
-| 58 | `bot_difficulty` | `uint32` | `optional` | `` |  |
-| 59 | `item_6` | `int32` | `optional` | `` | default = -1 |
-| 60 | `item_7` | `int32` | `optional` | `` | default = -1 |
-| 61 | `item_8` | `int32` | `optional` | `` | default = -1 |
-| 63 | `hero_pick_order` | `uint32` | `optional` | `` |  |
-| 64 | `hero_was_randomed` | `bool` | `optional` | `` |  |
-| 67 | `hero_damage_received` | `.CMsgDOTAMatch.Player.HeroDamageReceived` | `repeated` | `` |  |
-| 69 | `hero_was_dota_plus_suggestion` | `bool` | `optional` | `` |  |
-| 70 | `seconds_dead` | `uint32` | `optional` | `` |  |
-| 71 | `gold_lost_to_death` | `uint32` | `optional` | `` |  |
-| 72 | `pro_name` | `string` | `optional` | `` |  |
-| 73 | `real_name` | `string` | `optional` | `` |  |
-| 74 | `mmr_type` | `uint32` | `optional` | `` |  |
-| 75 | `lane_selection_flags` | `uint32` | `optional` | `` |  |
-| 76 | `item_9` | `int32` | `optional` | `` | default = -1 |
-| 77 | `bounty_runes` | `uint32` | `optional` | `` |  |
-| 78 | `outposts_captured` | `uint32` | `optional` | `` |  |
-| 79 | `hero_damage_dealt` | `.CMsgDOTAMatch.Player.HeroDamageReceived` | `repeated` | `` |  |
-| 80 | `team_number` | `.DOTA_GC_TEAM` | `optional` | `` | default = DOTA_GC_TEAM_GOOD_GUYS |
-| 81 | `team_slot` | `uint32` | `optional` | `` |  |
-| 82 | `selected_facet` | `uint32` | `optional` | `` |  |
-| 83 | `item_10` | `int32` | `optional` | `` | default = -1 |
-| 84 | `item_10_lvl` | `int32` | `optional` | `` |  |
-| 85 | `disable_duration` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `player_slot` | `uint32` | `optional` |  |  |
+| 3 | `hero_id` | `int32` | `optional` |  |  |
+| 4 | `item_0` | `int32` | `optional` |  | default = -1 |
+| 5 | `item_1` | `int32` | `optional` |  | default = -1 |
+| 6 | `item_2` | `int32` | `optional` |  | default = -1 |
+| 7 | `item_3` | `int32` | `optional` |  | default = -1 |
+| 8 | `item_4` | `int32` | `optional` |  | default = -1 |
+| 9 | `item_5` | `int32` | `optional` |  | default = -1 |
+| 10 | `expected_team_contribution` | `float` | `optional` |  |  |
+| 11 | `scaled_metric` | `float` | `optional` |  |  |
+| 12 | `previous_rank` | `uint32` | `optional` |  |  |
+| 13 | `rank_change` | `sint32` | `optional` |  |  |
+| 14 | `kills` | `uint32` | `optional` |  |  |
+| 15 | `deaths` | `uint32` | `optional` |  |  |
+| 16 | `assists` | `uint32` | `optional` |  |  |
+| 17 | `leaver_status` | `uint32` | `optional` |  |  |
+| 18 | `gold` | `uint32` | `optional` |  |  |
+| 19 | `last_hits` | `uint32` | `optional` |  |  |
+| 20 | `denies` | `uint32` | `optional` |  |  |
+| 21 | `gold_per_min` | `uint32` | `optional` |  |  |
+| 22 | `xp_per_min` | `uint32` | `optional` |  |  |
+| 23 | `gold_spent` | `uint32` | `optional` |  |  |
+| 24 | `hero_damage` | `uint32` | `optional` |  |  |
+| 25 | `tower_damage` | `uint32` | `optional` |  |  |
+| 26 | `hero_healing` | `uint32` | `optional` |  |  |
+| 27 | `level` | `uint32` | `optional` |  |  |
+| 28 | `time_last_seen` | `uint32` | `optional` |  |  |
+| 29 | `player_name` | `string` | `optional` |  |  |
+| 30 | `support_ability_value` | `uint32` | `optional` |  |  |
+| 32 | `feeding_detected` | `bool` | `optional` |  |  |
+| 34 | `search_rank` | `uint32` | `optional` |  |  |
+| 35 | `search_rank_uncertainty` | `uint32` | `optional` |  |  |
+| 36 | `rank_uncertainty_change` | `int32` | `optional` |  |  |
+| 37 | `hero_play_count` | `uint32` | `optional` |  |  |
+| 38 | `party_id` | `fixed64` | `optional` |  |  |
+| 39 | `scaled_kills` | `float` | `optional` |  |  |
+| 40 | `scaled_deaths` | `float` | `optional` |  |  |
+| 41 | `scaled_assists` | `float` | `optional` |  |  |
+| 42 | `claimed_farm_gold` | `uint32` | `optional` |  |  |
+| 43 | `support_gold` | `uint32` | `optional` |  |  |
+| 44 | `claimed_denies` | `uint32` | `optional` |  |  |
+| 45 | `claimed_misses` | `uint32` | `optional` |  |  |
+| 46 | `misses` | `uint32` | `optional` |  |  |
+| 47 | `ability_upgrades` | `.CMatchPlayerAbilityUpgrade` | `repeated` |  |  |
+| 48 | `additional_units_inventory` | `.CMatchAdditionalUnitInventory` | `repeated` |  |  |
+| 50 | `custom_game_data` | `.CMsgDOTAMatch.Player.CustomGameData` | `optional` |  |  |
+| 51 | `active_plus_subscription` | `bool` | `optional` |  |  |
+| 52 | `net_worth` | `uint32` | `optional` |  |  |
+| 54 | `scaled_hero_damage` | `uint32` | `optional` |  |  |
+| 55 | `scaled_tower_damage` | `uint32` | `optional` |  |  |
+| 56 | `scaled_hero_healing` | `uint32` | `optional` |  |  |
+| 57 | `permanent_buffs` | `.CMatchPlayerPermanentBuff` | `repeated` |  |  |
+| 58 | `bot_difficulty` | `uint32` | `optional` |  |  |
+| 59 | `item_6` | `int32` | `optional` |  | default = -1 |
+| 60 | `item_7` | `int32` | `optional` |  | default = -1 |
+| 61 | `item_8` | `int32` | `optional` |  | default = -1 |
+| 63 | `hero_pick_order` | `uint32` | `optional` |  |  |
+| 64 | `hero_was_randomed` | `bool` | `optional` |  |  |
+| 67 | `hero_damage_received` | `.CMsgDOTAMatch.Player.HeroDamageReceived` | `repeated` |  |  |
+| 69 | `hero_was_dota_plus_suggestion` | `bool` | `optional` |  |  |
+| 70 | `seconds_dead` | `uint32` | `optional` |  |  |
+| 71 | `gold_lost_to_death` | `uint32` | `optional` |  |  |
+| 72 | `pro_name` | `string` | `optional` |  |  |
+| 73 | `real_name` | `string` | `optional` |  |  |
+| 74 | `mmr_type` | `uint32` | `optional` |  |  |
+| 75 | `lane_selection_flags` | `uint32` | `optional` |  |  |
+| 76 | `item_9` | `int32` | `optional` |  | default = -1 |
+| 77 | `bounty_runes` | `uint32` | `optional` |  |  |
+| 78 | `outposts_captured` | `uint32` | `optional` |  |  |
+| 79 | `hero_damage_dealt` | `.CMsgDOTAMatch.Player.HeroDamageReceived` | `repeated` |  |  |
+| 80 | `team_number` | `.DOTA_GC_TEAM` | `optional` |  | default = DOTA_GC_TEAM_GOOD_GUYS |
+| 81 | `team_slot` | `uint32` | `optional` |  |  |
+| 82 | `selected_facet` | `uint32` | `optional` |  |  |
+| 83 | `item_10` | `int32` | `optional` |  | default = -1 |
+| 84 | `item_10_lvl` | `int32` | `optional` |  |  |
+| 85 | `disable_duration` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1461,8 +1461,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `dota_team` | `uint32` | `optional` | `` |  |
-| 2 | `winner` | `bool` | `optional` | `` |  |
+| 1 | `dota_team` | `uint32` | `optional` |  |  |
+| 2 | `winner` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1474,9 +1474,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `pre_reduction` | `uint32` | `optional` | `` |  |
-| 2 | `post_reduction` | `uint32` | `optional` | `` |  |
-| 3 | `damage_type` | `.CMsgDOTAMatch.Player.HeroDamageType` | `optional` | `` | default = HERO_DAMAGE_PHYSICAL |
+| 1 | `pre_reduction` | `uint32` | `optional` |  |  |
+| 2 | `post_reduction` | `uint32` | `optional` |  |  |
+| 3 | `damage_type` | `.CMsgDOTAMatch.Player.HeroDamageType` | `optional` |  | default = HERO_DAMAGE_PHYSICAL |
 
 </details>
 
@@ -1488,8 +1488,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1501,10 +1501,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `country_code` | `string` | `optional` | `` |  |
-| 2 | `description` | `string` | `optional` | `` |  |
-| 3 | `broadcaster_infos` | `.CMsgDOTAMatch.BroadcasterInfo` | `repeated` | `` |  |
-| 4 | `language_code` | `string` | `optional` | `` |  |
+| 1 | `country_code` | `string` | `optional` |  |  |
+| 2 | `description` | `string` | `optional` |  |  |
+| 3 | `broadcaster_infos` | `.CMsgDOTAMatch.BroadcasterInfo` | `repeated` |  |  |
+| 4 | `language_code` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1516,12 +1516,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `coach_name` | `string` | `optional` | `` |  |
-| 3 | `coach_rating` | `uint32` | `optional` | `` |  |
-| 4 | `coach_team` | `uint32` | `optional` | `` |  |
-| 5 | `coach_party_id` | `uint64` | `optional` | `` |  |
-| 6 | `is_private_coach` | `bool` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `coach_name` | `string` | `optional` |  |  |
+| 3 | `coach_rating` | `uint32` | `optional` |  |  |
+| 4 | `coach_team` | `uint32` | `optional` |  |  |
+| 5 | `coach_party_id` | `uint64` | `optional` |  |  |
+| 6 | `is_private_coach` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1533,8 +1533,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `custom_game_id` | `uint64` | `optional` | `` |  |
-| 2 | `map_name` | `string` | `optional` | `` |  |
+| 1 | `custom_game_id` | `uint64` | `optional` |  |  |
+| 2 | `map_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1546,8 +1546,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `stat_modifier` | `.CMsgPlayerCard.StatModifier` | `repeated` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `stat_modifier` | `.CMsgPlayerCard.StatModifier` | `repeated` |  |  |
 
 </details>
 
@@ -1559,8 +1559,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `stat` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `uint32` | `optional` | `` |  |
+| 1 | `stat` | `uint32` | `optional` |  |  |
+| 2 | `value` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1572,33 +1572,33 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `match_id` | `uint64` | `optional` | `` |  |
-| 3 | `match_completed` | `bool` | `optional` | `` |  |
-| 4 | `team_id` | `uint32` | `optional` | `` |  |
-| 5 | `league_id` | `uint32` | `optional` | `` |  |
-| 6 | `delay` | `uint32` | `optional` | `` |  |
-| 7 | `series_id` | `uint32` | `optional` | `` |  |
-| 8 | `series_type` | `uint32` | `optional` | `` |  |
-| 10 | `kills` | `uint32` | `optional` | `` |  |
-| 11 | `deaths` | `uint32` | `optional` | `` |  |
-| 12 | `cs` | `uint32` | `optional` | `` |  |
-| 13 | `gpm` | `float` | `optional` | `` |  |
-| 14 | `tower_kills` | `uint32` | `optional` | `` |  |
-| 15 | `roshan_kills` | `uint32` | `optional` | `` |  |
-| 16 | `teamfight_participation` | `float` | `optional` | `` |  |
-| 17 | `wards_placed` | `uint32` | `optional` | `` |  |
-| 18 | `camps_stacked` | `uint32` | `optional` | `` |  |
-| 19 | `runes_grabbed` | `uint32` | `optional` | `` |  |
-| 20 | `first_blood` | `uint32` | `optional` | `` |  |
-| 21 | `stuns` | `float` | `optional` | `` |  |
-| 22 | `smokes` | `uint32` | `optional` | `` |  |
-| 24 | `watchers` | `uint32` | `optional` | `` |  |
-| 25 | `lotuses` | `uint32` | `optional` | `` |  |
-| 26 | `tormentors` | `uint32` | `optional` | `` |  |
-| 27 | `courier_kills` | `uint32` | `optional` | `` |  |
-| 28 | `title_stats` | `fixed64` | `optional` | `` |  |
-| 29 | `madstone` | `uint32` | `optional` | `` |  |
+| 1 | `player_account_id` | `uint32` | `optional` |  |  |
+| 2 | `match_id` | `uint64` | `optional` |  |  |
+| 3 | `match_completed` | `bool` | `optional` |  |  |
+| 4 | `team_id` | `uint32` | `optional` |  |  |
+| 5 | `league_id` | `uint32` | `optional` |  |  |
+| 6 | `delay` | `uint32` | `optional` |  |  |
+| 7 | `series_id` | `uint32` | `optional` |  |  |
+| 8 | `series_type` | `uint32` | `optional` |  |  |
+| 10 | `kills` | `uint32` | `optional` |  |  |
+| 11 | `deaths` | `uint32` | `optional` |  |  |
+| 12 | `cs` | `uint32` | `optional` |  |  |
+| 13 | `gpm` | `float` | `optional` |  |  |
+| 14 | `tower_kills` | `uint32` | `optional` |  |  |
+| 15 | `roshan_kills` | `uint32` | `optional` |  |  |
+| 16 | `teamfight_participation` | `float` | `optional` |  |  |
+| 17 | `wards_placed` | `uint32` | `optional` |  |  |
+| 18 | `camps_stacked` | `uint32` | `optional` |  |  |
+| 19 | `runes_grabbed` | `uint32` | `optional` |  |  |
+| 20 | `first_blood` | `uint32` | `optional` |  |  |
+| 21 | `stuns` | `float` | `optional` |  |  |
+| 22 | `smokes` | `uint32` | `optional` |  |  |
+| 24 | `watchers` | `uint32` | `optional` |  |  |
+| 25 | `lotuses` | `uint32` | `optional` |  |  |
+| 26 | `tormentors` | `uint32` | `optional` |  |  |
+| 27 | `courier_kills` | `uint32` | `optional` |  |  |
+| 28 | `title_stats` | `fixed64` | `optional` |  |  |
+| 29 | `madstone` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1610,7 +1610,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `matches` | `.CMsgDOTAFantasyPlayerStats` | `repeated` | `` |  |
+| 1 | `matches` | `.CMsgDOTAFantasyPlayerStats` | `repeated` |  |  |
 
 </details>
 
@@ -1622,19 +1622,19 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `bots` | `.CMsgDOTABotDebugInfo.Bot` | `repeated` | `` |  |
-| 2 | `desire_push_lane_top` | `float` | `optional` | `` |  |
-| 3 | `desire_push_lane_mid` | `float` | `optional` | `` |  |
-| 4 | `desire_push_lane_bot` | `float` | `optional` | `` |  |
-| 5 | `desire_defend_lane_top` | `float` | `optional` | `` |  |
-| 6 | `desire_defend_lane_mid` | `float` | `optional` | `` |  |
-| 7 | `desire_defend_lane_bot` | `float` | `optional` | `` |  |
-| 8 | `desire_farm_lane_top` | `float` | `optional` | `` |  |
-| 9 | `desire_farm_lane_mid` | `float` | `optional` | `` |  |
-| 10 | `desire_farm_lane_bot` | `float` | `optional` | `` |  |
-| 11 | `desire_farm_roshan` | `float` | `optional` | `` |  |
-| 12 | `execution_time` | `float` | `optional` | `` |  |
-| 13 | `rune_status` | `uint32` | `repeated` | `` |  |
+| 1 | `bots` | `.CMsgDOTABotDebugInfo.Bot` | `repeated` |  |  |
+| 2 | `desire_push_lane_top` | `float` | `optional` |  |  |
+| 3 | `desire_push_lane_mid` | `float` | `optional` |  |  |
+| 4 | `desire_push_lane_bot` | `float` | `optional` |  |  |
+| 5 | `desire_defend_lane_top` | `float` | `optional` |  |  |
+| 6 | `desire_defend_lane_mid` | `float` | `optional` |  |  |
+| 7 | `desire_defend_lane_bot` | `float` | `optional` |  |  |
+| 8 | `desire_farm_lane_top` | `float` | `optional` |  |  |
+| 9 | `desire_farm_lane_mid` | `float` | `optional` |  |  |
+| 10 | `desire_farm_lane_bot` | `float` | `optional` |  |  |
+| 11 | `desire_farm_roshan` | `float` | `optional` |  |  |
+| 12 | `execution_time` | `float` | `optional` |  |  |
+| 13 | `rune_status` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -1646,18 +1646,18 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_owner_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `hero_id` | `int32` | `optional` | `` |  |
-| 3 | `difficulty` | `uint32` | `optional` | `` |  |
-| 4 | `power_current` | `uint32` | `optional` | `` |  |
-| 5 | `power_max` | `uint32` | `optional` | `` |  |
-| 6 | `move_target_x` | `uint32` | `optional` | `` |  |
-| 7 | `move_target_y` | `uint32` | `optional` | `` |  |
-| 8 | `move_target_z` | `uint32` | `optional` | `` |  |
-| 9 | `active_mode_id` | `uint32` | `optional` | `` |  |
-| 10 | `execution_time` | `float` | `optional` | `` |  |
-| 11 | `modes` | `.CMsgDOTABotDebugInfo.Bot.Mode` | `repeated` | `` |  |
-| 12 | `action` | `.CMsgDOTABotDebugInfo.Bot.Action` | `optional` | `` |  |
+| 1 | `player_owner_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `hero_id` | `int32` | `optional` |  |  |
+| 3 | `difficulty` | `uint32` | `optional` |  |  |
+| 4 | `power_current` | `uint32` | `optional` |  |  |
+| 5 | `power_max` | `uint32` | `optional` |  |  |
+| 6 | `move_target_x` | `uint32` | `optional` |  |  |
+| 7 | `move_target_y` | `uint32` | `optional` |  |  |
+| 8 | `move_target_z` | `uint32` | `optional` |  |  |
+| 9 | `active_mode_id` | `uint32` | `optional` |  |  |
+| 10 | `execution_time` | `float` | `optional` |  |  |
+| 11 | `modes` | `.CMsgDOTABotDebugInfo.Bot.Mode` | `repeated` |  |  |
+| 12 | `action` | `.CMsgDOTABotDebugInfo.Bot.Action` | `optional` |  |  |
 
 </details>
 
@@ -1669,12 +1669,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `mode_id` | `uint32` | `optional` | `` |  |
-| 2 | `desire` | `float` | `optional` | `` |  |
-| 3 | `target_entity` | `int32` | `optional` | `` | default = -1 |
-| 4 | `target_x` | `uint32` | `optional` | `` |  |
-| 5 | `target_y` | `uint32` | `optional` | `` |  |
-| 6 | `target_z` | `uint32` | `optional` | `` |  |
+| 1 | `mode_id` | `uint32` | `optional` |  |  |
+| 2 | `desire` | `float` | `optional` |  |  |
+| 3 | `target_entity` | `int32` | `optional` |  | default = -1 |
+| 4 | `target_x` | `uint32` | `optional` |  |  |
+| 5 | `target_y` | `uint32` | `optional` |  |  |
+| 6 | `target_z` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1686,8 +1686,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `action_id` | `uint32` | `optional` | `` |  |
-| 2 | `action_target` | `string` | `optional` | `` |  |
+| 1 | `action_id` | `uint32` | `optional` |  |  |
+| 2 | `action_target` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1699,9 +1699,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `win_percent` | `float` | `optional` | `` |  |
-| 3 | `longest_streak` | `uint32` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `win_percent` | `float` | `optional` |  |  |
+| 3 | `longest_streak` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1713,17 +1713,17 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `game_mode` | `.DOTA_GameMode` | `optional` | `` | default = DOTA_GAMEMODE_NONE |
-| 3 | `kills` | `uint32` | `optional` | `` |  |
-| 4 | `deaths` | `uint32` | `optional` | `` |  |
-| 5 | `assists` | `uint32` | `optional` | `` |  |
-| 6 | `duration` | `uint32` | `optional` | `` |  |
-| 7 | `player_slot` | `uint32` | `optional` | `` |  |
-| 8 | `match_outcome` | `.EMatchOutcome` | `optional` | `` | default = k_EMatchOutcome_Unknown |
-| 9 | `timestamp` | `uint32` | `optional` | `` |  |
-| 10 | `lobby_type` | `uint32` | `optional` | `` |  |
-| 11 | `team_number` | `uint32` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `game_mode` | `.DOTA_GameMode` | `optional` |  | default = DOTA_GAMEMODE_NONE |
+| 3 | `kills` | `uint32` | `optional` |  |  |
+| 4 | `deaths` | `uint32` | `optional` |  |  |
+| 5 | `assists` | `uint32` | `optional` |  |  |
+| 6 | `duration` | `uint32` | `optional` |  |  |
+| 7 | `player_slot` | `uint32` | `optional` |  |  |
+| 8 | `match_outcome` | `.EMatchOutcome` | `optional` |  | default = k_EMatchOutcome_Unknown |
+| 9 | `timestamp` | `uint32` | `optional` |  |  |
+| 10 | `lobby_type` | `uint32` | `optional` |  |  |
+| 11 | `team_number` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1735,7 +1735,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `tips` | `.CMsgMatchTips.SingleTip` | `repeated` | `` |  |
+| 2 | `tips` | `.CMsgMatchTips.SingleTip` | `repeated` |  |  |
 
 </details>
 
@@ -1747,10 +1747,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `source_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `target_account_id` | `uint32` | `optional` | `` |  |
-| 3 | `tip_amount` | `uint32` | `optional` | `` |  |
-| 4 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
+| 1 | `source_account_id` | `uint32` | `optional` |  |  |
+| 2 | `target_account_id` | `uint32` | `optional` |  |  |
+| 3 | `tip_amount` | `uint32` | `optional` |  |  |
+| 4 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
 
 </details>
 
@@ -1762,17 +1762,17 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `start_time` | `fixed32` | `optional` | `` |  |
-| 3 | `duration` | `uint32` | `optional` | `` |  |
-| 4 | `game_mode` | `.DOTA_GameMode` | `optional` | `` | default = DOTA_GAMEMODE_NONE |
-| 6 | `players` | `.CMsgDOTAMatchMinimal.Player` | `repeated` | `` |  |
-| 7 | `tourney` | `.CMsgDOTAMatchMinimal.Tourney` | `optional` | `` |  |
-| 8 | `match_outcome` | `.EMatchOutcome` | `optional` | `` | default = k_EMatchOutcome_Unknown |
-| 9 | `radiant_score` | `uint32` | `optional` | `` |  |
-| 10 | `dire_score` | `uint32` | `optional` | `` |  |
-| 11 | `lobby_type` | `uint32` | `optional` | `` |  |
-| 12 | `is_player_draft` | `bool` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `start_time` | `fixed32` | `optional` |  |  |
+| 3 | `duration` | `uint32` | `optional` |  |  |
+| 4 | `game_mode` | `.DOTA_GameMode` | `optional` |  | default = DOTA_GAMEMODE_NONE |
+| 6 | `players` | `.CMsgDOTAMatchMinimal.Player` | `repeated` |  |  |
+| 7 | `tourney` | `.CMsgDOTAMatchMinimal.Tourney` | `optional` |  |  |
+| 8 | `match_outcome` | `.EMatchOutcome` | `optional` |  | default = k_EMatchOutcome_Unknown |
+| 9 | `radiant_score` | `uint32` | `optional` |  |  |
+| 10 | `dire_score` | `uint32` | `optional` |  |  |
+| 11 | `lobby_type` | `uint32` | `optional` |  |  |
+| 12 | `is_player_draft` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1784,16 +1784,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `hero_id` | `int32` | `optional` | `` |  |
-| 3 | `kills` | `uint32` | `optional` | `` |  |
-| 4 | `deaths` | `uint32` | `optional` | `` |  |
-| 5 | `assists` | `uint32` | `optional` | `` |  |
-| 6 | `items` | `int32` | `repeated` | `` |  |
-| 7 | `player_slot` | `uint32` | `optional` | `` |  |
-| 8 | `pro_name` | `string` | `optional` | `` |  |
-| 9 | `level` | `uint32` | `optional` | `` |  |
-| 10 | `team_number` | `.DOTA_GC_TEAM` | `optional` | `` | default = DOTA_GC_TEAM_GOOD_GUYS |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `hero_id` | `int32` | `optional` |  |  |
+| 3 | `kills` | `uint32` | `optional` |  |  |
+| 4 | `deaths` | `uint32` | `optional` |  |  |
+| 5 | `assists` | `uint32` | `optional` |  |  |
+| 6 | `items` | `int32` | `repeated` |  |  |
+| 7 | `player_slot` | `uint32` | `optional` |  |  |
+| 8 | `pro_name` | `string` | `optional` |  |  |
+| 9 | `level` | `uint32` | `optional` |  |  |
+| 10 | `team_number` | `.DOTA_GC_TEAM` | `optional` |  | default = DOTA_GC_TEAM_GOOD_GUYS |
 
 </details>
 
@@ -1805,21 +1805,21 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 2 | `radiant_team_id` | `uint32` | `optional` | `` |  |
-| 3 | `radiant_team_name` | `string` | `optional` | `` |  |
-| 4 | `radiant_team_logo` | `fixed64` | `optional` | `` |  |
-| 5 | `dire_team_id` | `uint32` | `optional` | `` |  |
-| 6 | `dire_team_name` | `string` | `optional` | `` |  |
-| 7 | `dire_team_logo` | `fixed64` | `optional` | `` |  |
-| 8 | `series_type` | `uint32` | `optional` | `` |  |
-| 9 | `series_game` | `uint32` | `optional` | `` |  |
-| 10 | `weekend_tourney_tournament_id` | `uint32` | `optional` | `` |  |
-| 11 | `weekend_tourney_season_trophy_id` | `uint32` | `optional` | `` |  |
-| 12 | `weekend_tourney_division` | `uint32` | `optional` | `` |  |
-| 13 | `weekend_tourney_skill_level` | `uint32` | `optional` | `` |  |
-| 14 | `radiant_team_logo_url` | `string` | `optional` | `` |  |
-| 15 | `dire_team_logo_url` | `string` | `optional` | `` |  |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 2 | `radiant_team_id` | `uint32` | `optional` |  |  |
+| 3 | `radiant_team_name` | `string` | `optional` |  |  |
+| 4 | `radiant_team_logo` | `fixed64` | `optional` |  |  |
+| 5 | `dire_team_id` | `uint32` | `optional` |  |  |
+| 6 | `dire_team_name` | `string` | `optional` |  |  |
+| 7 | `dire_team_logo` | `fixed64` | `optional` |  |  |
+| 8 | `series_type` | `uint32` | `optional` |  |  |
+| 9 | `series_game` | `uint32` | `optional` |  |  |
+| 10 | `weekend_tourney_tournament_id` | `uint32` | `optional` |  |  |
+| 11 | `weekend_tourney_season_trophy_id` | `uint32` | `optional` |  |  |
+| 12 | `weekend_tourney_division` | `uint32` | `optional` |  |  |
+| 13 | `weekend_tourney_skill_level` | `uint32` | `optional` |  |  |
+| 14 | `radiant_team_logo_url` | `string` | `optional` |  |  |
+| 15 | `dire_team_logo_url` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1831,8 +1831,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def` | `uint32` | `optional` | `` |  |
-| 2 | `quantity_change` | `int32` | `optional` | `` |  |
+| 1 | `item_def` | `uint32` | `optional` |  |  |
+| 2 | `quantity_change` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1844,7 +1844,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_consumables_used` | `.CMsgMatchConsumableUsage.PlayerUsage` | `repeated` | `` |  |
+| 1 | `player_consumables_used` | `.CMsgMatchConsumableUsage.PlayerUsage` | `repeated` |  |  |
 
 </details>
 
@@ -1856,8 +1856,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `consumables_used` | `.CMsgConsumableUsage` | `repeated` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `consumables_used` | `.CMsgConsumableUsage` | `repeated` |  |  |
 
 </details>
 
@@ -1869,7 +1869,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_grants` | `.CMsgMatchEventActionGrants.PlayerGrants` | `repeated` | `` |  |
+| 1 | `player_grants` | `.CMsgMatchEventActionGrants.PlayerGrants` | `repeated` |  |  |
 
 </details>
 
@@ -1881,8 +1881,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 3 | `actions_granted` | `.CMsgPendingEventAward` | `repeated` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 3 | `actions_granted` | `.CMsgPendingEventAward` | `repeated` |  |  |
 
 </details>
 
@@ -1894,9 +1894,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `version` | `uint32` | `optional` | `` |  |
-| 2 | `custom_games_whitelist` | `uint64` | `repeated` | `` |  |
-| 3 | `disable_whitelist` | `bool` | `optional` | `` |  |
+| 1 | `version` | `uint32` | `optional` |  |  |
+| 2 | `custom_games_whitelist` | `uint64` | `repeated` |  |  |
+| 3 | `disable_whitelist` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1908,7 +1908,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `whitelist_entries` | `.CMsgCustomGameWhitelistForEdit.WhitelistEntry` | `repeated` | `` |  |
+| 1 | `whitelist_entries` | `.CMsgCustomGameWhitelistForEdit.WhitelistEntry` | `repeated` |  |  |
 
 </details>
 
@@ -1920,8 +1920,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `custom_game_id` | `uint64` | `optional` | `` |  |
-| 2 | `whitelist_state` | `.ECustomGameWhitelistState` | `optional` | `` | default = CUSTOM_GAME_WHITELIST_STATE_UNKNOWN |
+| 1 | `custom_game_id` | `uint64` | `optional` |  |  |
+| 2 | `whitelist_state` | `.ECustomGameWhitelistState` | `optional` |  | default = CUSTOM_GAME_WHITELIST_STATE_UNKNOWN |
 
 </details>
 
@@ -1933,14 +1933,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `timestamp` | `uint32` | `optional` | `` |  |
-| 3 | `duration` | `uint32` | `optional` | `` |  |
-| 4 | `win` | `bool` | `optional` | `` |  |
-| 5 | `hero_id` | `int32` | `optional` | `` |  |
-| 6 | `kills` | `uint32` | `optional` | `` |  |
-| 7 | `deaths` | `uint32` | `optional` | `` |  |
-| 8 | `assists` | `uint32` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `timestamp` | `uint32` | `optional` |  |  |
+| 3 | `duration` | `uint32` | `optional` |  |  |
+| 4 | `win` | `bool` | `optional` |  |  |
+| 5 | `hero_id` | `int32` | `optional` |  |  |
+| 6 | `kills` | `uint32` | `optional` |  |  |
+| 7 | `deaths` | `uint32` | `optional` |  |  |
+| 8 | `assists` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1952,8 +1952,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `wins` | `uint32` | `optional` | `` |  |
-| 2 | `losses` | `uint32` | `optional` | `` |  |
+| 1 | `wins` | `uint32` | `optional` |  |  |
+| 2 | `losses` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1965,8 +1965,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `outcomes` | `uint32` | `optional` | `` |  |
-| 2 | `match_count` | `uint32` | `optional` | `` |  |
+| 1 | `outcomes` | `uint32` | `optional` |  |  |
+| 2 | `match_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1978,8 +1978,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `commends` | `uint32` | `optional` | `` |  |
-| 2 | `match_count` | `uint32` | `optional` | `` |  |
+| 1 | `commends` | `uint32` | `optional` |  |  |
+| 2 | `match_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1991,14 +1991,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `recent_outcomes` | `.CMsgPlayerRecentMatchOutcomes` | `optional` | `` |  |
-| 2 | `total_record` | `.CMsgPlayerMatchRecord` | `optional` | `` |  |
-| 3 | `prediction_streak` | `uint32` | `optional` | `` |  |
-| 4 | `plus_prediction_streak` | `uint32` | `optional` | `` |  |
-| 5 | `recent_commends` | `.CMsgPlayerRecentCommends` | `optional` | `` |  |
-| 6 | `first_match_timestamp` | `uint32` | `optional` | `` |  |
-| 7 | `last_match` | `.CMsgPlayerRecentMatchInfo` | `optional` | `` |  |
-| 8 | `recent_mvps` | `.CMsgPlayerRecentMatchOutcomes` | `optional` | `` |  |
+| 1 | `recent_outcomes` | `.CMsgPlayerRecentMatchOutcomes` | `optional` |  |  |
+| 2 | `total_record` | `.CMsgPlayerMatchRecord` | `optional` |  |  |
+| 3 | `prediction_streak` | `uint32` | `optional` |  |  |
+| 4 | `plus_prediction_streak` | `uint32` | `optional` |  |  |
+| 5 | `recent_commends` | `.CMsgPlayerRecentCommends` | `optional` |  |  |
+| 6 | `first_match_timestamp` | `uint32` | `optional` |  |  |
+| 7 | `last_match` | `.CMsgPlayerRecentMatchInfo` | `optional` |  |  |
+| 8 | `recent_mvps` | `.CMsgPlayerRecentMatchOutcomes` | `optional` |  |  |
 
 </details>
 
@@ -2010,9 +2010,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `recent_outcomes` | `.CMsgPlayerRecentMatchOutcomes` | `optional` | `` |  |
-| 2 | `total_record` | `.CMsgPlayerMatchRecord` | `optional` | `` |  |
-| 3 | `last_match` | `.CMsgPlayerRecentMatchInfo` | `optional` | `` |  |
+| 1 | `recent_outcomes` | `.CMsgPlayerRecentMatchOutcomes` | `optional` |  |  |
+| 2 | `total_record` | `.CMsgPlayerMatchRecord` | `optional` |  |  |
+| 3 | `last_match` | `.CMsgPlayerRecentMatchInfo` | `optional` |  |  |
 
 </details>
 
@@ -2024,8 +2024,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_accomplishments` | `.CMsgPlayerRecentAccomplishments` | `optional` | `` |  |
-| 2 | `hero_accomplishments` | `.CMsgPlayerHeroRecentAccomplishments` | `optional` | `` |  |
+| 1 | `player_accomplishments` | `.CMsgPlayerRecentAccomplishments` | `optional` |  |  |
+| 2 | `hero_accomplishments` | `.CMsgPlayerHeroRecentAccomplishments` | `optional` |  |  |
 
 </details>
 
@@ -2037,8 +2037,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `hero_id` | `int32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `hero_id` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -2050,8 +2050,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgServerToGCRequestPlayerRecentAccomplishmentsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `player_accomplishments` | `.CMsgRecentAccomplishments` | `optional` | `` |  |
+| 1 | `result` | `.CMsgServerToGCRequestPlayerRecentAccomplishmentsResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `player_accomplishments` | `.CMsgRecentAccomplishments` | `optional` |  |  |
 
 </details>
 
@@ -2063,9 +2063,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint32` | `optional` | `` |  |
-| 2 | `hero_id` | `int32` | `optional` | `` |  |
-| 3 | `vote_count` | `uint32` | `optional` | `` |  |
+| 1 | `match_id` | `uint32` | `optional` |  |  |
+| 2 | `hero_id` | `int32` | `optional` |  |  |
+| 3 | `vote_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2077,10 +2077,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `num_matches_to_search` | `uint32` | `optional` | `` |  |
-| 3 | `min_shared_match_count` | `uint32` | `optional` | `` |  |
-| 4 | `num_additional_players` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `num_matches_to_search` | `uint32` | `optional` |  |  |
+| 3 | `min_shared_match_count` | `uint32` | `optional` |  |  |
+| 4 | `num_additional_players` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2092,7 +2092,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `accounts` | `.CMsgGCtoGCAssociatedExploiterAccountInfoResponse.Account` | `repeated` | `` |  |
+| 1 | `accounts` | `.CMsgGCtoGCAssociatedExploiterAccountInfoResponse.Account` | `repeated` |  |  |
 
 </details>
 
@@ -2104,13 +2104,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `num_common_matches` | `uint32` | `optional` | `` |  |
-| 3 | `earliest_common_match` | `uint32` | `optional` | `` |  |
-| 4 | `latest_common_match` | `uint32` | `optional` | `` |  |
-| 5 | `generation` | `uint32` | `optional` | `` |  |
-| 6 | `persona` | `string` | `optional` | `` |  |
-| 7 | `already_banned` | `bool` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `num_common_matches` | `uint32` | `optional` |  |  |
+| 3 | `earliest_common_match` | `uint32` | `optional` |  |  |
+| 4 | `latest_common_match` | `uint32` | `optional` |  |  |
+| 5 | `generation` | `uint32` | `optional` |  |  |
+| 6 | `persona` | `string` | `optional` |  |  |
+| 7 | `already_banned` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2122,9 +2122,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `slots` | `.CMsgPullTabsData.Slot` | `repeated` | `` |  |
-| 2 | `jackpots` | `.CMsgPullTabsData.Jackpot` | `repeated` | `` |  |
-| 3 | `last_board` | `uint32` | `optional` | `` |  |
+| 1 | `slots` | `.CMsgPullTabsData.Slot` | `repeated` |  |  |
+| 2 | `jackpots` | `.CMsgPullTabsData.Jackpot` | `repeated` |  |  |
+| 3 | `last_board` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2136,11 +2136,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `board_id` | `uint32` | `optional` | `` |  |
-| 3 | `hero_id` | `int32` | `optional` | `` |  |
-| 4 | `action_id` | `uint32` | `optional` | `` |  |
-| 5 | `redeemed` | `bool` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `board_id` | `uint32` | `optional` |  |  |
+| 3 | `hero_id` | `int32` | `optional` |  |  |
+| 4 | `action_id` | `uint32` | `optional` |  |  |
+| 5 | `redeemed` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2152,9 +2152,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `board_id` | `uint32` | `optional` | `` |  |
-| 2 | `action_id` | `uint32` | `optional` | `` |  |
-| 3 | `hero_id` | `int32` | `optional` | `` |  |
+| 1 | `board_id` | `uint32` | `optional` |  |  |
+| 2 | `action_id` | `uint32` | `optional` |  |  |
+| 3 | `hero_id` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -2166,11 +2166,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `bench_slots` | `.CMsgUnderDraftData.BenchSlot` | `repeated` | `` |  |
-| 2 | `shop_slots` | `.CMsgUnderDraftData.ShopSlot` | `repeated` | `` |  |
-| 3 | `gold` | `uint32` | `optional` | `` |  |
-| 4 | `total_gold` | `uint32` | `optional` | `` |  |
-| 5 | `not_restorable` | `bool` | `optional` | `` |  |
+| 1 | `bench_slots` | `.CMsgUnderDraftData.BenchSlot` | `repeated` |  |  |
+| 2 | `shop_slots` | `.CMsgUnderDraftData.ShopSlot` | `repeated` |  |  |
+| 3 | `gold` | `uint32` | `optional` |  |  |
+| 4 | `total_gold` | `uint32` | `optional` |  |  |
+| 5 | `not_restorable` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2182,9 +2182,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `slot_id` | `uint32` | `optional` | `` |  |
-| 2 | `hero_id` | `int32` | `optional` | `` |  |
-| 3 | `stars` | `uint32` | `optional` | `` |  |
+| 1 | `slot_id` | `uint32` | `optional` |  |  |
+| 2 | `hero_id` | `int32` | `optional` |  |  |
+| 3 | `stars` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2196,9 +2196,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `slot_id` | `uint32` | `optional` | `` |  |
-| 2 | `hero_id` | `int32` | `optional` | `` |  |
-| 3 | `is_special_reward` | `bool` | `optional` | `` |  |
+| 1 | `slot_id` | `uint32` | `optional` |  |  |
+| 2 | `hero_id` | `int32` | `optional` |  |  |
+| 3 | `is_special_reward` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2210,9 +2210,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `title` | `uint32` | `repeated` | `` |  |
-| 2 | `event_id` | `uint32` | `repeated` | `` |  |
-| 3 | `active` | `uint32` | `optional` | `` |  |
+| 1 | `title` | `uint32` | `repeated` |  |  |
+| 2 | `event_id` | `uint32` | `repeated` |  |  |
+| 3 | `active` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2224,12 +2224,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `question_id` | `uint32` | `optional` | `` |  |
-| 2 | `category` | `.EDOTATriviaQuestionCategory` | `optional` | `` | default = k_EDOTATriviaQuestionCategory_AbilityIcon |
-| 3 | `timestamp` | `uint32` | `optional` | `` |  |
-| 4 | `question_value` | `string` | `optional` | `` |  |
-| 5 | `answer_values` | `string` | `repeated` | `` |  |
-| 6 | `correct_answer_index` | `uint32` | `optional` | `` |  |
+| 1 | `question_id` | `uint32` | `optional` |  |  |
+| 2 | `category` | `.EDOTATriviaQuestionCategory` | `optional` |  | default = k_EDOTATriviaQuestionCategory_AbilityIcon |
+| 3 | `timestamp` | `uint32` | `optional` |  |  |
+| 4 | `question_value` | `string` | `optional` |  |  |
+| 5 | `answer_values` | `string` | `repeated` |  |  |
+| 6 | `correct_answer_index` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2241,8 +2241,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `summary_available` | `bool` | `optional` | `` |  |
-| 2 | `picked_count` | `uint32` | `repeated` | `` |  |
+| 1 | `summary_available` | `bool` | `optional` |  |  |
+| 2 | `picked_count` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -2254,9 +2254,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `value` | `float` | `optional` | `` |  |
-| 3 | `operation` | `uint32` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `value` | `float` | `optional` |  |  |
+| 3 | `operation` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2268,15 +2268,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `values_float` | `float` | `repeated` | `` |  |
-| 4 | `is_percentage` | `bool` | `optional` | `` |  |
-| 5 | `heading_loc` | `string` | `optional` | `` |  |
-| 6 | `bonuses` | `.CMsgGameDataSpecialValueBonus` | `repeated` | `` |  |
-| 7 | `values_shard` | `float` | `repeated` | `` |  |
-| 8 | `values_scepter` | `float` | `repeated` | `` |  |
-| 9 | `facet_bonus` | `.CMsgGameDataFacetAbilityBonus` | `optional` | `` |  |
-| 10 | `required_facet` | `string` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `values_float` | `float` | `repeated` |  |  |
+| 4 | `is_percentage` | `bool` | `optional` |  |  |
+| 5 | `heading_loc` | `string` | `optional` |  |  |
+| 6 | `bonuses` | `.CMsgGameDataSpecialValueBonus` | `repeated` |  |  |
+| 7 | `values_shard` | `float` | `repeated` |  |  |
+| 8 | `values_scepter` | `float` | `repeated` |  |  |
+| 9 | `facet_bonus` | `.CMsgGameDataFacetAbilityBonus` | `optional` |  |  |
+| 10 | `required_facet` | `string` | `optional` |  |  |
 
 </details>
 
@@ -2288,9 +2288,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `values` | `float` | `repeated` | `` |  |
-| 3 | `operation` | `uint32` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `values` | `float` | `repeated` |  |  |
+| 3 | `operation` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2302,46 +2302,46 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 5 | `name_loc` | `string` | `optional` | `` |  |
-| 6 | `desc_loc` | `string` | `optional` | `` |  |
-| 7 | `lore_loc` | `string` | `optional` | `` |  |
-| 8 | `notes_loc` | `string` | `repeated` | `` |  |
-| 9 | `shard_loc` | `string` | `optional` | `` |  |
-| 10 | `scepter_loc` | `string` | `optional` | `` |  |
-| 11 | `facets_loc` | `string` | `repeated` | `` |  |
-| 20 | `type` | `uint32` | `optional` | `` |  |
-| 21 | `behavior` | `uint64` | `optional` | `` |  |
-| 22 | `target_team` | `uint32` | `optional` | `` |  |
-| 23 | `target_type` | `uint32` | `optional` | `` |  |
-| 24 | `flags` | `uint32` | `optional` | `` |  |
-| 25 | `damage` | `uint32` | `optional` | `` |  |
-| 26 | `immunity` | `uint32` | `optional` | `` |  |
-| 27 | `dispellable` | `uint32` | `optional` | `` |  |
-| 28 | `max_level` | `uint32` | `optional` | `` |  |
-| 30 | `cast_ranges` | `uint32` | `repeated` | `` |  |
-| 31 | `cast_points` | `float` | `repeated` | `` |  |
-| 32 | `channel_times` | `float` | `repeated` | `` |  |
-| 33 | `cooldowns` | `float` | `repeated` | `` |  |
-| 34 | `durations` | `float` | `repeated` | `` |  |
-| 35 | `damages` | `uint32` | `repeated` | `` |  |
-| 36 | `mana_costs` | `uint32` | `repeated` | `` |  |
-| 37 | `gold_costs` | `uint32` | `repeated` | `` |  |
-| 38 | `health_costs` | `uint32` | `repeated` | `` |  |
-| 40 | `special_values` | `.CMsgGameDataSpecialValues` | `repeated` | `` |  |
-| 50 | `is_item` | `bool` | `optional` | `` |  |
-| 60 | `ability_has_scepter` | `bool` | `optional` | `` |  |
-| 61 | `ability_has_shard` | `bool` | `optional` | `` |  |
-| 62 | `ability_is_granted_by_scepter` | `bool` | `optional` | `` |  |
-| 63 | `ability_is_granted_by_shard` | `bool` | `optional` | `` |  |
-| 64 | `ability_is_innate` | `bool` | `optional` | `` |  |
-| 70 | `item_cost` | `uint32` | `optional` | `` |  |
-| 71 | `item_initial_charges` | `uint32` | `optional` | `` |  |
-| 72 | `item_neutral_tier` | `uint32` | `optional` | `` |  |
-| 73 | `item_stock_max` | `uint32` | `optional` | `` |  |
-| 74 | `item_stock_time` | `float` | `optional` | `` |  |
-| 85 | `item_quality` | `uint32` | `optional` | `` |  |
+| 1 | `id` | `int32` | `optional` |  | default = -1 |
+| 2 | `name` | `string` | `optional` |  |  |
+| 5 | `name_loc` | `string` | `optional` |  |  |
+| 6 | `desc_loc` | `string` | `optional` |  |  |
+| 7 | `lore_loc` | `string` | `optional` |  |  |
+| 8 | `notes_loc` | `string` | `repeated` |  |  |
+| 9 | `shard_loc` | `string` | `optional` |  |  |
+| 10 | `scepter_loc` | `string` | `optional` |  |  |
+| 11 | `facets_loc` | `string` | `repeated` |  |  |
+| 20 | `type` | `uint32` | `optional` |  |  |
+| 21 | `behavior` | `uint64` | `optional` |  |  |
+| 22 | `target_team` | `uint32` | `optional` |  |  |
+| 23 | `target_type` | `uint32` | `optional` |  |  |
+| 24 | `flags` | `uint32` | `optional` |  |  |
+| 25 | `damage` | `uint32` | `optional` |  |  |
+| 26 | `immunity` | `uint32` | `optional` |  |  |
+| 27 | `dispellable` | `uint32` | `optional` |  |  |
+| 28 | `max_level` | `uint32` | `optional` |  |  |
+| 30 | `cast_ranges` | `uint32` | `repeated` |  |  |
+| 31 | `cast_points` | `float` | `repeated` |  |  |
+| 32 | `channel_times` | `float` | `repeated` |  |  |
+| 33 | `cooldowns` | `float` | `repeated` |  |  |
+| 34 | `durations` | `float` | `repeated` |  |  |
+| 35 | `damages` | `uint32` | `repeated` |  |  |
+| 36 | `mana_costs` | `uint32` | `repeated` |  |  |
+| 37 | `gold_costs` | `uint32` | `repeated` |  |  |
+| 38 | `health_costs` | `uint32` | `repeated` |  |  |
+| 40 | `special_values` | `.CMsgGameDataSpecialValues` | `repeated` |  |  |
+| 50 | `is_item` | `bool` | `optional` |  |  |
+| 60 | `ability_has_scepter` | `bool` | `optional` |  |  |
+| 61 | `ability_has_shard` | `bool` | `optional` |  |  |
+| 62 | `ability_is_granted_by_scepter` | `bool` | `optional` |  |  |
+| 63 | `ability_is_granted_by_shard` | `bool` | `optional` |  |  |
+| 64 | `ability_is_innate` | `bool` | `optional` |  |  |
+| 70 | `item_cost` | `uint32` | `optional` |  |  |
+| 71 | `item_initial_charges` | `uint32` | `optional` |  |  |
+| 72 | `item_neutral_tier` | `uint32` | `optional` |  |  |
+| 73 | `item_stock_max` | `uint32` | `optional` |  |  |
+| 74 | `item_stock_time` | `float` | `optional` |  |  |
+| 85 | `item_quality` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2353,7 +2353,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `abilities` | `.CMsgGameDataAbilityOrItem` | `repeated` | `` |  |
+| 1 | `abilities` | `.CMsgGameDataAbilityOrItem` | `repeated` |  |  |
 
 </details>
 
@@ -2365,42 +2365,42 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `int32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `order_id` | `uint32` | `optional` | `` |  |
-| 5 | `name_loc` | `string` | `optional` | `` |  |
-| 6 | `bio_loc` | `string` | `optional` | `` |  |
-| 7 | `hype_loc` | `string` | `optional` | `` |  |
-| 8 | `npe_desc_loc` | `string` | `optional` | `` |  |
-| 10 | `str_base` | `uint32` | `optional` | `` |  |
-| 11 | `str_gain` | `float` | `optional` | `` |  |
-| 12 | `agi_base` | `uint32` | `optional` | `` |  |
-| 13 | `agi_gain` | `float` | `optional` | `` |  |
-| 14 | `int_base` | `uint32` | `optional` | `` |  |
-| 15 | `int_gain` | `float` | `optional` | `` |  |
-| 20 | `primary_attr` | `uint32` | `optional` | `` |  |
-| 21 | `complexity` | `uint32` | `optional` | `` |  |
-| 22 | `attack_capability` | `uint32` | `optional` | `` |  |
-| 23 | `role_levels` | `uint32` | `repeated` | `` |  |
-| 24 | `damage_min` | `int32` | `optional` | `` |  |
-| 25 | `damage_max` | `int32` | `optional` | `` |  |
-| 26 | `attack_rate` | `float` | `optional` | `` |  |
-| 27 | `attack_range` | `uint32` | `optional` | `` |  |
-| 28 | `projectile_speed` | `uint32` | `optional` | `` |  |
-| 29 | `armor` | `float` | `optional` | `` |  |
-| 30 | `magic_resistance` | `uint32` | `optional` | `` |  |
-| 31 | `movement_speed` | `uint32` | `optional` | `` |  |
-| 32 | `turn_rate` | `float` | `optional` | `` |  |
-| 33 | `sight_range_day` | `uint32` | `optional` | `` |  |
-| 34 | `sight_range_night` | `uint32` | `optional` | `` |  |
-| 35 | `max_health` | `uint32` | `optional` | `` |  |
-| 36 | `health_regen` | `float` | `optional` | `` |  |
-| 37 | `max_mana` | `uint32` | `optional` | `` |  |
-| 38 | `mana_regen` | `float` | `optional` | `` |  |
-| 40 | `abilities` | `.CMsgGameDataAbilityOrItem` | `repeated` | `` |  |
-| 41 | `talents` | `.CMsgGameDataAbilityOrItem` | `repeated` | `` |  |
-| 42 | `facet_abilities` | `.CMsgGameDataAbilityOrItemList` | `repeated` | `` |  |
-| 43 | `facets` | `.CMsgGameDataHero.Facet` | `repeated` | `` |  |
+| 1 | `id` | `int32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `order_id` | `uint32` | `optional` |  |  |
+| 5 | `name_loc` | `string` | `optional` |  |  |
+| 6 | `bio_loc` | `string` | `optional` |  |  |
+| 7 | `hype_loc` | `string` | `optional` |  |  |
+| 8 | `npe_desc_loc` | `string` | `optional` |  |  |
+| 10 | `str_base` | `uint32` | `optional` |  |  |
+| 11 | `str_gain` | `float` | `optional` |  |  |
+| 12 | `agi_base` | `uint32` | `optional` |  |  |
+| 13 | `agi_gain` | `float` | `optional` |  |  |
+| 14 | `int_base` | `uint32` | `optional` |  |  |
+| 15 | `int_gain` | `float` | `optional` |  |  |
+| 20 | `primary_attr` | `uint32` | `optional` |  |  |
+| 21 | `complexity` | `uint32` | `optional` |  |  |
+| 22 | `attack_capability` | `uint32` | `optional` |  |  |
+| 23 | `role_levels` | `uint32` | `repeated` |  |  |
+| 24 | `damage_min` | `int32` | `optional` |  |  |
+| 25 | `damage_max` | `int32` | `optional` |  |  |
+| 26 | `attack_rate` | `float` | `optional` |  |  |
+| 27 | `attack_range` | `uint32` | `optional` |  |  |
+| 28 | `projectile_speed` | `uint32` | `optional` |  |  |
+| 29 | `armor` | `float` | `optional` |  |  |
+| 30 | `magic_resistance` | `uint32` | `optional` |  |  |
+| 31 | `movement_speed` | `uint32` | `optional` |  |  |
+| 32 | `turn_rate` | `float` | `optional` |  |  |
+| 33 | `sight_range_day` | `uint32` | `optional` |  |  |
+| 34 | `sight_range_night` | `uint32` | `optional` |  |  |
+| 35 | `max_health` | `uint32` | `optional` |  |  |
+| 36 | `health_regen` | `float` | `optional` |  |  |
+| 37 | `max_mana` | `uint32` | `optional` |  |  |
+| 38 | `mana_regen` | `float` | `optional` |  |  |
+| 40 | `abilities` | `.CMsgGameDataAbilityOrItem` | `repeated` |  |  |
+| 41 | `talents` | `.CMsgGameDataAbilityOrItem` | `repeated` |  |  |
+| 42 | `facet_abilities` | `.CMsgGameDataAbilityOrItemList` | `repeated` |  |  |
+| 43 | `facets` | `.CMsgGameDataHero.Facet` | `repeated` |  |  |
 
 </details>
 
@@ -2412,13 +2412,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `color` | `uint32` | `optional` | `` |  |
-| 2 | `title_loc` | `string` | `optional` | `` |  |
-| 3 | `description_loc` | `string` | `optional` | `` |  |
-| 4 | `name` | `string` | `optional` | `` |  |
-| 5 | `icon` | `string` | `optional` | `` |  |
-| 6 | `gradient_id` | `int32` | `optional` | `` |  |
-| 7 | `index` | `uint32` | `optional` | `` |  |
+| 1 | `color` | `uint32` | `optional` |  |  |
+| 2 | `title_loc` | `string` | `optional` |  |  |
+| 3 | `description_loc` | `string` | `optional` |  |  |
+| 4 | `name` | `string` | `optional` |  |  |
+| 5 | `icon` | `string` | `optional` |  |  |
+| 6 | `gradient_id` | `int32` | `optional` |  |  |
+| 7 | `index` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2430,7 +2430,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `abilities` | `.CMsgGameDataAbilityOrItem` | `repeated` | `` |  |
+| 1 | `abilities` | `.CMsgGameDataAbilityOrItem` | `repeated` |  |  |
 
 </details>
 
@@ -2442,7 +2442,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `items` | `.CMsgGameDataAbilityOrItem` | `repeated` | `` |  |
+| 1 | `items` | `.CMsgGameDataAbilityOrItem` | `repeated` |  |  |
 
 </details>
 
@@ -2454,7 +2454,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `heroes` | `.CMsgGameDataHero` | `repeated` | `` |  |
+| 1 | `heroes` | `.CMsgGameDataHero` | `repeated` |  |  |
 
 </details>
 
@@ -2466,7 +2466,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `heroes` | `.CMsgGameDataHeroList.HeroInfo` | `repeated` | `` |  |
+| 1 | `heroes` | `.CMsgGameDataHeroList.HeroInfo` | `repeated` |  |  |
 
 </details>
 
@@ -2478,12 +2478,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `int32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `name_loc` | `string` | `optional` | `` |  |
-| 4 | `name_english_loc` | `string` | `optional` | `` |  |
-| 5 | `primary_attr` | `uint32` | `optional` | `` |  |
-| 6 | `complexity` | `uint32` | `optional` | `` |  |
+| 1 | `id` | `int32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `name_loc` | `string` | `optional` |  |  |
+| 4 | `name_english_loc` | `string` | `optional` |  |  |
+| 5 | `primary_attr` | `uint32` | `optional` |  |  |
+| 6 | `complexity` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2495,7 +2495,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `itemabilities` | `.CMsgGameDataItemAbilityList.ItemAbilityInfo` | `repeated` | `` |  |
+| 1 | `itemabilities` | `.CMsgGameDataItemAbilityList.ItemAbilityInfo` | `repeated` |  |  |
 
 </details>
 
@@ -2507,16 +2507,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `name_loc` | `string` | `optional` | `` |  |
-| 4 | `name_english_loc` | `string` | `optional` | `` |  |
-| 5 | `neutral_item_tier` | `int32` | `optional` | `` |  |
-| 6 | `is_pregame_suggested` | `bool` | `optional` | `` |  |
-| 7 | `is_earlygame_suggested` | `bool` | `optional` | `` |  |
-| 8 | `is_lategame_suggested` | `bool` | `optional` | `` |  |
-| 9 | `recipes` | `.CMsgGameDataItemAbilityList.ItemAbilityInfo.Recipe` | `repeated` | `` |  |
-| 10 | `is_innate` | `bool` | `optional` | `` |  |
+| 1 | `id` | `int32` | `optional` |  | default = -1 |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `name_loc` | `string` | `optional` |  |  |
+| 4 | `name_english_loc` | `string` | `optional` |  |  |
+| 5 | `neutral_item_tier` | `int32` | `optional` |  |  |
+| 6 | `is_pregame_suggested` | `bool` | `optional` |  |  |
+| 7 | `is_earlygame_suggested` | `bool` | `optional` |  |  |
+| 8 | `is_lategame_suggested` | `bool` | `optional` |  |  |
+| 9 | `recipes` | `.CMsgGameDataItemAbilityList.ItemAbilityInfo.Recipe` | `repeated` |  |  |
+| 10 | `is_innate` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2528,7 +2528,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `items` | `int32` | `repeated` | `` |  |
+| 1 | `items` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -2540,7 +2540,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `shuffle_draft_order` | `bool` | `optional` | `` |  |
+| 1 | `shuffle_draft_order` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2552,14 +2552,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` | (key_field) = true |
-| 2 | `expiration_date` | `fixed32` | `optional` | `` |  |
-| 3 | `bonus` | `float` | `optional` | `` | (key_field) = true |
-| 4 | `bonus_count` | `uint32` | `optional` | `` |  |
-| 5 | `item_id` | `uint64` | `optional` | `` |  |
-| 6 | `def_index` | `uint32` | `optional` | `` |  |
-| 7 | `seconds_left` | `uint32` | `optional` | `` |  |
-| 8 | `booster_type` | `uint32` | `optional` | `` | (key_field) = true |
+| 1 | `account_id` | `uint32` | `optional` |  | (key_field) = true |
+| 2 | `expiration_date` | `fixed32` | `optional` |  |  |
+| 3 | `bonus` | `float` | `optional` |  | (key_field) = true |
+| 4 | `bonus_count` | `uint32` | `optional` |  |  |
+| 5 | `item_id` | `uint64` | `optional` |  |  |
+| 6 | `def_index` | `uint32` | `optional` |  |  |
+| 7 | `seconds_left` | `uint32` | `optional` |  |  |
+| 8 | `booster_type` | `uint32` | `optional` |  | (key_field) = true |
 
 </details>
 
@@ -2571,14 +2571,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `league_id` | `uint32` | `optional` | `` |  |
-| 3 | `item_id` | `uint64` | `optional` | `` |  |
-| 4 | `original_purchaser_id` | `uint32` | `optional` | `` |  |
-| 5 | `passports_bought` | `uint32` | `optional` | `` |  |
-| 6 | `version` | `uint32` | `optional` | `` |  |
-| 7 | `def_index` | `uint32` | `optional` | `` |  |
-| 8 | `reward_flags` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `league_id` | `uint32` | `optional` |  |  |
+| 3 | `item_id` | `uint64` | `optional` |  |  |
+| 4 | `original_purchaser_id` | `uint32` | `optional` |  |  |
+| 5 | `passports_bought` | `uint32` | `optional` |  |  |
+| 6 | `version` | `uint32` | `optional` |  |  |
+| 7 | `def_index` | `uint32` | `optional` |  |  |
+| 8 | `reward_flags` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2590,16 +2590,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def_id` | `uint32` | `optional` | `` |  |
-| 2 | `sticker_num` | `uint32` | `optional` | `` |  |
-| 3 | `quality` | `uint32` | `optional` | `` |  |
-| 4 | `position_x` | `float` | `optional` | `` |  |
-| 5 | `position_y` | `float` | `optional` | `` |  |
-| 6 | `rotation` | `float` | `optional` | `` |  |
-| 7 | `scale` | `float` | `optional` | `` |  |
-| 8 | `position_z` | `float` | `optional` | `` |  |
-| 9 | `source_item_id` | `uint64` | `optional` | `` |  |
-| 10 | `depth_bias` | `uint32` | `optional` | `` |  |
+| 1 | `item_def_id` | `uint32` | `optional` |  |  |
+| 2 | `sticker_num` | `uint32` | `optional` |  |  |
+| 3 | `quality` | `uint32` | `optional` |  |  |
+| 4 | `position_x` | `float` | `optional` |  |  |
+| 5 | `position_y` | `float` | `optional` |  |  |
+| 6 | `rotation` | `float` | `optional` |  |  |
+| 7 | `scale` | `float` | `optional` |  |  |
+| 8 | `position_z` | `float` | `optional` |  |  |
+| 9 | `source_item_id` | `uint64` | `optional` |  |  |
+| 10 | `depth_bias` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2611,11 +2611,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `page_num` | `uint32` | `optional` | `` |  |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 3 | `team_id` | `uint32` | `optional` | `` |  |
-| 4 | `stickers` | `.CMsgStickerbookSticker` | `repeated` | `` |  |
-| 5 | `page_type` | `.EStickerbookPageType` | `optional` | `` | default = STICKER_PAGE_GENERIC |
+| 1 | `page_num` | `uint32` | `optional` |  |  |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 3 | `team_id` | `uint32` | `optional` |  |  |
+| 4 | `stickers` | `.CMsgStickerbookSticker` | `repeated` |  |  |
+| 5 | `page_type` | `.EStickerbookPageType` | `optional` |  | default = STICKER_PAGE_GENERIC |
 
 </details>
 
@@ -2627,7 +2627,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `page_numbers` | `uint32` | `repeated` | `` |  |
+| 1 | `page_numbers` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -2639,9 +2639,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `pages` | `.CMsgStickerbookPage` | `repeated` | `` |  |
-| 2 | `team_page_order_sequence` | `.CMsgStickerbookTeamPageOrderSequence` | `optional` | `` |  |
-| 3 | `favorite_page_num` | `uint32` | `optional` | `` |  |
+| 1 | `pages` | `.CMsgStickerbookPage` | `repeated` |  |  |
+| 2 | `team_page_order_sequence` | `.CMsgStickerbookTeamPageOrderSequence` | `optional` |  |  |
+| 3 | `favorite_page_num` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2653,10 +2653,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `item_def_id` | `uint32` | `optional` | `` |  |
-| 3 | `quality` | `uint32` | `optional` | `` |  |
-| 4 | `source_item_id` | `uint64` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `item_def_id` | `uint32` | `optional` |  |  |
+| 3 | `quality` | `uint32` | `optional` |  |  |
+| 4 | `source_item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -2668,7 +2668,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `heroes` | `.CMsgStickerHero` | `repeated` | `` |  |
+| 1 | `heroes` | `.CMsgStickerHero` | `repeated` |  |  |
 
 </details>
 
@@ -2680,9 +2680,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `lane_selection_flags` | `uint32` | `optional` | `` |  |
-| 2 | `match_count` | `uint32` | `optional` | `` |  |
-| 3 | `win_count` | `uint32` | `optional` | `` |  |
+| 1 | `lane_selection_flags` | `uint32` | `optional` |  |  |
+| 2 | `match_count` | `uint32` | `optional` |  |  |
+| 3 | `win_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2694,8 +2694,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `role_stats` | `.CMsgHeroRoleStats` | `repeated` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `role_stats` | `.CMsgHeroRoleStats` | `repeated` |  |  |
 
 </details>
 
@@ -2707,8 +2707,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `rank_tier` | `uint32` | `optional` | `` |  |
-| 2 | `hero_stats` | `.CMsgHeroRoleHeroStats` | `repeated` | `` |  |
+| 1 | `rank_tier` | `uint32` | `optional` |  |  |
+| 2 | `hero_stats` | `.CMsgHeroRoleHeroStats` | `repeated` |  |  |
 
 </details>
 
@@ -2720,9 +2720,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `start_timestamp` | `uint32` | `optional` | `` |  |
-| 2 | `end_timestamp` | `uint32` | `optional` | `` |  |
-| 3 | `rank_stats` | `.CMsgHeroRoleRankStats` | `repeated` | `` |  |
+| 1 | `start_timestamp` | `uint32` | `optional` |  |  |
+| 2 | `end_timestamp` | `uint32` | `optional` |  |  |
+| 3 | `rank_stats` | `.CMsgHeroRoleRankStats` | `repeated` |  |  |
 
 </details>
 
@@ -2734,16 +2734,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `timestamp` | `uint32` | `optional` | `` |  |
-| 2 | `lotuses_gained` | `uint64` | `optional` | `` |  |
-| 3 | `wisdom_runes_gained` | `uint64` | `optional` | `` |  |
-| 4 | `roshan_kills_day` | `uint64` | `optional` | `` |  |
-| 5 | `roshan_kills_night` | `uint64` | `optional` | `` |  |
-| 6 | `portals_used` | `uint64` | `optional` | `` |  |
-| 7 | `watchers_taken` | `uint64` | `optional` | `` |  |
-| 8 | `tormentor_kills` | `uint64` | `optional` | `` |  |
-| 9 | `outposts_captured` | `uint64` | `optional` | `` |  |
-| 10 | `shield_runes_gained` | `uint64` | `optional` | `` |  |
+| 1 | `timestamp` | `uint32` | `optional` |  |  |
+| 2 | `lotuses_gained` | `uint64` | `optional` |  |  |
+| 3 | `wisdom_runes_gained` | `uint64` | `optional` |  |  |
+| 4 | `roshan_kills_day` | `uint64` | `optional` |  |  |
+| 5 | `roshan_kills_night` | `uint64` | `optional` |  |  |
+| 6 | `portals_used` | `uint64` | `optional` |  |  |
+| 7 | `watchers_taken` | `uint64` | `optional` |  |  |
+| 8 | `tormentor_kills` | `uint64` | `optional` |  |  |
+| 9 | `outposts_captured` | `uint64` | `optional` |  |  |
+| 10 | `shield_runes_gained` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -2755,9 +2755,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `current` | `.CMsgMapStatsSnapshot` | `optional` | `` |  |
-| 2 | `window_start` | `.CMsgMapStatsSnapshot` | `optional` | `` |  |
-| 3 | `window_end` | `.CMsgMapStatsSnapshot` | `optional` | `` |  |
+| 1 | `current` | `.CMsgMapStatsSnapshot` | `optional` |  |  |
+| 2 | `window_start` | `.CMsgMapStatsSnapshot` | `optional` |  |  |
+| 3 | `window_end` | `.CMsgMapStatsSnapshot` | `optional` |  |  |
 
 </details>
 
@@ -2769,8 +2769,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tracked_stat_id` | `uint32` | `optional` | `` |  |
-| 2 | `tracked_stat_value` | `int32` | `optional` | `` |  |
+| 1 | `tracked_stat_id` | `uint32` | `optional` |  |  |
+| 2 | `tracked_stat_value` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -2782,9 +2782,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgDOTAClaimEventActionResponse.ResultCode` | `optional` | `` | default = Success |
-| 2 | `reward_results` | `.CMsgDOTAClaimEventActionResponse.GrantedRewardData` | `repeated` | `` |  |
-| 3 | `action_id` | `uint32` | `optional` | `` |  |
+| 1 | `result` | `.CMsgDOTAClaimEventActionResponse.ResultCode` | `optional` |  | default = Success |
+| 2 | `reward_results` | `.CMsgDOTAClaimEventActionResponse.GrantedRewardData` | `repeated` |  |  |
+| 3 | `action_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2796,8 +2796,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def` | `uint32` | `optional` | `` |  |
-| 2 | `item_category` | `uint32` | `optional` | `` |  |
+| 1 | `item_def` | `uint32` | `optional` |  |  |
+| 2 | `item_category` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2809,7 +2809,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def` | `uint32` | `repeated` | `` |  |
+| 1 | `item_def` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -2821,8 +2821,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `action_id` | `uint32` | `optional` | `` |  |
-| 2 | `result_reward_data` | `bytes` | `optional` | `` |  |
+| 1 | `action_id` | `uint32` | `optional` |  |  |
+| 2 | `result_reward_data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -2834,7 +2834,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tokens` | `.CMsgDOTAClaimEventActionResponse.OverworldTokenRewardData.TokenQuantity` | `repeated` | `` |  |
+| 1 | `tokens` | `.CMsgDOTAClaimEventActionResponse.OverworldTokenRewardData.TokenQuantity` | `repeated` |  |  |
 
 </details>
 
@@ -2846,8 +2846,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `token_id` | `uint32` | `optional` | `` |  |
-| 2 | `token_count` | `uint32` | `optional` | `` |  |
+| 1 | `token_id` | `uint32` | `optional` |  |  |
+| 2 | `token_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2859,7 +2859,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `materials` | `.CMsgDOTAClaimEventActionResponse.MonsterHunterMaterialRewardData.MaterialQuantity` | `repeated` | `` |  |
+| 1 | `materials` | `.CMsgDOTAClaimEventActionResponse.MonsterHunterMaterialRewardData.MaterialQuantity` | `repeated` |  |  |
 
 </details>
 
@@ -2871,8 +2871,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `material_id` | `uint32` | `optional` | `` |  |
-| 2 | `material_count` | `uint32` | `optional` | `` |  |
+| 1 | `material_id` | `uint32` | `optional` |  |  |
+| 2 | `material_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2884,11 +2884,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `grant_index` | `uint32` | `optional` | `` |  |
-| 2 | `score_index` | `uint32` | `optional` | `` |  |
-| 3 | `reward_index` | `uint32` | `optional` | `` |  |
-| 4 | `reward_data` | `bytes` | `optional` | `` |  |
-| 5 | `action_id` | `uint32` | `optional` | `` |  |
+| 1 | `grant_index` | `uint32` | `optional` |  |  |
+| 2 | `score_index` | `uint32` | `optional` |  |  |
+| 3 | `reward_index` | `uint32` | `optional` |  |  |
+| 4 | `reward_data` | `bytes` | `optional` |  |  |
+| 5 | `action_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2900,9 +2900,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `language` | `uint32` | `optional` | `` |  |
-| 2 | `feedback_item` | `uint32` | `optional` | `` |  |
-| 3 | `feedback` | `string` | `optional` | `` |  |
+| 1 | `language` | `uint32` | `optional` |  |  |
+| 2 | `feedback_item` | `uint32` | `optional` |  |  |
+| 3 | `feedback` | `string` | `optional` |  |  |
 
 </details>
 
@@ -2914,7 +2914,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCDotaLabsFeedbackResponse.EResponse` | `optional` | `` | default = k_eInternalError |
+| 1 | `response` | `.CMsgClientToGCDotaLabsFeedbackResponse.EResponse` | `optional` |  | default = k_eInternalError |
 
 </details>
 
@@ -2926,10 +2926,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `match_id` | `uint64` | `optional` | `` |  |
-| 3 | `correct` | `bool` | `optional` | `` |  |
-| 4 | `predictions` | `.CDotaMsg_PredictionResult.Prediction` | `repeated` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `match_id` | `uint64` | `optional` |  |  |
+| 3 | `correct` | `bool` | `optional` |  |  |
+| 4 | `predictions` | `.CDotaMsg_PredictionResult.Prediction` | `repeated` |  |  |
 
 </details>
 
@@ -2941,11 +2941,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def` | `uint32` | `optional` | `` |  |
-| 2 | `num_correct` | `uint32` | `optional` | `` |  |
-| 3 | `num_fails` | `uint32` | `optional` | `` |  |
-| 4 | `result` | `.CDotaMsg_PredictionResult.Prediction.EResult` | `optional` | `` | default = k_eResult_ItemGranted |
-| 6 | `granted_item_defs` | `uint32` | `repeated` | `` |  |
+| 1 | `item_def` | `uint32` | `optional` |  |  |
+| 2 | `num_correct` | `uint32` | `optional` |  |  |
+| 3 | `num_fails` | `uint32` | `optional` |  |  |
+| 4 | `result` | `.CDotaMsg_PredictionResult.Prediction.EResult` | `optional` |  | default = k_eResult_ItemGranted |
+| 6 | `granted_item_defs` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -2957,20 +2957,20 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ability_name_loc_token` | `string` | `optional` | `` |  |
-| 2 | `ability_category` | `.CDotaMsgStructuredTooltipProperties.EAbilityTooltipCategory` | `optional` | `` | default = kPassive |
-| 3 | `ability_level` | `int32` | `optional` | `` |  |
-| 4 | `current_mana_cost` | `int32` | `optional` | `` |  |
-| 5 | `current_health_cost` | `int32` | `optional` | `` |  |
-| 6 | `current_cooldown` | `float` | `optional` | `` |  |
-| 7 | `summary_description_loc_token` | `string` | `optional` | `` |  |
-| 8 | `summary_description_embed_values` | `.CDotaMsgStructuredTooltipProperties.Attribute` | `repeated` | `` |  |
-| 9 | `summary_description_surfaced_lines` | `string` | `repeated` | `` |  |
-| 10 | `summary_description_embedded_sub_abilities` | `.CDotaMsgStructuredTooltipProperties.SummaryDescriptionEmbeddedSubAbility` | `repeated` | `` |  |
-| 11 | `summary_description_aghs_scepter` | `string` | `optional` | `` |  |
-| 12 | `summary_description_aghs_shard` | `string` | `optional` | `` |  |
-| 13 | `preview_video_url` | `string` | `optional` | `` |  |
-| 20 | `chunks` | `.CDotaMsgStructuredTooltipProperties.TooltipContentChunk` | `repeated` | `` |  |
+| 1 | `ability_name_loc_token` | `string` | `optional` |  |  |
+| 2 | `ability_category` | `.CDotaMsgStructuredTooltipProperties.EAbilityTooltipCategory` | `optional` |  | default = kPassive |
+| 3 | `ability_level` | `int32` | `optional` |  |  |
+| 4 | `current_mana_cost` | `int32` | `optional` |  |  |
+| 5 | `current_health_cost` | `int32` | `optional` |  |  |
+| 6 | `current_cooldown` | `float` | `optional` |  |  |
+| 7 | `summary_description_loc_token` | `string` | `optional` |  |  |
+| 8 | `summary_description_embed_values` | `.CDotaMsgStructuredTooltipProperties.Attribute` | `repeated` |  |  |
+| 9 | `summary_description_surfaced_lines` | `string` | `repeated` |  |  |
+| 10 | `summary_description_embedded_sub_abilities` | `.CDotaMsgStructuredTooltipProperties.SummaryDescriptionEmbeddedSubAbility` | `repeated` |  |  |
+| 11 | `summary_description_aghs_scepter` | `string` | `optional` |  |  |
+| 12 | `summary_description_aghs_shard` | `string` | `optional` |  |  |
+| 13 | `preview_video_url` | `string` | `optional` |  |  |
+| 20 | `chunks` | `.CDotaMsgStructuredTooltipProperties.TooltipContentChunk` | `repeated` |  |  |
 
 </details>
 
@@ -2982,8 +2982,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `value` | `float` | `optional` | `` |  |
-| 2 | `is_active_value` | `bool` | `optional` | `` |  |
+| 1 | `value` | `float` | `optional` |  |  |
+| 2 | `is_active_value` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2995,7 +2995,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `single_value` | `.CDotaMsgStructuredTooltipProperties.AttributeValueValue` | `optional` | `` |  |
+| 1 | `single_value` | `.CDotaMsgStructuredTooltipProperties.AttributeValueValue` | `optional` |  |  |
 
 </details>
 
@@ -3007,7 +3007,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `values` | `.CDotaMsgStructuredTooltipProperties.AttributeValueValue` | `repeated` | `` |  |
+| 1 | `values` | `.CDotaMsgStructuredTooltipProperties.AttributeValueValue` | `repeated` |  |  |
 
 </details>
 
@@ -3019,8 +3019,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `prev` | `.CDotaMsgStructuredTooltipProperties.AttributeValueValue` | `optional` | `` |  |
-| 2 | `next` | `.CDotaMsgStructuredTooltipProperties.AttributeValueValue` | `optional` | `` |  |
+| 1 | `prev` | `.CDotaMsgStructuredTooltipProperties.AttributeValueValue` | `optional` |  |  |
+| 2 | `next` | `.CDotaMsgStructuredTooltipProperties.AttributeValueValue` | `optional` |  |  |
 
 </details>
 
@@ -3046,10 +3046,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `internal_name` | `string` | `optional` | `` |  |
-| 2 | `localized_name_text` | `string` | `optional` | `` |  |
-| 3 | `type` | `.CDotaMsgStructuredTooltipProperties.EAttributeType` | `optional` | `` | default = kUnknown |
-| 4 | `value` | `.CDotaMsgStructuredTooltipProperties.AttributeValue` | `optional` | `` |  |
+| 1 | `internal_name` | `string` | `optional` |  |  |
+| 2 | `localized_name_text` | `string` | `optional` |  |  |
+| 3 | `type` | `.CDotaMsgStructuredTooltipProperties.EAttributeType` | `optional` |  | default = kUnknown |
+| 4 | `value` | `.CDotaMsgStructuredTooltipProperties.AttributeValue` | `optional` |  |  |
 
 </details>
 
@@ -3073,8 +3073,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `title_loc_token` | `string` | `optional` | `` |  |
-| 2 | `desc_loc_token` | `string` | `optional` | `` |  |
+| 1 | `title_loc_token` | `string` | `optional` |  |  |
+| 2 | `desc_loc_token` | `string` | `optional` |  |  |
 
 </details>
 
@@ -3100,8 +3100,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `desc` | `.CDotaMsgStructuredTooltipProperties.AttributeGroupDescription` | `optional` | `` |  |
-| 2 | `attributes` | `.CDotaMsgStructuredTooltipProperties.Attribute` | `repeated` | `` |  |
+| 1 | `desc` | `.CDotaMsgStructuredTooltipProperties.AttributeGroupDescription` | `optional` |  |  |
+| 2 | `attributes` | `.CDotaMsgStructuredTooltipProperties.Attribute` | `repeated` |  |  |
 
 </details>
 
@@ -3113,7 +3113,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `groups` | `.CDotaMsgStructuredTooltipProperties.AttributeGroup` | `repeated` | `` |  |
+| 1 | `groups` | `.CDotaMsgStructuredTooltipProperties.AttributeGroup` | `repeated` |  |  |
 
 </details>
 
@@ -3137,9 +3137,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ability_name_loc_token` | `string` | `optional` | `` |  |
-| 2 | `ability_desc_loc_token` | `string` | `optional` | `` |  |
-| 3 | `ability_icon_url` | `string` | `optional` | `` |  |
+| 1 | `ability_name_loc_token` | `string` | `optional` |  |  |
+| 2 | `ability_desc_loc_token` | `string` | `optional` |  |  |
+| 3 | `ability_icon_url` | `string` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-server.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-server.md
@@ -36,8 +36,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `detection_type` | `.EPoorNetworkConditionsType` | `optional` | `` | default = k_EPoorNetworkConditions_None |
-| 2 | `players` | `.CMsgPoorNetworkConditions.Player` | `repeated` | `` |  |
+| 1 | `detection_type` | `.EPoorNetworkConditionsType` | `optional` |  | default = k_EPoorNetworkConditions_None |
+| 2 | `players` | `.CMsgPoorNetworkConditions.Player` | `repeated` |  |  |
 
 </details>
 
@@ -49,10 +49,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `disconnect_reason` | `.ENetworkDisconnectionReason` | `optional` | `` | default = NETWORK_DISCONNECT_INVALID |
-| 3 | `num_bad_intervals` | `uint32` | `optional` | `` |  |
-| 4 | `peak_loss_pct` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `disconnect_reason` | `.ENetworkDisconnectionReason` | `optional` |  | default = NETWORK_DISCONNECT_INVALID |
+| 3 | `num_bad_intervals` | `uint32` | `optional` |  |  |
+| 4 | `peak_loss_pct` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -64,18 +64,18 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `lobby_id` | `fixed64` | `optional` | `` |  |
-| 3 | `game_state` | `.DOTA_GameState` | `optional` | `` | default = DOTA_GAMERULES_STATE_INIT |
-| 4 | `sentinel_save_time` | `fixed32` | `optional` | `` |  |
-| 5 | `server_steam_id` | `fixed64` | `optional` | `` |  |
-| 6 | `server_public_ip_addr` | `fixed32` | `optional` | `` |  |
-| 7 | `server_port` | `uint32` | `optional` | `` |  |
-| 8 | `server_cluster` | `uint32` | `optional` | `` |  |
-| 9 | `pid` | `uint32` | `optional` | `` |  |
-| 10 | `engine` | `uint32` | `optional` | `` |  |
-| 11 | `custom_game_id` | `fixed64` | `optional` | `` |  |
-| 12 | `tournament_id` | `uint32` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `lobby_id` | `fixed64` | `optional` |  |  |
+| 3 | `game_state` | `.DOTA_GameState` | `optional` |  | default = DOTA_GAMERULES_STATE_INIT |
+| 4 | `sentinel_save_time` | `fixed32` | `optional` |  |  |
+| 5 | `server_steam_id` | `fixed64` | `optional` |  |  |
+| 6 | `server_public_ip_addr` | `fixed32` | `optional` |  |  |
+| 7 | `server_port` | `uint32` | `optional` |  |  |
+| 8 | `server_cluster` | `uint32` | `optional` |  |  |
+| 9 | `pid` | `uint32` | `optional` |  |  |
+| 10 | `engine` | `uint32` | `optional` |  |  |
+| 11 | `custom_game_id` | `fixed64` | `optional` |  |  |
+| 12 | `tournament_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -87,17 +87,17 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `connected_players` | `.CMsgConnectedPlayers.Player` | `repeated` | `` |  |
-| 2 | `game_state` | `.DOTA_GameState` | `optional` | `` | default = DOTA_GAMERULES_STATE_INIT |
-| 6 | `first_blood_happened` | `bool` | `optional` | `` |  |
-| 7 | `disconnected_players` | `.CMsgConnectedPlayers.Player` | `repeated` | `` |  |
-| 8 | `send_reason` | `.CMsgConnectedPlayers.SendReason` | `optional` | `` | default = INVALID |
-| 10 | `poor_network_conditions` | `.CMsgPoorNetworkConditions` | `optional` | `` |  |
-| 11 | `radiant_kills` | `uint32` | `optional` | `` |  |
-| 12 | `dire_kills` | `uint32` | `optional` | `` |  |
-| 14 | `radiant_lead` | `int32` | `optional` | `` |  |
-| 15 | `building_state` | `uint32` | `optional` | `` |  |
-| 16 | `player_draft` | `.CMsgConnectedPlayers.PlayerDraft` | `repeated` | `` |  |
+| 1 | `connected_players` | `.CMsgConnectedPlayers.Player` | `repeated` |  |  |
+| 2 | `game_state` | `.DOTA_GameState` | `optional` |  | default = DOTA_GAMERULES_STATE_INIT |
+| 6 | `first_blood_happened` | `bool` | `optional` |  |  |
+| 7 | `disconnected_players` | `.CMsgConnectedPlayers.Player` | `repeated` |  |  |
+| 8 | `send_reason` | `.CMsgConnectedPlayers.SendReason` | `optional` |  | default = INVALID |
+| 10 | `poor_network_conditions` | `.CMsgPoorNetworkConditions` | `optional` |  |  |
+| 11 | `radiant_kills` | `uint32` | `optional` |  |  |
+| 12 | `dire_kills` | `uint32` | `optional` |  |  |
+| 14 | `radiant_lead` | `int32` | `optional` |  |  |
+| 15 | `building_state` | `uint32` | `optional` |  |  |
+| 16 | `player_draft` | `.CMsgConnectedPlayers.PlayerDraft` | `repeated` |  |  |
 
 </details>
 
@@ -109,10 +109,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steam_id` | `fixed64` | `optional` | `` |  |
-| 2 | `hero_id` | `int32` | `optional` | `` |  |
-| 3 | `leaver_state` | `.CMsgLeaverState` | `optional` | `` |  |
-| 4 | `disconnect_reason` | `.ENetworkDisconnectionReason` | `optional` | `` | default = NETWORK_DISCONNECT_INVALID |
+| 1 | `steam_id` | `fixed64` | `optional` |  |  |
+| 2 | `hero_id` | `int32` | `optional` |  |  |
+| 3 | `leaver_state` | `.CMsgLeaverState` | `optional` |  |  |
+| 4 | `disconnect_reason` | `.ENetworkDisconnectionReason` | `optional` |  | default = NETWORK_DISCONNECT_INVALID |
 
 </details>
 
@@ -124,9 +124,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steam_id` | `fixed64` | `optional` | `` |  |
-| 2 | `team` | `.DOTA_GC_TEAM` | `optional` | `` | default = DOTA_GC_TEAM_GOOD_GUYS |
-| 3 | `team_slot` | `int32` | `optional` | `` |  |
+| 1 | `steam_id` | `fixed64` | `optional` |  |  |
+| 2 | `team` | `.DOTA_GC_TEAM` | `optional` |  | default = DOTA_GC_TEAM_GOOD_GUYS |
+| 3 | `team_slot` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -138,32 +138,32 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `server_public_ip_addr` | `fixed32` | `optional` | `` |  |
-| 2 | `server_private_ip_addr` | `fixed32` | `optional` | `` |  |
-| 3 | `server_port` | `uint32` | `optional` | `` |  |
-| 4 | `server_tv_port` | `uint32` | `optional` | `` |  |
-| 5 | `server_key` | `string` | `optional` | `` |  |
-| 6 | `server_hibernation` | `bool` | `optional` | `` |  |
-| 7 | `server_type` | `.CMsgGameServerInfo.ServerType` | `optional` | `` | default = UNSPECIFIED |
-| 8 | `server_region` | `uint32` | `optional` | `` |  |
-| 9 | `server_loadavg` | `float` | `optional` | `` |  |
-| 10 | `server_tv_broadcast_time` | `float` | `optional` | `` |  |
-| 11 | `server_game_time` | `float` | `optional` | `` |  |
-| 12 | `server_relay_connected_steam_id` | `fixed64` | `optional` | `` |  |
-| 13 | `relay_slots_max` | `uint32` | `optional` | `` |  |
-| 14 | `relays_connected` | `int32` | `optional` | `` |  |
-| 15 | `relay_clients_connected` | `int32` | `optional` | `` |  |
-| 16 | `relayed_game_server_steam_id` | `fixed64` | `optional` | `` |  |
-| 17 | `parent_relay_count` | `uint32` | `optional` | `` |  |
-| 18 | `tv_secret_code` | `fixed64` | `optional` | `` |  |
-| 19 | `server_version` | `uint32` | `optional` | `` |  |
-| 20 | `server_cluster` | `uint32` | `optional` | `` |  |
-| 22 | `assigned_server_tv_port` | `uint32` | `optional` | `` |  |
-| 23 | `allow_custom_games` | `.CMsgGameServerInfo.CustomGames` | `optional` | `` | default = BOTH |
-| 24 | `build_version` | `uint32` | `optional` | `` |  |
-| 26 | `srcds_instance` | `uint32` | `optional` | `` |  |
-| 27 | `legacy_server_steamdatagram_address` | `bytes` | `optional` | `` |  |
-| 28 | `dev_force_server_type` | `bool` | `optional` | `` |  |
+| 1 | `server_public_ip_addr` | `fixed32` | `optional` |  |  |
+| 2 | `server_private_ip_addr` | `fixed32` | `optional` |  |  |
+| 3 | `server_port` | `uint32` | `optional` |  |  |
+| 4 | `server_tv_port` | `uint32` | `optional` |  |  |
+| 5 | `server_key` | `string` | `optional` |  |  |
+| 6 | `server_hibernation` | `bool` | `optional` |  |  |
+| 7 | `server_type` | `.CMsgGameServerInfo.ServerType` | `optional` |  | default = UNSPECIFIED |
+| 8 | `server_region` | `uint32` | `optional` |  |  |
+| 9 | `server_loadavg` | `float` | `optional` |  |  |
+| 10 | `server_tv_broadcast_time` | `float` | `optional` |  |  |
+| 11 | `server_game_time` | `float` | `optional` |  |  |
+| 12 | `server_relay_connected_steam_id` | `fixed64` | `optional` |  |  |
+| 13 | `relay_slots_max` | `uint32` | `optional` |  |  |
+| 14 | `relays_connected` | `int32` | `optional` |  |  |
+| 15 | `relay_clients_connected` | `int32` | `optional` |  |  |
+| 16 | `relayed_game_server_steam_id` | `fixed64` | `optional` |  |  |
+| 17 | `parent_relay_count` | `uint32` | `optional` |  |  |
+| 18 | `tv_secret_code` | `fixed64` | `optional` |  |  |
+| 19 | `server_version` | `uint32` | `optional` |  |  |
+| 20 | `server_cluster` | `uint32` | `optional` |  |  |
+| 22 | `assigned_server_tv_port` | `uint32` | `optional` |  |  |
+| 23 | `allow_custom_games` | `.CMsgGameServerInfo.CustomGames` | `optional` |  | default = BOTH |
+| 24 | `build_version` | `uint32` | `optional` |  |  |
+| 26 | `srcds_instance` | `uint32` | `optional` |  |  |
+| 27 | `legacy_server_steamdatagram_address` | `bytes` | `optional` |  |  |
+| 28 | `dev_force_server_type` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -175,12 +175,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steam_id` | `fixed64` | `optional` | `` |  |
-| 2 | `leaver_status` | `.DOTALeaverStatus_t` | `optional` | `` | default = DOTA_LEAVER_NONE |
-| 4 | `leaver_state` | `.CMsgLeaverState` | `optional` | `` |  |
-| 5 | `server_cluster` | `uint32` | `optional` | `` |  |
-| 6 | `disconnect_reason` | `.ENetworkDisconnectionReason` | `optional` | `` | default = NETWORK_DISCONNECT_INVALID |
-| 7 | `poor_network_conditions` | `.CMsgPoorNetworkConditions` | `optional` | `` |  |
+| 1 | `steam_id` | `fixed64` | `optional` |  |  |
+| 2 | `leaver_status` | `.DOTALeaverStatus_t` | `optional` |  | default = DOTA_LEAVER_NONE |
+| 4 | `leaver_state` | `.CMsgLeaverState` | `optional` |  |  |
+| 5 | `server_cluster` | `uint32` | `optional` |  |  |
+| 6 | `disconnect_reason` | `.ENetworkDisconnectionReason` | `optional` |  | default = NETWORK_DISCONNECT_INVALID |
+| 7 | `poor_network_conditions` | `.CMsgPoorNetworkConditions` | `optional` |  |  |
 
 </details>
 
@@ -192,7 +192,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `uint32` | `optional` | `` |  |
+| 1 | `result` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -204,7 +204,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `stats` | `.CMsgDOTAFantasyPlayerStats` | `repeated` | `` |  |
+| 2 | `stats` | `.CMsgDOTAFantasyPlayerStats` | `repeated` |  |  |
 
 </details>
 
@@ -216,7 +216,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `stats` | `.CMsgDOTAFantasyPlayerStats` | `repeated` | `` |  |
+| 2 | `stats` | `.CMsgDOTAFantasyPlayerStats` | `repeated` |  |  |
 
 </details>
 
@@ -228,7 +228,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `delayed` | `.CMsgDOTARealtimeGameStatsTerse` | `optional` | `` |  |
+| 1 | `delayed` | `.CMsgDOTARealtimeGameStatsTerse` | `optional` |  |  |
 
 </details>
 
@@ -240,7 +240,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `delayed` | `bool` | `optional` | `` |  |
+| 1 | `delayed` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -252,7 +252,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `active` | `bool` | `optional` | `` |  |
+| 1 | `active` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -264,7 +264,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `teams` | `.CMsgSignOutGameplayStats.CTeam` | `repeated` | `` |  |
+| 1 | `teams` | `.CMsgSignOutGameplayStats.CTeam` | `repeated` |  |  |
 
 </details>
 
@@ -276,10 +276,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steam_id` | `fixed64` | `optional` | `` |  |
-| 2 | `player_slot` | `uint32` | `optional` | `` |  |
-| 3 | `hero_id` | `int32` | `optional` | `` |  |
-| 4 | `timed_player_stats` | `.CMatchPlayerTimedStats` | `repeated` | `` |  |
+| 1 | `steam_id` | `fixed64` | `optional` |  |  |
+| 2 | `player_slot` | `uint32` | `optional` |  |  |
+| 3 | `hero_id` | `int32` | `optional` |  |  |
+| 4 | `timed_player_stats` | `.CMatchPlayerTimedStats` | `repeated` |  |  |
 
 </details>
 
@@ -291,10 +291,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `is_winning_team` | `bool` | `optional` | `` |  |
-| 2 | `is_radiant_team` | `bool` | `optional` | `` |  |
-| 3 | `timed_team_stats` | `.CMatchTeamTimedStats` | `repeated` | `` |  |
-| 4 | `players` | `.CMsgSignOutGameplayStats.CPlayer` | `repeated` | `` |  |
+| 1 | `is_winning_team` | `bool` | `optional` |  |  |
+| 2 | `is_radiant_team` | `bool` | `optional` |  |  |
+| 3 | `timed_team_stats` | `.CMatchTeamTimedStats` | `repeated` |  |  |
+| 4 | `players` | `.CMsgSignOutGameplayStats.CPlayer` | `repeated` |  |  |
 
 </details>
 
@@ -306,36 +306,36 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` | (key_field) = true |
-| 2 | `duration` | `uint32` | `optional` | `` |  |
-| 3 | `good_guys_win` | `bool` | `optional` | `` |  |
-| 4 | `date` | `fixed32` | `optional` | `` |  |
-| 6 | `teams` | `.CMsgGameMatchSignOut.CTeam` | `repeated` | `` |  |
-| 8 | `tower_status` | `uint32` | `repeated` | `` |  |
-| 9 | `barracks_status` | `uint32` | `repeated` | `` |  |
-| 10 | `cluster` | `uint32` | `optional` | `` |  |
-| 11 | `server_addr` | `string` | `optional` | `` |  |
-| 12 | `first_blood_time` | `uint32` | `optional` | `` |  |
-| 14 | `event_score` | `uint32` | `optional` | `` |  |
-| 17 | `player_strange_count_adjustments` | `.CMsgEconPlayerStrangeCountAdjustment` | `repeated` | `` |  |
-| 18 | `automatic_surrender` | `bool` | `optional` | `` |  |
-| 19 | `server_version` | `uint32` | `optional` | `` |  |
-| 20 | `additional_msgs` | `.CMsgGameMatchSignOut.CAdditionalSignoutMsg` | `repeated` | `` |  |
-| 22 | `average_networth_delta` | `sint32` | `optional` | `` |  |
-| 35 | `poor_network_conditions` | `.CMsgPoorNetworkConditions` | `optional` | `` |  |
-| 36 | `social_feed_events` | `.CMsgGameMatchSignOut.CSocialFeedMatchEvent` | `repeated` | `` |  |
-| 37 | `custom_game_data` | `.CMsgGameMatchSignOut.CCustomGameData` | `optional` | `` |  |
-| 38 | `match_flags` | `uint32` | `optional` | `` |  |
-| 39 | `team_scores` | `uint32` | `repeated` | `` |  |
-| 40 | `pre_game_duration` | `uint32` | `optional` | `` |  |
-| 41 | `fantasy_stats` | `.CMsgDOTAFantasyPlayerStats` | `repeated` | `` |  |
-| 42 | `event_game_leaderboard_entries` | `.CMsgGameMatchSignOut.EventGameLeaderboardEntry` | `repeated` | `` |  |
-| 43 | `ward_placements` | `.CMsgGameMatchSignOut.WardPlacement` | `repeated` | `` |  |
-| 44 | `gameplay_stats` | `.CMsgSignOutGameplayStats` | `optional` | `` |  |
-| 54 | `extra_messages` | `.CExtraMsgBlock` | `repeated` | `` |  |
-| 56 | `winning_team` | `.DOTA_GC_TEAM` | `optional` | `` | default = DOTA_GC_TEAM_GOOD_GUYS |
-| 57 | `normalized_win_probability_diff` | `float` | `optional` | `` |  |
-| 58 | `match_tracked_stats` | `.CMsgTrackedStat` | `repeated` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  | (key_field) = true |
+| 2 | `duration` | `uint32` | `optional` |  |  |
+| 3 | `good_guys_win` | `bool` | `optional` |  |  |
+| 4 | `date` | `fixed32` | `optional` |  |  |
+| 6 | `teams` | `.CMsgGameMatchSignOut.CTeam` | `repeated` |  |  |
+| 8 | `tower_status` | `uint32` | `repeated` |  |  |
+| 9 | `barracks_status` | `uint32` | `repeated` |  |  |
+| 10 | `cluster` | `uint32` | `optional` |  |  |
+| 11 | `server_addr` | `string` | `optional` |  |  |
+| 12 | `first_blood_time` | `uint32` | `optional` |  |  |
+| 14 | `event_score` | `uint32` | `optional` |  |  |
+| 17 | `player_strange_count_adjustments` | `.CMsgEconPlayerStrangeCountAdjustment` | `repeated` |  |  |
+| 18 | `automatic_surrender` | `bool` | `optional` |  |  |
+| 19 | `server_version` | `uint32` | `optional` |  |  |
+| 20 | `additional_msgs` | `.CMsgGameMatchSignOut.CAdditionalSignoutMsg` | `repeated` |  |  |
+| 22 | `average_networth_delta` | `sint32` | `optional` |  |  |
+| 35 | `poor_network_conditions` | `.CMsgPoorNetworkConditions` | `optional` |  |  |
+| 36 | `social_feed_events` | `.CMsgGameMatchSignOut.CSocialFeedMatchEvent` | `repeated` |  |  |
+| 37 | `custom_game_data` | `.CMsgGameMatchSignOut.CCustomGameData` | `optional` |  |  |
+| 38 | `match_flags` | `uint32` | `optional` |  |  |
+| 39 | `team_scores` | `uint32` | `repeated` |  |  |
+| 40 | `pre_game_duration` | `uint32` | `optional` |  |  |
+| 41 | `fantasy_stats` | `.CMsgDOTAFantasyPlayerStats` | `repeated` |  |  |
+| 42 | `event_game_leaderboard_entries` | `.CMsgGameMatchSignOut.EventGameLeaderboardEntry` | `repeated` |  |  |
+| 43 | `ward_placements` | `.CMsgGameMatchSignOut.WardPlacement` | `repeated` |  |  |
+| 44 | `gameplay_stats` | `.CMsgSignOutGameplayStats` | `optional` |  |  |
+| 54 | `extra_messages` | `.CExtraMsgBlock` | `repeated` |  |  |
+| 56 | `winning_team` | `.DOTA_GC_TEAM` | `optional` |  | default = DOTA_GC_TEAM_GOOD_GUYS |
+| 57 | `normalized_win_probability_diff` | `float` | `optional` |  |  |
+| 58 | `match_tracked_stats` | `.CMsgTrackedStat` | `repeated` |  |  |
 
 </details>
 
@@ -347,8 +347,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `players` | `.CMsgGameMatchSignOut.CTeam.CPlayer` | `repeated` | `` |  |
-| 2 | `team_tracked_stats` | `.CMsgTrackedStat` | `repeated` | `` |  |
+| 1 | `players` | `.CMsgGameMatchSignOut.CTeam.CPlayer` | `repeated` |  |  |
+| 2 | `team_tracked_stats` | `.CMsgTrackedStat` | `repeated` |  |  |
 
 </details>
 
@@ -360,80 +360,80 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steam_id` | `fixed64` | `optional` | `` |  |
-| 3 | `hero_id` | `int32` | `optional` | `` |  |
-| 4 | `items` | `int32` | `repeated` | `` |  |
-| 5 | `gold` | `uint32` | `optional` | `` |  |
-| 6 | `kills` | `uint32` | `optional` | `` |  |
-| 7 | `deaths` | `uint32` | `optional` | `` |  |
-| 8 | `assists` | `uint32` | `optional` | `` |  |
-| 9 | `leaver_status` | `uint32` | `optional` | `` |  |
-| 10 | `last_hits` | `uint32` | `optional` | `` |  |
-| 11 | `denies` | `uint32` | `optional` | `` |  |
-| 12 | `gold_per_min` | `uint32` | `optional` | `` |  |
-| 13 | `xp_per_minute` | `uint32` | `optional` | `` |  |
-| 14 | `gold_spent` | `uint32` | `optional` | `` |  |
-| 15 | `level` | `uint32` | `optional` | `` |  |
-| 16 | `scaled_hero_damage` | `uint32` | `optional` | `` |  |
-| 17 | `scaled_tower_damage` | `uint32` | `optional` | `` |  |
-| 18 | `scaled_hero_healing` | `uint32` | `optional` | `` |  |
-| 19 | `time_last_seen` | `uint32` | `optional` | `` |  |
-| 20 | `support_ability_value` | `uint32` | `optional` | `` |  |
-| 21 | `party_id` | `uint64` | `optional` | `` |  |
-| 27 | `claimed_farm_gold` | `uint32` | `optional` | `` |  |
-| 28 | `support_gold` | `uint32` | `optional` | `` |  |
-| 29 | `claimed_denies` | `uint32` | `optional` | `` |  |
-| 30 | `claimed_misses` | `uint32` | `optional` | `` |  |
-| 31 | `misses` | `uint32` | `optional` | `` |  |
-| 32 | `ability_upgrades` | `.CMatchPlayerAbilityUpgrade` | `repeated` | `` |  |
-| 33 | `additional_units_inventory` | `.CMatchAdditionalUnitInventory` | `repeated` | `` |  |
-| 34 | `net_worth` | `uint32` | `optional` | `` |  |
-| 35 | `custom_game_data` | `.CMsgGameMatchSignOut.CTeam.CPlayer.CCustomGameData` | `optional` | `` |  |
-| 36 | `match_player_flags` | `uint32` | `optional` | `` |  |
-| 37 | `hero_damage` | `uint32` | `optional` | `` |  |
-| 38 | `tower_damage` | `uint32` | `optional` | `` |  |
-| 39 | `hero_healing` | `uint32` | `optional` | `` |  |
-| 40 | `permanent_buffs` | `.CMatchPlayerPermanentBuff` | `repeated` | `` |  |
-| 41 | `talent_ability_ids` | `int32` | `repeated` | `` |  |
-| 42 | `hero_pick_order` | `uint32` | `optional` | `` |  |
-| 43 | `hero_was_randomed` | `bool` | `optional` | `` |  |
-| 45 | `lane` | `uint32` | `optional` | `` |  |
-| 47 | `is_using_plus_guide` | `bool` | `optional` | `` |  |
-| 48 | `hero_damage_received` | `.CMsgGameMatchSignOut.CTeam.CPlayer.HeroDamageReceived` | `repeated` | `` |  |
-| 50 | `hero_was_dota_plus_suggestion` | `bool` | `optional` | `` |  |
-| 51 | `seconds_dead` | `uint32` | `optional` | `` |  |
-| 52 | `gold_lost_to_death` | `uint32` | `optional` | `` |  |
-| 53 | `command_count` | `uint32` | `optional` | `` |  |
-| 54 | `mouse_click_cast_command_count` | `uint32` | `optional` | `` |  |
-| 55 | `teleports_used` | `uint32` | `optional` | `` |  |
-| 56 | `cavern_crawl_preferred_map_variant` | `uint32` | `optional` | `` | default = 255 |
-| 57 | `bounty_runes` | `uint32` | `optional` | `` |  |
-| 58 | `outposts_captured` | `uint32` | `optional` | `` |  |
-| 59 | `dewards` | `uint32` | `optional` | `` |  |
-| 60 | `wards_placed` | `uint32` | `optional` | `` |  |
-| 61 | `camps_stacked` | `uint32` | `optional` | `` |  |
-| 62 | `player_slot` | `uint32` | `optional` | `` |  |
-| 63 | `item_purchase_times` | `uint32` | `repeated` | `` |  |
-| 64 | `hero_damage_dealt` | `.CMsgGameMatchSignOut.CTeam.CPlayer.HeroDamageReceived` | `repeated` | `` |  |
-| 66 | `predicted_position` | `uint32` | `optional` | `` |  |
-| 67 | `lane_outcomes` | `uint32` | `optional` | `` | default = 255 |
-| 68 | `friendly_t1_destroyed_time` | `uint32` | `optional` | `` |  |
-| 69 | `enemy_t1_destroyed_time` | `uint32` | `optional` | `` |  |
-| 70 | `friendly_roshan_kills` | `uint32` | `optional` | `` |  |
-| 71 | `enemy_roshan_kills` | `uint32` | `optional` | `` |  |
-| 72 | `power_runes` | `uint32` | `optional` | `` |  |
-| 73 | `water_runes` | `uint32` | `optional` | `` |  |
-| 74 | `stun_duration` | `float` | `optional` | `` |  |
-| 75 | `team_number` | `.DOTA_GC_TEAM` | `optional` | `` | default = DOTA_GC_TEAM_GOOD_GUYS |
-| 76 | `team_slot` | `uint32` | `optional` | `` |  |
-| 77 | `time_purchased_shard` | `uint32` | `optional` | `` |  |
-| 78 | `time_purchased_aghs` | `uint32` | `optional` | `` |  |
-| 79 | `ability_draft_abilities` | `int32` | `repeated` | `` |  |
-| 80 | `player_tracked_stats` | `.CMsgTrackedStat` | `repeated` | `` |  |
-| 81 | `predicted_rank` | `uint32` | `optional` | `` |  |
-| 82 | `selected_facet` | `uint32` | `optional` | `` |  |
-| 83 | `enhancement_level` | `uint32` | `optional` | `` |  |
-| 84 | `disable_duration` | `uint32` | `optional` | `` |  |
+| 1 | `steam_id` | `fixed64` | `optional` |  |  |
+| 3 | `hero_id` | `int32` | `optional` |  |  |
+| 4 | `items` | `int32` | `repeated` |  |  |
+| 5 | `gold` | `uint32` | `optional` |  |  |
+| 6 | `kills` | `uint32` | `optional` |  |  |
+| 7 | `deaths` | `uint32` | `optional` |  |  |
+| 8 | `assists` | `uint32` | `optional` |  |  |
+| 9 | `leaver_status` | `uint32` | `optional` |  |  |
+| 10 | `last_hits` | `uint32` | `optional` |  |  |
+| 11 | `denies` | `uint32` | `optional` |  |  |
+| 12 | `gold_per_min` | `uint32` | `optional` |  |  |
+| 13 | `xp_per_minute` | `uint32` | `optional` |  |  |
+| 14 | `gold_spent` | `uint32` | `optional` |  |  |
+| 15 | `level` | `uint32` | `optional` |  |  |
+| 16 | `scaled_hero_damage` | `uint32` | `optional` |  |  |
+| 17 | `scaled_tower_damage` | `uint32` | `optional` |  |  |
+| 18 | `scaled_hero_healing` | `uint32` | `optional` |  |  |
+| 19 | `time_last_seen` | `uint32` | `optional` |  |  |
+| 20 | `support_ability_value` | `uint32` | `optional` |  |  |
+| 21 | `party_id` | `uint64` | `optional` |  |  |
+| 27 | `claimed_farm_gold` | `uint32` | `optional` |  |  |
+| 28 | `support_gold` | `uint32` | `optional` |  |  |
+| 29 | `claimed_denies` | `uint32` | `optional` |  |  |
+| 30 | `claimed_misses` | `uint32` | `optional` |  |  |
+| 31 | `misses` | `uint32` | `optional` |  |  |
+| 32 | `ability_upgrades` | `.CMatchPlayerAbilityUpgrade` | `repeated` |  |  |
+| 33 | `additional_units_inventory` | `.CMatchAdditionalUnitInventory` | `repeated` |  |  |
+| 34 | `net_worth` | `uint32` | `optional` |  |  |
+| 35 | `custom_game_data` | `.CMsgGameMatchSignOut.CTeam.CPlayer.CCustomGameData` | `optional` |  |  |
+| 36 | `match_player_flags` | `uint32` | `optional` |  |  |
+| 37 | `hero_damage` | `uint32` | `optional` |  |  |
+| 38 | `tower_damage` | `uint32` | `optional` |  |  |
+| 39 | `hero_healing` | `uint32` | `optional` |  |  |
+| 40 | `permanent_buffs` | `.CMatchPlayerPermanentBuff` | `repeated` |  |  |
+| 41 | `talent_ability_ids` | `int32` | `repeated` |  |  |
+| 42 | `hero_pick_order` | `uint32` | `optional` |  |  |
+| 43 | `hero_was_randomed` | `bool` | `optional` |  |  |
+| 45 | `lane` | `uint32` | `optional` |  |  |
+| 47 | `is_using_plus_guide` | `bool` | `optional` |  |  |
+| 48 | `hero_damage_received` | `.CMsgGameMatchSignOut.CTeam.CPlayer.HeroDamageReceived` | `repeated` |  |  |
+| 50 | `hero_was_dota_plus_suggestion` | `bool` | `optional` |  |  |
+| 51 | `seconds_dead` | `uint32` | `optional` |  |  |
+| 52 | `gold_lost_to_death` | `uint32` | `optional` |  |  |
+| 53 | `command_count` | `uint32` | `optional` |  |  |
+| 54 | `mouse_click_cast_command_count` | `uint32` | `optional` |  |  |
+| 55 | `teleports_used` | `uint32` | `optional` |  |  |
+| 56 | `cavern_crawl_preferred_map_variant` | `uint32` | `optional` |  | default = 255 |
+| 57 | `bounty_runes` | `uint32` | `optional` |  |  |
+| 58 | `outposts_captured` | `uint32` | `optional` |  |  |
+| 59 | `dewards` | `uint32` | `optional` |  |  |
+| 60 | `wards_placed` | `uint32` | `optional` |  |  |
+| 61 | `camps_stacked` | `uint32` | `optional` |  |  |
+| 62 | `player_slot` | `uint32` | `optional` |  |  |
+| 63 | `item_purchase_times` | `uint32` | `repeated` |  |  |
+| 64 | `hero_damage_dealt` | `.CMsgGameMatchSignOut.CTeam.CPlayer.HeroDamageReceived` | `repeated` |  |  |
+| 66 | `predicted_position` | `uint32` | `optional` |  |  |
+| 67 | `lane_outcomes` | `uint32` | `optional` |  | default = 255 |
+| 68 | `friendly_t1_destroyed_time` | `uint32` | `optional` |  |  |
+| 69 | `enemy_t1_destroyed_time` | `uint32` | `optional` |  |  |
+| 70 | `friendly_roshan_kills` | `uint32` | `optional` |  |  |
+| 71 | `enemy_roshan_kills` | `uint32` | `optional` |  |  |
+| 72 | `power_runes` | `uint32` | `optional` |  |  |
+| 73 | `water_runes` | `uint32` | `optional` |  |  |
+| 74 | `stun_duration` | `float` | `optional` |  |  |
+| 75 | `team_number` | `.DOTA_GC_TEAM` | `optional` |  | default = DOTA_GC_TEAM_GOOD_GUYS |
+| 76 | `team_slot` | `uint32` | `optional` |  |  |
+| 77 | `time_purchased_shard` | `uint32` | `optional` |  |  |
+| 78 | `time_purchased_aghs` | `uint32` | `optional` |  |  |
+| 79 | `ability_draft_abilities` | `int32` | `repeated` |  |  |
+| 80 | `player_tracked_stats` | `.CMsgTrackedStat` | `repeated` |  |  |
+| 81 | `predicted_rank` | `uint32` | `optional` |  |  |
+| 82 | `selected_facet` | `uint32` | `optional` |  |  |
+| 83 | `enhancement_level` | `uint32` | `optional` |  |  |
+| 84 | `disable_duration` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -445,8 +445,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `dota_team` | `uint32` | `optional` | `` |  |
-| 2 | `winner` | `bool` | `optional` | `` |  |
+| 1 | `dota_team` | `uint32` | `optional` |  |  |
+| 2 | `winner` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -458,9 +458,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `pre_reduction` | `uint32` | `optional` | `` |  |
-| 2 | `post_reduction` | `uint32` | `optional` | `` |  |
-| 3 | `damage_type` | `.CMsgGameMatchSignOut.CTeam.CPlayer.HeroDamageType` | `optional` | `` | default = HERO_DAMAGE_PHYSICAL |
+| 1 | `pre_reduction` | `uint32` | `optional` |  |  |
+| 2 | `post_reduction` | `uint32` | `optional` |  |  |
+| 3 | `damage_type` | `.CMsgGameMatchSignOut.CTeam.CPlayer.HeroDamageType` | `optional` |  | default = HERO_DAMAGE_PHYSICAL |
 
 </details>
 
@@ -472,8 +472,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `uint32` | `optional` | `` |  |
-| 2 | `contents` | `bytes` | `optional` | `` |  |
+| 1 | `id` | `uint32` | `optional` |  |  |
+| 2 | `contents` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -485,11 +485,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `timestamp` | `uint32` | `optional` | `` |  |
-| 3 | `event_type` | `uint32` | `optional` | `` |  |
-| 4 | `game_time` | `int32` | `optional` | `` |  |
-| 5 | `replay_time` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `timestamp` | `uint32` | `optional` |  |  |
+| 3 | `event_type` | `uint32` | `optional` |  |  |
+| 4 | `game_time` | `int32` | `optional` |  |  |
+| 5 | `replay_time` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -501,7 +501,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `publish_timestamp` | `uint32` | `optional` | `` |  |
+| 1 | `publish_timestamp` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -513,13 +513,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name_suffix` | `string` | `optional` | `` |  |
-| 2 | `score` | `int32` | `optional` | `` |  |
-| 3 | `extra_data_1` | `uint32` | `optional` | `` |  |
-| 4 | `extra_data_2` | `uint32` | `optional` | `` |  |
-| 5 | `extra_data_3` | `uint32` | `optional` | `` |  |
-| 6 | `extra_data_4` | `uint32` | `optional` | `` |  |
-| 7 | `extra_data_5` | `uint32` | `optional` | `` |  |
+| 1 | `name_suffix` | `string` | `optional` |  |  |
+| 2 | `score` | `int32` | `optional` |  |  |
+| 3 | `extra_data_1` | `uint32` | `optional` |  |  |
+| 4 | `extra_data_2` | `uint32` | `optional` |  |  |
+| 5 | `extra_data_3` | `uint32` | `optional` |  |  |
+| 6 | `extra_data_4` | `uint32` | `optional` |  |  |
+| 7 | `extra_data_5` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -531,14 +531,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `team_id` | `uint32` | `optional` | `` |  |
-| 3 | `placed_time` | `uint32` | `optional` | `` |  |
-| 4 | `building_state` | `uint32` | `optional` | `` |  |
-| 5 | `creep_state` | `uint32` | `optional` | `` |  |
-| 6 | `roshan_alive` | `bool` | `optional` | `` |  |
-| 7 | `position_x` | `uint32` | `optional` | `` |  |
-| 8 | `position_y` | `uint32` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `team_id` | `uint32` | `optional` |  |  |
+| 3 | `placed_time` | `uint32` | `optional` |  |  |
+| 4 | `building_state` | `uint32` | `optional` |  |  |
+| 5 | `creep_state` | `uint32` | `optional` |  |  |
+| 6 | `roshan_alive` | `bool` | `optional` |  |  |
+| 7 | `position_x` | `uint32` | `optional` |  |  |
+| 8 | `position_y` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -550,9 +550,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `radiant_captain_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `dire_captain_account_id` | `uint32` | `optional` | `` |  |
-| 3 | `picks_bans` | `.CMatchHeroSelectEvent` | `repeated` | `` |  |
+| 1 | `radiant_captain_account_id` | `uint32` | `optional` |  |  |
+| 2 | `dire_captain_account_id` | `uint32` | `optional` |  |  |
+| 3 | `picks_bans` | `.CMatchHeroSelectEvent` | `repeated` |  |  |
 
 </details>
 
@@ -564,10 +564,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `allow_cheats` | `bool` | `optional` | `` |  |
-| 2 | `bot_difficulty_radiant` | `.DOTABotDifficulty` | `optional` | `` | default = BOT_DIFFICULTY_PASSIVE |
-| 3 | `created_lobby` | `bool` | `optional` | `` |  |
-| 5 | `bot_difficulty_dire` | `.DOTABotDifficulty` | `optional` | `` | default = BOT_DIFFICULTY_PASSIVE |
+| 1 | `allow_cheats` | `bool` | `optional` |  |  |
+| 2 | `bot_difficulty_radiant` | `.DOTABotDifficulty` | `optional` |  | default = BOT_DIFFICULTY_PASSIVE |
+| 3 | `created_lobby` | `bool` | `optional` |  |  |
+| 5 | `bot_difficulty_dire` | `.DOTABotDifficulty` | `optional` |  | default = BOT_DIFFICULTY_PASSIVE |
 
 </details>
 
@@ -579,7 +579,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `text_mute_messages` | `.CMsgSignOutTextMuteInfo.TextMuteMessage` | `repeated` | `` |  |
+| 1 | `text_mute_messages` | `.CMsgSignOutTextMuteInfo.TextMuteMessage` | `repeated` |  |  |
 
 </details>
 
@@ -591,9 +591,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `region` | `uint32` | `optional` | `` |  |
-| 2 | `caused_text_mute` | `bool` | `optional` | `` |  |
-| 3 | `chat_message` | `string` | `optional` | `` |  |
+| 1 | `region` | `uint32` | `optional` |  |  |
+| 2 | `caused_text_mute` | `bool` | `optional` |  |  |
+| 3 | `chat_message` | `string` | `optional` |  |  |
 
 </details>
 
@@ -605,36 +605,36 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `int32` | `optional` | `` |  |
-| 2 | `match_id` | `uint64` | `optional` | `` |  |
-| 3 | `rank` | `uint32` | `optional` | `` |  |
-| 4 | `hero_id` | `int32` | `optional` | `` |  |
-| 5 | `rampages` | `uint32` | `optional` | `` |  |
-| 6 | `triple_kills` | `uint32` | `optional` | `` |  |
-| 7 | `first_blood_claimed` | `uint32` | `optional` | `` |  |
-| 8 | `first_blood_given` | `uint32` | `optional` | `` |  |
-| 9 | `couriers_killed` | `uint32` | `optional` | `` |  |
-| 10 | `aegises_snatched` | `uint32` | `optional` | `` |  |
-| 11 | `cheeses_eaten` | `uint32` | `optional` | `` |  |
-| 12 | `creeps_stacked` | `uint32` | `optional` | `` |  |
-| 13 | `fight_score` | `float` | `optional` | `` |  |
-| 14 | `farm_score` | `float` | `optional` | `` |  |
-| 15 | `support_score` | `float` | `optional` | `` |  |
-| 16 | `push_score` | `float` | `optional` | `` |  |
-| 17 | `kills` | `uint32` | `optional` | `` |  |
-| 18 | `deaths` | `uint32` | `optional` | `` |  |
-| 19 | `assists` | `uint32` | `optional` | `` |  |
-| 20 | `last_hits` | `uint32` | `optional` | `` |  |
-| 21 | `denies` | `uint32` | `optional` | `` |  |
-| 22 | `gpm` | `float` | `optional` | `` |  |
-| 23 | `xppm` | `float` | `optional` | `` |  |
-| 24 | `net_worth` | `float` | `optional` | `` |  |
-| 25 | `damage` | `float` | `optional` | `` |  |
-| 26 | `heals` | `float` | `optional` | `` |  |
-| 27 | `rapiers_purchased` | `uint32` | `optional` | `` |  |
-| 28 | `observer_wards_placed` | `uint32` | `optional` | `` |  |
-| 29 | `wards_destroyed` | `uint32` | `optional` | `` |  |
-| 30 | `lobby_type` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `int32` | `optional` |  |  |
+| 2 | `match_id` | `uint64` | `optional` |  |  |
+| 3 | `rank` | `uint32` | `optional` |  |  |
+| 4 | `hero_id` | `int32` | `optional` |  |  |
+| 5 | `rampages` | `uint32` | `optional` |  |  |
+| 6 | `triple_kills` | `uint32` | `optional` |  |  |
+| 7 | `first_blood_claimed` | `uint32` | `optional` |  |  |
+| 8 | `first_blood_given` | `uint32` | `optional` |  |  |
+| 9 | `couriers_killed` | `uint32` | `optional` |  |  |
+| 10 | `aegises_snatched` | `uint32` | `optional` |  |  |
+| 11 | `cheeses_eaten` | `uint32` | `optional` |  |  |
+| 12 | `creeps_stacked` | `uint32` | `optional` |  |  |
+| 13 | `fight_score` | `float` | `optional` |  |  |
+| 14 | `farm_score` | `float` | `optional` |  |  |
+| 15 | `support_score` | `float` | `optional` |  |  |
+| 16 | `push_score` | `float` | `optional` |  |  |
+| 17 | `kills` | `uint32` | `optional` |  |  |
+| 18 | `deaths` | `uint32` | `optional` |  |  |
+| 19 | `assists` | `uint32` | `optional` |  |  |
+| 20 | `last_hits` | `uint32` | `optional` |  |  |
+| 21 | `denies` | `uint32` | `optional` |  |  |
+| 22 | `gpm` | `float` | `optional` |  |  |
+| 23 | `xppm` | `float` | `optional` |  |  |
+| 24 | `net_worth` | `float` | `optional` |  |  |
+| 25 | `damage` | `float` | `optional` |  |  |
+| 26 | `heals` | `float` | `optional` |  |  |
+| 27 | `rapiers_purchased` | `uint32` | `optional` |  |  |
+| 28 | `observer_wards_placed` | `uint32` | `optional` |  |  |
+| 29 | `wards_destroyed` | `uint32` | `optional` |  |  |
+| 30 | `lobby_type` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -646,7 +646,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `players` | `.CMsgSignOutCommunicationSummary.PlayerCommunication` | `repeated` | `` |  |
+| 1 | `players` | `.CMsgSignOutCommunicationSummary.PlayerCommunication` | `repeated` |  |  |
 
 </details>
 
@@ -658,24 +658,24 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `pings` | `uint32` | `optional` | `` |  |
-| 3 | `max_pings_per_interval` | `uint32` | `optional` | `` |  |
-| 4 | `teammate_pings` | `uint32` | `optional` | `` |  |
-| 5 | `max_teammate_pings_per_interval` | `uint32` | `optional` | `` |  |
-| 6 | `team_chat_messages` | `uint32` | `optional` | `` |  |
-| 7 | `all_chat_messages` | `uint32` | `optional` | `` |  |
-| 8 | `chat_wheel_messages` | `uint32` | `optional` | `` |  |
-| 9 | `pauses` | `uint32` | `optional` | `` |  |
-| 10 | `unpauses` | `uint32` | `optional` | `` |  |
-| 11 | `lines_drawn` | `uint32` | `optional` | `` |  |
-| 12 | `voice_chat_seconds` | `uint32` | `optional` | `` |  |
-| 13 | `chat_mutes` | `uint32` | `optional` | `` |  |
-| 14 | `voice_mutes` | `uint32` | `optional` | `` |  |
-| 15 | `ping_details` | `.CMsgSignOutCommunicationSummary.PlayerCommunication.PingDetail` | `repeated` | `` |  |
-| 16 | `comms_blocks_solo` | `uint32` | `optional` | `` |  |
-| 17 | `comms_blocks_mass` | `uint32` | `optional` | `` |  |
-| 18 | `chat_log` | `string` | `repeated` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `pings` | `uint32` | `optional` |  |  |
+| 3 | `max_pings_per_interval` | `uint32` | `optional` |  |  |
+| 4 | `teammate_pings` | `uint32` | `optional` |  |  |
+| 5 | `max_teammate_pings_per_interval` | `uint32` | `optional` |  |  |
+| 6 | `team_chat_messages` | `uint32` | `optional` |  |  |
+| 7 | `all_chat_messages` | `uint32` | `optional` |  |  |
+| 8 | `chat_wheel_messages` | `uint32` | `optional` |  |  |
+| 9 | `pauses` | `uint32` | `optional` |  |  |
+| 10 | `unpauses` | `uint32` | `optional` |  |  |
+| 11 | `lines_drawn` | `uint32` | `optional` |  |  |
+| 12 | `voice_chat_seconds` | `uint32` | `optional` |  |  |
+| 13 | `chat_mutes` | `uint32` | `optional` |  |  |
+| 14 | `voice_mutes` | `uint32` | `optional` |  |  |
+| 15 | `ping_details` | `.CMsgSignOutCommunicationSummary.PlayerCommunication.PingDetail` | `repeated` |  |  |
+| 16 | `comms_blocks_solo` | `uint32` | `optional` |  |  |
+| 17 | `comms_blocks_mass` | `uint32` | `optional` |  |  |
+| 18 | `chat_log` | `string` | `repeated` |  |  |
 
 </details>
 
@@ -687,8 +687,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `type` | `uint32` | `optional` | `` | default = 4294967295 |
-| 2 | `count` | `uint32` | `optional` | `` |  |
+| 1 | `type` | `uint32` | `optional` |  | default = 4294967295 |
+| 2 | `count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -700,18 +700,18 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `replay_salt` | `fixed32` | `optional` | `` |  |
-| 5 | `leagueid` | `uint32` | `optional` | `` |  |
-| 7 | `metadata_private_key` | `fixed32` | `optional` | `` |  |
-| 8 | `match_details` | `.CMsgDOTAMatch` | `optional` | `` |  |
-| 9 | `players_metadata` | `.CMsgGameMatchSignoutResponse.PlayerMetadata` | `repeated` | `` |  |
-| 10 | `mvp_data` | `.CMvpData` | `optional` | `` |  |
-| 11 | `ow_private_key` | `fixed64` | `optional` | `` |  |
-| 12 | `ow_salt` | `fixed32` | `optional` | `` |  |
-| 13 | `ow_replay_id` | `uint64` | `optional` | `` |  |
-| 14 | `overworld_rewards` | `.CMsgOverworldMatchRewards` | `optional` | `` |  |
-| 15 | `monster_hunter_rewards` | `.CMsgMonsterHunterMatchRewards` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `replay_salt` | `fixed32` | `optional` |  |  |
+| 5 | `leagueid` | `uint32` | `optional` |  |  |
+| 7 | `metadata_private_key` | `fixed32` | `optional` |  |  |
+| 8 | `match_details` | `.CMsgDOTAMatch` | `optional` |  |  |
+| 9 | `players_metadata` | `.CMsgGameMatchSignoutResponse.PlayerMetadata` | `repeated` |  |  |
+| 10 | `mvp_data` | `.CMvpData` | `optional` |  |  |
+| 11 | `ow_private_key` | `fixed64` | `optional` |  |  |
+| 12 | `ow_salt` | `fixed32` | `optional` |  |  |
+| 13 | `ow_replay_id` | `uint64` | `optional` |  |  |
+| 14 | `overworld_rewards` | `.CMsgOverworldMatchRewards` | `optional` |  |  |
+| 15 | `monster_hunter_rewards` | `.CMsgMonsterHunterMatchRewards` | `optional` |  |  |
 
 </details>
 
@@ -723,19 +723,19 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `avg_kills_x16` | `uint32` | `optional` | `` |  |
-| 3 | `avg_deaths_x16` | `uint32` | `optional` | `` |  |
-| 4 | `avg_assists_x16` | `uint32` | `optional` | `` |  |
-| 5 | `avg_gpm_x16` | `uint32` | `optional` | `` |  |
-| 6 | `avg_xpm_x16` | `uint32` | `optional` | `` |  |
-| 7 | `best_kills_x16` | `uint32` | `optional` | `` |  |
-| 8 | `best_assists_x16` | `uint32` | `optional` | `` |  |
-| 9 | `best_gpm_x16` | `uint32` | `optional` | `` |  |
-| 10 | `best_xpm_x16` | `uint32` | `optional` | `` |  |
-| 11 | `win_streak` | `uint32` | `optional` | `` |  |
-| 12 | `best_win_streak` | `uint32` | `optional` | `` |  |
-| 13 | `games_played` | `uint32` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `avg_kills_x16` | `uint32` | `optional` |  |  |
+| 3 | `avg_deaths_x16` | `uint32` | `optional` |  |  |
+| 4 | `avg_assists_x16` | `uint32` | `optional` |  |  |
+| 5 | `avg_gpm_x16` | `uint32` | `optional` |  |  |
+| 6 | `avg_xpm_x16` | `uint32` | `optional` |  |  |
+| 7 | `best_kills_x16` | `uint32` | `optional` |  |  |
+| 8 | `best_assists_x16` | `uint32` | `optional` |  |  |
+| 9 | `best_gpm_x16` | `uint32` | `optional` |  |  |
+| 10 | `best_xpm_x16` | `uint32` | `optional` |  |  |
+| 11 | `win_streak` | `uint32` | `optional` |  |  |
+| 12 | `best_win_streak` | `uint32` | `optional` |  |  |
+| 13 | `games_played` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -747,10 +747,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `server_version` | `uint32` | `optional` | `` |  |
-| 2 | `local_attempt` | `uint32` | `optional` | `` |  |
-| 3 | `total_attempt` | `uint32` | `optional` | `` |  |
-| 4 | `seconds_waited` | `uint32` | `optional` | `` |  |
+| 1 | `server_version` | `uint32` | `optional` |  |  |
+| 2 | `local_attempt` | `uint32` | `optional` |  |  |
+| 3 | `total_attempt` | `uint32` | `optional` |  |  |
+| 4 | `seconds_waited` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -762,9 +762,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `permission_granted` | `bool` | `optional` | `` | default = false |
-| 2 | `abandon_signout` | `bool` | `optional` | `` | default = false |
-| 3 | `retry_delay_seconds` | `uint32` | `optional` | `` | default = 0 |
+| 1 | `permission_granted` | `bool` | `optional` |  | default = false |
+| 2 | `abandon_signout` | `bool` | `optional` |  | default = false |
+| 3 | `retry_delay_seconds` | `uint32` | `optional` |  | default = 0 |
 
 </details>
 
@@ -776,11 +776,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 2 | `game_name` | `string` | `optional` | `` |  |
-| 3 | `map_name` | `string` | `optional` | `` |  |
-| 4 | `event_game_data` | `bytes` | `optional` | `` |  |
-| 5 | `start_time` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 2 | `game_name` | `string` | `optional` |  |  |
+| 3 | `map_name` | `string` | `optional` |  |  |
+| 4 | `event_game_data` | `bytes` | `optional` |  |  |
+| 5 | `start_time` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -792,36 +792,36 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `average_frame_time` | `float` | `repeated` | `` |  |
-| 2 | `max_frame_time` | `float` | `repeated` | `` |  |
-| 3 | `server_average_frame_time` | `float` | `optional` | `` |  |
-| 4 | `server_max_frame_time` | `float` | `optional` | `` |  |
-| 5 | `average_compute_time` | `float` | `repeated` | `` |  |
-| 6 | `max_compute_time` | `float` | `repeated` | `` |  |
-| 7 | `average_client_tick_time` | `float` | `repeated` | `` |  |
-| 8 | `max_client_tick_time` | `float` | `repeated` | `` |  |
-| 9 | `average_client_simulate_time` | `float` | `repeated` | `` |  |
-| 10 | `max_client_simulate_time` | `float` | `repeated` | `` |  |
-| 11 | `average_output_time` | `float` | `repeated` | `` |  |
-| 12 | `max_output_time` | `float` | `repeated` | `` |  |
-| 13 | `average_wait_for_rendering_to_complete_time` | `float` | `repeated` | `` |  |
-| 14 | `max_wait_for_rendering_to_complete_time` | `float` | `repeated` | `` |  |
-| 15 | `average_swap_time` | `float` | `repeated` | `` |  |
-| 16 | `max_swap_time` | `float` | `repeated` | `` |  |
-| 17 | `average_frame_update_time` | `float` | `repeated` | `` |  |
-| 18 | `max_frame_update_time` | `float` | `repeated` | `` |  |
-| 19 | `average_idle_time` | `float` | `repeated` | `` |  |
-| 20 | `max_idle_time` | `float` | `repeated` | `` |  |
-| 21 | `average_input_processing_time` | `float` | `repeated` | `` |  |
-| 22 | `max_input_processing_time` | `float` | `repeated` | `` |  |
-| 23 | `num_slow_frames` | `uint32` | `optional` | `` |  |
-| 24 | `server_average_oversleep_frame_time` | `float` | `optional` | `` |  |
-| 25 | `server_max_oversleep_frame_time` | `float` | `optional` | `` |  |
-| 26 | `server_average_sleep_frame_time` | `float` | `optional` | `` |  |
-| 27 | `server_max_sleep_frame_time` | `float` | `optional` | `` |  |
-| 28 | `num_multitick_frames` | `uint32` | `optional` | `` |  |
-| 29 | `average_missed_snapshot_rate` | `float` | `repeated` | `` |  |
-| 30 | `max_missed_snapshot_rate` | `float` | `repeated` | `` |  |
+| 1 | `average_frame_time` | `float` | `repeated` |  |  |
+| 2 | `max_frame_time` | `float` | `repeated` |  |  |
+| 3 | `server_average_frame_time` | `float` | `optional` |  |  |
+| 4 | `server_max_frame_time` | `float` | `optional` |  |  |
+| 5 | `average_compute_time` | `float` | `repeated` |  |  |
+| 6 | `max_compute_time` | `float` | `repeated` |  |  |
+| 7 | `average_client_tick_time` | `float` | `repeated` |  |  |
+| 8 | `max_client_tick_time` | `float` | `repeated` |  |  |
+| 9 | `average_client_simulate_time` | `float` | `repeated` |  |  |
+| 10 | `max_client_simulate_time` | `float` | `repeated` |  |  |
+| 11 | `average_output_time` | `float` | `repeated` |  |  |
+| 12 | `max_output_time` | `float` | `repeated` |  |  |
+| 13 | `average_wait_for_rendering_to_complete_time` | `float` | `repeated` |  |  |
+| 14 | `max_wait_for_rendering_to_complete_time` | `float` | `repeated` |  |  |
+| 15 | `average_swap_time` | `float` | `repeated` |  |  |
+| 16 | `max_swap_time` | `float` | `repeated` |  |  |
+| 17 | `average_frame_update_time` | `float` | `repeated` |  |  |
+| 18 | `max_frame_update_time` | `float` | `repeated` |  |  |
+| 19 | `average_idle_time` | `float` | `repeated` |  |  |
+| 20 | `max_idle_time` | `float` | `repeated` |  |  |
+| 21 | `average_input_processing_time` | `float` | `repeated` |  |  |
+| 22 | `max_input_processing_time` | `float` | `repeated` |  |  |
+| 23 | `num_slow_frames` | `uint32` | `optional` |  |  |
+| 24 | `server_average_oversleep_frame_time` | `float` | `optional` |  |  |
+| 25 | `server_max_oversleep_frame_time` | `float` | `optional` |  |  |
+| 26 | `server_average_sleep_frame_time` | `float` | `optional` |  |  |
+| 27 | `server_max_sleep_frame_time` | `float` | `optional` |  |  |
+| 28 | `num_multitick_frames` | `uint32` | `optional` |  |  |
+| 29 | `average_missed_snapshot_rate` | `float` | `repeated` |  |  |
+| 30 | `max_missed_snapshot_rate` | `float` | `repeated` |  |  |
 
 </details>
 
@@ -833,8 +833,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_bans` | `int32` | `repeated` | `` |  |
-| 2 | `hero_ban_votes` | `int32` | `repeated` | `` |  |
+| 1 | `hero_bans` | `int32` | `repeated` |  |  |
+| 2 | `hero_ban_votes` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -846,15 +846,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tournament_id` | `uint32` | `optional` | `` |  |
-| 2 | `tournament_game_id` | `uint32` | `optional` | `` |  |
-| 3 | `duration` | `float` | `optional` | `` |  |
-| 4 | `hltv_delay` | `int32` | `optional` | `` |  |
-| 5 | `team_good` | `.CMsgDOTALiveScoreboardUpdate.Team` | `optional` | `` |  |
-| 6 | `team_bad` | `.CMsgDOTALiveScoreboardUpdate.Team` | `optional` | `` |  |
-| 7 | `roshan_respawn_timer` | `uint32` | `optional` | `` |  |
-| 8 | `league_id` | `uint32` | `optional` | `` |  |
-| 9 | `match_id` | `uint64` | `optional` | `` |  |
+| 1 | `tournament_id` | `uint32` | `optional` |  |  |
+| 2 | `tournament_game_id` | `uint32` | `optional` |  |  |
+| 3 | `duration` | `float` | `optional` |  |  |
+| 4 | `hltv_delay` | `int32` | `optional` |  |  |
+| 5 | `team_good` | `.CMsgDOTALiveScoreboardUpdate.Team` | `optional` |  |  |
+| 6 | `team_bad` | `.CMsgDOTALiveScoreboardUpdate.Team` | `optional` |  |  |
+| 7 | `roshan_respawn_timer` | `uint32` | `optional` |  |  |
+| 8 | `league_id` | `uint32` | `optional` |  |  |
+| 9 | `match_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -866,12 +866,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `players` | `.CMsgDOTALiveScoreboardUpdate.Team.Player` | `repeated` | `` |  |
-| 2 | `score` | `uint32` | `optional` | `` |  |
-| 3 | `tower_state` | `uint32` | `optional` | `` |  |
-| 4 | `barracks_state` | `uint32` | `optional` | `` |  |
-| 5 | `hero_picks` | `int32` | `repeated` | `` |  |
-| 6 | `hero_bans` | `int32` | `repeated` | `` |  |
+| 1 | `players` | `.CMsgDOTALiveScoreboardUpdate.Team.Player` | `repeated` |  |  |
+| 2 | `score` | `uint32` | `optional` |  |  |
+| 3 | `tower_state` | `uint32` | `optional` |  |  |
+| 4 | `barracks_state` | `uint32` | `optional` |  |  |
+| 5 | `hero_picks` | `int32` | `repeated` |  |  |
+| 6 | `hero_bans` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -883,33 +883,33 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_slot` | `uint32` | `optional` | `` |  |
-| 2 | `player_name` | `string` | `optional` | `` |  |
-| 3 | `hero_name` | `string` | `optional` | `` |  |
-| 4 | `hero_id` | `int32` | `optional` | `` |  |
-| 5 | `kills` | `uint32` | `optional` | `` |  |
-| 6 | `deaths` | `uint32` | `optional` | `` |  |
-| 7 | `assists` | `uint32` | `optional` | `` |  |
-| 8 | `last_hits` | `uint32` | `optional` | `` |  |
-| 9 | `denies` | `uint32` | `optional` | `` |  |
-| 10 | `gold` | `uint32` | `optional` | `` |  |
-| 11 | `level` | `uint32` | `optional` | `` |  |
-| 12 | `gold_per_min` | `float` | `optional` | `` |  |
-| 13 | `xp_per_min` | `float` | `optional` | `` |  |
-| 14 | `ultimate_state` | `.CMsgDOTALiveScoreboardUpdate.Team.Player.DOTAUltimateState` | `optional` | `` | default = k_EDOTAUltimateStateNotLearned |
-| 15 | `ultimate_cooldown` | `float` | `optional` | `` |  |
-| 16 | `item0` | `int32` | `optional` | `` | default = -1 |
-| 17 | `item1` | `int32` | `optional` | `` | default = -1 |
-| 18 | `item2` | `int32` | `optional` | `` | default = -1 |
-| 19 | `item3` | `int32` | `optional` | `` | default = -1 |
-| 20 | `item4` | `int32` | `optional` | `` | default = -1 |
-| 21 | `item5` | `int32` | `optional` | `` | default = -1 |
-| 22 | `respawn_timer` | `uint32` | `optional` | `` |  |
-| 23 | `account_id` | `uint32` | `optional` | `` |  |
-| 24 | `position_x` | `float` | `optional` | `` |  |
-| 25 | `position_y` | `float` | `optional` | `` |  |
-| 26 | `net_worth` | `uint32` | `optional` | `` |  |
-| 27 | `abilities` | `.CMsgDOTALiveScoreboardUpdate.Team.Player.HeroAbility` | `repeated` | `` |  |
+| 1 | `player_slot` | `uint32` | `optional` |  |  |
+| 2 | `player_name` | `string` | `optional` |  |  |
+| 3 | `hero_name` | `string` | `optional` |  |  |
+| 4 | `hero_id` | `int32` | `optional` |  |  |
+| 5 | `kills` | `uint32` | `optional` |  |  |
+| 6 | `deaths` | `uint32` | `optional` |  |  |
+| 7 | `assists` | `uint32` | `optional` |  |  |
+| 8 | `last_hits` | `uint32` | `optional` |  |  |
+| 9 | `denies` | `uint32` | `optional` |  |  |
+| 10 | `gold` | `uint32` | `optional` |  |  |
+| 11 | `level` | `uint32` | `optional` |  |  |
+| 12 | `gold_per_min` | `float` | `optional` |  |  |
+| 13 | `xp_per_min` | `float` | `optional` |  |  |
+| 14 | `ultimate_state` | `.CMsgDOTALiveScoreboardUpdate.Team.Player.DOTAUltimateState` | `optional` |  | default = k_EDOTAUltimateStateNotLearned |
+| 15 | `ultimate_cooldown` | `float` | `optional` |  |  |
+| 16 | `item0` | `int32` | `optional` |  | default = -1 |
+| 17 | `item1` | `int32` | `optional` |  | default = -1 |
+| 18 | `item2` | `int32` | `optional` |  | default = -1 |
+| 19 | `item3` | `int32` | `optional` |  | default = -1 |
+| 20 | `item4` | `int32` | `optional` |  | default = -1 |
+| 21 | `item5` | `int32` | `optional` |  | default = -1 |
+| 22 | `respawn_timer` | `uint32` | `optional` |  |  |
+| 23 | `account_id` | `uint32` | `optional` |  |  |
+| 24 | `position_x` | `float` | `optional` |  |  |
+| 25 | `position_y` | `float` | `optional` |  |  |
+| 26 | `net_worth` | `uint32` | `optional` |  |  |
+| 27 | `abilities` | `.CMsgDOTALiveScoreboardUpdate.Team.Player.HeroAbility` | `repeated` |  |  |
 
 </details>
 
@@ -921,9 +921,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ability_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `ability_level` | `uint32` | `optional` | `` |  |
-| 3 | `tome_upgraded` | `bool` | `optional` | `` |  |
+| 1 | `ability_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `ability_level` | `uint32` | `optional` |  |  |
+| 3 | `tome_upgraded` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -935,9 +935,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_ids` | `uint32` | `repeated` | `` | packed = true |
-| 4 | `rank_types` | `uint32` | `repeated` | `` | packed = true |
-| 5 | `lobby_type` | `int32` | `optional` | `` |  |
+| 1 | `account_ids` | `uint32` | `repeated` |  | packed = true |
+| 4 | `rank_types` | `uint32` | `repeated` |  | packed = true |
+| 5 | `lobby_type` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -949,7 +949,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 6 | `results` | `.CMsgServerToGCRequestBatchPlayerResourcesResponse.Result` | `repeated` | `` |  |
+| 6 | `results` | `.CMsgServerToGCRequestBatchPlayerResourcesResponse.Result` | `repeated` |  |  |
 
 </details>
 
@@ -961,20 +961,20 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 4 | `rank` | `uint32` | `optional` | `` |  |
-| 5 | `rank_calibrated` | `bool` | `optional` | `` |  |
-| 6 | `low_priority` | `bool` | `optional` | `` |  |
-| 7 | `is_new_player` | `bool` | `optional` | `` |  |
-| 8 | `is_guide_player` | `bool` | `optional` | `` |  |
-| 9 | `comm_level` | `int32` | `optional` | `` |  |
-| 10 | `behavior_level` | `int32` | `optional` | `` |  |
-| 11 | `wins` | `int32` | `optional` | `` |  |
-| 12 | `losses` | `int32` | `optional` | `` |  |
-| 13 | `smurf_category` | `int32` | `optional` | `` |  |
-| 14 | `comm_score` | `int32` | `optional` | `` |  |
-| 15 | `behavior_score` | `int32` | `optional` | `` |  |
-| 16 | `rank_uncertainty` | `int32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 4 | `rank` | `uint32` | `optional` |  |  |
+| 5 | `rank_calibrated` | `bool` | `optional` |  |  |
+| 6 | `low_priority` | `bool` | `optional` |  |  |
+| 7 | `is_new_player` | `bool` | `optional` |  |  |
+| 8 | `is_guide_player` | `bool` | `optional` |  |  |
+| 9 | `comm_level` | `int32` | `optional` |  |  |
+| 10 | `behavior_level` | `int32` | `optional` |  |  |
+| 11 | `wins` | `int32` | `optional` |  |  |
+| 12 | `losses` | `int32` | `optional` |  |  |
+| 13 | `smurf_category` | `int32` | `optional` |  |  |
+| 14 | `comm_score` | `int32` | `optional` |  |  |
+| 15 | `behavior_score` | `int32` | `optional` |  |  |
+| 16 | `rank_uncertainty` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -986,8 +986,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `failed_loaders` | `fixed64` | `repeated` | `` |  |
-| 2 | `abandoned_loaders` | `fixed64` | `repeated` | `` |  |
+| 1 | `failed_loaders` | `fixed64` | `repeated` |  |  |
+| 2 | `abandoned_loaders` | `fixed64` | `repeated` |  |  |
 
 </details>
 
@@ -999,13 +999,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `source_tv_public_addr` | `uint32` | `optional` | `` |  |
-| 2 | `source_tv_private_addr` | `uint32` | `optional` | `` |  |
-| 3 | `source_tv_port` | `uint32` | `optional` | `` |  |
-| 4 | `game_server_steam_id` | `uint64` | `optional` | `` |  |
-| 5 | `parent_count` | `uint32` | `optional` | `` |  |
-| 6 | `tv_unique_secret_code` | `fixed64` | `optional` | `` |  |
-| 7 | `source_tv_steamid` | `fixed64` | `optional` | `` |  |
+| 1 | `source_tv_public_addr` | `uint32` | `optional` |  |  |
+| 2 | `source_tv_private_addr` | `uint32` | `optional` |  |  |
+| 3 | `source_tv_port` | `uint32` | `optional` |  |  |
+| 4 | `game_server_steam_id` | `uint64` | `optional` |  |  |
+| 5 | `parent_count` | `uint32` | `optional` |  |  |
+| 6 | `tv_unique_secret_code` | `fixed64` | `optional` |  |  |
+| 7 | `source_tv_steamid` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -1017,7 +1017,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `relay_steamid` | `fixed64` | `optional` | `` |  |
+| 1 | `relay_steamid` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -1029,7 +1029,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1041,10 +1041,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `uint32` | `optional` | `` |  |
-| 2 | `low_priority` | `bool` | `optional` | `` |  |
-| 3 | `text_chat_banned` | `bool` | `optional` | `` |  |
-| 4 | `voice_chat_banned` | `bool` | `optional` | `` |  |
+| 1 | `result` | `uint32` | `optional` |  |  |
+| 2 | `low_priority` | `bool` | `optional` |  |  |
+| 3 | `text_chat_banned` | `bool` | `optional` |  |  |
+| 4 | `voice_chat_banned` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1056,18 +1056,18 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `killer_account_id` | `fixed32` | `optional` | `` |  |
-| 2 | `victim_account_id` | `fixed32` | `optional` | `` |  |
-| 3 | `event_type` | `.DOTA_TournamentEvents` | `optional` | `` | default = TE_FIRST_BLOOD |
-| 4 | `tv_delay` | `int32` | `optional` | `` |  |
-| 5 | `dota_time` | `int32` | `optional` | `` |  |
-| 6 | `replay_time` | `float` | `optional` | `` |  |
-| 7 | `loot_list` | `string` | `optional` | `` |  |
-| 8 | `event_team` | `uint32` | `optional` | `` |  |
-| 9 | `multi_kill_count` | `uint32` | `optional` | `` |  |
-| 10 | `winner_score` | `uint32` | `optional` | `` |  |
-| 11 | `loser_score` | `uint32` | `optional` | `` |  |
-| 12 | `hero_statues` | `.CProtoItemHeroStatue` | `repeated` | `` |  |
+| 1 | `killer_account_id` | `fixed32` | `optional` |  |  |
+| 2 | `victim_account_id` | `fixed32` | `optional` |  |  |
+| 3 | `event_type` | `.DOTA_TournamentEvents` | `optional` |  | default = TE_FIRST_BLOOD |
+| 4 | `tv_delay` | `int32` | `optional` |  |  |
+| 5 | `dota_time` | `int32` | `optional` |  |  |
+| 6 | `replay_time` | `float` | `optional` |  |  |
+| 7 | `loot_list` | `string` | `optional` |  |  |
+| 8 | `event_team` | `uint32` | `optional` |  |  |
+| 9 | `multi_kill_count` | `uint32` | `optional` |  |  |
+| 10 | `winner_score` | `uint32` | `optional` |  |  |
+| 11 | `loser_score` | `uint32` | `optional` |  |  |
+| 12 | `hero_statues` | `.CProtoItemHeroStatue` | `repeated` |  |  |
 
 </details>
 
@@ -1079,8 +1079,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_type` | `.DOTA_TournamentEvents` | `optional` | `` | default = TE_FIRST_BLOOD |
-| 6 | `viewers_granted` | `uint32` | `optional` | `` |  |
+| 1 | `event_type` | `.DOTA_TournamentEvents` | `optional` |  | default = TE_FIRST_BLOOD |
+| 6 | `viewers_granted` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1092,7 +1092,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -1104,8 +1104,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `fanfare_goodguys` | `uint32` | `optional` | `` |  |
-| 2 | `fanfare_badguys` | `uint32` | `optional` | `` |  |
+| 1 | `fanfare_goodguys` | `uint32` | `optional` |  |  |
+| 2 | `fanfare_badguys` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1117,11 +1117,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `award_points` | `.CMsgDOTAAwardEventPoints.AwardPoints` | `repeated` | `` |  |
-| 2 | `match_id` | `uint64` | `optional` | `` |  |
-| 4 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 5 | `timestamp` | `uint32` | `optional` | `` |  |
-| 6 | `audit_action` | `uint32` | `optional` | `` |  |
+| 1 | `award_points` | `.CMsgDOTAAwardEventPoints.AwardPoints` | `repeated` |  |  |
+| 2 | `match_id` | `uint64` | `optional` |  |  |
+| 4 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 5 | `timestamp` | `uint32` | `optional` |  |  |
+| 6 | `audit_action` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1133,12 +1133,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `points` | `int32` | `optional` | `` |  |
-| 3 | `premium_points` | `int32` | `optional` | `` |  |
-| 5 | `trade_ban_time` | `uint32` | `optional` | `` |  |
-| 6 | `eligible_for_periodic_adjustment` | `bool` | `optional` | `` | default = false |
-| 7 | `point_cap_periodic_resource_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `points` | `int32` | `optional` |  |  |
+| 3 | `premium_points` | `int32` | `optional` |  |  |
+| 5 | `trade_ban_time` | `uint32` | `optional` |  |  |
+| 6 | `eligible_for_periodic_adjustment` | `bool` | `optional` |  | default = false |
+| 7 | `point_cap_periodic_resource_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1150,8 +1150,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `request_id` | `fixed64` | `optional` | `` |  |
-| 2 | `request_time` | `uint64` | `optional` | `` |  |
+| 1 | `request_id` | `fixed64` | `optional` |  |  |
+| 2 | `request_time` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -1163,9 +1163,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `request_id` | `fixed64` | `optional` | `` |  |
-| 2 | `request_time` | `uint64` | `optional` | `` |  |
-| 3 | `cluster` | `uint32` | `optional` | `` |  |
+| 1 | `request_id` | `fixed64` | `optional` |  |  |
+| 2 | `request_time` | `uint64` | `optional` |  |  |
+| 3 | `cluster` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1177,11 +1177,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `region_id` | `uint32` | `optional` | `` |  |
-| 3 | `league_id` | `uint32` | `optional` | `` |  |
-| 4 | `players` | `.CMsgServerToGCMatchConnectionStats.Player` | `repeated` | `` |  |
-| 5 | `cluster_id` | `uint32` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `region_id` | `uint32` | `optional` |  |  |
+| 3 | `league_id` | `uint32` | `optional` |  |  |
+| 4 | `players` | `.CMsgServerToGCMatchConnectionStats.Player` | `repeated` |  |  |
+| 5 | `cluster_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1193,12 +1193,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `ip` | `fixed32` | `optional` | `` |  |
-| 3 | `avg_ping_ms` | `uint32` | `optional` | `` |  |
-| 5 | `packet_loss` | `float` | `optional` | `` |  |
-| 6 | `ping_deviation` | `float` | `optional` | `` |  |
-| 7 | `full_resends` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `ip` | `fixed32` | `optional` |  |  |
+| 3 | `avg_ping_ms` | `uint32` | `optional` |  |  |
+| 5 | `packet_loss` | `float` | `optional` |  |  |
+| 6 | `ping_deviation` | `float` | `optional` |  |  |
+| 7 | `full_resends` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1210,7 +1210,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `spectator_count` | `uint32` | `optional` | `` |  |
+| 1 | `spectator_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1222,9 +1222,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `version` | `uint32` | `optional` | `` |  |
-| 2 | `dictionary` | `.CSerializedCombatLog.Dictionary` | `optional` | `` |  |
-| 3 | `entries` | `.CMsgDOTACombatLogEntry` | `repeated` | `` |  |
+| 1 | `version` | `uint32` | `optional` |  |  |
+| 2 | `dictionary` | `.CSerializedCombatLog.Dictionary` | `optional` |  |  |
+| 3 | `entries` | `.CMsgDOTACombatLogEntry` | `repeated` |  |  |
 
 </details>
 
@@ -1236,7 +1236,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `strings` | `.CSerializedCombatLog.Dictionary.DictString` | `repeated` | `` |  |
+| 1 | `strings` | `.CSerializedCombatLog.Dictionary.DictString` | `repeated` |  |  |
 
 </details>
 
@@ -1248,8 +1248,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `string` | `optional` | `` |  |
+| 1 | `id` | `uint32` | `optional` |  |  |
+| 2 | `value` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1261,7 +1261,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `records` | `.CMsgServerToGCVictoryPredictions.Record` | `repeated` | `` |  |
+| 1 | `records` | `.CMsgServerToGCVictoryPredictions.Record` | `repeated` |  |  |
 
 </details>
 
@@ -1273,8 +1273,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `uint64` | `optional` | `` |  |
-| 2 | `item_def` | `uint32` | `optional` | `` |  |
+| 1 | `item_id` | `uint64` | `optional` |  |  |
+| 2 | `item_def` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1286,9 +1286,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 5 | `item_ids` | `uint64` | `repeated` | `` |  |
-| 6 | `prediction_items` | `.CMsgServerToGCVictoryPredictions.PredictionItem` | `repeated` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 5 | `item_ids` | `uint64` | `repeated` |  |  |
+| 6 | `prediction_items` | `.CMsgServerToGCVictoryPredictions.PredictionItem` | `repeated` |  |  |
 
 </details>
 
@@ -1312,7 +1312,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `uint32` | `optional` | `` |  |
+| 1 | `response` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1324,8 +1324,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `reporter_account_id` | `uint32` | `optional` | `` |  |
+| 1 | `target_account_id` | `uint32` | `optional` |  |  |
+| 2 | `reporter_account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1337,11 +1337,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `reporter_account_id` | `uint32` | `optional` | `` |  |
-| 3 | `match_id` | `fixed64` | `optional` | `` |  |
-| 4 | `timestamp` | `uint32` | `repeated` | `` |  |
-| 5 | `line` | `string` | `repeated` | `` |  |
+| 1 | `target_account_id` | `uint32` | `optional` |  |  |
+| 2 | `reporter_account_id` | `uint32` | `optional` |  |  |
+| 3 | `match_id` | `fixed64` | `optional` |  |  |
+| 4 | `timestamp` | `uint32` | `repeated` |  |  |
+| 5 | `line` | `string` | `repeated` |  |  |
 
 </details>
 
@@ -1353,11 +1353,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `reporter_account_id` | `uint32` | `optional` | `` |  |
-| 3 | `ban_reason` | `uint32` | `optional` | `` |  |
-| 4 | `ban_duration` | `uint32` | `optional` | `` |  |
-| 5 | `toxicity_score` | `float` | `optional` | `` |  |
+| 1 | `target_account_id` | `uint32` | `optional` |  |  |
+| 2 | `reporter_account_id` | `uint32` | `optional` |  |  |
+| 3 | `ban_reason` | `uint32` | `optional` |  |  |
+| 4 | `ban_duration` | `uint32` | `optional` |  |  |
+| 5 | `toxicity_score` | `float` | `optional` |  |  |
 
 </details>
 
@@ -1369,14 +1369,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `winning_players` | `fixed64` | `repeated` | `` |  |
-| 2 | `losing_players` | `fixed64` | `repeated` | `` |  |
-| 3 | `arcana_owners` | `fixed64` | `repeated` | `` |  |
-| 4 | `assassin_won` | `bool` | `optional` | `` |  |
-| 5 | `target_hero_id` | `int32` | `optional` | `` |  |
-| 6 | `contract_completed` | `bool` | `optional` | `` |  |
-| 7 | `contract_complete_time` | `float` | `optional` | `` |  |
-| 8 | `pa_is_radiant` | `bool` | `optional` | `` |  |
+| 1 | `winning_players` | `fixed64` | `repeated` |  |  |
+| 2 | `losing_players` | `fixed64` | `repeated` |  |  |
+| 3 | `arcana_owners` | `fixed64` | `repeated` |  |  |
+| 4 | `assassin_won` | `bool` | `optional` |  |  |
+| 5 | `target_hero_id` | `int32` | `optional` |  |  |
+| 6 | `contract_completed` | `bool` | `optional` |  |  |
+| 7 | `contract_complete_time` | `float` | `optional` |  |  |
+| 8 | `pa_is_radiant` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1388,8 +1388,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ingameevent_id` | `uint32` | `optional` | `` |  |
-| 2 | `summaries` | `.CMsgServerToGCKillSummaries.KillSummary` | `repeated` | `` |  |
+| 1 | `ingameevent_id` | `uint32` | `optional` |  |  |
+| 2 | `summaries` | `.CMsgServerToGCKillSummaries.KillSummary` | `repeated` |  |  |
 
 </details>
 
@@ -1401,9 +1401,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `killer_hero_id` | `uint32` | `optional` | `` |  |
-| 2 | `victim_hero_id` | `uint32` | `optional` | `` |  |
-| 3 | `kill_count` | `uint32` | `optional` | `` |  |
+| 1 | `killer_hero_id` | `uint32` | `optional` |  |  |
+| 2 | `victim_hero_id` | `uint32` | `optional` |  |  |
+| 3 | `kill_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1415,8 +1415,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `item_id` | `uint64` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -1428,11 +1428,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `completed` | `.CMsgSignOutUpdatePlayerChallenge.Challenge` | `repeated` | `` |  |
-| 3 | `rerolled` | `.CMsgSignOutUpdatePlayerChallenge.Challenge` | `repeated` | `` |  |
-| 4 | `match_id` | `uint64` | `optional` | `` |  |
-| 5 | `hero_id` | `int32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `completed` | `.CMsgSignOutUpdatePlayerChallenge.Challenge` | `repeated` |  |  |
+| 3 | `rerolled` | `.CMsgSignOutUpdatePlayerChallenge.Challenge` | `repeated` |  |  |
+| 4 | `match_id` | `uint64` | `optional` |  |  |
+| 5 | `hero_id` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1444,11 +1444,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 2 | `slot_id` | `uint32` | `optional` | `` |  |
-| 3 | `sequence_id` | `uint32` | `optional` | `` |  |
-| 4 | `progress` | `uint32` | `optional` | `` |  |
-| 5 | `challenge_rank` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 2 | `slot_id` | `uint32` | `optional` |  |  |
+| 3 | `sequence_id` | `uint32` | `optional` |  |  |
+| 4 | `progress` | `uint32` | `optional` |  |  |
+| 5 | `challenge_rank` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1460,8 +1460,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `reroll_msg` | `.CMsgClientToGCRerollPlayerChallenge` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `reroll_msg` | `.CMsgClientToGCRerollPlayerChallenge` | `optional` |  |  |
 
 </details>
 
@@ -1473,11 +1473,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `players` | `.CMsgSpendWager.Player` | `repeated` | `` |  |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 3 | `timestamp` | `uint32` | `optional` | `` |  |
-| 4 | `match_id` | `uint64` | `optional` | `` |  |
-| 5 | `server_steam_id` | `uint64` | `optional` | `` |  |
+| 1 | `players` | `.CMsgSpendWager.Player` | `repeated` |  |  |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 3 | `timestamp` | `uint32` | `optional` |  |  |
+| 4 | `match_id` | `uint64` | `optional` |  |  |
+| 5 | `server_steam_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -1489,9 +1489,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `wager` | `uint32` | `optional` | `` |  |
-| 3 | `wager_token_item_id` | `uint64` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `wager` | `uint32` | `optional` |  |  |
+| 3 | `wager_token_item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -1503,10 +1503,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `players` | `.CMsgSignOutXPCoins.Player` | `repeated` | `` |  |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 3 | `match_id` | `uint64` | `optional` | `` |  |
-| 4 | `timestamp` | `uint32` | `optional` | `` |  |
+| 1 | `players` | `.CMsgSignOutXPCoins.Player` | `repeated` |  |  |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 3 | `match_id` | `uint64` | `optional` |  |  |
+| 4 | `timestamp` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1518,12 +1518,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `xp_gained` | `uint32` | `optional` | `` |  |
-| 3 | `coins_spent` | `uint32` | `optional` | `` |  |
-| 4 | `wager_token_item_id` | `uint64` | `optional` | `` |  |
-| 5 | `rank_wager` | `uint32` | `optional` | `` |  |
-| 6 | `wager_streak` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `xp_gained` | `uint32` | `optional` |  |  |
+| 3 | `coins_spent` | `uint32` | `optional` |  |  |
+| 4 | `wager_token_item_id` | `uint64` | `optional` |  |  |
+| 5 | `rank_wager` | `uint32` | `optional` |  |  |
+| 6 | `wager_streak` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1535,10 +1535,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `bounties` | `.CMsgSignOutBounties.Bounty` | `repeated` | `` |  |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 3 | `match_id` | `uint64` | `optional` | `` |  |
-| 4 | `timestamp` | `uint32` | `optional` | `` |  |
+| 1 | `bounties` | `.CMsgSignOutBounties.Bounty` | `repeated` |  |  |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 3 | `match_id` | `uint64` | `optional` |  |  |
+| 4 | `timestamp` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1550,9 +1550,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `issuer_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `completer_account_id` | `uint32` | `optional` | `` |  |
-| 3 | `target_account_id` | `uint32` | `optional` | `` |  |
+| 1 | `issuer_account_id` | `uint32` | `optional` |  |  |
+| 2 | `completer_account_id` | `uint32` | `optional` |  |  |
+| 3 | `target_account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1564,8 +1564,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 2 | `event_increments` | `.CMsgSignOutCommunityGoalProgress.EventGoalIncrement` | `repeated` | `` |  |
+| 1 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 2 | `event_increments` | `.CMsgSignOutCommunityGoalProgress.EventGoalIncrement` | `repeated` |  |  |
 
 </details>
 
@@ -1577,8 +1577,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_goal_id` | `uint32` | `optional` | `` |  |
-| 2 | `increment_amount` | `uint32` | `optional` | `` |  |
+| 1 | `event_goal_id` | `uint32` | `optional` |  |  |
+| 2 | `increment_amount` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1590,9 +1590,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `hltv_delay` | `uint32` | `optional` | `` |  |
-| 3 | `league_id` | `uint32` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `hltv_delay` | `uint32` | `optional` |  |  |
+| 3 | `league_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1604,7 +1604,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `bool` | `optional` | `` |  |
+| 1 | `result` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1616,10 +1616,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `results` | `.CMsgServerToGCCompendiumInGamePredictionResults.PredictionResult` | `repeated` | `` |  |
-| 3 | `league_id` | `uint32` | `optional` | `` |  |
-| 4 | `league_node_id` | `uint32` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `results` | `.CMsgServerToGCCompendiumInGamePredictionResults.PredictionResult` | `repeated` |  |  |
+| 3 | `league_id` | `uint32` | `optional` |  |  |
+| 4 | `league_node_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1631,9 +1631,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `prediction_id` | `uint32` | `optional` | `` |  |
-| 2 | `prediction_value` | `uint32` | `optional` | `` |  |
-| 3 | `prediction_value_is_mask` | `bool` | `optional` | `` |  |
+| 1 | `prediction_id` | `uint32` | `optional` |  |  |
+| 2 | `prediction_value` | `uint32` | `optional` |  |  |
+| 3 | `prediction_value_is_mask` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1645,9 +1645,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `predictions_chosen` | `.CMsgServerToGCCompendiumChosenInGamePredictions.Prediction` | `repeated` | `` |  |
-| 3 | `league_id` | `uint32` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `predictions_chosen` | `.CMsgServerToGCCompendiumChosenInGamePredictions.Prediction` | `repeated` |  |  |
+| 3 | `league_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1659,7 +1659,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `prediction_id` | `uint32` | `optional` | `` |  |
+| 1 | `prediction_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1671,7 +1671,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `results` | `.CMsgServerToGCCompendiumInGamePredictionResults` | `optional` | `` |  |
+| 1 | `results` | `.CMsgServerToGCCompendiumInGamePredictionResults` | `optional` |  |  |
 
 </details>
 
@@ -1683,9 +1683,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `mmr` | `uint32` | `optional` | `` |  |
-| 3 | `players` | `.CMsgServerToGCMatchPlayerItemPurchaseHistory.Player` | `repeated` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `mmr` | `uint32` | `optional` |  |  |
+| 3 | `players` | `.CMsgServerToGCMatchPlayerItemPurchaseHistory.Player` | `repeated` |  |  |
 
 </details>
 
@@ -1697,12 +1697,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item` | `int32` | `optional` | `` | default = -1 |
-| 2 | `gold` | `uint32` | `optional` | `` |  |
-| 3 | `net_worth` | `uint32` | `optional` | `` |  |
-| 4 | `game_time` | `uint32` | `optional` | `` |  |
-| 5 | `inventory_items` | `int32` | `repeated` | `` |  |
-| 7 | `talents_skilled` | `bool` | `repeated` | `` |  |
+| 1 | `item` | `int32` | `optional` |  | default = -1 |
+| 2 | `gold` | `uint32` | `optional` |  |  |
+| 3 | `net_worth` | `uint32` | `optional` |  |  |
+| 4 | `game_time` | `uint32` | `optional` |  |  |
+| 5 | `inventory_items` | `int32` | `repeated` |  |  |
+| 7 | `talents_skilled` | `bool` | `repeated` |  |  |
 
 </details>
 
@@ -1714,14 +1714,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_slot` | `uint32` | `optional` | `` |  |
-| 2 | `account_id` | `uint32` | `optional` | `` |  |
-| 3 | `hero_id` | `int32` | `optional` | `` |  |
-| 4 | `allied_hero_ids` | `int32` | `repeated` | `` |  |
-| 5 | `enemy_hero_ids` | `int32` | `repeated` | `` |  |
-| 6 | `item_purchases` | `.CMsgServerToGCMatchPlayerItemPurchaseHistory.ItemPurchase` | `repeated` | `` |  |
-| 7 | `lane` | `uint32` | `optional` | `` |  |
-| 8 | `is_winner` | `bool` | `optional` | `` |  |
+| 1 | `player_slot` | `uint32` | `optional` |  |  |
+| 2 | `account_id` | `uint32` | `optional` |  |  |
+| 3 | `hero_id` | `int32` | `optional` |  |  |
+| 4 | `allied_hero_ids` | `int32` | `repeated` |  |  |
+| 5 | `enemy_hero_ids` | `int32` | `repeated` |  |  |
+| 6 | `item_purchases` | `.CMsgServerToGCMatchPlayerItemPurchaseHistory.ItemPurchase` | `repeated` |  |  |
+| 7 | `lane` | `uint32` | `optional` |  |  |
+| 8 | `is_winner` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1733,8 +1733,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `players` | `.CMsgServerToGCMatchPlayerNeutralItemEquipHistory.Player` | `repeated` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `players` | `.CMsgServerToGCMatchPlayerNeutralItemEquipHistory.Player` | `repeated` |  |  |
 
 </details>
 
@@ -1746,11 +1746,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item` | `int32` | `optional` | `` | default = -1 |
-| 2 | `game_time` | `uint32` | `optional` | `` |  |
-| 3 | `inventory_items` | `int32` | `repeated` | `` |  |
-| 4 | `talents_skilled` | `bool` | `repeated` | `` |  |
-| 5 | `available_neutral_items` | `int32` | `repeated` | `` |  |
+| 1 | `item` | `int32` | `optional` |  | default = -1 |
+| 2 | `game_time` | `uint32` | `optional` |  |  |
+| 3 | `inventory_items` | `int32` | `repeated` |  |  |
+| 4 | `talents_skilled` | `bool` | `repeated` |  |  |
+| 5 | `available_neutral_items` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -1762,11 +1762,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `allied_hero_ids` | `int32` | `repeated` | `` |  |
-| 3 | `enemy_hero_ids` | `int32` | `repeated` | `` |  |
-| 4 | `item_equips` | `.CMsgServerToGCMatchPlayerNeutralItemEquipHistory.ItemEquip` | `repeated` | `` |  |
-| 5 | `is_winner` | `bool` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `allied_hero_ids` | `int32` | `repeated` |  |  |
+| 3 | `enemy_hero_ids` | `int32` | `repeated` |  |  |
+| 4 | `item_equips` | `.CMsgServerToGCMatchPlayerNeutralItemEquipHistory.ItemEquip` | `repeated` |  |  |
+| 5 | `is_winner` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1778,10 +1778,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `radiant_won` | `bool` | `optional` | `` |  |
-| 3 | `mmr` | `uint32` | `optional` | `` |  |
-| 4 | `match_states` | `.CMsgServerToGCMatchStateHistory.MatchState` | `repeated` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `radiant_won` | `bool` | `optional` |  |  |
+| 3 | `mmr` | `uint32` | `optional` |  |  |
+| 4 | `match_states` | `.CMsgServerToGCMatchStateHistory.MatchState` | `repeated` |  |  |
 
 </details>
 
@@ -1793,15 +1793,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `net_worth` | `uint32` | `optional` | `` |  |
-| 3 | `level` | `uint32` | `optional` | `` |  |
-| 4 | `deaths` | `uint32` | `optional` | `` |  |
-| 5 | `respawn_time` | `uint32` | `optional` | `` |  |
-| 6 | `has_buyback` | `bool` | `optional` | `` |  |
-| 7 | `has_aegis` | `bool` | `optional` | `` |  |
-| 8 | `has_rapier` | `bool` | `optional` | `` |  |
-| 9 | `distance` | `uint32` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `net_worth` | `uint32` | `optional` |  |  |
+| 3 | `level` | `uint32` | `optional` |  |  |
+| 4 | `deaths` | `uint32` | `optional` |  |  |
+| 5 | `respawn_time` | `uint32` | `optional` |  |  |
+| 6 | `has_buyback` | `bool` | `optional` |  |  |
+| 7 | `has_aegis` | `bool` | `optional` |  |  |
+| 8 | `has_rapier` | `bool` | `optional` |  |  |
+| 9 | `distance` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1813,16 +1813,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team` | `uint32` | `optional` | `` |  |
-| 2 | `player_states` | `.CMsgServerToGCMatchStateHistory.PlayerState` | `repeated` | `` | (steamml_max_entries) = 5 |
-| 3 | `tower_health_pct` | `uint32` | `repeated` | `` | (steamml_max_entries) = 11 |
-| 4 | `barracks_health_pct` | `uint32` | `repeated` | `` | (steamml_max_entries) = 3 |
-| 5 | `ancient_health_pct` | `uint32` | `optional` | `` |  |
-| 6 | `glyph_cooldown` | `uint32` | `optional` | `` |  |
-| 7 | `kills` | `uint32` | `optional` | `` |  |
-| 8 | `creep_distance_safe` | `uint32` | `optional` | `` |  |
-| 9 | `creep_distance_mid` | `uint32` | `optional` | `` |  |
-| 10 | `creep_distance_off` | `uint32` | `optional` | `` |  |
+| 1 | `team` | `uint32` | `optional` |  |  |
+| 2 | `player_states` | `.CMsgServerToGCMatchStateHistory.PlayerState` | `repeated` |  | (steamml_max_entries) = 5 |
+| 3 | `tower_health_pct` | `uint32` | `repeated` |  | (steamml_max_entries) = 11 |
+| 4 | `barracks_health_pct` | `uint32` | `repeated` |  | (steamml_max_entries) = 3 |
+| 5 | `ancient_health_pct` | `uint32` | `optional` |  |  |
+| 6 | `glyph_cooldown` | `uint32` | `optional` |  |  |
+| 7 | `kills` | `uint32` | `optional` |  |  |
+| 8 | `creep_distance_safe` | `uint32` | `optional` |  |  |
+| 9 | `creep_distance_mid` | `uint32` | `optional` |  |  |
+| 10 | `creep_distance_off` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1834,9 +1834,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `game_time` | `uint32` | `optional` | `` |  |
-| 2 | `radiant_state` | `.CMsgServerToGCMatchStateHistory.TeamState` | `optional` | `` |  |
-| 3 | `dire_state` | `.CMsgServerToGCMatchStateHistory.TeamState` | `optional` | `` |  |
+| 1 | `game_time` | `uint32` | `optional` |  |  |
+| 2 | `radiant_state` | `.CMsgServerToGCMatchStateHistory.TeamState` | `optional` |  |  |
+| 3 | `dire_state` | `.CMsgServerToGCMatchStateHistory.TeamState` | `optional` |  |  |
 
 </details>
 
@@ -1848,9 +1848,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_state` | `.CMsgServerToGCMatchStateHistory.MatchState` | `optional` | `` |  |
-| 2 | `mmr` | `uint32` | `optional` | `` |  |
-| 3 | `radiant_won` | `bool` | `optional` | `` |  |
+| 1 | `match_state` | `.CMsgServerToGCMatchStateHistory.MatchState` | `optional` |  |  |
+| 2 | `mmr` | `uint32` | `optional` |  |  |
+| 3 | `radiant_won` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1862,8 +1862,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_ids` | `int32` | `repeated` | `` | (steamml_max_entries) = 10 |
-| 2 | `lanes` | `uint32` | `repeated` | `` | (steamml_max_entries) = 6 |
+| 1 | `hero_ids` | `int32` | `repeated` |  | (steamml_max_entries) = 10 |
+| 2 | `lanes` | `uint32` | `repeated` |  | (steamml_max_entries) = 6 |
 
 </details>
 
@@ -1875,12 +1875,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `mmr` | `uint32` | `optional` | `` |  |
-| 2 | `hero_id` | `int32` | `optional` | `` |  |
-| 3 | `enemy_hero_ids` | `int32` | `repeated` | `` | (steamml_max_entries) = 4 |
-| 4 | `lane` | `uint32` | `optional` | `` |  |
-| 5 | `abilities` | `int32` | `repeated` | `` | (steamml_max_entries) = 25 |
-| 6 | `selected_ability` | `int32` | `optional` | `` | default = -1 |
+| 1 | `mmr` | `uint32` | `optional` |  |  |
+| 2 | `hero_id` | `int32` | `optional` |  |  |
+| 3 | `enemy_hero_ids` | `int32` | `repeated` |  | (steamml_max_entries) = 4 |
+| 4 | `lane` | `uint32` | `optional` |  |  |
+| 5 | `abilities` | `int32` | `repeated` |  | (steamml_max_entries) = 25 |
+| 6 | `selected_ability` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -1892,13 +1892,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `mmr` | `uint32` | `optional` | `` |  |
-| 2 | `lane` | `uint32` | `optional` | `` |  |
-| 3 | `balance` | `float` | `optional` | `` |  |
-| 4 | `hero_id` | `int32` | `optional` | `` |  |
-| 5 | `allied_hero_ids` | `int32` | `repeated` | `` | (steamml_max_entries) = 4 |
-| 6 | `enemy_hero_ids` | `int32` | `repeated` | `` | (steamml_max_entries) = 5 |
-| 7 | `items` | `int32` | `repeated` | `` | (steamml_max_entries) = 9 |
+| 1 | `mmr` | `uint32` | `optional` |  |  |
+| 2 | `lane` | `uint32` | `optional` |  |  |
+| 3 | `balance` | `float` | `optional` |  |  |
+| 4 | `hero_id` | `int32` | `optional` |  |  |
+| 5 | `allied_hero_ids` | `int32` | `repeated` |  | (steamml_max_entries) = 4 |
+| 6 | `enemy_hero_ids` | `int32` | `repeated` |  | (steamml_max_entries) = 5 |
+| 7 | `items` | `int32` | `repeated` |  | (steamml_max_entries) = 9 |
 
 </details>
 
@@ -1910,13 +1910,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `mmr` | `uint32` | `optional` | `` |  |
-| 2 | `lane` | `uint32` | `optional` | `` |  |
-| 3 | `hero_id` | `int32` | `optional` | `` |  |
-| 4 | `allied_hero_ids` | `int32` | `repeated` | `` | (steamml_max_entries) = 4 |
-| 5 | `enemy_hero_ids` | `int32` | `repeated` | `` | (steamml_max_entries) = 5 |
-| 6 | `items` | `int32` | `repeated` | `` | (steamml_max_entries) = 20 |
-| 7 | `items_to_be_purchased` | `int32` | `repeated` | `` | (steamml_max_entries) = 20 |
+| 1 | `mmr` | `uint32` | `optional` |  |  |
+| 2 | `lane` | `uint32` | `optional` |  |  |
+| 3 | `hero_id` | `int32` | `optional` |  |  |
+| 4 | `allied_hero_ids` | `int32` | `repeated` |  | (steamml_max_entries) = 4 |
+| 5 | `enemy_hero_ids` | `int32` | `repeated` |  | (steamml_max_entries) = 5 |
+| 6 | `items` | `int32` | `repeated` |  | (steamml_max_entries) = 20 |
+| 7 | `items_to_be_purchased` | `int32` | `repeated` |  | (steamml_max_entries) = 20 |
 
 </details>
 
@@ -1928,13 +1928,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `mmr` | `uint32` | `optional` | `` |  |
-| 2 | `lane` | `uint32` | `optional` | `` |  |
-| 3 | `hero_id` | `int32` | `optional` | `` |  |
-| 4 | `allied_hero_ids` | `int32` | `repeated` | `` | (steamml_max_entries) = 4 |
-| 5 | `enemy_hero_ids` | `int32` | `repeated` | `` | (steamml_max_entries) = 5 |
-| 6 | `items` | `int32` | `repeated` | `` | (steamml_max_entries) = 20 |
-| 7 | `item_to_be_purchased` | `int32` | `optional` | `` | default = -1 |
+| 1 | `mmr` | `uint32` | `optional` |  |  |
+| 2 | `lane` | `uint32` | `optional` |  |  |
+| 3 | `hero_id` | `int32` | `optional` |  |  |
+| 4 | `allied_hero_ids` | `int32` | `repeated` |  | (steamml_max_entries) = 4 |
+| 5 | `enemy_hero_ids` | `int32` | `repeated` |  | (steamml_max_entries) = 5 |
+| 6 | `items` | `int32` | `repeated` |  | (steamml_max_entries) = 20 |
+| 7 | `item_to_be_purchased` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -1946,11 +1946,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `account_id` | `uint32` | `optional` | `` |  |
-| 3 | `preferred_map_variant` | `uint32` | `optional` | `` | default = 255 |
-| 4 | `hero_id` | `int32` | `optional` | `` |  |
-| 5 | `turbo_mode` | `bool` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `account_id` | `uint32` | `optional` |  |  |
+| 3 | `preferred_map_variant` | `uint32` | `optional` |  | default = 255 |
+| 4 | `hero_id` | `int32` | `optional` |  |  |
+| 5 | `turbo_mode` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1962,9 +1962,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `average_rank` | `uint32` | `optional` | `` |  |
-| 3 | `challenge_records` | `.CMsgServerToGCPlayerChallengeHistory.PlayerChallenge` | `repeated` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `average_rank` | `uint32` | `optional` |  |  |
+| 3 | `challenge_records` | `.CMsgServerToGCPlayerChallengeHistory.PlayerChallenge` | `repeated` |  |  |
 
 </details>
 
@@ -1976,16 +1976,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `challenge_type` | `.EPlayerChallengeHistoryType` | `optional` | `` | default = k_EPlayerChallengeHistoryType_Invalid |
-| 3 | `challenge_id1` | `uint32` | `optional` | `` |  |
-| 4 | `challenge_id2` | `uint32` | `optional` | `` |  |
-| 5 | `progress_value_start` | `uint32` | `optional` | `` |  |
-| 6 | `progress_value_end` | `uint32` | `optional` | `` |  |
-| 7 | `team_won` | `bool` | `optional` | `` |  |
-| 8 | `audit_data` | `uint64` | `optional` | `` |  |
-| 9 | `hero_id` | `int32` | `optional` | `` |  |
-| 10 | `rank_completed` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `challenge_type` | `.EPlayerChallengeHistoryType` | `optional` |  | default = k_EPlayerChallengeHistoryType_Invalid |
+| 3 | `challenge_id1` | `uint32` | `optional` |  |  |
+| 4 | `challenge_id2` | `uint32` | `optional` |  |  |
+| 5 | `progress_value_start` | `uint32` | `optional` |  |  |
+| 6 | `progress_value_end` | `uint32` | `optional` |  |  |
+| 7 | `team_won` | `bool` | `optional` |  |  |
+| 8 | `audit_data` | `uint64` | `optional` |  |  |
+| 9 | `hero_id` | `int32` | `optional` |  |  |
+| 10 | `rank_completed` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1997,11 +1997,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `bool` | `optional` | `` |  |
-| 2 | `potential_winnings` | `uint32` | `optional` | `` |  |
-| 3 | `map_results` | `.CMsgServerToGCCavernCrawlIsHeroActiveResponse.MapResults` | `repeated` | `` |  |
-| 4 | `potential_plus_shard_winnings` | `uint32` | `optional` | `` |  |
-| 5 | `map_variant` | `uint32` | `optional` | `` | default = 255 |
+| 1 | `result` | `bool` | `optional` |  |  |
+| 2 | `potential_winnings` | `uint32` | `optional` |  |  |
+| 3 | `map_results` | `.CMsgServerToGCCavernCrawlIsHeroActiveResponse.MapResults` | `repeated` |  |  |
+| 4 | `potential_plus_shard_winnings` | `uint32` | `optional` |  |  |
+| 5 | `map_variant` | `uint32` | `optional` |  | default = 255 |
 
 </details>
 
@@ -2013,8 +2013,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `path_id_completed` | `uint32` | `optional` | `` | default = 255 |
-| 2 | `room_id_claimed` | `uint32` | `optional` | `` | default = 255 |
+| 1 | `path_id_completed` | `uint32` | `optional` |  | default = 255 |
+| 2 | `room_id_claimed` | `uint32` | `optional` |  | default = 255 |
 
 </details>
 
@@ -2026,7 +2026,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `neutral_items` | `.CMsgNeutralItemStats.NeutralItem` | `repeated` | `` |  |
+| 1 | `neutral_items` | `.CMsgNeutralItemStats.NeutralItem` | `repeated` |  |  |
 
 </details>
 
@@ -2038,12 +2038,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `time_dropped` | `uint32` | `optional` | `` |  |
-| 3 | `team` | `uint32` | `optional` | `` |  |
-| 4 | `time_last_equipped` | `uint32` | `optional` | `` |  |
-| 5 | `time_last_unequipped` | `uint32` | `optional` | `` |  |
-| 6 | `duration_equipped` | `uint32` | `optional` | `` |  |
+| 1 | `item_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `time_dropped` | `uint32` | `optional` |  |  |
+| 3 | `team` | `uint32` | `optional` |  |  |
+| 4 | `time_last_equipped` | `uint32` | `optional` |  |  |
+| 5 | `time_last_unequipped` | `uint32` | `optional` |  |  |
+| 6 | `duration_equipped` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2055,7 +2055,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ban_data` | `.CMsgGCToServerLobbyHeroBanRates.HeroBanEntry` | `repeated` | `` |  |
+| 1 | `ban_data` | `.CMsgGCToServerLobbyHeroBanRates.HeroBanEntry` | `repeated` |  |  |
 
 </details>
 
@@ -2067,9 +2067,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `ban_count` | `uint32` | `optional` | `` |  |
-| 3 | `pick_count` | `uint32` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `ban_count` | `uint32` | `optional` |  |  |
+| 3 | `pick_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2081,7 +2081,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_contracts` | `.CMsgSignOutGuildContractProgress.PlayerContract` | `repeated` | `` |  |
+| 1 | `player_contracts` | `.CMsgSignOutGuildContractProgress.PlayerContract` | `repeated` |  |  |
 
 </details>
 
@@ -2093,9 +2093,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `event_id` | `uint32` | `optional` | `` |  |
-| 3 | `contracts` | `uint64` | `repeated` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `event_id` | `uint32` | `optional` |  |  |
+| 3 | `contracts` | `uint64` | `repeated` |  |  |
 
 </details>
 
@@ -2107,8 +2107,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `completed_contracts` | `.CMsgSignOutGuildContractProgress.CompletedGuildEventContracts` | `repeated` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `completed_contracts` | `.CMsgSignOutGuildContractProgress.CompletedGuildEventContracts` | `repeated` |  |  |
 
 </details>
 
@@ -2120,7 +2120,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_challenges_progresses` | `.CMsgSignOutGuildChallengeProgress.ChallengeProgress` | `repeated` | `` |  |
+| 1 | `guild_challenges_progresses` | `.CMsgSignOutGuildChallengeProgress.ChallengeProgress` | `repeated` |  |  |
 
 </details>
 
@@ -2132,13 +2132,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `event_id` | `uint32` | `optional` | `` |  |
-| 3 | `challenge_instance_id` | `uint32` | `optional` | `` |  |
-| 4 | `challenge_instance_timestamp` | `uint32` | `optional` | `` |  |
-| 5 | `challenge_period_serial` | `uint32` | `optional` | `` |  |
-| 6 | `progress` | `uint32` | `optional` | `` |  |
-| 7 | `challenge_parameter` | `uint32` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `event_id` | `uint32` | `optional` |  |  |
+| 3 | `challenge_instance_id` | `uint32` | `optional` |  |  |
+| 4 | `challenge_instance_timestamp` | `uint32` | `optional` |  |  |
+| 5 | `challenge_period_serial` | `uint32` | `optional` |  |  |
+| 6 | `progress` | `uint32` | `optional` |  |  |
+| 7 | `challenge_parameter` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2150,11 +2150,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `game_mode` | `uint32` | `optional` | `` |  |
-| 3 | `winning_team` | `uint32` | `optional` | `` |  |
-| 4 | `game_time` | `float` | `optional` | `` |  |
-| 5 | `players` | `.CMsgSignOutMVPStats.Player` | `repeated` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `game_mode` | `uint32` | `optional` |  |  |
+| 3 | `winning_team` | `uint32` | `optional` |  |  |
+| 4 | `game_time` | `float` | `optional` |  |  |
+| 5 | `players` | `.CMsgSignOutMVPStats.Player` | `repeated` |  |  |
 
 </details>
 
@@ -2166,31 +2166,31 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_id` | `uint32` | `optional` | `` |  |
-| 2 | `team_networth_rank` | `uint32` | `optional` | `` |  |
-| 3 | `account_id` | `uint32` | `optional` | `` |  |
-| 4 | `hero_id` | `int32` | `optional` | `` |  |
-| 5 | `role` | `uint32` | `optional` | `` |  |
-| 6 | `kills` | `int32` | `optional` | `` |  |
-| 7 | `deaths` | `int32` | `optional` | `` |  |
-| 8 | `assists` | `int32` | `optional` | `` |  |
-| 9 | `xp` | `int32` | `optional` | `` |  |
-| 10 | `net_worth` | `int32` | `optional` | `` |  |
-| 12 | `support_gold_spent` | `int32` | `optional` | `` |  |
-| 13 | `wards_placed` | `int32` | `optional` | `` |  |
-| 14 | `wards_spotted_for_dewarding` | `int32` | `optional` | `` |  |
-| 15 | `camps_stacked` | `int32` | `optional` | `` |  |
-| 16 | `last_hits` | `int32` | `optional` | `` |  |
-| 17 | `denies` | `int32` | `optional` | `` |  |
-| 19 | `building_damage` | `int32` | `optional` | `` |  |
-| 20 | `other_damage` | `int32` | `optional` | `` |  |
-| 26 | `triple_kills` | `int32` | `optional` | `` |  |
-| 28 | `rampages` | `int32` | `optional` | `` |  |
-| 31 | `first_blood` | `int32` | `optional` | `` |  |
-| 32 | `player_slot` | `uint32` | `optional` | `` |  |
-| 33 | `rank` | `uint32` | `optional` | `` |  |
-| 34 | `kill_eater_events` | `.CMsgSignOutMVPStats.Player.KillEaterEvent` | `repeated` | `` |  |
-| 35 | `highest_killstreak` | `uint32` | `optional` | `` |  |
+| 1 | `team_id` | `uint32` | `optional` |  |  |
+| 2 | `team_networth_rank` | `uint32` | `optional` |  |  |
+| 3 | `account_id` | `uint32` | `optional` |  |  |
+| 4 | `hero_id` | `int32` | `optional` |  |  |
+| 5 | `role` | `uint32` | `optional` |  |  |
+| 6 | `kills` | `int32` | `optional` |  |  |
+| 7 | `deaths` | `int32` | `optional` |  |  |
+| 8 | `assists` | `int32` | `optional` |  |  |
+| 9 | `xp` | `int32` | `optional` |  |  |
+| 10 | `net_worth` | `int32` | `optional` |  |  |
+| 12 | `support_gold_spent` | `int32` | `optional` |  |  |
+| 13 | `wards_placed` | `int32` | `optional` |  |  |
+| 14 | `wards_spotted_for_dewarding` | `int32` | `optional` |  |  |
+| 15 | `camps_stacked` | `int32` | `optional` |  |  |
+| 16 | `last_hits` | `int32` | `optional` |  |  |
+| 17 | `denies` | `int32` | `optional` |  |  |
+| 19 | `building_damage` | `int32` | `optional` |  |  |
+| 20 | `other_damage` | `int32` | `optional` |  |  |
+| 26 | `triple_kills` | `int32` | `optional` |  |  |
+| 28 | `rampages` | `int32` | `optional` |  |  |
+| 31 | `first_blood` | `int32` | `optional` |  |  |
+| 32 | `player_slot` | `uint32` | `optional` |  |  |
+| 33 | `rank` | `uint32` | `optional` |  |  |
+| 34 | `kill_eater_events` | `.CMsgSignOutMVPStats.Player.KillEaterEvent` | `repeated` |  |  |
+| 35 | `highest_killstreak` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2202,8 +2202,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_type` | `uint32` | `optional` | `` |  |
-| 2 | `amount` | `uint32` | `optional` | `` |  |
+| 1 | `event_type` | `uint32` | `optional` |  |  |
+| 2 | `amount` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2215,7 +2215,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_ids` | `uint32` | `repeated` | `` |  |
+| 1 | `account_ids` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -2227,7 +2227,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_contracts` | `.CMsgServerToGCGetGuildContractsResponse.Player` | `repeated` | `` |  |
+| 1 | `player_contracts` | `.CMsgServerToGCGetGuildContractsResponse.Player` | `repeated` |  |  |
 
 </details>
 
@@ -2239,11 +2239,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `contract_id` | `uint64` | `optional` | `` |  |
-| 2 | `challenge_instance_id` | `uint32` | `optional` | `` |  |
-| 3 | `challenge_parameter` | `uint32` | `optional` | `` |  |
-| 4 | `contract_stars` | `uint32` | `optional` | `` |  |
-| 5 | `contract_slot` | `uint32` | `optional` | `` |  |
+| 1 | `contract_id` | `uint64` | `optional` |  |  |
+| 2 | `challenge_instance_id` | `uint32` | `optional` |  |  |
+| 3 | `challenge_parameter` | `uint32` | `optional` |  |  |
+| 4 | `contract_stars` | `uint32` | `optional` |  |  |
+| 5 | `contract_slot` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2255,10 +2255,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `guild_id` | `uint32` | `optional` | `` |  |
-| 3 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 4 | `contracts` | `.CMsgServerToGCGetGuildContractsResponse.ContractDetails` | `repeated` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `guild_id` | `uint32` | `optional` |  |  |
+| 3 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 4 | `contracts` | `.CMsgServerToGCGetGuildContractsResponse.ContractDetails` | `repeated` |  |  |
 
 </details>
 
@@ -2270,8 +2270,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_candy_data` | `.CMsgMatchDiretideCandy.PlayerCandy` | `repeated` | `` |  |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
+| 1 | `player_candy_data` | `.CMsgMatchDiretideCandy.PlayerCandy` | `repeated` |  |  |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
 
 </details>
 
@@ -2283,8 +2283,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `amount` | `uint32` | `optional` | `` |  |
-| 2 | `audit` | `uint32` | `optional` | `` |  |
+| 1 | `amount` | `uint32` | `optional` |  |  |
+| 2 | `audit` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2296,10 +2296,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 3 | `candy_amount` | `uint32` | `optional` | `` |  |
-| 4 | `consumes_periodic_resource` | `bool` | `optional` | `` |  |
-| 5 | `candy_breakdown` | `.CMsgMatchDiretideCandy.CandyDetails` | `repeated` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 3 | `candy_amount` | `uint32` | `optional` |  |  |
+| 4 | `consumes_periodic_resource` | `bool` | `optional` |  |  |
+| 5 | `candy_breakdown` | `.CMsgMatchDiretideCandy.CandyDetails` | `repeated` |  |  |
 
 </details>
 
@@ -2311,7 +2311,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cheer_types` | `.CMsgGCToServerCheerData.CheerTypeCount` | `repeated` | `` |  |
+| 1 | `cheer_types` | `.CMsgGCToServerCheerData.CheerTypeCount` | `repeated` |  |  |
 
 </details>
 
@@ -2323,8 +2323,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cheer_type` | `uint32` | `optional` | `` |  |
-| 2 | `cheer_count` | `uint32` | `optional` | `` |  |
+| 1 | `cheer_type` | `uint32` | `optional` |  |  |
+| 2 | `cheer_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2336,24 +2336,24 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cheers_enabled` | `bool` | `optional` | `` |  |
-| 2 | `is_valid_league_id` | `bool` | `optional` | `` |  |
-| 3 | `window_duration` | `float` | `optional` | `` |  |
-| 4 | `window_bucket_count` | `uint32` | `optional` | `` |  |
-| 6 | `crowd_level_push_time` | `float` | `optional` | `` |  |
-| 10 | `crowd_level_low` | `uint32` | `optional` | `` |  |
-| 11 | `crowd_level_medium` | `uint32` | `optional` | `` |  |
-| 12 | `crowd_level_high` | `uint32` | `optional` | `` |  |
-| 13 | `cheer_scale_start` | `float` | `optional` | `` |  |
-| 14 | `cheer_scale_speed` | `float` | `optional` | `` |  |
-| 15 | `cheer_scale_push_mark` | `uint32` | `optional` | `` |  |
-| 16 | `cheer_scale_pull_mark` | `uint32` | `optional` | `` |  |
-| 17 | `cheer_scale_pct_of_max_cps_clamp` | `float` | `optional` | `` |  |
-| 18 | `cheer_factor_bronze` | `float` | `optional` | `` |  |
-| 19 | `cheer_factor_silver` | `float` | `optional` | `` |  |
-| 20 | `cheer_factor_gold` | `float` | `optional` | `` |  |
-| 21 | `cheer_scale_dampener_value` | `float` | `optional` | `` |  |
-| 22 | `cheer_scale_dampener_lerp_time` | `uint32` | `optional` | `` |  |
+| 1 | `cheers_enabled` | `bool` | `optional` |  |  |
+| 2 | `is_valid_league_id` | `bool` | `optional` |  |  |
+| 3 | `window_duration` | `float` | `optional` |  |  |
+| 4 | `window_bucket_count` | `uint32` | `optional` |  |  |
+| 6 | `crowd_level_push_time` | `float` | `optional` |  |  |
+| 10 | `crowd_level_low` | `uint32` | `optional` |  |  |
+| 11 | `crowd_level_medium` | `uint32` | `optional` |  |  |
+| 12 | `crowd_level_high` | `uint32` | `optional` |  |  |
+| 13 | `cheer_scale_start` | `float` | `optional` |  |  |
+| 14 | `cheer_scale_speed` | `float` | `optional` |  |  |
+| 15 | `cheer_scale_push_mark` | `uint32` | `optional` |  |  |
+| 16 | `cheer_scale_pull_mark` | `uint32` | `optional` |  |  |
+| 17 | `cheer_scale_pct_of_max_cps_clamp` | `float` | `optional` |  |  |
+| 18 | `cheer_factor_bronze` | `float` | `optional` |  |  |
+| 19 | `cheer_factor_silver` | `float` | `optional` |  |  |
+| 20 | `cheer_factor_gold` | `float` | `optional` |  |  |
+| 21 | `cheer_scale_dampener_value` | `float` | `optional` |  |  |
+| 22 | `cheer_scale_dampener_lerp_time` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2365,7 +2365,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cheer_config` | `.CMsgCheerConfig` | `optional` | `` |  |
+| 1 | `cheer_config` | `.CMsgCheerConfig` | `optional` |  |  |
 
 </details>
 
@@ -2377,7 +2377,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2389,7 +2389,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `cheer_config` | `.CMsgCheerConfig` | `optional` | `` |  |
+| 2 | `cheer_config` | `.CMsgCheerConfig` | `optional` |  |  |
 
 </details>
 
@@ -2401,7 +2401,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `scales` | `float` | `repeated` | `` |  |
+| 1 | `scales` | `float` | `repeated` |  |  |
 
 </details>
 
@@ -2425,10 +2425,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cheer_counts` | `uint32` | `repeated` | `` |  |
-| 2 | `max_per_second` | `float` | `optional` | `` |  |
-| 3 | `cheer_scale` | `float` | `optional` | `` |  |
-| 4 | `override_scale` | `float` | `optional` | `` |  |
+| 1 | `cheer_counts` | `uint32` | `repeated` |  |  |
+| 2 | `max_per_second` | `float` | `optional` |  |  |
+| 3 | `cheer_scale` | `float` | `optional` |  |  |
+| 4 | `override_scale` | `float` | `optional` |  |  |
 
 </details>
 
@@ -2440,9 +2440,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cheer_types` | `.CMsgCheerTypeState` | `repeated` | `` |  |
-| 2 | `radiant_crowd_level` | `uint32` | `optional` | `` |  |
-| 3 | `dire_crowd_level` | `uint32` | `optional` | `` |  |
+| 1 | `cheer_types` | `.CMsgCheerTypeState` | `repeated` |  |  |
+| 2 | `radiant_crowd_level` | `uint32` | `optional` |  |  |
+| 3 | `dire_crowd_level` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2454,8 +2454,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cheer_config` | `.CMsgCheerConfig` | `optional` | `` |  |
-| 2 | `cheer_state` | `.CMsgCheerState` | `optional` | `` |  |
+| 1 | `cheer_config` | `.CMsgCheerConfig` | `optional` |  |  |
+| 2 | `cheer_state` | `.CMsgCheerState` | `optional` |  |  |
 
 </details>
 
@@ -2467,7 +2467,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_ids` | `uint32` | `repeated` | `` |  |
+| 1 | `account_ids` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -2479,7 +2479,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `players` | `.CMsgServerToGCGetStickerHeroesResponse.Player` | `repeated` | `` |  |
+| 1 | `players` | `.CMsgServerToGCGetStickerHeroesResponse.Player` | `repeated` |  |  |
 
 </details>
 
@@ -2491,8 +2491,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `stickers` | `.CMsgStickerHeroes` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `stickers` | `.CMsgStickerHeroes` | `optional` |  |  |
 
 </details>
 
@@ -2504,11 +2504,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `average_mmr` | `uint32` | `optional` | `` |  |
-| 2 | `radiant_won` | `bool` | `optional` | `` |  |
-| 3 | `duration` | `uint32` | `optional` | `` |  |
-| 4 | `game_mode` | `uint32` | `optional` | `` |  |
-| 5 | `lobby_type` | `uint32` | `optional` | `` |  |
+| 1 | `average_mmr` | `uint32` | `optional` |  |  |
+| 2 | `radiant_won` | `bool` | `optional` |  |  |
+| 3 | `duration` | `uint32` | `optional` |  |  |
+| 4 | `game_mode` | `uint32` | `optional` |  |  |
+| 5 | `lobby_type` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2520,12 +2520,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `average_mmr` | `uint32` | `optional` | `` |  |
-| 2 | `team_won` | `bool` | `optional` | `` |  |
-| 3 | `duration` | `uint32` | `optional` | `` |  |
-| 4 | `game_mode` | `uint32` | `optional` | `` |  |
-| 5 | `lobby_type` | `uint32` | `optional` | `` |  |
-| 6 | `player_mmr` | `uint32` | `optional` | `` |  |
+| 1 | `average_mmr` | `uint32` | `optional` |  |  |
+| 2 | `team_won` | `bool` | `optional` |  |  |
+| 3 | `duration` | `uint32` | `optional` |  |  |
+| 4 | `game_mode` | `uint32` | `optional` |  |  |
+| 5 | `lobby_type` | `uint32` | `optional` |  |  |
+| 6 | `player_mmr` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2537,9 +2537,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `radiant_players` | `.CMsgSteamLearnMatchInfoTeam.Player` | `repeated` | `` | (steamlearn_count) = 5 |
-| 2 | `dire_players` | `.CMsgSteamLearnMatchInfoTeam.Player` | `repeated` | `` | (steamlearn_count) = 5 |
-| 3 | `radiant_team_won` | `bool` | `optional` | `` |  |
+| 1 | `radiant_players` | `.CMsgSteamLearnMatchInfoTeam.Player` | `repeated` |  | (steamlearn_count) = 5 |
+| 2 | `dire_players` | `.CMsgSteamLearnMatchInfoTeam.Player` | `repeated` |  | (steamlearn_count) = 5 |
+| 3 | `radiant_team_won` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2551,11 +2551,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `prematch_mmr` | `uint32` | `optional` | `` |  |
-| 2 | `prematch_rank_uncertainty` | `uint32` | `optional` | `` |  |
-| 3 | `prematch_behavior_score` | `uint32` | `optional` | `` |  |
-| 4 | `prematch_comm_score` | `uint32` | `optional` | `` |  |
-| 5 | `num_players_in_party` | `uint32` | `optional` | `` |  |
+| 1 | `prematch_mmr` | `uint32` | `optional` |  |  |
+| 2 | `prematch_rank_uncertainty` | `uint32` | `optional` |  |  |
+| 3 | `prematch_behavior_score` | `uint32` | `optional` |  |  |
+| 4 | `prematch_comm_score` | `uint32` | `optional` |  |  |
+| 5 | `num_players_in_party` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2567,14 +2567,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `radiant_hero_ids` | `int32` | `repeated` | `` | (steamlearn_count) = 5 |
-| 2 | `dire_hero_ids` | `int32` | `repeated` | `` | (steamlearn_count) = 5 |
-| 3 | `radiant_lanes` | `uint32` | `repeated` | `` | (steamlearn_count) = 5 |
-| 4 | `dire_lanes` | `uint32` | `repeated` | `` | (steamlearn_count) = 5 |
-| 5 | `radiant_hero_facets` | `uint32` | `repeated` | `` | (steamlearn_count) = 5 |
-| 6 | `dire_hero_facets` | `uint32` | `repeated` | `` | (steamlearn_count) = 5 |
-| 7 | `radiant_positions` | `uint32` | `repeated` | `` | (steamlearn_count) = 5 |
-| 8 | `dire_positions` | `uint32` | `repeated` | `` | (steamlearn_count) = 5 |
+| 1 | `radiant_hero_ids` | `int32` | `repeated` |  | (steamlearn_count) = 5 |
+| 2 | `dire_hero_ids` | `int32` | `repeated` |  | (steamlearn_count) = 5 |
+| 3 | `radiant_lanes` | `uint32` | `repeated` |  | (steamlearn_count) = 5 |
+| 4 | `dire_lanes` | `uint32` | `repeated` |  | (steamlearn_count) = 5 |
+| 5 | `radiant_hero_facets` | `uint32` | `repeated` |  | (steamlearn_count) = 5 |
+| 6 | `dire_hero_facets` | `uint32` | `repeated` |  | (steamlearn_count) = 5 |
+| 7 | `radiant_positions` | `uint32` | `repeated` |  | (steamlearn_count) = 5 |
+| 8 | `dire_positions` | `uint32` | `repeated` |  | (steamlearn_count) = 5 |
 
 </details>
 
@@ -2586,12 +2586,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `radiant_hero_ids` | `int32` | `repeated` | `` | (steamlearn_count) = 5 |
-| 2 | `dire_hero_ids` | `int32` | `repeated` | `` | (steamlearn_count) = 5 |
-| 3 | `radiant_lanes` | `uint32` | `repeated` | `` | (steamlearn_count) = 5 |
-| 4 | `dire_lanes` | `uint32` | `repeated` | `` | (steamlearn_count) = 5 |
-| 5 | `radiant_positions` | `uint32` | `repeated` | `` | (steamlearn_count) = 5 |
-| 6 | `dire_positions` | `uint32` | `repeated` | `` | (steamlearn_count) = 5 |
+| 1 | `radiant_hero_ids` | `int32` | `repeated` |  | (steamlearn_count) = 5 |
+| 2 | `dire_hero_ids` | `int32` | `repeated` |  | (steamlearn_count) = 5 |
+| 3 | `radiant_lanes` | `uint32` | `repeated` |  | (steamlearn_count) = 5 |
+| 4 | `dire_lanes` | `uint32` | `repeated` |  | (steamlearn_count) = 5 |
+| 5 | `radiant_positions` | `uint32` | `repeated` |  | (steamlearn_count) = 5 |
+| 6 | `dire_positions` | `uint32` | `repeated` |  | (steamlearn_count) = 5 |
 
 </details>
 
@@ -2603,13 +2603,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `facet` | `uint32` | `optional` | `` |  |
-| 3 | `hero_and_facet` | `uint32` | `optional` | `` |  |
-| 4 | `lane` | `uint32` | `optional` | `` |  |
-| 5 | `position` | `uint32` | `optional` | `` |  |
-| 6 | `allied_hero_and_facet` | `uint32` | `repeated` | `` | (steamlearn_count) = 4 |
-| 7 | `enemy_hero_and_facet` | `uint32` | `repeated` | `` | (steamlearn_count) = 5 |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `facet` | `uint32` | `optional` |  |  |
+| 3 | `hero_and_facet` | `uint32` | `optional` |  |  |
+| 4 | `lane` | `uint32` | `optional` |  |  |
+| 5 | `position` | `uint32` | `optional` |  |  |
+| 6 | `allied_hero_and_facet` | `uint32` | `repeated` |  | (steamlearn_count) = 4 |
+| 7 | `enemy_hero_and_facet` | `uint32` | `repeated` |  | (steamlearn_count) = 5 |
 
 </details>
 
@@ -2621,11 +2621,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `lane` | `uint32` | `optional` | `` |  |
-| 3 | `position` | `uint32` | `optional` | `` |  |
-| 4 | `allied_heroes` | `uint32` | `repeated` | `` | (steamlearn_count) = 4 |
-| 5 | `enemy_heroes` | `uint32` | `repeated` | `` | (steamlearn_count) = 5 |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `lane` | `uint32` | `optional` |  |  |
+| 3 | `position` | `uint32` | `optional` |  |  |
+| 4 | `allied_heroes` | `uint32` | `repeated` |  | (steamlearn_count) = 4 |
+| 5 | `enemy_heroes` | `uint32` | `repeated` |  | (steamlearn_count) = 5 |
 
 </details>
 
@@ -2637,7 +2637,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `stat_buckets` | `.CMsgSteamLearnPlayerTimedStats.StatBucket` | `repeated` | `` | (steamlearn_count) = 90 |
+| 1 | `stat_buckets` | `.CMsgSteamLearnPlayerTimedStats.StatBucket` | `repeated` |  | (steamlearn_count) = 90 |
 
 </details>
 
@@ -2649,18 +2649,18 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `game_time` | `float` | `optional` | `` |  |
-| 2 | `kills` | `uint32` | `optional` | `` |  |
-| 3 | `deaths` | `uint32` | `optional` | `` |  |
-| 4 | `assists` | `uint32` | `optional` | `` |  |
-| 5 | `experience` | `uint32` | `optional` | `` |  |
-| 6 | `last_hits` | `uint32` | `optional` | `` |  |
-| 7 | `denies` | `uint32` | `optional` | `` |  |
-| 8 | `net_worth` | `uint32` | `optional` | `` |  |
-| 9 | `idle_time` | `float` | `optional` | `` |  |
-| 10 | `commands_issued` | `uint32` | `optional` | `` |  |
-| 11 | `sentry_wards_placed` | `uint32` | `optional` | `` |  |
-| 12 | `observer_wards_placed` | `uint32` | `optional` | `` |  |
+| 1 | `game_time` | `float` | `optional` |  |  |
+| 2 | `kills` | `uint32` | `optional` |  |  |
+| 3 | `deaths` | `uint32` | `optional` |  |  |
+| 4 | `assists` | `uint32` | `optional` |  |  |
+| 5 | `experience` | `uint32` | `optional` |  |  |
+| 6 | `last_hits` | `uint32` | `optional` |  |  |
+| 7 | `denies` | `uint32` | `optional` |  |  |
+| 8 | `net_worth` | `uint32` | `optional` |  |  |
+| 9 | `idle_time` | `float` | `optional` |  |  |
+| 10 | `commands_issued` | `uint32` | `optional` |  |  |
+| 11 | `sentry_wards_placed` | `uint32` | `optional` |  |  |
+| 12 | `observer_wards_placed` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2672,9 +2672,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `game_time` | `float` | `optional` | `` |  |
-| 2 | `radiant_state` | `.CMsgSteamLearnMatchStateV5.TeamState` | `optional` | `` |  |
-| 3 | `dire_state` | `.CMsgSteamLearnMatchStateV5.TeamState` | `optional` | `` |  |
+| 1 | `game_time` | `float` | `optional` |  |  |
+| 2 | `radiant_state` | `.CMsgSteamLearnMatchStateV5.TeamState` | `optional` |  |  |
+| 3 | `dire_state` | `.CMsgSteamLearnMatchStateV5.TeamState` | `optional` |  |  |
 
 </details>
 
@@ -2686,16 +2686,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `net_worth` | `uint32` | `optional` | `` |  |
-| 3 | `level` | `uint32` | `optional` | `` |  |
-| 4 | `deaths` | `uint32` | `optional` | `` |  |
-| 5 | `respawn_time` | `uint32` | `optional` | `` |  |
-| 6 | `has_buyback` | `bool` | `optional` | `` |  |
-| 7 | `has_aegis` | `bool` | `optional` | `` |  |
-| 8 | `has_rapier` | `bool` | `optional` | `` |  |
-| 9 | `distance` | `uint32` | `optional` | `` |  |
-| 10 | `hero_facet` | `uint32` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `net_worth` | `uint32` | `optional` |  |  |
+| 3 | `level` | `uint32` | `optional` |  |  |
+| 4 | `deaths` | `uint32` | `optional` |  |  |
+| 5 | `respawn_time` | `uint32` | `optional` |  |  |
+| 6 | `has_buyback` | `bool` | `optional` |  |  |
+| 7 | `has_aegis` | `bool` | `optional` |  |  |
+| 8 | `has_rapier` | `bool` | `optional` |  |  |
+| 9 | `distance` | `uint32` | `optional` |  |  |
+| 10 | `hero_facet` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2707,16 +2707,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team` | `uint32` | `optional` | `` |  |
-| 2 | `player_states` | `.CMsgSteamLearnMatchStateV5.PlayerState` | `repeated` | `` | (steamlearn_count) = 5 |
-| 3 | `tower_health_pct` | `uint32` | `repeated` | `` | (steamlearn_count) = 11 |
-| 4 | `barracks_health_pct` | `uint32` | `repeated` | `` | (steamlearn_count) = 6 |
-| 5 | `ancient_health_pct` | `uint32` | `optional` | `` |  |
-| 6 | `glyph_cooldown` | `uint32` | `optional` | `` |  |
-| 7 | `kills` | `uint32` | `optional` | `` |  |
-| 8 | `creep_distance_safe` | `uint32` | `optional` | `` |  |
-| 9 | `creep_distance_mid` | `uint32` | `optional` | `` |  |
-| 10 | `creep_distance_off` | `uint32` | `optional` | `` |  |
+| 1 | `team` | `uint32` | `optional` |  |  |
+| 2 | `player_states` | `.CMsgSteamLearnMatchStateV5.PlayerState` | `repeated` |  | (steamlearn_count) = 5 |
+| 3 | `tower_health_pct` | `uint32` | `repeated` |  | (steamlearn_count) = 11 |
+| 4 | `barracks_health_pct` | `uint32` | `repeated` |  | (steamlearn_count) = 6 |
+| 5 | `ancient_health_pct` | `uint32` | `optional` |  |  |
+| 6 | `glyph_cooldown` | `uint32` | `optional` |  |  |
+| 7 | `kills` | `uint32` | `optional` |  |  |
+| 8 | `creep_distance_safe` | `uint32` | `optional` |  |  |
+| 9 | `creep_distance_mid` | `uint32` | `optional` |  |  |
+| 10 | `creep_distance_off` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2728,8 +2728,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `purchase_history` | `int32` | `repeated` | `` | (steamlearn_count) = 50 |
+| 1 | `item_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `purchase_history` | `int32` | `repeated` |  | (steamlearn_count) = 50 |
 
 </details>
 
@@ -2741,9 +2741,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_ids` | `int32` | `repeated` | `` | (steamlearn_count) = 10 |
-| 2 | `is_radiant_team` | `uint32` | `optional` | `` |  |
-| 3 | `is_using_dota_plus` | `bool` | `optional` | `` |  |
+| 1 | `item_ids` | `int32` | `repeated` |  | (steamlearn_count) = 10 |
+| 2 | `is_radiant_team` | `uint32` | `optional` |  |  |
+| 3 | `is_using_dota_plus` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2755,8 +2755,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `purchase_history` | `int32` | `repeated` | `` | (steamlearn_count) = 10 |
-| 2 | `item_id` | `int32` | `optional` | `` | default = -1, (steamlearn_count) = 10 |
+| 1 | `purchase_history` | `int32` | `repeated` |  | (steamlearn_count) = 10 |
+| 2 | `item_id` | `int32` | `optional` |  | default = -1, (steamlearn_count) = 10 |
 
 </details>
 
@@ -2768,11 +2768,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tier` | `uint32` | `optional` | `` |  |
-| 2 | `trinket_options` | `int32` | `repeated` | `` | (steamlearn_count) = 4 |
-| 3 | `enhancement_options` | `int32` | `repeated` | `` | (steamlearn_count) = 4 |
-| 4 | `trinket_id` | `int32` | `optional` | `` | default = -1 |
-| 5 | `enhancement_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `tier` | `uint32` | `optional` |  |  |
+| 2 | `trinket_options` | `int32` | `repeated` |  | (steamlearn_count) = 4 |
+| 3 | `enhancement_options` | `int32` | `repeated` |  | (steamlearn_count) = 4 |
+| 4 | `trinket_id` | `int32` | `optional` |  | default = -1 |
+| 5 | `enhancement_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -2784,11 +2784,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tier` | `uint32` | `optional` | `` |  |
-| 2 | `trinket_options` | `int32` | `repeated` | `` | (steamlearn_count) = 5 |
-| 3 | `enhancement_options` | `int32` | `repeated` | `` | (steamlearn_count) = 5 |
-| 4 | `trinket_id` | `int32` | `optional` | `` | default = -1 |
-| 5 | `enhancement_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `tier` | `uint32` | `optional` |  |  |
+| 2 | `trinket_options` | `int32` | `repeated` |  | (steamlearn_count) = 5 |
+| 3 | `enhancement_options` | `int32` | `repeated` |  | (steamlearn_count) = 5 |
+| 4 | `trinket_id` | `int32` | `optional` |  | default = -1 |
+| 5 | `enhancement_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -2800,10 +2800,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ability_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `skilled_abilities` | `int32` | `repeated` | `` | (steamlearn_count) = 30 |
-| 3 | `game_time` | `float` | `optional` | `` |  |
-| 4 | `is_using_dota_plus` | `bool` | `optional` | `` |  |
+| 1 | `ability_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `skilled_abilities` | `int32` | `repeated` |  | (steamlearn_count) = 30 |
+| 3 | `game_time` | `float` | `optional` |  |  |
+| 4 | `is_using_dota_plus` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2815,9 +2815,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ward_loc` | `.CMsgSteamLearnWardPlacement.Location` | `optional` | `` |  |
-| 2 | `existing_ward_locs` | `.CMsgSteamLearnWardPlacement.Location` | `repeated` | `` | (steamlearn_count) = 6 |
-| 3 | `team` | `uint32` | `optional` | `` |  |
+| 1 | `ward_loc` | `.CMsgSteamLearnWardPlacement.Location` | `optional` |  |  |
+| 2 | `existing_ward_locs` | `.CMsgSteamLearnWardPlacement.Location` | `repeated` |  | (steamlearn_count) = 6 |
+| 3 | `team` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2829,8 +2829,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `x` | `float` | `optional` | `` |  |
-| 2 | `y` | `float` | `optional` | `` |  |
+| 1 | `x` | `float` | `optional` |  |  |
+| 2 | `y` | `float` | `optional` |  |  |
 
 </details>
 
@@ -2842,18 +2842,18 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `net_worth` | `uint32` | `optional` | `` |  |
-| 2 | `level` | `uint32` | `optional` | `` |  |
-| 3 | `deaths` | `uint32` | `optional` | `` |  |
-| 4 | `respawn_time` | `uint32` | `optional` | `` |  |
-| 5 | `has_buyback` | `bool` | `optional` | `` |  |
-| 6 | `has_aegis` | `bool` | `optional` | `` |  |
-| 7 | `has_rapier` | `bool` | `optional` | `` |  |
-| 8 | `team_net_worth` | `uint32` | `optional` | `` |  |
-| 9 | `enemy_team_net_worth` | `uint32` | `optional` | `` |  |
-| 10 | `team_kills` | `uint32` | `optional` | `` |  |
-| 11 | `enemy_team_kills` | `uint32` | `optional` | `` |  |
-| 12 | `game_time` | `float` | `optional` | `` |  |
+| 1 | `net_worth` | `uint32` | `optional` |  |  |
+| 2 | `level` | `uint32` | `optional` |  |  |
+| 3 | `deaths` | `uint32` | `optional` |  |  |
+| 4 | `respawn_time` | `uint32` | `optional` |  |  |
+| 5 | `has_buyback` | `bool` | `optional` |  |  |
+| 6 | `has_aegis` | `bool` | `optional` |  |  |
+| 7 | `has_rapier` | `bool` | `optional` |  |  |
+| 8 | `team_net_worth` | `uint32` | `optional` |  |  |
+| 9 | `enemy_team_net_worth` | `uint32` | `optional` |  |  |
+| 10 | `team_kills` | `uint32` | `optional` |  |  |
+| 11 | `enemy_team_kills` | `uint32` | `optional` |  |  |
+| 12 | `game_time` | `float` | `optional` |  |  |
 
 </details>
 
@@ -2865,7 +2865,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_game_data` | `bytes` | `optional` | `` |  |
+| 1 | `event_game_data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -2877,8 +2877,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `players` | `.CMsgSignOutMapStats.Player` | `repeated` | `` |  |
-| 2 | `global_stats` | `.CMsgMapStatsSnapshot` | `optional` | `` |  |
+| 1 | `players` | `.CMsgSignOutMapStats.Player` | `repeated` |  |  |
+| 2 | `global_stats` | `.CMsgMapStatsSnapshot` | `optional` |  |  |
 
 </details>
 
@@ -2890,8 +2890,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `personal_stats` | `.CMsgMapStatsSnapshot` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `personal_stats` | `.CMsgMapStatsSnapshot` | `optional` |  |  |
 
 </details>
 
@@ -2903,9 +2903,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `defindex` | `uint32` | `optional` | `` |  |
-| 2 | `gifter_account_id` | `uint32` | `optional` | `` |  |
-| 3 | `target_account_ids` | `uint32` | `repeated` | `` |  |
+| 1 | `defindex` | `uint32` | `optional` |  |  |
+| 2 | `gifter_account_id` | `uint32` | `optional` |  |  |
+| 3 | `target_account_ids` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -2917,8 +2917,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.ENewBloomGiftingResponse` | `optional` | `` | default = kENewBloomGifting_UnknownFailure |
-| 2 | `received_account_ids` | `uint32` | `repeated` | `` |  |
+| 1 | `result` | `.ENewBloomGiftingResponse` | `optional` |  | default = kENewBloomGifting_UnknownFailure |
+| 2 | `received_account_ids` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -2930,8 +2930,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `players` | `.CMsgSignOutOverworld.Player` | `repeated` | `` |  |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
+| 1 | `players` | `.CMsgSignOutOverworld.Player` | `repeated` |  |  |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
 
 </details>
 
@@ -2943,9 +2943,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `overworld_id` | `uint32` | `optional` | `` |  |
-| 3 | `desired_token_rewards` | `uint32` | `repeated` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `overworld_id` | `uint32` | `optional` |  |  |
+| 3 | `desired_token_rewards` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -2957,8 +2957,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `players` | `.CMsgSignOutCraftworks.Player` | `repeated` | `` |  |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
+| 1 | `players` | `.CMsgSignOutCraftworks.Player` | `repeated` |  |  |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
 
 </details>
 
@@ -2970,8 +2970,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `components` | `.CMsgCraftworksComponents` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `components` | `.CMsgCraftworksComponents` | `optional` |  |  |
 
 </details>
 
@@ -2983,8 +2983,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `players` | `.CMsgSignOutMonsterHunter.Player` | `repeated` | `` |  |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
+| 1 | `players` | `.CMsgSignOutMonsterHunter.Player` | `repeated` |  |  |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
 
 </details>
 
@@ -2996,9 +2996,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `investigation_game_state` | `.CMsgMonsterHunterInvestigationGameState` | `optional` | `` |  |
-| 3 | `codex_update_data` | `.CMsgMonsterHunterCodexUpdateData` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `investigation_game_state` | `.CMsgMonsterHunterInvestigationGameState` | `optional` |  |  |
+| 3 | `codex_update_data` | `.CMsgMonsterHunterCodexUpdateData` | `optional` |  |  |
 
 </details>
 
@@ -3010,11 +3010,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `ticks_per_interval_average` | `float` | `optional` | `` |  |
-| 3 | `custom_game_id` | `uint64` | `optional` | `` |  |
-| 4 | `bot_script_id_radiant` | `uint64` | `optional` | `` |  |
-| 5 | `bot_script_id_dire` | `uint64` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `ticks_per_interval_average` | `float` | `optional` |  |  |
+| 3 | `custom_game_id` | `uint64` | `optional` |  |  |
+| 4 | `bot_script_id_radiant` | `uint64` | `optional` |  |  |
+| 5 | `bot_script_id_dire` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -3026,9 +3026,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `description` | `string` | `optional` | `` |  |
-| 2 | `unit_name` | `string` | `optional` | `` |  |
-| 3 | `ability_name` | `string` | `optional` | `` |  |
+| 1 | `description` | `string` | `optional` |  |  |
+| 2 | `unit_name` | `string` | `optional` |  |  |
+| 3 | `ability_name` | `string` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-gcmessages-webapi.md
+++ b/docs/cookbook/proto-fields/dota-gcmessages-webapi.md
@@ -27,14 +27,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `matches` | `.CMsgArcanaVotes.Match` | `repeated` | `` |  |
-| 2 | `round_time_remaining` | `uint32` | `optional` | `` |  |
-| 3 | `round_number` | `uint32` | `optional` | `` |  |
-| 4 | `voting_state` | `uint32` | `optional` | `` |  |
-| 5 | `is_current_round_calibrating` | `bool` | `optional` | `` |  |
-| 6 | `closest_active_match_id` | `uint32` | `optional` | `` |  |
-| 7 | `event_id` | `uint32` | `optional` | `` |  |
-| 8 | `voting_start_time` | `uint32` | `optional` | `` |  |
+| 1 | `matches` | `.CMsgArcanaVotes.Match` | `repeated` |  |  |
+| 2 | `round_time_remaining` | `uint32` | `optional` |  |  |
+| 3 | `round_number` | `uint32` | `optional` |  |  |
+| 4 | `voting_state` | `uint32` | `optional` |  |  |
+| 5 | `is_current_round_calibrating` | `bool` | `optional` |  |  |
+| 6 | `closest_active_match_id` | `uint32` | `optional` |  |  |
+| 7 | `event_id` | `uint32` | `optional` |  |  |
+| 8 | `voting_start_time` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -46,17 +46,17 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint32` | `optional` | `` |  |
-| 2 | `hero_id_0` | `int32` | `optional` | `` |  |
-| 3 | `hero_id_1` | `int32` | `optional` | `` |  |
-| 4 | `hero_seeding_0` | `uint32` | `optional` | `` |  |
-| 5 | `hero_seeding_1` | `uint32` | `optional` | `` |  |
-| 6 | `vote_count_0` | `uint32` | `optional` | `` |  |
-| 7 | `vote_count_1` | `uint32` | `optional` | `` |  |
-| 8 | `voting_state` | `uint32` | `optional` | `` |  |
-| 9 | `round_number` | `uint32` | `optional` | `` |  |
-| 10 | `is_votes_hidden` | `bool` | `optional` | `` |  |
-| 11 | `calibration_time_remaining` | `uint32` | `optional` | `` |  |
+| 1 | `match_id` | `uint32` | `optional` |  |  |
+| 2 | `hero_id_0` | `int32` | `optional` |  |  |
+| 3 | `hero_id_1` | `int32` | `optional` |  |  |
+| 4 | `hero_seeding_0` | `uint32` | `optional` |  |  |
+| 5 | `hero_seeding_1` | `uint32` | `optional` |  |  |
+| 6 | `vote_count_0` | `uint32` | `optional` |  |  |
+| 7 | `vote_count_1` | `uint32` | `optional` |  |  |
+| 8 | `voting_state` | `uint32` | `optional` |  |  |
+| 9 | `round_number` | `uint32` | `optional` |  |  |
+| 10 | `is_votes_hidden` | `bool` | `optional` |  |  |
+| 11 | `calibration_time_remaining` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -68,7 +68,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `elements` | `.CMsgDOTADPCFeed.Element` | `repeated` | `` |  |
+| 1 | `elements` | `.CMsgDOTADPCFeed.Element` | `repeated` |  |  |
 
 </details>
 
@@ -80,19 +80,19 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `type` | `.CMsgDOTADPCFeed.EFeedElementType` | `optional` | `` | default = FEED_SERIES_RESULT |
-| 2 | `timestamp` | `uint32` | `optional` | `` |  |
-| 3 | `series_id` | `uint32` | `optional` | `` |  |
-| 4 | `match_id` | `uint64` | `optional` | `` |  |
-| 5 | `team_id` | `uint32` | `optional` | `` |  |
-| 6 | `account_id` | `uint32` | `optional` | `` |  |
-| 7 | `league_id` | `uint32` | `optional` | `` |  |
-| 8 | `node_id` | `uint32` | `optional` | `` |  |
-| 9 | `data_1` | `uint32` | `optional` | `` |  |
-| 10 | `data_2` | `uint32` | `optional` | `` |  |
-| 11 | `data_3` | `uint32` | `optional` | `` |  |
-| 12 | `data_4` | `uint32` | `optional` | `` |  |
-| 13 | `server_steam_id` | `uint64` | `optional` | `` |  |
+| 1 | `type` | `.CMsgDOTADPCFeed.EFeedElementType` | `optional` |  | default = FEED_SERIES_RESULT |
+| 2 | `timestamp` | `uint32` | `optional` |  |  |
+| 3 | `series_id` | `uint32` | `optional` |  |  |
+| 4 | `match_id` | `uint64` | `optional` |  |  |
+| 5 | `team_id` | `uint32` | `optional` |  |  |
+| 6 | `account_id` | `uint32` | `optional` |  |  |
+| 7 | `league_id` | `uint32` | `optional` |  |  |
+| 8 | `node_id` | `uint32` | `optional` |  |  |
+| 9 | `data_1` | `uint32` | `optional` |  |  |
+| 10 | `data_2` | `uint32` | `optional` |  |  |
+| 11 | `data_3` | `uint32` | `optional` |  |  |
+| 12 | `data_4` | `uint32` | `optional` |  |  |
+| 13 | `server_steam_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -104,7 +104,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `is_plus_subscriber` | `bool` | `optional` | `` |  |
+| 1 | `is_plus_subscriber` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -116,14 +116,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `has_valid_match` | `bool` | `optional` | `` |  |
-| 2 | `match_hero_info` | `.CMsgDraftTrivia.DraftTriviaMatchInfo` | `optional` | `` |  |
-| 3 | `match_rank_tier` | `uint32` | `optional` | `` |  |
-| 4 | `end_time` | `uint32` | `optional` | `` |  |
-| 5 | `event_id` | `uint32` | `optional` | `` |  |
-| 6 | `current_match_voted_radiant` | `bool` | `optional` | `` |  |
-| 7 | `previous_result` | `.CMsgDraftTrivia.PreviousResult` | `optional` | `` |  |
-| 8 | `current_streak` | `uint32` | `optional` | `` |  |
+| 1 | `has_valid_match` | `bool` | `optional` |  |  |
+| 2 | `match_hero_info` | `.CMsgDraftTrivia.DraftTriviaMatchInfo` | `optional` |  |  |
+| 3 | `match_rank_tier` | `uint32` | `optional` |  |  |
+| 4 | `end_time` | `uint32` | `optional` |  |  |
+| 5 | `event_id` | `uint32` | `optional` |  |  |
+| 6 | `current_match_voted_radiant` | `bool` | `optional` |  |  |
+| 7 | `previous_result` | `.CMsgDraftTrivia.PreviousResult` | `optional` |  |  |
+| 8 | `current_streak` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -135,8 +135,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `role` | `uint32` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `role` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -148,8 +148,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `radiant_heroes` | `.CMsgDraftTrivia.DraftTriviaHeroInfo` | `repeated` | `` |  |
-| 2 | `dire_heroes` | `.CMsgDraftTrivia.DraftTriviaHeroInfo` | `repeated` | `` |  |
+| 1 | `radiant_heroes` | `.CMsgDraftTrivia.DraftTriviaHeroInfo` | `repeated` |  |  |
+| 2 | `dire_heroes` | `.CMsgDraftTrivia.DraftTriviaHeroInfo` | `repeated` |  |  |
 
 </details>
 
@@ -161,12 +161,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `voted_correctly` | `bool` | `optional` | `` |  |
-| 2 | `voted_radiant` | `bool` | `optional` | `` |  |
-| 3 | `match_hero_info` | `.CMsgDraftTrivia.DraftTriviaMatchInfo` | `optional` | `` |  |
-| 4 | `match_rank_tier` | `uint32` | `optional` | `` |  |
-| 5 | `end_time` | `uint32` | `optional` | `` |  |
-| 6 | `match_id` | `uint64` | `optional` | `` |  |
+| 1 | `voted_correctly` | `bool` | `optional` |  |  |
+| 2 | `voted_radiant` | `bool` | `optional` |  |  |
+| 3 | `match_hero_info` | `.CMsgDraftTrivia.DraftTriviaMatchInfo` | `optional` |  |  |
+| 4 | `match_rank_tier` | `uint32` | `optional` |  |  |
+| 5 | `end_time` | `uint32` | `optional` |  |  |
+| 6 | `match_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -178,10 +178,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `asset_type` | `.ETeamFanContentAssetType` | `optional` | `` | default = k_eFanContentAssetType_LogoPNG |
-| 2 | `asset_index` | `uint32` | `optional` | `` |  |
-| 3 | `asset_status` | `.ETeamFanContentAssetStatus` | `optional` | `` | default = k_eFanContentAssetStatus_None |
-| 4 | `crc` | `uint32` | `optional` | `` |  |
+| 1 | `asset_type` | `.ETeamFanContentAssetType` | `optional` |  | default = k_eFanContentAssetType_LogoPNG |
+| 2 | `asset_index` | `uint32` | `optional` |  |  |
+| 3 | `asset_status` | `.ETeamFanContentAssetStatus` | `optional` |  | default = k_eFanContentAssetStatus_None |
+| 4 | `crc` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -193,7 +193,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgTeamFanContentAssetStatusResponse.EResult` | `optional` | `` | default = k_eSuccess |
+| 1 | `result` | `.CMsgTeamFanContentAssetStatusResponse.EResult` | `optional` |  | default = k_eSuccess |
 
 </details>
 
@@ -205,7 +205,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_status_list` | `.CMsgTeamFanContentStatus.TeamStatus` | `repeated` | `` |  |
+| 1 | `team_status_list` | `.CMsgTeamFanContentStatus.TeamStatus` | `repeated` |  |  |
 
 </details>
 
@@ -217,24 +217,24 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `team_id` | `uint32` | `optional` | `` |  |
-| 3 | `logo_url` | `string` | `optional` | `` |  |
-| 4 | `status` | `.ETeamFanContentStatus` | `optional` | `` | default = TEAM_FAN_CONTENT_STATUS_INVALID |
-| 5 | `timestamp` | `uint32` | `optional` | `` |  |
-| 7 | `ugc_logo` | `uint64` | `optional` | `` |  |
-| 8 | `workshop_account_id` | `uint32` | `optional` | `` |  |
-| 9 | `abbreviation` | `string` | `optional` | `` |  |
-| 10 | `voiceline_count` | `uint32` | `optional` | `` |  |
-| 11 | `spray_count` | `uint32` | `optional` | `` |  |
-| 12 | `emoticon_count` | `uint32` | `optional` | `` |  |
-| 13 | `wallpaper_count` | `uint32` | `optional` | `` |  |
-| 14 | `comment` | `string` | `optional` | `` |  |
-| 15 | `comment_timestamp` | `uint32` | `optional` | `` |  |
-| 16 | `asset_status` | `.CMsgTeamFanContentAssetStatus` | `repeated` | `` |  |
-| 17 | `email_timestamp` | `uint32` | `optional` | `` |  |
-| 18 | `email_tier` | `uint32` | `optional` | `` |  |
-| 19 | `languages` | `string` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `team_id` | `uint32` | `optional` |  |  |
+| 3 | `logo_url` | `string` | `optional` |  |  |
+| 4 | `status` | `.ETeamFanContentStatus` | `optional` |  | default = TEAM_FAN_CONTENT_STATUS_INVALID |
+| 5 | `timestamp` | `uint32` | `optional` |  |  |
+| 7 | `ugc_logo` | `uint64` | `optional` |  |  |
+| 8 | `workshop_account_id` | `uint32` | `optional` |  |  |
+| 9 | `abbreviation` | `string` | `optional` |  |  |
+| 10 | `voiceline_count` | `uint32` | `optional` |  |  |
+| 11 | `spray_count` | `uint32` | `optional` |  |  |
+| 12 | `emoticon_count` | `uint32` | `optional` |  |  |
+| 13 | `wallpaper_count` | `uint32` | `optional` |  |  |
+| 14 | `comment` | `string` | `optional` |  |  |
+| 15 | `comment_timestamp` | `uint32` | `optional` |  |  |
+| 16 | `asset_status` | `.CMsgTeamFanContentAssetStatus` | `repeated` |  |  |
+| 17 | `email_timestamp` | `uint32` | `optional` |  |  |
+| 18 | `email_tier` | `uint32` | `optional` |  |  |
+| 19 | `languages` | `string` | `optional` |  |  |
 
 </details>
 
@@ -246,7 +246,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_autographs` | `.CMsgTeamFanContentAutographStatus.TeamStatus` | `repeated` | `` |  |
+| 1 | `team_autographs` | `.CMsgTeamFanContentAutographStatus.TeamStatus` | `repeated` |  |  |
 
 </details>
 
@@ -258,10 +258,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `pro_name` | `string` | `optional` | `` |  |
-| 2 | `account_id` | `uint32` | `optional` | `` |  |
-| 3 | `timestamp` | `uint32` | `optional` | `` |  |
-| 4 | `file` | `string` | `optional` | `` |  |
+| 1 | `pro_name` | `string` | `optional` |  |  |
+| 2 | `account_id` | `uint32` | `optional` |  |  |
+| 3 | `timestamp` | `uint32` | `optional` |  |  |
+| 4 | `file` | `string` | `optional` |  |  |
 
 </details>
 
@@ -273,10 +273,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `team_id` | `uint32` | `optional` | `` |  |
-| 3 | `autographs` | `.CMsgTeamFanContentAutographStatus.AutographStatus` | `repeated` | `` |  |
-| 4 | `workshop_account_id` | `uint32` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `team_id` | `uint32` | `optional` |  |  |
+| 3 | `autographs` | `.CMsgTeamFanContentAutographStatus.AutographStatus` | `repeated` |  |  |
+| 4 | `workshop_account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -288,10 +288,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `asset_type` | `.ETalentContentAssetType` | `optional` | `` | default = k_eTalentContentAssetType_Photo |
-| 2 | `asset_index` | `uint32` | `optional` | `` |  |
-| 3 | `asset_status` | `.ETalentContentAssetStatus` | `optional` | `` | default = k_eTalentContentAssetStatus_None |
-| 4 | `revision` | `uint32` | `optional` | `` |  |
+| 1 | `asset_type` | `.ETalentContentAssetType` | `optional` |  | default = k_eTalentContentAssetType_Photo |
+| 2 | `asset_index` | `uint32` | `optional` |  |  |
+| 3 | `asset_status` | `.ETalentContentAssetStatus` | `optional` |  | default = k_eTalentContentAssetStatus_None |
+| 4 | `revision` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -303,7 +303,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `talent_status` | `.CMsgTalentContentStatus.TalentDetails` | `repeated` | `` |  |
+| 1 | `talent_status` | `.CMsgTalentContentStatus.TalentDetails` | `repeated` |  |  |
 
 </details>
 
@@ -315,9 +315,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `zip_file` | `string` | `optional` | `` |  |
-| 2 | `timestamp` | `uint32` | `optional` | `` |  |
-| 3 | `revision_number` | `uint32` | `optional` | `` |  |
+| 1 | `zip_file` | `string` | `optional` |  |  |
+| 2 | `timestamp` | `uint32` | `optional` |  |  |
+| 3 | `revision_number` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -329,17 +329,17 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `full_name` | `string` | `optional` | `` |  |
-| 3 | `nickname` | `string` | `optional` | `` |  |
-| 4 | `workshop_item_id` | `uint32` | `optional` | `` |  |
-| 5 | `status` | `.ETalentContentStatus` | `optional` | `` | default = TALENT_CONTENT_STATUS_INVALID |
-| 8 | `asset_status` | `.CMsgTalentContentAssetStatus` | `repeated` | `` |  |
-| 9 | `broadcast_language` | `uint32` | `optional` | `` |  |
-| 10 | `revision` | `.CMsgTalentContentStatus.SubmitRevision` | `repeated` | `` |  |
-| 11 | `revision_count` | `uint32` | `optional` | `` |  |
-| 12 | `workshop_item_status` | `.CMsgTalentContentStatus.EWorkshopItemStatus` | `optional` | `` | default = k_eSuccess |
-| 13 | `workshop_item_details` | `string` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `full_name` | `string` | `optional` |  |  |
+| 3 | `nickname` | `string` | `optional` |  |  |
+| 4 | `workshop_item_id` | `uint32` | `optional` |  |  |
+| 5 | `status` | `.ETalentContentStatus` | `optional` |  | default = TALENT_CONTENT_STATUS_INVALID |
+| 8 | `asset_status` | `.CMsgTalentContentAssetStatus` | `repeated` |  |  |
+| 9 | `broadcast_language` | `uint32` | `optional` |  |  |
+| 10 | `revision` | `.CMsgTalentContentStatus.SubmitRevision` | `repeated` |  |  |
+| 11 | `revision_count` | `uint32` | `optional` |  |  |
+| 12 | `workshop_item_status` | `.CMsgTalentContentStatus.EWorkshopItemStatus` | `optional` |  | default = k_eSuccess |
+| 13 | `workshop_item_details` | `string` | `optional` |  |  |
 
 </details>
 
@@ -351,7 +351,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgSetTalentContentResponse.EResult` | `optional` | `` | default = k_eSuccess |
+| 1 | `result` | `.CMsgSetTalentContentResponse.EResult` | `optional` |  | default = k_eSuccess |
 
 </details>
 
@@ -363,21 +363,21 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event` | `.CMsgDPCEvent.ELeagueEvent` | `optional` | `` | default = EVENT_INVALID |
-| 2 | `event_type` | `.CMsgDPCEvent.ELeagueEventType` | `optional` | `` | default = UNKNOWN |
-| 3 | `leagues` | `.CMsgDPCEvent.League` | `repeated` | `` |  |
-| 4 | `registration_period` | `uint32` | `optional` | `` |  |
-| 5 | `is_event_upcoming` | `bool` | `optional` | `` |  |
-| 6 | `is_event_completed` | `bool` | `optional` | `` |  |
-| 7 | `event_name` | `string` | `optional` | `` |  |
-| 8 | `multicast_league_id` | `uint32` | `optional` | `` |  |
-| 9 | `multicast_streams` | `uint32` | `repeated` | `` |  |
-| 10 | `tour` | `.CMsgDPCEvent.ETour` | `optional` | `` | default = TOUR_NONE |
-| 12 | `timestamp_drop_lock` | `uint32` | `optional` | `` |  |
-| 13 | `timestamp_add_lock` | `uint32` | `optional` | `` |  |
-| 14 | `timestamp_content_deadline` | `uint32` | `optional` | `` |  |
-| 15 | `is_fantasy_enabled` | `bool` | `optional` | `` |  |
-| 16 | `timestamp_content_review_deadline` | `uint32` | `optional` | `` |  |
+| 1 | `event` | `.CMsgDPCEvent.ELeagueEvent` | `optional` |  | default = EVENT_INVALID |
+| 2 | `event_type` | `.CMsgDPCEvent.ELeagueEventType` | `optional` |  | default = UNKNOWN |
+| 3 | `leagues` | `.CMsgDPCEvent.League` | `repeated` |  |  |
+| 4 | `registration_period` | `uint32` | `optional` |  |  |
+| 5 | `is_event_upcoming` | `bool` | `optional` |  |  |
+| 6 | `is_event_completed` | `bool` | `optional` |  |  |
+| 7 | `event_name` | `string` | `optional` |  |  |
+| 8 | `multicast_league_id` | `uint32` | `optional` |  |  |
+| 9 | `multicast_streams` | `uint32` | `repeated` |  |  |
+| 10 | `tour` | `.CMsgDPCEvent.ETour` | `optional` |  | default = TOUR_NONE |
+| 12 | `timestamp_drop_lock` | `uint32` | `optional` |  |  |
+| 13 | `timestamp_add_lock` | `uint32` | `optional` |  |  |
+| 14 | `timestamp_content_deadline` | `uint32` | `optional` |  |  |
+| 15 | `is_fantasy_enabled` | `bool` | `optional` |  |  |
+| 16 | `timestamp_content_review_deadline` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -389,8 +389,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `phase` | `.CMsgDPCEvent.ELeagueEventPhase` | `optional` | `` | default = PHASE_INVALID |
-| 2 | `node_group_id` | `uint32` | `optional` | `` |  |
+| 1 | `phase` | `.CMsgDPCEvent.ELeagueEventPhase` | `optional` |  | default = PHASE_INVALID |
+| 2 | `node_group_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -402,10 +402,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `region` | `.ELeagueRegion` | `optional` | `` | default = LEAGUE_REGION_UNSET |
-| 2 | `division` | `.ELeagueDivision` | `optional` | `` | default = LEAGUE_DIVISION_UNSET |
-| 3 | `league_id` | `uint32` | `optional` | `` |  |
-| 4 | `phases` | `.CMsgDPCEvent.PhaseInfo` | `repeated` | `` |  |
+| 1 | `region` | `.ELeagueRegion` | `optional` |  | default = LEAGUE_REGION_UNSET |
+| 2 | `division` | `.ELeagueDivision` | `optional` |  | default = LEAGUE_DIVISION_UNSET |
+| 3 | `league_id` | `uint32` | `optional` |  |  |
+| 4 | `phases` | `.CMsgDPCEvent.PhaseInfo` | `repeated` |  |  |
 
 </details>
 
@@ -417,7 +417,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `events` | `.CMsgDPCEvent` | `repeated` | `` |  |
+| 1 | `events` | `.CMsgDPCEvent` | `repeated` |  |  |
 
 </details>
 
@@ -429,7 +429,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `periods` | `.CMsgDOTAFantasyCardLineup.Period` | `repeated` | `` |  |
+| 1 | `periods` | `.CMsgDOTAFantasyCardLineup.Period` | `repeated` |  |  |
 
 </details>
 
@@ -441,8 +441,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `bonus_stat` | `uint32` | `optional` | `` |  |
-| 2 | `bonus_value` | `uint32` | `optional` | `` |  |
+| 1 | `bonus_stat` | `uint32` | `optional` |  |  |
+| 2 | `bonus_value` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -454,15 +454,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `player_name` | `string` | `optional` | `` |  |
-| 3 | `team_id` | `uint32` | `optional` | `` |  |
-| 4 | `team_name` | `string` | `optional` | `` |  |
-| 5 | `role` | `uint32` | `optional` | `` |  |
-| 6 | `bonuses` | `.CMsgDOTAFantasyCardLineup.CardBonus` | `repeated` | `` |  |
-| 7 | `score` | `float` | `optional` | `` |  |
-| 8 | `finalized` | `bool` | `optional` | `` |  |
-| 9 | `item_id` | `uint64` | `optional` | `` |  |
+| 1 | `player_account_id` | `uint32` | `optional` |  |  |
+| 2 | `player_name` | `string` | `optional` |  |  |
+| 3 | `team_id` | `uint32` | `optional` |  |  |
+| 4 | `team_name` | `string` | `optional` |  |  |
+| 5 | `role` | `uint32` | `optional` |  |  |
+| 6 | `bonuses` | `.CMsgDOTAFantasyCardLineup.CardBonus` | `repeated` |  |  |
+| 7 | `score` | `float` | `optional` |  |  |
+| 8 | `finalized` | `bool` | `optional` |  |  |
+| 9 | `item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -474,9 +474,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `league_id` | `uint32` | `optional` | `` |  |
-| 2 | `cards` | `.CMsgDOTAFantasyCardLineup.Card` | `repeated` | `` |  |
-| 3 | `score` | `float` | `optional` | `` |  |
+| 1 | `league_id` | `uint32` | `optional` |  |  |
+| 2 | `cards` | `.CMsgDOTAFantasyCardLineup.Card` | `repeated` |  |  |
+| 3 | `score` | `float` | `optional` |  |  |
 
 </details>
 
@@ -488,10 +488,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `fantasy_period` | `uint32` | `optional` | `` | default = 4294967295 |
-| 2 | `timestamp_start` | `uint32` | `optional` | `` |  |
-| 3 | `timestamp_end` | `uint32` | `optional` | `` |  |
-| 4 | `leagues` | `.CMsgDOTAFantasyCardLineup.League` | `repeated` | `` |  |
+| 1 | `fantasy_period` | `uint32` | `optional` |  | default = 4294967295 |
+| 2 | `timestamp_start` | `uint32` | `optional` |  |  |
+| 3 | `timestamp_end` | `uint32` | `optional` |  |  |
+| 4 | `leagues` | `.CMsgDOTAFantasyCardLineup.League` | `repeated` |  |  |
 
 </details>
 
@@ -503,7 +503,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cards` | `.CMsgDOTAFantasyCardList.Card` | `repeated` | `` |  |
+| 1 | `cards` | `.CMsgDOTAFantasyCardList.Card` | `repeated` |  |  |
 
 </details>
 
@@ -515,8 +515,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `bonus_stat` | `uint32` | `optional` | `` |  |
-| 2 | `bonus_value` | `uint32` | `optional` | `` |  |
+| 1 | `bonus_stat` | `uint32` | `optional` |  |  |
+| 2 | `bonus_value` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -528,13 +528,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `player_name` | `string` | `optional` | `` |  |
-| 3 | `team_id` | `uint32` | `optional` | `` |  |
-| 4 | `team_name` | `string` | `optional` | `` |  |
-| 5 | `role` | `uint32` | `optional` | `` |  |
-| 6 | `bonuses` | `.CMsgDOTAFantasyCardList.CardBonus` | `repeated` | `` |  |
-| 8 | `item_id` | `uint64` | `optional` | `` |  |
+| 1 | `player_account_id` | `uint32` | `optional` |  |  |
+| 2 | `player_name` | `string` | `optional` |  |  |
+| 3 | `team_id` | `uint32` | `optional` |  |  |
+| 4 | `team_name` | `string` | `optional` |  |  |
+| 5 | `role` | `uint32` | `optional` |  |  |
+| 6 | `bonuses` | `.CMsgDOTAFantasyCardList.CardBonus` | `repeated` |  |  |
+| 8 | `item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -546,7 +546,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `rows` | `.CMsgChatToxicityToxicPlayerMatchesReport.IndividualRow` | `repeated` | `` |  |
+| 1 | `rows` | `.CMsgChatToxicityToxicPlayerMatchesReport.IndividualRow` | `repeated` |  |  |
 
 </details>
 
@@ -558,12 +558,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `num_matches_seen` | `uint32` | `optional` | `` |  |
-| 3 | `num_messages` | `uint32` | `optional` | `` |  |
-| 4 | `num_messages_toxic` | `uint32` | `optional` | `` |  |
-| 5 | `first_match_seen` | `uint64` | `optional` | `` |  |
-| 6 | `last_match_seen` | `uint64` | `optional` | `` |  |
+| 1 | `player_account_id` | `uint32` | `optional` |  |  |
+| 2 | `num_matches_seen` | `uint32` | `optional` |  |  |
+| 3 | `num_messages` | `uint32` | `optional` |  |  |
+| 4 | `num_messages_toxic` | `uint32` | `optional` |  |  |
+| 5 | `first_match_seen` | `uint64` | `optional` |  |  |
+| 6 | `last_match_seen` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -575,12 +575,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `num_matches_seen` | `uint32` | `optional` | `` |  |
-| 2 | `num_messages` | `uint32` | `optional` | `` |  |
-| 4 | `num_messages_ml_thinks_toxic` | `uint32` | `optional` | `` |  |
-| 5 | `status` | `string` | `optional` | `` |  |
-| 6 | `result` | `uint32` | `optional` | `` |  |
-| 7 | `message` | `string` | `optional` | `` |  |
+| 1 | `num_matches_seen` | `uint32` | `optional` |  |  |
+| 2 | `num_messages` | `uint32` | `optional` |  |  |
+| 4 | `num_messages_ml_thinks_toxic` | `uint32` | `optional` |  |  |
+| 5 | `status` | `string` | `optional` |  |  |
+| 6 | `result` | `uint32` | `optional` |  |  |
+| 7 | `message` | `string` | `optional` |  |  |
 
 </details>
 
@@ -592,10 +592,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_id` | `uint32` | `optional` | `` |  |
-| 2 | `team_name` | `string` | `optional` | `` |  |
-| 3 | `actions` | `.CMsgGetTeamAuditInformation.Action` | `repeated` | `` |  |
-| 4 | `last_updated` | `uint32` | `optional` | `` |  |
+| 1 | `team_id` | `uint32` | `optional` |  |  |
+| 2 | `team_name` | `string` | `optional` |  |  |
+| 3 | `actions` | `.CMsgGetTeamAuditInformation.Action` | `repeated` |  |  |
+| 4 | `last_updated` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -607,12 +607,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `registration_period` | `uint32` | `optional` | `` |  |
-| 2 | `account_id` | `uint32` | `optional` | `` |  |
-| 3 | `action` | `uint32` | `optional` | `` |  |
-| 4 | `timestamp` | `uint32` | `optional` | `` |  |
-| 5 | `player_name` | `string` | `optional` | `` |  |
-| 6 | `player_real_name` | `string` | `optional` | `` |  |
+| 1 | `registration_period` | `uint32` | `optional` |  |  |
+| 2 | `account_id` | `uint32` | `optional` |  |  |
+| 3 | `action` | `uint32` | `optional` |  |  |
+| 4 | `timestamp` | `uint32` | `optional` |  |  |
+| 5 | `player_name` | `string` | `optional` |  |  |
+| 6 | `player_real_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -624,8 +624,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match` | `.CMsgDOTAMatch` | `optional` | `` |  |
-| 2 | `metadata` | `.CDOTAMatchMetadata` | `optional` | `` |  |
+| 1 | `match` | `.CMsgDOTAMatch` | `optional` |  |  |
+| 2 | `metadata` | `.CDOTAMatchMetadata` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-match-metadata.md
+++ b/docs/cookbook/proto-fields/dota-match-metadata.md
@@ -32,10 +32,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `version` | `int32` | `optional` | `` |  |
-| 2 | `match_id` | `uint64` | `optional` | `` |  |
-| 3 | `metadata` | `.CDOTAMatchMetadata` | `optional` | `` |  |
-| 5 | `private_metadata` | `bytes` | `optional` | `` |  |
+| 1 | `version` | `int32` | `optional` |  |  |
+| 2 | `match_id` | `uint64` | `optional` |  |  |
+| 3 | `metadata` | `.CDOTAMatchMetadata` | `optional` |  |  |
+| 5 | `private_metadata` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -47,18 +47,18 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `teams` | `.CDOTAMatchMetadata.Team` | `repeated` | `` |  |
-| 3 | `lobby_id` | `fixed64` | `optional` | `` |  |
-| 4 | `report_until_time` | `fixed64` | `optional` | `` |  |
-| 5 | `event_game_custom_table` | `bytes` | `optional` | `` |  |
-| 6 | `primary_event_id` | `uint32` | `optional` | `` |  |
-| 8 | `matchmaking_stats` | `.CMsgMatchMatchmakingStats` | `optional` | `` |  |
-| 9 | `mvp_data` | `.CMvpData` | `optional` | `` |  |
-| 10 | `guild_challenge_progress` | `.CDOTAMatchMetadata.GuildChallengeProgress` | `repeated` | `` |  |
-| 11 | `custom_post_game_table` | `bytes` | `optional` | `` |  |
-| 12 | `match_tips` | `.CDOTAMatchMetadata.Tip` | `repeated` | `` |  |
-| 13 | `match_tracked_stats` | `.CMsgTrackedStat` | `repeated` | `` |  |
-| 14 | `primary_event_id_for_display` | `uint32` | `optional` | `` |  |
+| 1 | `teams` | `.CDOTAMatchMetadata.Team` | `repeated` |  |  |
+| 3 | `lobby_id` | `fixed64` | `optional` |  |  |
+| 4 | `report_until_time` | `fixed64` | `optional` |  |  |
+| 5 | `event_game_custom_table` | `bytes` | `optional` |  |  |
+| 6 | `primary_event_id` | `uint32` | `optional` |  |  |
+| 8 | `matchmaking_stats` | `.CMsgMatchMatchmakingStats` | `optional` |  |  |
+| 9 | `mvp_data` | `.CMvpData` | `optional` |  |  |
+| 10 | `guild_challenge_progress` | `.CDOTAMatchMetadata.GuildChallengeProgress` | `repeated` |  |  |
+| 11 | `custom_post_game_table` | `bytes` | `optional` |  |  |
+| 12 | `match_tips` | `.CDOTAMatchMetadata.Tip` | `repeated` |  |  |
+| 13 | `match_tracked_stats` | `.CMsgTrackedStat` | `repeated` |  |  |
+| 14 | `primary_event_id_for_display` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -70,11 +70,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `def_index` | `uint32` | `optional` | `` |  |
-| 2 | `quality` | `uint32` | `optional` | `` | default = 4 |
-| 3 | `attribute` | `.CSOEconItemAttribute` | `repeated` | `` |  |
-| 4 | `style` | `uint32` | `optional` | `` | default = 0 |
-| 5 | `equipped_state` | `.CSOEconItemEquipped` | `repeated` | `` |  |
+| 1 | `def_index` | `uint32` | `optional` |  |  |
+| 2 | `quality` | `uint32` | `optional` |  | default = 4 |
+| 3 | `attribute` | `.CSOEconItemAttribute` | `repeated` |  |  |
+| 4 | `style` | `uint32` | `optional` |  | default = 0 |
+| 5 | `equipped_state` | `.CSOEconItemEquipped` | `repeated` |  |  |
 
 </details>
 
@@ -86,16 +86,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `dota_team` | `uint32` | `optional` | `` |  |
-| 2 | `players` | `.CDOTAMatchMetadata.Team.Player` | `repeated` | `` |  |
-| 3 | `graph_experience` | `float` | `repeated` | `` |  |
-| 4 | `graph_gold_earned` | `float` | `repeated` | `` |  |
-| 5 | `graph_net_worth` | `float` | `repeated` | `` |  |
-| 6 | `cm_first_pick` | `bool` | `optional` | `` |  |
-| 7 | `cm_captain_player_id` | `int32` | `optional` | `` | default = -1 |
-| 10 | `cm_penalty` | `uint32` | `optional` | `` |  |
-| 11 | `team_tracked_stats` | `.CMsgTrackedStat` | `repeated` | `` |  |
-| 12 | `kills` | `.CDOTAMatchMetadata.Team.KillInfo` | `repeated` | `` |  |
+| 1 | `dota_team` | `uint32` | `optional` |  |  |
+| 2 | `players` | `.CDOTAMatchMetadata.Team.Player` | `repeated` |  |  |
+| 3 | `graph_experience` | `float` | `repeated` |  |  |
+| 4 | `graph_gold_earned` | `float` | `repeated` |  |  |
+| 5 | `graph_net_worth` | `float` | `repeated` |  |  |
+| 6 | `cm_first_pick` | `bool` | `optional` |  |  |
+| 7 | `cm_captain_player_id` | `int32` | `optional` |  | default = -1 |
+| 10 | `cm_penalty` | `uint32` | `optional` |  |  |
+| 11 | `team_tracked_stats` | `.CMsgTrackedStat` | `repeated` |  |  |
+| 12 | `kills` | `.CDOTAMatchMetadata.Team.KillInfo` | `repeated` |  |  |
 
 </details>
 
@@ -107,8 +107,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `victim_slot` | `uint32` | `optional` | `` |  |
-| 2 | `count` | `uint32` | `optional` | `` |  |
+| 1 | `victim_slot` | `uint32` | `optional` |  |  |
+| 2 | `count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -120,8 +120,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `purchase_time` | `int32` | `optional` | `` |  |
+| 1 | `item_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `purchase_time` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -133,18 +133,18 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `int32` | `repeated` | `` |  |
-| 2 | `game_time` | `int32` | `optional` | `` |  |
-| 3 | `kills` | `uint32` | `optional` | `` |  |
-| 4 | `deaths` | `uint32` | `optional` | `` |  |
-| 5 | `assists` | `uint32` | `optional` | `` |  |
-| 6 | `level` | `uint32` | `optional` | `` |  |
-| 7 | `backpack_item_id` | `int32` | `repeated` | `` |  |
-| 8 | `neutral_item_id` | `int32` | `optional` | `` | default = -1 |
-| 9 | `neutral_enhancement_id` | `int32` | `optional` | `` | default = -1 |
-| 10 | `last_hits` | `uint32` | `optional` | `` |  |
-| 11 | `denies` | `uint32` | `optional` | `` |  |
-| 12 | `flags` | `uint32` | `optional` | `` |  |
+| 1 | `item_id` | `int32` | `repeated` |  |  |
+| 2 | `game_time` | `int32` | `optional` |  |  |
+| 3 | `kills` | `uint32` | `optional` |  |  |
+| 4 | `deaths` | `uint32` | `optional` |  |  |
+| 5 | `assists` | `uint32` | `optional` |  |  |
+| 6 | `level` | `uint32` | `optional` |  |  |
+| 7 | `backpack_item_id` | `int32` | `repeated` |  |  |
+| 8 | `neutral_item_id` | `int32` | `optional` |  | default = -1 |
+| 9 | `neutral_enhancement_id` | `int32` | `optional` |  | default = -1 |
+| 10 | `last_hits` | `uint32` | `optional` |  |  |
+| 11 | `denies` | `uint32` | `optional` |  |  |
+| 12 | `flags` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -156,8 +156,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name_token` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `float` | `optional` | `` |  |
+| 1 | `name_token` | `uint32` | `optional` |  |  |
+| 2 | `value` | `float` | `optional` |  |  |
 
 </details>
 
@@ -169,13 +169,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `kill_eater_type` | `uint32` | `optional` | `` |  |
-| 2 | `gem_item_def_index` | `uint32` | `optional` | `` |  |
-| 3 | `required_hero_id` | `int32` | `optional` | `` |  |
-| 4 | `starting_value` | `uint32` | `optional` | `` |  |
-| 5 | `ending_value` | `uint32` | `optional` | `` |  |
-| 6 | `owner_item_def_index` | `uint32` | `optional` | `` |  |
-| 7 | `owner_item_id` | `uint64` | `optional` | `` |  |
+| 1 | `kill_eater_type` | `uint32` | `optional` |  |  |
+| 2 | `gem_item_def_index` | `uint32` | `optional` |  |  |
+| 3 | `required_hero_id` | `int32` | `optional` |  |  |
+| 4 | `starting_value` | `uint32` | `optional` |  |  |
+| 5 | `ending_value` | `uint32` | `optional` |  |  |
+| 6 | `owner_item_def_index` | `uint32` | `optional` |  |  |
+| 7 | `owner_item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -187,10 +187,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `uint64` | `optional` | `` |  |
-| 2 | `item_def_index` | `uint32` | `optional` | `` |  |
-| 3 | `starting_value` | `uint32` | `optional` | `` |  |
-| 4 | `is_victory` | `bool` | `optional` | `` |  |
+| 1 | `item_id` | `uint64` | `optional` |  |  |
+| 2 | `item_def_index` | `uint32` | `optional` |  |  |
+| 3 | `starting_value` | `uint32` | `optional` |  |  |
+| 4 | `is_victory` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -202,10 +202,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `slot_id` | `uint32` | `optional` | `` |  |
-| 2 | `start_value` | `uint32` | `optional` | `` |  |
-| 3 | `end_value` | `uint32` | `optional` | `` |  |
-| 4 | `completed` | `bool` | `optional` | `` |  |
+| 1 | `slot_id` | `uint32` | `optional` |  |  |
+| 2 | `start_value` | `uint32` | `optional` |  |  |
+| 3 | `end_value` | `uint32` | `optional` |  |  |
+| 4 | `completed` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -217,8 +217,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `completed_path_id` | `uint32` | `optional` | `` | default = 255 |
-| 2 | `claimed_room_id` | `uint32` | `optional` | `` | default = 255 |
+| 1 | `completed_path_id` | `uint32` | `optional` |  | default = 255 |
+| 2 | `claimed_room_id` | `uint32` | `optional` |  | default = 255 |
 
 </details>
 
@@ -230,10 +230,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `action_id` | `uint32` | `optional` | `` |  |
-| 2 | `quantity` | `uint32` | `optional` | `` |  |
-| 3 | `audit` | `uint32` | `optional` | `` |  |
-| 5 | `audit_data` | `uint64` | `optional` | `` |  |
+| 1 | `action_id` | `uint32` | `optional` |  |  |
+| 2 | `quantity` | `uint32` | `optional` |  |  |
+| 3 | `audit` | `uint32` | `optional` |  |  |
+| 5 | `audit_data` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -245,8 +245,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `points` | `uint32` | `optional` | `` |  |
-| 2 | `reason` | `uint32` | `optional` | `` |  |
+| 1 | `points` | `uint32` | `optional` |  |  |
+| 2 | `reason` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -258,9 +258,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `periodic_resource_id` | `uint32` | `optional` | `` |  |
-| 2 | `remaining` | `uint32` | `optional` | `` |  |
-| 3 | `max` | `uint32` | `optional` | `` |  |
+| 1 | `periodic_resource_id` | `uint32` | `optional` |  |  |
+| 2 | `remaining` | `uint32` | `optional` |  |  |
+| 3 | `max` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -272,32 +272,32 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `event_points` | `uint32` | `optional` | `` |  |
-| 3 | `challenge_instance_id` | `uint32` | `optional` | `` |  |
-| 4 | `challenge_quest_id` | `uint32` | `optional` | `` |  |
-| 5 | `challenge_quest_challenge_id` | `uint32` | `optional` | `` |  |
-| 6 | `challenge_completed` | `bool` | `optional` | `` |  |
-| 7 | `challenge_rank_completed` | `uint32` | `optional` | `` |  |
-| 8 | `challenge_rank_previously_completed` | `uint32` | `optional` | `` |  |
-| 9 | `event_owned` | `bool` | `optional` | `` |  |
-| 10 | `sub_challenges_with_progress` | `.CDOTAMatchMetadata.Team.SubChallenge` | `repeated` | `` |  |
-| 11 | `wager_winnings` | `uint32` | `optional` | `` |  |
-| 12 | `cavern_challenge_active` | `bool` | `optional` | `` |  |
-| 13 | `cavern_challenge_winnings` | `uint32` | `optional` | `` |  |
-| 14 | `amount_wagered` | `uint32` | `optional` | `` |  |
-| 16 | `periodic_point_adjustments` | `uint32` | `optional` | `` |  |
-| 17 | `cavern_challenge_map_results` | `.CDOTAMatchMetadata.Team.CavernChallengeResult` | `repeated` | `` |  |
-| 18 | `cavern_challenge_plus_shard_winnings` | `uint32` | `optional` | `` |  |
-| 19 | `actions_granted` | `.CDOTAMatchMetadata.Team.ActionGrant` | `repeated` | `` |  |
-| 20 | `cavern_crawl_map_variant` | `uint32` | `optional` | `` | default = 255 |
-| 21 | `team_wager_bonus_pct` | `uint32` | `optional` | `` |  |
-| 22 | `wager_streak_pct` | `uint32` | `optional` | `` |  |
-| 23 | `candy_points_granted` | `.CDOTAMatchMetadata.Team.CandyGrant` | `repeated` | `` |  |
-| 24 | `active_season_id` | `uint32` | `optional` | `` |  |
-| 25 | `cavern_crawl_half_credit` | `bool` | `optional` | `` |  |
-| 26 | `periodic_resources` | `.CDOTAMatchMetadata.Team.PeriodicResourceData` | `repeated` | `` |  |
-| 27 | `extra_event_messages` | `.CExtraMsgBlock` | `repeated` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `event_points` | `uint32` | `optional` |  |  |
+| 3 | `challenge_instance_id` | `uint32` | `optional` |  |  |
+| 4 | `challenge_quest_id` | `uint32` | `optional` |  |  |
+| 5 | `challenge_quest_challenge_id` | `uint32` | `optional` |  |  |
+| 6 | `challenge_completed` | `bool` | `optional` |  |  |
+| 7 | `challenge_rank_completed` | `uint32` | `optional` |  |  |
+| 8 | `challenge_rank_previously_completed` | `uint32` | `optional` |  |  |
+| 9 | `event_owned` | `bool` | `optional` |  |  |
+| 10 | `sub_challenges_with_progress` | `.CDOTAMatchMetadata.Team.SubChallenge` | `repeated` |  |  |
+| 11 | `wager_winnings` | `uint32` | `optional` |  |  |
+| 12 | `cavern_challenge_active` | `bool` | `optional` |  |  |
+| 13 | `cavern_challenge_winnings` | `uint32` | `optional` |  |  |
+| 14 | `amount_wagered` | `uint32` | `optional` |  |  |
+| 16 | `periodic_point_adjustments` | `uint32` | `optional` |  |  |
+| 17 | `cavern_challenge_map_results` | `.CDOTAMatchMetadata.Team.CavernChallengeResult` | `repeated` |  |  |
+| 18 | `cavern_challenge_plus_shard_winnings` | `uint32` | `optional` |  |  |
+| 19 | `actions_granted` | `.CDOTAMatchMetadata.Team.ActionGrant` | `repeated` |  |  |
+| 20 | `cavern_crawl_map_variant` | `uint32` | `optional` |  | default = 255 |
+| 21 | `team_wager_bonus_pct` | `uint32` | `optional` |  |  |
+| 22 | `wager_streak_pct` | `uint32` | `optional` |  |  |
+| 23 | `candy_points_granted` | `.CDOTAMatchMetadata.Team.CandyGrant` | `repeated` |  |  |
+| 24 | `active_season_id` | `uint32` | `optional` |  |  |
+| 25 | `cavern_crawl_half_credit` | `bool` | `optional` |  |  |
+| 26 | `periodic_resources` | `.CDOTAMatchMetadata.Team.PeriodicResourceData` | `repeated` |  |  |
+| 27 | `extra_event_messages` | `.CExtraMsgBlock` | `repeated` |  |  |
 
 </details>
 
@@ -309,9 +309,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `start_value` | `uint32` | `optional` | `` |  |
-| 2 | `end_value` | `uint32` | `optional` | `` |  |
-| 3 | `max_value` | `uint32` | `optional` | `` |  |
+| 1 | `start_value` | `uint32` | `optional` |  |  |
+| 2 | `end_value` | `uint32` | `optional` |  |  |
+| 3 | `max_value` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -323,11 +323,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `kill_type` | `.CDOTAMatchMetadata.Team.KillInfo.KillType` | `optional` | `` | default = KILL_TYPE_PLAYER |
-| 2 | `victim_player_slot` | `uint32` | `optional` | `` |  |
-| 3 | `killer_player_slot` | `uint32` | `repeated` | `` |  |
-| 4 | `time` | `int32` | `optional` | `` |  |
-| 5 | `bounty` | `int32` | `optional` | `` |  |
+| 1 | `kill_type` | `.CDOTAMatchMetadata.Team.KillInfo.KillType` | `optional` |  | default = KILL_TYPE_PLAYER |
+| 2 | `victim_player_slot` | `uint32` | `optional` |  |  |
+| 3 | `killer_player_slot` | `uint32` | `repeated` |  |  |
+| 4 | `time` | `int32` | `optional` |  |  |
+| 5 | `bounty` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -339,63 +339,63 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `ability_upgrades` | `int32` | `repeated` | `` |  |
-| 3 | `player_slot` | `uint32` | `optional` | `` |  |
-| 5 | `kills` | `.CDOTAMatchMetadata.Team.PlayerKill` | `repeated` | `` |  |
-| 6 | `items` | `.CDOTAMatchMetadata.Team.ItemPurchase` | `repeated` | `` |  |
-| 7 | `avg_kills_x16` | `uint32` | `optional` | `` |  |
-| 8 | `avg_deaths_x16` | `uint32` | `optional` | `` |  |
-| 9 | `avg_assists_x16` | `uint32` | `optional` | `` |  |
-| 10 | `avg_gpm_x16` | `uint32` | `optional` | `` |  |
-| 11 | `avg_xpm_x16` | `uint32` | `optional` | `` |  |
-| 12 | `best_kills_x16` | `uint32` | `optional` | `` |  |
-| 13 | `best_assists_x16` | `uint32` | `optional` | `` |  |
-| 14 | `best_gpm_x16` | `uint32` | `optional` | `` |  |
-| 15 | `best_xpm_x16` | `uint32` | `optional` | `` |  |
-| 16 | `win_streak` | `uint32` | `optional` | `` |  |
-| 17 | `best_win_streak` | `uint32` | `optional` | `` |  |
-| 18 | `fight_score` | `float` | `optional` | `` |  |
-| 19 | `farm_score` | `float` | `optional` | `` |  |
-| 20 | `support_score` | `float` | `optional` | `` |  |
-| 21 | `push_score` | `float` | `optional` | `` |  |
-| 22 | `level_up_times` | `uint32` | `repeated` | `` |  |
-| 23 | `graph_net_worth` | `float` | `repeated` | `` |  |
-| 24 | `inventory_snapshot` | `.CDOTAMatchMetadata.Team.InventorySnapshot` | `repeated` | `` |  |
-| 25 | `avg_stats_calibrated` | `bool` | `optional` | `` |  |
-| 26 | `auto_style_criteria` | `.CDOTAMatchMetadata.Team.AutoStyleCriteria` | `repeated` | `` |  |
-| 29 | `event_data` | `.CDOTAMatchMetadata.Team.EventData` | `repeated` | `` |  |
-| 30 | `strange_gem_progress` | `.CDOTAMatchMetadata.Team.StrangeGemProgress` | `repeated` | `` |  |
-| 31 | `hero_xp` | `uint32` | `optional` | `` |  |
-| 32 | `camps_stacked` | `uint32` | `optional` | `` |  |
-| 33 | `victory_prediction` | `.CDOTAMatchMetadata.Team.VictoryPrediction` | `repeated` | `` |  |
-| 34 | `lane_selection_flags` | `uint32` | `optional` | `` |  |
-| 35 | `rampages` | `uint32` | `optional` | `` |  |
-| 36 | `triple_kills` | `uint32` | `optional` | `` |  |
-| 37 | `aegis_snatched` | `uint32` | `optional` | `` |  |
-| 38 | `rapiers_purchased` | `uint32` | `optional` | `` |  |
-| 39 | `couriers_killed` | `uint32` | `optional` | `` |  |
-| 40 | `net_worth_rank` | `uint32` | `optional` | `` |  |
-| 41 | `support_gold_spent` | `uint32` | `optional` | `` |  |
-| 42 | `observer_wards_placed` | `uint32` | `optional` | `` |  |
-| 43 | `sentry_wards_placed` | `uint32` | `optional` | `` |  |
-| 44 | `wards_dewarded` | `uint32` | `optional` | `` |  |
-| 45 | `stun_duration` | `float` | `optional` | `` |  |
-| 46 | `rank_mmr_boost_type` | `.EDOTAMMRBoostType` | `optional` | `` | default = k_EDOTAMMRBoostType_None |
-| 48 | `contract_progress` | `.CDOTAMatchMetadata.Team.Player.ContractProgress` | `repeated` | `` |  |
-| 49 | `guild_ids` | `uint32` | `repeated` | `` |  |
-| 50 | `graph_hero_damage` | `float` | `repeated` | `` |  |
-| 51 | `team_number` | `.DOTA_GC_TEAM` | `optional` | `` | default = DOTA_GC_TEAM_GOOD_GUYS |
-| 52 | `team_slot` | `uint32` | `optional` | `` |  |
-| 53 | `featured_gamemode_progress` | `.CDOTAMatchMetadata.Team.FeaturedGamemodeProgress` | `optional` | `` |  |
-| 54 | `featured_hero_sticker_index` | `uint32` | `optional` | `` |  |
-| 55 | `featured_hero_sticker_quality` | `uint32` | `optional` | `` |  |
-| 56 | `equipped_econ_items` | `.CDOTAMatchMetadata.EconItem` | `repeated` | `` |  |
-| 57 | `game_player_id` | `int32` | `optional` | `` | default = -1 |
-| 58 | `player_tracked_stats` | `.CMsgTrackedStat` | `repeated` | `` |  |
-| 59 | `overworld_rewards` | `.CDOTAMatchMetadata.Team.Player.OverworldRewards` | `optional` | `` |  |
-| 60 | `craftworks_quest_rewards` | `.CMsgCraftworksQuestReward` | `repeated` | `` |  |
-| 61 | `ad_facet_hero_id` | `int32` | `optional` | `` |  |
-| 62 | `monster_hunter_rewards` | `.CMsgMonsterHunterMatchRewards.Player` | `optional` | `` |  |
+| 2 | `ability_upgrades` | `int32` | `repeated` |  |  |
+| 3 | `player_slot` | `uint32` | `optional` |  |  |
+| 5 | `kills` | `.CDOTAMatchMetadata.Team.PlayerKill` | `repeated` |  |  |
+| 6 | `items` | `.CDOTAMatchMetadata.Team.ItemPurchase` | `repeated` |  |  |
+| 7 | `avg_kills_x16` | `uint32` | `optional` |  |  |
+| 8 | `avg_deaths_x16` | `uint32` | `optional` |  |  |
+| 9 | `avg_assists_x16` | `uint32` | `optional` |  |  |
+| 10 | `avg_gpm_x16` | `uint32` | `optional` |  |  |
+| 11 | `avg_xpm_x16` | `uint32` | `optional` |  |  |
+| 12 | `best_kills_x16` | `uint32` | `optional` |  |  |
+| 13 | `best_assists_x16` | `uint32` | `optional` |  |  |
+| 14 | `best_gpm_x16` | `uint32` | `optional` |  |  |
+| 15 | `best_xpm_x16` | `uint32` | `optional` |  |  |
+| 16 | `win_streak` | `uint32` | `optional` |  |  |
+| 17 | `best_win_streak` | `uint32` | `optional` |  |  |
+| 18 | `fight_score` | `float` | `optional` |  |  |
+| 19 | `farm_score` | `float` | `optional` |  |  |
+| 20 | `support_score` | `float` | `optional` |  |  |
+| 21 | `push_score` | `float` | `optional` |  |  |
+| 22 | `level_up_times` | `uint32` | `repeated` |  |  |
+| 23 | `graph_net_worth` | `float` | `repeated` |  |  |
+| 24 | `inventory_snapshot` | `.CDOTAMatchMetadata.Team.InventorySnapshot` | `repeated` |  |  |
+| 25 | `avg_stats_calibrated` | `bool` | `optional` |  |  |
+| 26 | `auto_style_criteria` | `.CDOTAMatchMetadata.Team.AutoStyleCriteria` | `repeated` |  |  |
+| 29 | `event_data` | `.CDOTAMatchMetadata.Team.EventData` | `repeated` |  |  |
+| 30 | `strange_gem_progress` | `.CDOTAMatchMetadata.Team.StrangeGemProgress` | `repeated` |  |  |
+| 31 | `hero_xp` | `uint32` | `optional` |  |  |
+| 32 | `camps_stacked` | `uint32` | `optional` |  |  |
+| 33 | `victory_prediction` | `.CDOTAMatchMetadata.Team.VictoryPrediction` | `repeated` |  |  |
+| 34 | `lane_selection_flags` | `uint32` | `optional` |  |  |
+| 35 | `rampages` | `uint32` | `optional` |  |  |
+| 36 | `triple_kills` | `uint32` | `optional` |  |  |
+| 37 | `aegis_snatched` | `uint32` | `optional` |  |  |
+| 38 | `rapiers_purchased` | `uint32` | `optional` |  |  |
+| 39 | `couriers_killed` | `uint32` | `optional` |  |  |
+| 40 | `net_worth_rank` | `uint32` | `optional` |  |  |
+| 41 | `support_gold_spent` | `uint32` | `optional` |  |  |
+| 42 | `observer_wards_placed` | `uint32` | `optional` |  |  |
+| 43 | `sentry_wards_placed` | `uint32` | `optional` |  |  |
+| 44 | `wards_dewarded` | `uint32` | `optional` |  |  |
+| 45 | `stun_duration` | `float` | `optional` |  |  |
+| 46 | `rank_mmr_boost_type` | `.EDOTAMMRBoostType` | `optional` |  | default = k_EDOTAMMRBoostType_None |
+| 48 | `contract_progress` | `.CDOTAMatchMetadata.Team.Player.ContractProgress` | `repeated` |  |  |
+| 49 | `guild_ids` | `uint32` | `repeated` |  |  |
+| 50 | `graph_hero_damage` | `float` | `repeated` |  |  |
+| 51 | `team_number` | `.DOTA_GC_TEAM` | `optional` |  | default = DOTA_GC_TEAM_GOOD_GUYS |
+| 52 | `team_slot` | `uint32` | `optional` |  |  |
+| 53 | `featured_gamemode_progress` | `.CDOTAMatchMetadata.Team.FeaturedGamemodeProgress` | `optional` |  |  |
+| 54 | `featured_hero_sticker_index` | `uint32` | `optional` |  |  |
+| 55 | `featured_hero_sticker_quality` | `uint32` | `optional` |  |  |
+| 56 | `equipped_econ_items` | `.CDOTAMatchMetadata.EconItem` | `repeated` |  |  |
+| 57 | `game_player_id` | `int32` | `optional` |  | default = -1 |
+| 58 | `player_tracked_stats` | `.CMsgTrackedStat` | `repeated` |  |  |
+| 59 | `overworld_rewards` | `.CDOTAMatchMetadata.Team.Player.OverworldRewards` | `optional` |  |  |
+| 60 | `craftworks_quest_rewards` | `.CMsgCraftworksQuestReward` | `repeated` |  |  |
+| 61 | `ad_facet_hero_id` | `int32` | `optional` |  |  |
+| 62 | `monster_hunter_rewards` | `.CMsgMonsterHunterMatchRewards.Player` | `optional` |  |  |
 
 </details>
 
@@ -407,13 +407,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `event_id` | `uint32` | `optional` | `` |  |
-| 3 | `challenge_instance_id` | `uint32` | `optional` | `` |  |
-| 4 | `challenge_parameter` | `uint32` | `optional` | `` |  |
-| 5 | `contract_stars` | `uint32` | `optional` | `` |  |
-| 6 | `contract_slot` | `uint32` | `optional` | `` |  |
-| 7 | `completed` | `bool` | `optional` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `event_id` | `uint32` | `optional` |  |  |
+| 3 | `challenge_instance_id` | `uint32` | `optional` |  |  |
+| 4 | `challenge_parameter` | `uint32` | `optional` |  |  |
+| 5 | `contract_stars` | `uint32` | `optional` |  |  |
+| 6 | `contract_slot` | `uint32` | `optional` |  |  |
+| 7 | `completed` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -425,8 +425,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `overworld_id` | `uint32` | `optional` | `` |  |
-| 2 | `tokens` | `.CMsgOverworldTokenQuantity` | `optional` | `` |  |
+| 1 | `overworld_id` | `uint32` | `optional` |  |  |
+| 2 | `tokens` | `.CMsgOverworldTokenQuantity` | `optional` |  |  |
 
 </details>
 
@@ -438,14 +438,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guild_id` | `uint32` | `optional` | `` |  |
-| 2 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 3 | `challenge_instance_id` | `uint32` | `optional` | `` |  |
-| 4 | `challenge_parameter` | `uint32` | `optional` | `` |  |
-| 5 | `challenge_timestamp` | `uint32` | `optional` | `` |  |
-| 6 | `challenge_progress_at_start` | `uint32` | `optional` | `` |  |
-| 7 | `challenge_progress_accumulated` | `uint32` | `optional` | `` |  |
-| 8 | `individual_progress` | `.CDOTAMatchMetadata.GuildChallengeProgress.IndividualProgress` | `repeated` | `` |  |
+| 1 | `guild_id` | `uint32` | `optional` |  |  |
+| 2 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 3 | `challenge_instance_id` | `uint32` | `optional` |  |  |
+| 4 | `challenge_parameter` | `uint32` | `optional` |  |  |
+| 5 | `challenge_timestamp` | `uint32` | `optional` |  |  |
+| 6 | `challenge_progress_at_start` | `uint32` | `optional` |  |  |
+| 7 | `challenge_progress_accumulated` | `uint32` | `optional` |  |  |
+| 8 | `individual_progress` | `.CDOTAMatchMetadata.GuildChallengeProgress.IndividualProgress` | `repeated` |  |  |
 
 </details>
 
@@ -457,8 +457,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `progress` | `uint32` | `optional` | `` |  |
-| 3 | `player_slot` | `uint32` | `optional` | `` |  |
+| 2 | `progress` | `uint32` | `optional` |  |  |
+| 3 | `player_slot` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -470,10 +470,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `source_player_slot` | `uint32` | `optional` | `` |  |
-| 2 | `target_player_slot` | `uint32` | `optional` | `` |  |
-| 3 | `tip_amount` | `uint32` | `optional` | `` |  |
-| 4 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
+| 1 | `source_player_slot` | `uint32` | `optional` |  |  |
+| 2 | `target_player_slot` | `uint32` | `optional` |  |  |
+| 3 | `tip_amount` | `uint32` | `optional` |  |  |
+| 4 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
 
 </details>
 
@@ -485,10 +485,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `teams` | `.CDOTAMatchPrivateMetadata.Team` | `repeated` | `` |  |
-| 2 | `graph_win_probability` | `float` | `repeated` | `` |  |
-| 3 | `string_names` | `.CDOTAMatchPrivateMetadata.StringName` | `repeated` | `` |  |
-| 4 | `contributions` | `.CDOTAMatchPrivateMetadata.ContributionsCombatSegment` | `repeated` | `` |  |
+| 1 | `teams` | `.CDOTAMatchPrivateMetadata.Team` | `repeated` |  |  |
+| 2 | `graph_win_probability` | `float` | `repeated` |  |  |
+| 3 | `string_names` | `.CDOTAMatchPrivateMetadata.StringName` | `repeated` |  |  |
+| 4 | `contributions` | `.CDOTAMatchPrivateMetadata.ContributionsCombatSegment` | `repeated` |  |  |
 
 </details>
 
@@ -500,8 +500,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `uint32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
+| 1 | `id` | `uint32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -513,9 +513,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `dota_team` | `uint32` | `optional` | `` |  |
-| 2 | `players` | `.CDOTAMatchPrivateMetadata.Team.Player` | `repeated` | `` |  |
-| 3 | `buildings` | `.CDOTAMatchPrivateMetadata.Team.Building` | `repeated` | `` |  |
+| 1 | `dota_team` | `uint32` | `optional` |  |  |
+| 2 | `players` | `.CDOTAMatchPrivateMetadata.Team.Player` | `repeated` |  |  |
+| 3 | `buildings` | `.CDOTAMatchPrivateMetadata.Team.Building` | `repeated` |  |  |
 
 </details>
 
@@ -527,20 +527,20 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `player_slot` | `uint32` | `optional` | `` |  |
-| 3 | `position_stream` | `bytes` | `optional` | `` |  |
-| 4 | `combat_segments` | `.CDOTAMatchPrivateMetadata.Team.Player.CombatSegment` | `repeated` | `` |  |
-| 5 | `damage_unit_names` | `string` | `repeated` | `` |  |
-| 6 | `buff_records` | `.CDOTAMatchPrivateMetadata.Team.Player.BuffRecord` | `repeated` | `` |  |
-| 7 | `graph_kills` | `float` | `repeated` | `` |  |
-| 8 | `graph_deaths` | `float` | `repeated` | `` |  |
-| 9 | `graph_assists` | `float` | `repeated` | `` |  |
-| 10 | `graph_lasthits` | `float` | `repeated` | `` |  |
-| 11 | `graph_denies` | `float` | `repeated` | `` |  |
-| 12 | `gold_received` | `.CDOTAMatchPrivateMetadata.Team.Player.GoldReceived` | `optional` | `` |  |
-| 13 | `xp_received` | `.CDOTAMatchPrivateMetadata.Team.Player.XPReceived` | `optional` | `` |  |
-| 14 | `team_number` | `.DOTA_GC_TEAM` | `optional` | `` | default = DOTA_GC_TEAM_GOOD_GUYS |
-| 15 | `team_slot` | `uint32` | `optional` | `` |  |
+| 2 | `player_slot` | `uint32` | `optional` |  |  |
+| 3 | `position_stream` | `bytes` | `optional` |  |  |
+| 4 | `combat_segments` | `.CDOTAMatchPrivateMetadata.Team.Player.CombatSegment` | `repeated` |  |  |
+| 5 | `damage_unit_names` | `string` | `repeated` |  |  |
+| 6 | `buff_records` | `.CDOTAMatchPrivateMetadata.Team.Player.BuffRecord` | `repeated` |  |  |
+| 7 | `graph_kills` | `float` | `repeated` |  |  |
+| 8 | `graph_deaths` | `float` | `repeated` |  |  |
+| 9 | `graph_assists` | `float` | `repeated` |  |  |
+| 10 | `graph_lasthits` | `float` | `repeated` |  |  |
+| 11 | `graph_denies` | `float` | `repeated` |  |  |
+| 12 | `gold_received` | `.CDOTAMatchPrivateMetadata.Team.Player.GoldReceived` | `optional` |  |  |
+| 13 | `xp_received` | `.CDOTAMatchPrivateMetadata.Team.Player.XPReceived` | `optional` |  |  |
+| 14 | `team_number` | `.DOTA_GC_TEAM` | `optional` |  | default = DOTA_GC_TEAM_GOOD_GUYS |
+| 15 | `team_slot` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -552,9 +552,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `game_time` | `int32` | `optional` | `` |  |
-| 2 | `damage_by_ability` | `.CDOTAMatchPrivateMetadata.Team.Player.CombatSegment.DamageByAbility` | `repeated` | `` |  |
-| 3 | `healing_by_ability` | `.CDOTAMatchPrivateMetadata.Team.Player.CombatSegment.HealingByAbility` | `repeated` | `` |  |
+| 1 | `game_time` | `int32` | `optional` |  |  |
+| 2 | `damage_by_ability` | `.CDOTAMatchPrivateMetadata.Team.Player.CombatSegment.DamageByAbility` | `repeated` |  |  |
+| 3 | `healing_by_ability` | `.CDOTAMatchPrivateMetadata.Team.Player.CombatSegment.HealingByAbility` | `repeated` |  |  |
 
 </details>
 
@@ -566,9 +566,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ability_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `by_hero_targets` | `.CDOTAMatchPrivateMetadata.Team.Player.CombatSegment.DamageByAbility.ByHeroTarget` | `repeated` | `` |  |
-| 3 | `source_unit_index` | `uint32` | `optional` | `` |  |
+| 1 | `ability_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `by_hero_targets` | `.CDOTAMatchPrivateMetadata.Team.Player.CombatSegment.DamageByAbility.ByHeroTarget` | `repeated` |  |  |
+| 3 | `source_unit_index` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -580,8 +580,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `damage` | `uint32` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `damage` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -593,9 +593,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ability_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `by_hero_targets` | `.CDOTAMatchPrivateMetadata.Team.Player.CombatSegment.HealingByAbility.ByHeroTarget` | `repeated` | `` |  |
-| 3 | `source_unit_index` | `uint32` | `optional` | `` |  |
+| 1 | `ability_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `by_hero_targets` | `.CDOTAMatchPrivateMetadata.Team.Player.CombatSegment.HealingByAbility.ByHeroTarget` | `repeated` |  |  |
+| 3 | `source_unit_index` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -607,8 +607,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `healing` | `uint32` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `healing` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -620,9 +620,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `buff_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `by_hero_targets` | `.CDOTAMatchPrivateMetadata.Team.Player.BuffRecord.ByHeroTarget` | `repeated` | `` |  |
-| 3 | `buff_modifier_name` | `string` | `optional` | `` |  |
+| 1 | `buff_ability_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `by_hero_targets` | `.CDOTAMatchPrivateMetadata.Team.Player.BuffRecord.ByHeroTarget` | `repeated` |  |  |
+| 3 | `buff_modifier_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -634,10 +634,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `elapsed_duration` | `float` | `optional` | `` |  |
-| 3 | `is_hidden` | `bool` | `optional` | `` |  |
-| 4 | `instance_count` | `int32` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `elapsed_duration` | `float` | `optional` |  |  |
+| 3 | `is_hidden` | `bool` | `optional` |  |  |
+| 4 | `instance_count` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -649,14 +649,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `creep` | `uint32` | `optional` | `` |  |
-| 2 | `heroes` | `uint32` | `optional` | `` |  |
-| 3 | `bounty_runes` | `uint32` | `optional` | `` |  |
-| 4 | `passive` | `uint32` | `optional` | `` |  |
-| 5 | `buildings` | `uint32` | `optional` | `` |  |
-| 6 | `abilities` | `uint32` | `optional` | `` |  |
-| 7 | `wards` | `uint32` | `optional` | `` |  |
-| 8 | `other` | `uint32` | `optional` | `` |  |
+| 1 | `creep` | `uint32` | `optional` |  |  |
+| 2 | `heroes` | `uint32` | `optional` |  |  |
+| 3 | `bounty_runes` | `uint32` | `optional` |  |  |
+| 4 | `passive` | `uint32` | `optional` |  |  |
+| 5 | `buildings` | `uint32` | `optional` |  |  |
+| 6 | `abilities` | `uint32` | `optional` |  |  |
+| 7 | `wards` | `uint32` | `optional` |  |  |
+| 8 | `other` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -668,13 +668,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `creep` | `uint32` | `optional` | `` |  |
-| 2 | `heroes` | `uint32` | `optional` | `` |  |
-| 3 | `roshan` | `uint32` | `optional` | `` |  |
-| 4 | `tome_of_knowledge` | `uint32` | `optional` | `` |  |
-| 5 | `outpost` | `uint32` | `optional` | `` |  |
-| 6 | `other` | `uint32` | `optional` | `` |  |
-| 7 | `abilities` | `uint32` | `optional` | `` |  |
+| 1 | `creep` | `uint32` | `optional` |  |  |
+| 2 | `heroes` | `uint32` | `optional` |  |  |
+| 3 | `roshan` | `uint32` | `optional` |  |  |
+| 4 | `tome_of_knowledge` | `uint32` | `optional` |  |  |
+| 5 | `outpost` | `uint32` | `optional` |  |  |
+| 6 | `other` | `uint32` | `optional` |  |  |
+| 7 | `abilities` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -686,10 +686,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `unit_name` | `string` | `optional` | `` |  |
-| 2 | `position_quant_x` | `uint32` | `optional` | `` |  |
-| 3 | `position_quant_y` | `uint32` | `optional` | `` |  |
-| 4 | `death_time` | `float` | `optional` | `` |  |
+| 1 | `unit_name` | `string` | `optional` |  |  |
+| 2 | `position_quant_x` | `uint32` | `optional` |  |  |
+| 3 | `position_quant_y` | `uint32` | `optional` |  |  |
+| 4 | `death_time` | `float` | `optional` |  |  |
 
 </details>
 
@@ -701,13 +701,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `game_time` | `int32` | `optional` | `` |  |
-| 2 | `damage_contributions` | `.CDOTAMatchPrivateMetadata.ContributionsCombatSegment.DamageContributionRecord` | `repeated` | `` |  |
-| 3 | `damage_mitigations` | `.CDOTAMatchPrivateMetadata.ContributionsCombatSegment.DamageMitigationRecord` | `repeated` | `` |  |
-| 4 | `healing_contributions` | `.CDOTAMatchPrivateMetadata.ContributionsCombatSegment.HealingContributionRecord` | `repeated` | `` |  |
-| 5 | `healing_reductions` | `.CDOTAMatchPrivateMetadata.ContributionsCombatSegment.HealingReductionRecord` | `repeated` | `` |  |
-| 6 | `killing_blows` | `.CDOTAMatchPrivateMetadata.ContributionsCombatSegment.KillingBlow` | `repeated` | `` |  |
-| 7 | `dispels` | `.CDOTAMatchPrivateMetadata.ContributionsCombatSegment.Dispel` | `repeated` | `` |  |
+| 1 | `game_time` | `int32` | `optional` |  |  |
+| 2 | `damage_contributions` | `.CDOTAMatchPrivateMetadata.ContributionsCombatSegment.DamageContributionRecord` | `repeated` |  |  |
+| 3 | `damage_mitigations` | `.CDOTAMatchPrivateMetadata.ContributionsCombatSegment.DamageMitigationRecord` | `repeated` |  |  |
+| 4 | `healing_contributions` | `.CDOTAMatchPrivateMetadata.ContributionsCombatSegment.HealingContributionRecord` | `repeated` |  |  |
+| 5 | `healing_reductions` | `.CDOTAMatchPrivateMetadata.ContributionsCombatSegment.HealingReductionRecord` | `repeated` |  |  |
+| 6 | `killing_blows` | `.CDOTAMatchPrivateMetadata.ContributionsCombatSegment.KillingBlow` | `repeated` |  |  |
+| 7 | `dispels` | `.CDOTAMatchPrivateMetadata.ContributionsCombatSegment.Dispel` | `repeated` |  |  |
 
 </details>
 
@@ -719,13 +719,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `attacker_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `attacker_hero_id` | `int32` | `optional` | `` |  |
-| 3 | `target_hero_id` | `int32` | `optional` | `` |  |
-| 4 | `contributor_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 5 | `contributor_hero_id` | `int32` | `optional` | `` |  |
-| 6 | `value` | `uint32` | `optional` | `` |  |
-| 7 | `type` | `uint32` | `optional` | `` |  |
+| 1 | `attacker_ability_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `attacker_hero_id` | `int32` | `optional` |  |  |
+| 3 | `target_hero_id` | `int32` | `optional` |  |  |
+| 4 | `contributor_ability_id` | `int32` | `optional` |  | default = -1 |
+| 5 | `contributor_hero_id` | `int32` | `optional` |  |  |
+| 6 | `value` | `uint32` | `optional` |  |  |
+| 7 | `type` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -737,13 +737,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `attacker_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `attacker_hero_id` | `int32` | `optional` | `` |  |
-| 3 | `target_hero_id` | `int32` | `optional` | `` |  |
-| 4 | `contributor_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 5 | `contributor_hero_id` | `int32` | `optional` | `` |  |
-| 6 | `value` | `uint32` | `optional` | `` |  |
-| 7 | `type` | `uint32` | `optional` | `` |  |
+| 1 | `attacker_ability_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `attacker_hero_id` | `int32` | `optional` |  |  |
+| 3 | `target_hero_id` | `int32` | `optional` |  |  |
+| 4 | `contributor_ability_id` | `int32` | `optional` |  | default = -1 |
+| 5 | `contributor_hero_id` | `int32` | `optional` |  |  |
+| 6 | `value` | `uint32` | `optional` |  |  |
+| 7 | `type` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -755,13 +755,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `attacker_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `attacker_hero_id` | `int32` | `optional` | `` |  |
-| 3 | `target_hero_id` | `int32` | `optional` | `` |  |
-| 4 | `contributor_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 5 | `contributor_hero_id` | `int32` | `optional` | `` |  |
-| 6 | `value` | `uint32` | `optional` | `` |  |
-| 7 | `type` | `uint32` | `optional` | `` |  |
+| 1 | `attacker_ability_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `attacker_hero_id` | `int32` | `optional` |  |  |
+| 3 | `target_hero_id` | `int32` | `optional` |  |  |
+| 4 | `contributor_ability_id` | `int32` | `optional` |  | default = -1 |
+| 5 | `contributor_hero_id` | `int32` | `optional` |  |  |
+| 6 | `value` | `uint32` | `optional` |  |  |
+| 7 | `type` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -773,13 +773,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `attacker_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `attacker_hero_id` | `int32` | `optional` | `` |  |
-| 3 | `target_hero_id` | `int32` | `optional` | `` |  |
-| 4 | `contributor_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 5 | `contributor_hero_id` | `int32` | `optional` | `` |  |
-| 6 | `value` | `uint32` | `optional` | `` |  |
-| 7 | `type` | `uint32` | `optional` | `` |  |
+| 1 | `attacker_ability_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `attacker_hero_id` | `int32` | `optional` |  |  |
+| 3 | `target_hero_id` | `int32` | `optional` |  |  |
+| 4 | `contributor_ability_id` | `int32` | `optional` |  | default = -1 |
+| 5 | `contributor_hero_id` | `int32` | `optional` |  |  |
+| 6 | `value` | `uint32` | `optional` |  |  |
+| 7 | `type` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -791,9 +791,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `attacker_hero_id` | `int32` | `optional` | `` |  |
-| 2 | `target_hero_id` | `int32` | `optional` | `` |  |
-| 3 | `inflictor_ability_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `attacker_hero_id` | `int32` | `optional` |  |  |
+| 2 | `target_hero_id` | `int32` | `optional` |  |  |
+| 3 | `inflictor_ability_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -805,11 +805,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `attacker_hero_id` | `int32` | `optional` | `` |  |
-| 2 | `target_hero_id` | `int32` | `optional` | `` |  |
-| 3 | `inflictor_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 4 | `modifier_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 5 | `duration_reduced` | `float` | `optional` | `` |  |
+| 1 | `attacker_hero_id` | `int32` | `optional` |  |  |
+| 2 | `target_hero_id` | `int32` | `optional` |  |  |
+| 3 | `inflictor_ability_id` | `int32` | `optional` |  | default = -1 |
+| 4 | `modifier_ability_id` | `int32` | `optional` |  | default = -1 |
+| 5 | `duration_reduced` | `float` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-modifiers.md
+++ b/docs/cookbook/proto-fields/dota-modifiers.md
@@ -23,48 +23,48 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `entry_type` | `.DOTA_MODIFIER_ENTRY_TYPE` | `optional` | `` | default = DOTA_MODIFIER_ENTRY_TYPE_ACTIVE |
-| 2 | `parent` | `uint32` | `optional` | `` | default = 16777215 |
-| 3 | `index` | `int32` | `optional` | `` |  |
-| 4 | `serial_num` | `int32` | `optional` | `` |  |
-| 5 | `modifier_class` | `int32` | `optional` | `` |  |
-| 6 | `ability_level` | `int32` | `optional` | `` |  |
-| 7 | `stack_count` | `int32` | `optional` | `` |  |
-| 8 | `creation_time` | `float` | `optional` | `` |  |
-| 9 | `duration` | `float` | `optional` | `` | default = -1 |
-| 10 | `caster` | `uint32` | `optional` | `` | default = 16777215 |
-| 11 | `ability` | `uint32` | `optional` | `` | default = 16777215 |
-| 12 | `armor` | `int32` | `optional` | `` |  |
-| 13 | `fade_time` | `float` | `optional` | `` |  |
-| 14 | `subtle` | `bool` | `optional` | `` |  |
-| 15 | `channel_time` | `float` | `optional` | `` |  |
-| 16 | `v_start` | `.CMsgVector` | `optional` | `` |  |
-| 17 | `v_end` | `.CMsgVector` | `optional` | `` |  |
-| 18 | `portal_loop_appear` | `string` | `optional` | `` |  |
-| 19 | `portal_loop_disappear` | `string` | `optional` | `` |  |
-| 20 | `hero_loop_appear` | `string` | `optional` | `` |  |
-| 21 | `hero_loop_disappear` | `string` | `optional` | `` |  |
-| 22 | `movement_speed` | `int32` | `optional` | `` |  |
-| 23 | `aura` | `bool` | `optional` | `` |  |
-| 24 | `activity` | `int32` | `optional` | `` |  |
-| 25 | `damage` | `int32` | `optional` | `` |  |
-| 26 | `range` | `int32` | `optional` | `` |  |
-| 27 | `dd_modifier_index` | `int32` | `optional` | `` |  |
-| 28 | `dd_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 29 | `illusion_label` | `string` | `optional` | `` |  |
-| 30 | `active` | `bool` | `optional` | `` |  |
-| 31 | `player_ids` | `string` | `optional` | `` |  |
-| 32 | `lua_name` | `string` | `optional` | `` |  |
-| 33 | `attack_speed` | `int32` | `optional` | `` |  |
-| 34 | `aura_owner` | `uint32` | `optional` | `` | default = 16777215 |
-| 35 | `bonus_all_stats` | `int32` | `optional` | `` |  |
-| 36 | `bonus_health` | `int32` | `optional` | `` |  |
-| 37 | `bonus_mana` | `int32` | `optional` | `` |  |
-| 38 | `custom_entity` | `uint32` | `optional` | `` | default = 16777215 |
-| 39 | `aura_within_range` | `bool` | `optional` | `` |  |
-| 40 | `move_slow` | `float` | `optional` | `` |  |
-| 41 | `has_scepter` | `bool` | `optional` | `` |  |
-| 42 | `has_shard` | `bool` | `optional` | `` |  |
+| 1 | `entry_type` | `.DOTA_MODIFIER_ENTRY_TYPE` | `optional` |  | default = DOTA_MODIFIER_ENTRY_TYPE_ACTIVE |
+| 2 | `parent` | `uint32` | `optional` |  | default = 16777215 |
+| 3 | `index` | `int32` | `optional` |  |  |
+| 4 | `serial_num` | `int32` | `optional` |  |  |
+| 5 | `modifier_class` | `int32` | `optional` |  |  |
+| 6 | `ability_level` | `int32` | `optional` |  |  |
+| 7 | `stack_count` | `int32` | `optional` |  |  |
+| 8 | `creation_time` | `float` | `optional` |  |  |
+| 9 | `duration` | `float` | `optional` |  | default = -1 |
+| 10 | `caster` | `uint32` | `optional` |  | default = 16777215 |
+| 11 | `ability` | `uint32` | `optional` |  | default = 16777215 |
+| 12 | `armor` | `int32` | `optional` |  |  |
+| 13 | `fade_time` | `float` | `optional` |  |  |
+| 14 | `subtle` | `bool` | `optional` |  |  |
+| 15 | `channel_time` | `float` | `optional` |  |  |
+| 16 | `v_start` | `.CMsgVector` | `optional` |  |  |
+| 17 | `v_end` | `.CMsgVector` | `optional` |  |  |
+| 18 | `portal_loop_appear` | `string` | `optional` |  |  |
+| 19 | `portal_loop_disappear` | `string` | `optional` |  |  |
+| 20 | `hero_loop_appear` | `string` | `optional` |  |  |
+| 21 | `hero_loop_disappear` | `string` | `optional` |  |  |
+| 22 | `movement_speed` | `int32` | `optional` |  |  |
+| 23 | `aura` | `bool` | `optional` |  |  |
+| 24 | `activity` | `int32` | `optional` |  |  |
+| 25 | `damage` | `int32` | `optional` |  |  |
+| 26 | `range` | `int32` | `optional` |  |  |
+| 27 | `dd_modifier_index` | `int32` | `optional` |  |  |
+| 28 | `dd_ability_id` | `int32` | `optional` |  | default = -1 |
+| 29 | `illusion_label` | `string` | `optional` |  |  |
+| 30 | `active` | `bool` | `optional` |  |  |
+| 31 | `player_ids` | `string` | `optional` |  |  |
+| 32 | `lua_name` | `string` | `optional` |  |  |
+| 33 | `attack_speed` | `int32` | `optional` |  |  |
+| 34 | `aura_owner` | `uint32` | `optional` |  | default = 16777215 |
+| 35 | `bonus_all_stats` | `int32` | `optional` |  |  |
+| 36 | `bonus_health` | `int32` | `optional` |  |  |
+| 37 | `bonus_mana` | `int32` | `optional` |  |  |
+| 38 | `custom_entity` | `uint32` | `optional` |  | default = 16777215 |
+| 39 | `aura_within_range` | `bool` | `optional` |  |  |
+| 40 | `move_slow` | `float` | `optional` |  |  |
+| 41 | `has_scepter` | `bool` | `optional` |  |  |
+| 42 | `has_shard` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -76,8 +76,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `modifier_type` | `int32` | `optional` | `` |  |
-| 2 | `modifier_filename` | `string` | `optional` | `` |  |
+| 1 | `modifier_type` | `int32` | `optional` |  |  |
+| 2 | `modifier_filename` | `string` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-scenariomessages.md
+++ b/docs/cookbook/proto-fields/dota-scenariomessages.md
@@ -23,8 +23,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `x` | `float` | `optional` | `` |  |
-| 2 | `y` | `float` | `optional` | `` |  |
+| 1 | `x` | `float` | `optional` |  |  |
+| 2 | `y` | `float` | `optional` |  |  |
 
 </details>
 
@@ -36,10 +36,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `kill_count` | `int32` | `optional` | `` |  |
-| 2 | `state` | `int32` | `optional` | `` |  |
-| 3 | `cooldown` | `float` | `optional` | `` |  |
-| 4 | `killer_team` | `int32` | `optional` | `` |  |
+| 1 | `kill_count` | `int32` | `optional` |  |  |
+| 2 | `state` | `int32` | `optional` |  |  |
+| 3 | `cooldown` | `float` | `optional` |  |  |
+| 4 | `killer_team` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -51,9 +51,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_number` | `int32` | `optional` | `` |  |
-| 2 | `owner_player_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `cooldown` | `float` | `optional` | `` | default = -1 |
+| 1 | `team_number` | `int32` | `optional` |  |  |
+| 2 | `owner_player_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `cooldown` | `float` | `optional` |  | default = -1 |
 
 </details>
 
@@ -65,13 +65,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `position` | `.CScenario_Position` | `optional` | `` |  |
-| 2 | `unit_name` | `string` | `optional` | `` |  |
-| 3 | `team_number` | `int32` | `optional` | `` |  |
-| 4 | `health_frac` | `float` | `optional` | `` | default = 1 |
-| 10 | `owning_camp` | `string` | `optional` | `` |  |
-| 11 | `owning_camp_position` | `.CScenario_Position` | `optional` | `` |  |
-| 20 | `invade_goal` | `string` | `optional` | `` |  |
+| 1 | `position` | `.CScenario_Position` | `optional` |  |  |
+| 2 | `unit_name` | `string` | `optional` |  |  |
+| 3 | `team_number` | `int32` | `optional` |  |  |
+| 4 | `health_frac` | `float` | `optional` |  | default = 1 |
+| 10 | `owning_camp` | `string` | `optional` |  |  |
+| 11 | `owning_camp_position` | `.CScenario_Position` | `optional` |  |  |
+| 20 | `invade_goal` | `string` | `optional` |  |  |
 
 </details>
 
@@ -83,8 +83,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `owner_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `team_id` | `int32` | `optional` | `` |  |
+| 1 | `owner_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `team_id` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -96,7 +96,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `position` | `.CScenario_Position` | `optional` | `` |  |
+| 1 | `position` | `.CScenario_Position` | `optional` |  |  |
 
 </details>
 
@@ -108,15 +108,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `lobby_id` | `uint64` | `optional` | `` |  |
-| 2 | `game` | `.CMsgDotaScenario.Game` | `optional` | `` |  |
-| 3 | `teams` | `.CMsgDotaScenario.Team` | `repeated` | `` |  |
-| 4 | `heroes` | `.CMsgDotaScenario.Hero` | `repeated` | `` |  |
-| 5 | `stock` | `.CMsgDotaScenario.Stock` | `repeated` | `` |  |
-| 6 | `buildings` | `.CMsgDotaScenario.Building` | `repeated` | `` |  |
-| 7 | `entities` | `.CMsgDotaScenario.Entity` | `repeated` | `` |  |
-| 8 | `items` | `.CMsgDotaScenario.Item` | `repeated` | `` |  |
-| 9 | `modifiers` | `.CMsgDotaScenario.Modifier` | `repeated` | `` |  |
+| 1 | `lobby_id` | `uint64` | `optional` |  |  |
+| 2 | `game` | `.CMsgDotaScenario.Game` | `optional` |  |  |
+| 3 | `teams` | `.CMsgDotaScenario.Team` | `repeated` |  |  |
+| 4 | `heroes` | `.CMsgDotaScenario.Hero` | `repeated` |  |  |
+| 5 | `stock` | `.CMsgDotaScenario.Stock` | `repeated` |  |  |
+| 6 | `buildings` | `.CMsgDotaScenario.Building` | `repeated` |  |  |
+| 7 | `entities` | `.CMsgDotaScenario.Entity` | `repeated` |  |  |
+| 8 | `items` | `.CMsgDotaScenario.Item` | `repeated` |  |  |
+| 9 | `modifiers` | `.CMsgDotaScenario.Modifier` | `repeated` |  |  |
 
 </details>
 
@@ -128,11 +128,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `neutral_stash_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `entity_idx` | `int32` | `optional` | `` | default = -1 |
-| 4 | `roshan` | `bool` | `optional` | `` | default = false |
-| 10 | `ability_name` | `string` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `neutral_stash_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `entity_idx` | `int32` | `optional` |  | default = -1 |
+| 4 | `roshan` | `bool` | `optional` |  | default = false |
+| 10 | `ability_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -144,11 +144,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `game_mode` | `int32` | `optional` | `` |  |
-| 3 | `clock_time` | `float` | `optional` | `` |  |
-| 4 | `internal_time` | `float` | `optional` | `` |  |
-| 5 | `roshan` | `.CScenarioGame_RoshanSpawner` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `game_mode` | `int32` | `optional` |  |  |
+| 3 | `clock_time` | `float` | `optional` |  |  |
+| 4 | `internal_time` | `float` | `optional` |  |  |
+| 5 | `roshan` | `.CScenarioGame_RoshanSpawner` | `optional` |  |  |
 
 </details>
 
@@ -160,9 +160,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `consumed` | `bool` | `optional` | `` |  |
-| 3 | `tier` | `int32` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `consumed` | `bool` | `optional` |  |  |
+| 3 | `tier` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -174,13 +174,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_number` | `int32` | `optional` | `` |  |
-| 2 | `neutral_items` | `.CMsgDotaScenario.TeamNeutralItem` | `repeated` | `` |  |
-| 3 | `hero_kills` | `int32` | `optional` | `` |  |
-| 4 | `tower_kills` | `int32` | `optional` | `` |  |
-| 5 | `barracks_kills` | `int32` | `optional` | `` |  |
-| 6 | `glyph_cooldown` | `float` | `optional` | `` |  |
-| 7 | `radar_cooldown` | `float` | `optional` | `` |  |
+| 1 | `team_number` | `int32` | `optional` |  |  |
+| 2 | `neutral_items` | `.CMsgDotaScenario.TeamNeutralItem` | `repeated` |  |  |
+| 3 | `hero_kills` | `int32` | `optional` |  |  |
+| 4 | `tower_kills` | `int32` | `optional` |  |  |
+| 5 | `barracks_kills` | `int32` | `optional` |  |  |
+| 6 | `glyph_cooldown` | `float` | `optional` |  |  |
+| 7 | `radar_cooldown` | `float` | `optional` |  |  |
 
 </details>
 
@@ -192,8 +192,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `value` | `int32` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `value` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -205,8 +205,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `value` | `float` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `value` | `float` | `optional` |  |  |
 
 </details>
 
@@ -218,11 +218,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `damage_type` | `int32` | `optional` | `` |  |
-| 2 | `received_pre_reduction` | `float` | `optional` | `` |  |
-| 3 | `received_post_reduction` | `float` | `optional` | `` |  |
-| 4 | `outgoing_pre_reduction` | `float` | `optional` | `` |  |
-| 5 | `outgoing_post_reduction` | `float` | `optional` | `` |  |
+| 1 | `damage_type` | `int32` | `optional` |  |  |
+| 2 | `received_pre_reduction` | `float` | `optional` |  |  |
+| 3 | `received_post_reduction` | `float` | `optional` |  |  |
+| 4 | `outgoing_pre_reduction` | `float` | `optional` |  |  |
+| 5 | `outgoing_post_reduction` | `float` | `optional` |  |  |
 
 </details>
 
@@ -234,9 +234,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `level` | `int32` | `optional` | `` |  |
-| 3 | `tome_upgraded` | `bool` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `level` | `int32` | `optional` |  |  |
+| 3 | `tome_upgraded` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -248,9 +248,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `choice_index` | `int32` | `optional` | `` |  |
-| 2 | `artifact_name` | `string` | `optional` | `` |  |
-| 3 | `enchantment_name` | `string` | `optional` | `` |  |
+| 1 | `choice_index` | `int32` | `optional` |  |  |
+| 2 | `artifact_name` | `string` | `optional` |  |  |
+| 3 | `enchantment_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -262,10 +262,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tier` | `uint32` | `optional` | `` |  |
-| 2 | `choices` | `.CMsgDotaScenario.HeroNeutralChoice` | `repeated` | `` |  |
-| 3 | `selected_artifact` | `int32` | `optional` | `` |  |
-| 4 | `selected_enchantment` | `int32` | `optional` | `` |  |
+| 1 | `tier` | `uint32` | `optional` |  |  |
+| 2 | `choices` | `.CMsgDotaScenario.HeroNeutralChoice` | `repeated` |  |  |
+| 3 | `selected_artifact` | `int32` | `optional` |  |  |
+| 4 | `selected_enchantment` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -277,74 +277,74 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steam_id` | `fixed64` | `optional` | `` |  |
-| 2 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `team_id` | `int32` | `optional` | `` |  |
-| 4 | `hero` | `string` | `optional` | `` |  |
-| 5 | `total_xp` | `int32` | `optional` | `` |  |
-| 6 | `bkb_charges_used` | `int32` | `optional` | `` |  |
-| 7 | `aeon_charges_used` | `int32` | `optional` | `` |  |
-| 8 | `reliable_gold` | `int32` | `optional` | `` |  |
-| 9 | `unreliable_gold` | `int32` | `optional` | `` |  |
-| 10 | `total_earned_gold` | `int32` | `optional` | `` |  |
-| 11 | `shared_gold` | `int32` | `optional` | `` |  |
-| 12 | `hero_kill_gold` | `int32` | `optional` | `` |  |
-| 13 | `creep_kill_gold` | `int32` | `optional` | `` |  |
-| 14 | `neutral_kill_gold` | `int32` | `optional` | `` |  |
-| 15 | `courier_gold` | `int32` | `optional` | `` |  |
-| 16 | `bounty_gold` | `int32` | `optional` | `` |  |
-| 17 | `roshan_gold` | `int32` | `optional` | `` |  |
-| 18 | `building_gold` | `int32` | `optional` | `` |  |
-| 19 | `other_gold` | `int32` | `optional` | `` |  |
-| 26 | `income_gold` | `int32` | `optional` | `` |  |
-| 27 | `ward_kill_gold` | `int32` | `optional` | `` |  |
-| 28 | `ability_gold` | `int32` | `optional` | `` |  |
-| 29 | `denies` | `int32` | `optional` | `` |  |
-| 30 | `last_hits` | `int32` | `optional` | `` |  |
-| 31 | `last_hit_streak` | `int32` | `optional` | `` |  |
-| 32 | `last_hit_multikill` | `int32` | `optional` | `` |  |
-| 33 | `nearby_creep_death_count` | `int32` | `optional` | `` |  |
-| 34 | `claimed_deny_count` | `int32` | `optional` | `` |  |
-| 35 | `claimed_miss_count` | `int32` | `optional` | `` |  |
-| 36 | `miss_count` | `int32` | `optional` | `` |  |
-| 40 | `buyback_cooldown_time` | `float` | `optional` | `` |  |
-| 41 | `buyback_gold_limit_time` | `float` | `optional` | `` |  |
-| 44 | `stun_duration` | `float` | `optional` | `` |  |
-| 45 | `healing` | `float` | `optional` | `` |  |
-| 46 | `tower_kills` | `int32` | `optional` | `` |  |
-| 47 | `roshan_kills` | `int32` | `optional` | `` |  |
-| 48 | `observer_wards_placed` | `int32` | `optional` | `` |  |
-| 49 | `sentry_wards_placed` | `int32` | `optional` | `` |  |
-| 50 | `creeps_stacked` | `int32` | `optional` | `` |  |
-| 51 | `camps_stacked` | `int32` | `optional` | `` |  |
-| 52 | `rune_pickups` | `int32` | `optional` | `` |  |
-| 53 | `gold_spent_on_support` | `int32` | `optional` | `` |  |
-| 54 | `hero_damage` | `float` | `optional` | `` |  |
-| 55 | `wards_purchased` | `int32` | `optional` | `` |  |
-| 56 | `wards_destroyed` | `int32` | `optional` | `` |  |
-| 58 | `gold_spent_on_consumables` | `int32` | `optional` | `` |  |
-| 59 | `gold_spent_on_items` | `int32` | `optional` | `` |  |
-| 60 | `gold_spent_on_buybacks` | `int32` | `optional` | `` |  |
-| 61 | `gold_lost_to_death` | `int32` | `optional` | `` |  |
-| 62 | `kills` | `int32` | `optional` | `` |  |
-| 63 | `assists` | `int32` | `optional` | `` |  |
-| 64 | `deaths` | `int32` | `optional` | `` |  |
-| 65 | `kill_streak` | `int32` | `optional` | `` |  |
-| 68 | `respawn_seconds` | `int32` | `optional` | `` | default = -1 |
-| 69 | `last_buyback_time` | `int32` | `optional` | `` |  |
-| 71 | `first_blood_claimed` | `bool` | `optional` | `` |  |
-| 72 | `first_blood_given` | `bool` | `optional` | `` |  |
-| 73 | `bounty_runes` | `int32` | `optional` | `` |  |
-| 74 | `outposts_captured` | `int32` | `optional` | `` |  |
-| 75 | `position` | `.CScenario_Position` | `optional` | `` |  |
-| 150 | `enemy_kills` | `.CMsgDotaScenario.HeroHeroInt` | `repeated` | `` |  |
-| 151 | `damage_stats` | `.CMsgDotaScenario.DamageStatsByType` | `repeated` | `` |  |
-| 152 | `abilities` | `.CMsgDotaScenario.HeroAbility` | `repeated` | `` |  |
-| 153 | `hero_facet` | `uint32` | `optional` | `` |  |
-| 154 | `total_madstone` | `uint32` | `optional` | `` |  |
-| 155 | `current_madstone` | `uint32` | `optional` | `` |  |
-| 156 | `neutral_tiers` | `.CMsgDotaScenario.HeroNeutralTier` | `repeated` | `` |  |
-| 157 | `refresher_charges_used` | `int32` | `optional` | `` |  |
+| 1 | `steam_id` | `fixed64` | `optional` |  |  |
+| 2 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `team_id` | `int32` | `optional` |  |  |
+| 4 | `hero` | `string` | `optional` |  |  |
+| 5 | `total_xp` | `int32` | `optional` |  |  |
+| 6 | `bkb_charges_used` | `int32` | `optional` |  |  |
+| 7 | `aeon_charges_used` | `int32` | `optional` |  |  |
+| 8 | `reliable_gold` | `int32` | `optional` |  |  |
+| 9 | `unreliable_gold` | `int32` | `optional` |  |  |
+| 10 | `total_earned_gold` | `int32` | `optional` |  |  |
+| 11 | `shared_gold` | `int32` | `optional` |  |  |
+| 12 | `hero_kill_gold` | `int32` | `optional` |  |  |
+| 13 | `creep_kill_gold` | `int32` | `optional` |  |  |
+| 14 | `neutral_kill_gold` | `int32` | `optional` |  |  |
+| 15 | `courier_gold` | `int32` | `optional` |  |  |
+| 16 | `bounty_gold` | `int32` | `optional` |  |  |
+| 17 | `roshan_gold` | `int32` | `optional` |  |  |
+| 18 | `building_gold` | `int32` | `optional` |  |  |
+| 19 | `other_gold` | `int32` | `optional` |  |  |
+| 26 | `income_gold` | `int32` | `optional` |  |  |
+| 27 | `ward_kill_gold` | `int32` | `optional` |  |  |
+| 28 | `ability_gold` | `int32` | `optional` |  |  |
+| 29 | `denies` | `int32` | `optional` |  |  |
+| 30 | `last_hits` | `int32` | `optional` |  |  |
+| 31 | `last_hit_streak` | `int32` | `optional` |  |  |
+| 32 | `last_hit_multikill` | `int32` | `optional` |  |  |
+| 33 | `nearby_creep_death_count` | `int32` | `optional` |  |  |
+| 34 | `claimed_deny_count` | `int32` | `optional` |  |  |
+| 35 | `claimed_miss_count` | `int32` | `optional` |  |  |
+| 36 | `miss_count` | `int32` | `optional` |  |  |
+| 40 | `buyback_cooldown_time` | `float` | `optional` |  |  |
+| 41 | `buyback_gold_limit_time` | `float` | `optional` |  |  |
+| 44 | `stun_duration` | `float` | `optional` |  |  |
+| 45 | `healing` | `float` | `optional` |  |  |
+| 46 | `tower_kills` | `int32` | `optional` |  |  |
+| 47 | `roshan_kills` | `int32` | `optional` |  |  |
+| 48 | `observer_wards_placed` | `int32` | `optional` |  |  |
+| 49 | `sentry_wards_placed` | `int32` | `optional` |  |  |
+| 50 | `creeps_stacked` | `int32` | `optional` |  |  |
+| 51 | `camps_stacked` | `int32` | `optional` |  |  |
+| 52 | `rune_pickups` | `int32` | `optional` |  |  |
+| 53 | `gold_spent_on_support` | `int32` | `optional` |  |  |
+| 54 | `hero_damage` | `float` | `optional` |  |  |
+| 55 | `wards_purchased` | `int32` | `optional` |  |  |
+| 56 | `wards_destroyed` | `int32` | `optional` |  |  |
+| 58 | `gold_spent_on_consumables` | `int32` | `optional` |  |  |
+| 59 | `gold_spent_on_items` | `int32` | `optional` |  |  |
+| 60 | `gold_spent_on_buybacks` | `int32` | `optional` |  |  |
+| 61 | `gold_lost_to_death` | `int32` | `optional` |  |  |
+| 62 | `kills` | `int32` | `optional` |  |  |
+| 63 | `assists` | `int32` | `optional` |  |  |
+| 64 | `deaths` | `int32` | `optional` |  |  |
+| 65 | `kill_streak` | `int32` | `optional` |  |  |
+| 68 | `respawn_seconds` | `int32` | `optional` |  | default = -1 |
+| 69 | `last_buyback_time` | `int32` | `optional` |  |  |
+| 71 | `first_blood_claimed` | `bool` | `optional` |  |  |
+| 72 | `first_blood_given` | `bool` | `optional` |  |  |
+| 73 | `bounty_runes` | `int32` | `optional` |  |  |
+| 74 | `outposts_captured` | `int32` | `optional` |  |  |
+| 75 | `position` | `.CScenario_Position` | `optional` |  |  |
+| 150 | `enemy_kills` | `.CMsgDotaScenario.HeroHeroInt` | `repeated` |  |  |
+| 151 | `damage_stats` | `.CMsgDotaScenario.DamageStatsByType` | `repeated` |  |  |
+| 152 | `abilities` | `.CMsgDotaScenario.HeroAbility` | `repeated` |  |  |
+| 153 | `hero_facet` | `uint32` | `optional` |  |  |
+| 154 | `total_madstone` | `uint32` | `optional` |  |  |
+| 155 | `current_madstone` | `uint32` | `optional` |  |  |
+| 156 | `neutral_tiers` | `.CMsgDotaScenario.HeroNeutralTier` | `repeated` |  |  |
+| 157 | `refresher_charges_used` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -356,12 +356,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `team_number` | `int32` | `optional` | `` | default = -1 |
-| 3 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 4 | `current_stock` | `int32` | `optional` | `` |  |
-| 5 | `cooldown` | `float` | `optional` | `` |  |
-| 6 | `bonus_stock` | `int32` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `team_number` | `int32` | `optional` |  | default = -1 |
+| 3 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 4 | `current_stock` | `int32` | `optional` |  |  |
+| 5 | `cooldown` | `float` | `optional` |  |  |
+| 6 | `bonus_stock` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -373,11 +373,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `entity_name` | `string` | `optional` | `` |  |
-| 2 | `entity_class` | `string` | `optional` | `` |  |
-| 3 | `team_id` | `int32` | `optional` | `` |  |
-| 4 | `is_destroyed` | `bool` | `optional` | `` |  |
-| 5 | `health_frac` | `float` | `optional` | `` | default = 1 |
+| 1 | `entity_name` | `string` | `optional` |  |  |
+| 2 | `entity_class` | `string` | `optional` |  |  |
+| 3 | `team_id` | `int32` | `optional` |  |  |
+| 4 | `is_destroyed` | `bool` | `optional` |  |  |
+| 5 | `health_frac` | `float` | `optional` |  | default = 1 |
 
 </details>
 
@@ -389,10 +389,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `courier` | `.CScenarioEnt_Courier` | `optional` | `` |  |
-| 2 | `npc` | `.CScenarioEnt_NPC` | `optional` | `` |  |
-| 3 | `spirit_bear` | `.CScenarioEnt_SpiritBear` | `optional` | `` |  |
-| 4 | `dropped_item` | `.CScenarioEnt_DroppedItem` | `optional` | `` |  |
+| 1 | `courier` | `.CScenarioEnt_Courier` | `optional` |  |  |
+| 2 | `npc` | `.CScenarioEnt_NPC` | `optional` |  |  |
+| 3 | `spirit_bear` | `.CScenarioEnt_SpiritBear` | `optional` |  |  |
+| 4 | `dropped_item` | `.CScenarioEnt_DroppedItem` | `optional` |  |  |
 
 </details>
 
@@ -404,16 +404,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `location` | `.CMsgDotaScenario.EntityRef` | `optional` | `` |  |
-| 3 | `owner_id` | `int32` | `optional` | `` | default = -1 |
-| 4 | `item_slot` | `int32` | `optional` | `` |  |
-| 5 | `neutral_drop_team` | `int32` | `optional` | `` |  |
-| 6 | `charges` | `int32` | `optional` | `` |  |
-| 7 | `secondary_charges` | `int32` | `optional` | `` |  |
-| 8 | `lifetime` | `float` | `optional` | `` | default = -1 |
-| 9 | `stored_rune_type` | `int32` | `optional` | `` | default = -1 |
-| 10 | `level` | `int32` | `optional` | `` | default = 1 |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `location` | `.CMsgDotaScenario.EntityRef` | `optional` |  |  |
+| 3 | `owner_id` | `int32` | `optional` |  | default = -1 |
+| 4 | `item_slot` | `int32` | `optional` |  |  |
+| 5 | `neutral_drop_team` | `int32` | `optional` |  |  |
+| 6 | `charges` | `int32` | `optional` |  |  |
+| 7 | `secondary_charges` | `int32` | `optional` |  |  |
+| 8 | `lifetime` | `float` | `optional` |  | default = -1 |
+| 9 | `stored_rune_type` | `int32` | `optional` |  | default = -1 |
+| 10 | `level` | `int32` | `optional` |  | default = 1 |
 
 </details>
 
@@ -425,22 +425,22 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `parent` | `.CMsgDotaScenario.EntityRef` | `optional` | `` |  |
-| 3 | `caster` | `.CMsgDotaScenario.EntityRef` | `optional` | `` |  |
-| 4 | `ability` | `.CMsgDotaScenario.EntityRef` | `optional` | `` |  |
-| 5 | `duration` | `float` | `optional` | `` | default = -1 |
-| 6 | `lifetime_remaining` | `float` | `optional` | `` | default = 0 |
-| 7 | `stack_count` | `int32` | `optional` | `` |  |
-| 8 | `create_even_if_existing` | `bool` | `optional` | `` |  |
-| 9 | `create_without_caster` | `bool` | `optional` | `` |  |
-| 10 | `create_without_ability` | `bool` | `optional` | `` |  |
-| 100 | `moonshard_consumed_bonus` | `int32` | `optional` | `` |  |
-| 101 | `moonshard_consumed_bonus_night_vision` | `int32` | `optional` | `` |  |
-| 110 | `wardtruesight_range` | `int32` | `optional` | `` |  |
-| 120 | `ultimate_scepter_consumed_alchemist_bonus_all_stats` | `int32` | `optional` | `` |  |
-| 121 | `ultimate_scepter_consumed_alchemist_bonus_health` | `int32` | `optional` | `` |  |
-| 122 | `ultimate_scepter_consumed_alchemist_bonus_mana` | `int32` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `parent` | `.CMsgDotaScenario.EntityRef` | `optional` |  |  |
+| 3 | `caster` | `.CMsgDotaScenario.EntityRef` | `optional` |  |  |
+| 4 | `ability` | `.CMsgDotaScenario.EntityRef` | `optional` |  |  |
+| 5 | `duration` | `float` | `optional` |  | default = -1 |
+| 6 | `lifetime_remaining` | `float` | `optional` |  | default = 0 |
+| 7 | `stack_count` | `int32` | `optional` |  |  |
+| 8 | `create_even_if_existing` | `bool` | `optional` |  |  |
+| 9 | `create_without_caster` | `bool` | `optional` |  |  |
+| 10 | `create_without_ability` | `bool` | `optional` |  |  |
+| 100 | `moonshard_consumed_bonus` | `int32` | `optional` |  |  |
+| 101 | `moonshard_consumed_bonus_night_vision` | `int32` | `optional` |  |  |
+| 110 | `wardtruesight_range` | `int32` | `optional` |  |  |
+| 120 | `ultimate_scepter_consumed_alchemist_bonus_all_stats` | `int32` | `optional` |  |  |
+| 121 | `ultimate_scepter_consumed_alchemist_bonus_health` | `int32` | `optional` |  |  |
+| 122 | `ultimate_scepter_consumed_alchemist_bonus_mana` | `int32` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-shared-enums.md
+++ b/docs/cookbook/proto-fields/dota-shared-enums.md
@@ -19,13 +19,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `logical_processors` | `uint32` | `optional` | `` |  |
-| 2 | `cpu_cycles_per_second` | `fixed64` | `optional` | `` |  |
-| 3 | `total_physical_memory` | `fixed64` | `optional` | `` |  |
-| 4 | `is_64_bit_os` | `bool` | `optional` | `` |  |
-| 5 | `upload_measurement` | `uint64` | `optional` | `` |  |
-| 6 | `prefer_not_host` | `bool` | `optional` | `` |  |
-| 7 | `crc` | `uint32` | `repeated` | `` |  |
+| 1 | `logical_processors` | `uint32` | `optional` |  |  |
+| 2 | `cpu_cycles_per_second` | `fixed64` | `optional` |  |  |
+| 3 | `total_physical_memory` | `fixed64` | `optional` |  |  |
+| 4 | `is_64_bit_os` | `bool` | `optional` |  |  |
+| 5 | `upload_measurement` | `uint64` | `optional` |  |  |
+| 6 | `prefer_not_host` | `bool` | `optional` |  |  |
+| 7 | `crc` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -37,10 +37,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `save_time` | `uint32` | `optional` | `` |  |
-| 3 | `players` | `.CDOTASaveGame.Player` | `repeated` | `` |  |
-| 4 | `save_instances` | `.CDOTASaveGame.SaveInstance` | `repeated` | `` |  |
-| 5 | `match_id` | `uint64` | `optional` | `` |  |
+| 2 | `save_time` | `uint32` | `optional` |  |  |
+| 3 | `players` | `.CDOTASaveGame.Player` | `repeated` |  |  |
+| 4 | `save_instances` | `.CDOTASaveGame.SaveInstance` | `repeated` |  |  |
+| 5 | `match_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -52,9 +52,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team` | `.DOTA_GC_TEAM` | `optional` | `` | default = DOTA_GC_TEAM_GOOD_GUYS |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `hero` | `string` | `optional` | `` |  |
+| 1 | `team` | `.DOTA_GC_TEAM` | `optional` |  | default = DOTA_GC_TEAM_GOOD_GUYS |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `hero` | `string` | `optional` |  |  |
 
 </details>
 
@@ -66,12 +66,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `game_time` | `uint32` | `optional` | `` |  |
-| 3 | `team1_score` | `uint32` | `optional` | `` |  |
-| 4 | `team2_score` | `uint32` | `optional` | `` |  |
-| 5 | `player_positions` | `.CDOTASaveGame.SaveInstance.PlayerPositions` | `repeated` | `` |  |
-| 6 | `save_id` | `uint32` | `optional` | `` |  |
-| 7 | `save_time` | `uint32` | `optional` | `` |  |
+| 2 | `game_time` | `uint32` | `optional` |  |  |
+| 3 | `team1_score` | `uint32` | `optional` |  |  |
+| 4 | `team2_score` | `uint32` | `optional` |  |  |
+| 5 | `player_positions` | `.CDOTASaveGame.SaveInstance.PlayerPositions` | `repeated` |  |  |
+| 6 | `save_id` | `uint32` | `optional` |  |  |
+| 7 | `save_time` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -83,8 +83,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `x` | `float` | `optional` | `` |  |
-| 2 | `y` | `float` | `optional` | `` |  |
+| 1 | `x` | `float` | `optional` |  |  |
+| 2 | `y` | `float` | `optional` |  |  |
 
 </details>
 
@@ -96,88 +96,88 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `type` | `.DOTA_COMBATLOG_TYPES` | `optional` | `` | default = DOTA_COMBATLOG_INVALID |
-| 2 | `target_name` | `uint32` | `optional` | `` |  |
-| 3 | `target_source_name` | `uint32` | `optional` | `` |  |
-| 4 | `attacker_name` | `uint32` | `optional` | `` |  |
-| 5 | `damage_source_name` | `uint32` | `optional` | `` |  |
-| 6 | `inflictor_name` | `uint32` | `optional` | `` |  |
-| 7 | `is_attacker_illusion` | `bool` | `optional` | `` |  |
-| 8 | `is_attacker_hero` | `bool` | `optional` | `` |  |
-| 9 | `is_target_illusion` | `bool` | `optional` | `` |  |
-| 10 | `is_target_hero` | `bool` | `optional` | `` |  |
-| 11 | `is_visible_radiant` | `bool` | `optional` | `` |  |
-| 12 | `is_visible_dire` | `bool` | `optional` | `` |  |
-| 13 | `value` | `uint32` | `optional` | `` |  |
-| 14 | `health` | `int32` | `optional` | `` |  |
-| 15 | `timestamp` | `float` | `optional` | `` |  |
-| 16 | `stun_duration` | `float` | `optional` | `` |  |
-| 17 | `slow_duration` | `float` | `optional` | `` |  |
-| 18 | `is_ability_toggle_on` | `bool` | `optional` | `` |  |
-| 19 | `is_ability_toggle_off` | `bool` | `optional` | `` |  |
-| 20 | `ability_level` | `uint32` | `optional` | `` |  |
-| 21 | `location_x` | `float` | `optional` | `` |  |
-| 22 | `location_y` | `float` | `optional` | `` |  |
-| 23 | `gold_reason` | `uint32` | `optional` | `` |  |
-| 24 | `timestamp_raw` | `float` | `optional` | `` |  |
-| 25 | `modifier_duration` | `float` | `optional` | `` |  |
-| 26 | `xp_reason` | `uint32` | `optional` | `` |  |
-| 27 | `last_hits` | `uint32` | `optional` | `` |  |
-| 28 | `attacker_team` | `uint32` | `optional` | `` |  |
-| 29 | `target_team` | `uint32` | `optional` | `` |  |
-| 30 | `obs_wards_placed` | `uint32` | `optional` | `` |  |
-| 31 | `assist_player0` | `uint32` | `optional` | `` |  |
-| 32 | `assist_player1` | `uint32` | `optional` | `` |  |
-| 33 | `assist_player2` | `uint32` | `optional` | `` |  |
-| 34 | `assist_player3` | `uint32` | `optional` | `` |  |
-| 35 | `stack_count` | `uint32` | `optional` | `` |  |
-| 36 | `hidden_modifier` | `bool` | `optional` | `` |  |
-| 37 | `is_target_building` | `bool` | `optional` | `` |  |
-| 38 | `neutral_camp_type` | `uint32` | `optional` | `` |  |
-| 39 | `rune_type` | `uint32` | `optional` | `` |  |
-| 40 | `assist_players` | `int32` | `repeated` | `` |  |
-| 41 | `is_heal_save` | `bool` | `optional` | `` |  |
-| 42 | `is_ultimate_ability` | `bool` | `optional` | `` |  |
-| 43 | `attacker_hero_level` | `uint32` | `optional` | `` |  |
-| 44 | `target_hero_level` | `uint32` | `optional` | `` |  |
-| 45 | `xpm` | `uint32` | `optional` | `` |  |
-| 46 | `gpm` | `uint32` | `optional` | `` |  |
-| 47 | `event_location` | `uint32` | `optional` | `` |  |
-| 48 | `target_is_self` | `bool` | `optional` | `` |  |
-| 49 | `damage_type` | `uint32` | `optional` | `` |  |
-| 50 | `invisibility_modifier` | `bool` | `optional` | `` |  |
-| 51 | `damage_category` | `uint32` | `optional` | `` |  |
-| 52 | `networth` | `uint32` | `optional` | `` |  |
-| 53 | `building_type` | `uint32` | `optional` | `` |  |
-| 54 | `modifier_elapsed_duration` | `float` | `optional` | `` |  |
-| 55 | `silence_modifier` | `bool` | `optional` | `` |  |
-| 56 | `heal_from_lifesteal` | `bool` | `optional` | `` |  |
-| 57 | `modifier_purged` | `bool` | `optional` | `` |  |
-| 58 | `spell_evaded` | `bool` | `optional` | `` |  |
-| 59 | `motion_controller_modifier` | `bool` | `optional` | `` |  |
-| 60 | `long_range_kill` | `bool` | `optional` | `` |  |
-| 61 | `modifier_purge_ability` | `uint32` | `optional` | `` |  |
-| 62 | `modifier_purge_npc` | `uint32` | `optional` | `` |  |
-| 63 | `root_modifier` | `bool` | `optional` | `` |  |
-| 64 | `total_unit_death_count` | `uint32` | `optional` | `` |  |
-| 65 | `aura_modifier` | `bool` | `optional` | `` |  |
-| 66 | `armor_debuff_modifier` | `bool` | `optional` | `` |  |
-| 67 | `no_physical_damage_modifier` | `bool` | `optional` | `` |  |
-| 68 | `modifier_ability` | `uint32` | `optional` | `` |  |
-| 69 | `modifier_hidden` | `bool` | `optional` | `` |  |
-| 70 | `inflictor_is_stolen_ability` | `bool` | `optional` | `` |  |
-| 71 | `kill_eater_event` | `uint32` | `optional` | `` |  |
-| 72 | `unit_status_label` | `uint32` | `optional` | `` |  |
-| 73 | `spell_generated_attack` | `bool` | `optional` | `` |  |
-| 74 | `at_night_time` | `bool` | `optional` | `` |  |
-| 75 | `attacker_has_scepter` | `bool` | `optional` | `` |  |
-| 76 | `neutral_camp_team` | `uint32` | `optional` | `` |  |
-| 77 | `regenerated_health` | `float` | `optional` | `` |  |
-| 78 | `will_reincarnate` | `bool` | `optional` | `` |  |
-| 79 | `uses_charges` | `bool` | `optional` | `` |  |
-| 80 | `tracked_stat_id` | `uint32` | `optional` | `` |  |
-| 81 | `modifier_purged_duration` | `float` | `optional` | `` |  |
-| 82 | `heal_from_regen` | `bool` | `optional` | `` |  |
+| 1 | `type` | `.DOTA_COMBATLOG_TYPES` | `optional` |  | default = DOTA_COMBATLOG_INVALID |
+| 2 | `target_name` | `uint32` | `optional` |  |  |
+| 3 | `target_source_name` | `uint32` | `optional` |  |  |
+| 4 | `attacker_name` | `uint32` | `optional` |  |  |
+| 5 | `damage_source_name` | `uint32` | `optional` |  |  |
+| 6 | `inflictor_name` | `uint32` | `optional` |  |  |
+| 7 | `is_attacker_illusion` | `bool` | `optional` |  |  |
+| 8 | `is_attacker_hero` | `bool` | `optional` |  |  |
+| 9 | `is_target_illusion` | `bool` | `optional` |  |  |
+| 10 | `is_target_hero` | `bool` | `optional` |  |  |
+| 11 | `is_visible_radiant` | `bool` | `optional` |  |  |
+| 12 | `is_visible_dire` | `bool` | `optional` |  |  |
+| 13 | `value` | `uint32` | `optional` |  |  |
+| 14 | `health` | `int32` | `optional` |  |  |
+| 15 | `timestamp` | `float` | `optional` |  |  |
+| 16 | `stun_duration` | `float` | `optional` |  |  |
+| 17 | `slow_duration` | `float` | `optional` |  |  |
+| 18 | `is_ability_toggle_on` | `bool` | `optional` |  |  |
+| 19 | `is_ability_toggle_off` | `bool` | `optional` |  |  |
+| 20 | `ability_level` | `uint32` | `optional` |  |  |
+| 21 | `location_x` | `float` | `optional` |  |  |
+| 22 | `location_y` | `float` | `optional` |  |  |
+| 23 | `gold_reason` | `uint32` | `optional` |  |  |
+| 24 | `timestamp_raw` | `float` | `optional` |  |  |
+| 25 | `modifier_duration` | `float` | `optional` |  |  |
+| 26 | `xp_reason` | `uint32` | `optional` |  |  |
+| 27 | `last_hits` | `uint32` | `optional` |  |  |
+| 28 | `attacker_team` | `uint32` | `optional` |  |  |
+| 29 | `target_team` | `uint32` | `optional` |  |  |
+| 30 | `obs_wards_placed` | `uint32` | `optional` |  |  |
+| 31 | `assist_player0` | `uint32` | `optional` |  |  |
+| 32 | `assist_player1` | `uint32` | `optional` |  |  |
+| 33 | `assist_player2` | `uint32` | `optional` |  |  |
+| 34 | `assist_player3` | `uint32` | `optional` |  |  |
+| 35 | `stack_count` | `uint32` | `optional` |  |  |
+| 36 | `hidden_modifier` | `bool` | `optional` |  |  |
+| 37 | `is_target_building` | `bool` | `optional` |  |  |
+| 38 | `neutral_camp_type` | `uint32` | `optional` |  |  |
+| 39 | `rune_type` | `uint32` | `optional` |  |  |
+| 40 | `assist_players` | `int32` | `repeated` |  |  |
+| 41 | `is_heal_save` | `bool` | `optional` |  |  |
+| 42 | `is_ultimate_ability` | `bool` | `optional` |  |  |
+| 43 | `attacker_hero_level` | `uint32` | `optional` |  |  |
+| 44 | `target_hero_level` | `uint32` | `optional` |  |  |
+| 45 | `xpm` | `uint32` | `optional` |  |  |
+| 46 | `gpm` | `uint32` | `optional` |  |  |
+| 47 | `event_location` | `uint32` | `optional` |  |  |
+| 48 | `target_is_self` | `bool` | `optional` |  |  |
+| 49 | `damage_type` | `uint32` | `optional` |  |  |
+| 50 | `invisibility_modifier` | `bool` | `optional` |  |  |
+| 51 | `damage_category` | `uint32` | `optional` |  |  |
+| 52 | `networth` | `uint32` | `optional` |  |  |
+| 53 | `building_type` | `uint32` | `optional` |  |  |
+| 54 | `modifier_elapsed_duration` | `float` | `optional` |  |  |
+| 55 | `silence_modifier` | `bool` | `optional` |  |  |
+| 56 | `heal_from_lifesteal` | `bool` | `optional` |  |  |
+| 57 | `modifier_purged` | `bool` | `optional` |  |  |
+| 58 | `spell_evaded` | `bool` | `optional` |  |  |
+| 59 | `motion_controller_modifier` | `bool` | `optional` |  |  |
+| 60 | `long_range_kill` | `bool` | `optional` |  |  |
+| 61 | `modifier_purge_ability` | `uint32` | `optional` |  |  |
+| 62 | `modifier_purge_npc` | `uint32` | `optional` |  |  |
+| 63 | `root_modifier` | `bool` | `optional` |  |  |
+| 64 | `total_unit_death_count` | `uint32` | `optional` |  |  |
+| 65 | `aura_modifier` | `bool` | `optional` |  |  |
+| 66 | `armor_debuff_modifier` | `bool` | `optional` |  |  |
+| 67 | `no_physical_damage_modifier` | `bool` | `optional` |  |  |
+| 68 | `modifier_ability` | `uint32` | `optional` |  |  |
+| 69 | `modifier_hidden` | `bool` | `optional` |  |  |
+| 70 | `inflictor_is_stolen_ability` | `bool` | `optional` |  |  |
+| 71 | `kill_eater_event` | `uint32` | `optional` |  |  |
+| 72 | `unit_status_label` | `uint32` | `optional` |  |  |
+| 73 | `spell_generated_attack` | `bool` | `optional` |  |  |
+| 74 | `at_night_time` | `bool` | `optional` |  |  |
+| 75 | `attacker_has_scepter` | `bool` | `optional` |  |  |
+| 76 | `neutral_camp_team` | `uint32` | `optional` |  |  |
+| 77 | `regenerated_health` | `float` | `optional` |  |  |
+| 78 | `will_reincarnate` | `bool` | `optional` |  |  |
+| 79 | `uses_charges` | `bool` | `optional` |  |  |
+| 80 | `tracked_stat_id` | `uint32` | `optional` |  |  |
+| 81 | `modifier_purged_duration` | `float` | `optional` |  |  |
+| 82 | `heal_from_regen` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -189,12 +189,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EEvent` | `optional` | `` | default = EVENT_ID_NONE |
-| 2 | `action_id` | `uint32` | `optional` | `` |  |
-| 3 | `num_to_grant` | `uint32` | `optional` | `` |  |
-| 4 | `score_mode` | `.EEventActionScoreMode` | `optional` | `` | default = k_eEventActionScoreMode_Add |
-| 5 | `audit_action` | `uint32` | `optional` | `` |  |
-| 6 | `audit_data` | `uint64` | `optional` | `` |  |
+| 1 | `event_id` | `.EEvent` | `optional` |  | default = EVENT_ID_NONE |
+| 2 | `action_id` | `uint32` | `optional` |  |  |
+| 3 | `num_to_grant` | `uint32` | `optional` |  |  |
+| 4 | `score_mode` | `.EEventActionScoreMode` | `optional` |  | default = k_eEventActionScoreMode_Add |
+| 5 | `audit_action` | `uint32` | `optional` |  |  |
+| 6 | `audit_data` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -206,7 +206,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `material_counts` | `.CMsgMonsterHunterMaterialQuantity.MaterialCountsEntry` | `repeated` | `` |  |
+| 1 | `material_counts` | `.CMsgMonsterHunterMaterialQuantity.MaterialCountsEntry` | `repeated` |  |  |
 
 </details>
 
@@ -218,8 +218,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `int32` | `optional` | `` |  |
+| 1 | `key` | `uint32` | `optional` |  |  |
+| 2 | `value` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -231,11 +231,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `persona_id` | `int32` | `optional` | `` |  |
-| 3 | `match_rewards` | `.CMsgMonsterHunterMaterialQuantity` | `optional` | `` |  |
-| 4 | `hunt_rewards` | `.CMsgMonsterHunterMaterialQuantity` | `optional` | `` |  |
-| 5 | `success_state` | `bool` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `persona_id` | `int32` | `optional` |  |  |
+| 3 | `match_rewards` | `.CMsgMonsterHunterMaterialQuantity` | `optional` |  |  |
+| 4 | `hunt_rewards` | `.CMsgMonsterHunterMaterialQuantity` | `optional` |  |  |
+| 5 | `success_state` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -247,8 +247,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `selected_investigation` | `.CMsgMonsterHunterInvestigation` | `optional` | `` |  |
-| 2 | `hunted_by` | `.CMsgMonsterHunterInvestigationGameState.HuntedBy` | `repeated` | `` |  |
+| 1 | `selected_investigation` | `.CMsgMonsterHunterInvestigation` | `optional` |  |  |
+| 2 | `hunted_by` | `.CMsgMonsterHunterInvestigationGameState.HuntedBy` | `repeated` |  |  |
 
 </details>
 
@@ -260,10 +260,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `persona_id` | `int32` | `optional` | `` |  |
-| 3 | `hunt_rewards` | `.CMsgMonsterHunterMaterialQuantity` | `optional` | `` |  |
-| 4 | `success_state` | `bool` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `persona_id` | `int32` | `optional` |  |  |
+| 3 | `hunt_rewards` | `.CMsgMonsterHunterMaterialQuantity` | `optional` |  |  |
+| 4 | `success_state` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -275,10 +275,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_hero` | `int32` | `optional` | `` |  |
-| 2 | `allies` | `int32` | `repeated` | `` |  |
-| 3 | `enemies` | `int32` | `repeated` | `` |  |
-| 4 | `player_kills` | `.CMsgMonsterHunterCodexUpdateData.KillInfo` | `repeated` | `` |  |
+| 1 | `player_hero` | `int32` | `optional` |  |  |
+| 2 | `allies` | `int32` | `repeated` |  |  |
+| 3 | `enemies` | `int32` | `repeated` |  |  |
+| 4 | `player_kills` | `.CMsgMonsterHunterCodexUpdateData.KillInfo` | `repeated` |  |  |
 
 </details>
 
@@ -290,8 +290,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_id` | `int32` | `optional` | `` |  |
-| 2 | `kill_count` | `int32` | `optional` | `` |  |
+| 1 | `hero_id` | `int32` | `optional` |  |  |
+| 2 | `kill_count` | `int32` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-usercmd.md
+++ b/docs/cookbook/proto-fields/dota-usercmd.md
@@ -24,16 +24,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `base` | `.CBaseUserCmdPB` | `optional` | `` |  |
-| 2 | `spectator_query_unit_entindex` | `int32` | `optional` | `` |  |
-| 3 | `crosshairtrace` | `.CMsgVector` | `optional` | `` |  |
-| 4 | `cameraposition_x` | `int32` | `optional` | `` |  |
-| 5 | `cameraposition_y` | `int32` | `optional` | `` |  |
-| 6 | `clickbehavior` | `uint32` | `optional` | `` |  |
-| 7 | `statspanel` | `uint32` | `optional` | `` |  |
-| 8 | `shoppanel` | `uint32` | `optional` | `` |  |
-| 9 | `stats_dropdown` | `uint32` | `optional` | `` |  |
-| 10 | `stats_dropdown_sort` | `uint32` | `optional` | `` |  |
+| 1 | `base` | `.CBaseUserCmdPB` | `optional` |  |  |
+| 2 | `spectator_query_unit_entindex` | `int32` | `optional` |  |  |
+| 3 | `crosshairtrace` | `.CMsgVector` | `optional` |  |  |
+| 4 | `cameraposition_x` | `int32` | `optional` |  |  |
+| 5 | `cameraposition_y` | `int32` | `optional` |  |  |
+| 6 | `clickbehavior` | `uint32` | `optional` |  |  |
+| 7 | `statspanel` | `uint32` | `optional` |  |  |
+| 8 | `shoppanel` | `uint32` | `optional` |  |  |
+| 9 | `stats_dropdown` | `uint32` | `optional` |  |  |
+| 10 | `stats_dropdown_sort` | `uint32` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/dota-usermessages.md
+++ b/docs/cookbook/proto-fields/dota-usermessages.md
@@ -25,7 +25,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `message` | `string` | `optional` | `` |  |
+| 1 | `message` | `string` | `optional` |  |  |
 
 </details>
 
@@ -37,8 +37,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `ping` | `uint32` | `optional` | `` |  |
-| 3 | `loss` | `uint32` | `optional` | `` |  |
+| 2 | `ping` | `uint32` | `optional` |  |  |
+| 3 | `loss` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -50,7 +50,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -62,17 +62,17 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `type` | `.DOTA_CHAT_MESSAGE` | `optional` | `` | default = CHAT_MESSAGE_INVALID |
-| 2 | `value` | `uint32` | `optional` | `` |  |
-| 3 | `playerid_1` | `sint32` | `optional` | `` | default = -1 |
-| 4 | `playerid_2` | `sint32` | `optional` | `` | default = -1 |
-| 5 | `playerid_3` | `sint32` | `optional` | `` | default = -1 |
-| 6 | `playerid_4` | `sint32` | `optional` | `` | default = -1 |
-| 7 | `playerid_5` | `sint32` | `optional` | `` | default = -1 |
-| 8 | `playerid_6` | `sint32` | `optional` | `` | default = -1 |
-| 9 | `value2` | `uint32` | `optional` | `` |  |
-| 10 | `value3` | `uint32` | `optional` | `` |  |
-| 11 | `time` | `float` | `optional` | `` |  |
+| 1 | `type` | `.DOTA_CHAT_MESSAGE` | `optional` |  | default = CHAT_MESSAGE_INVALID |
+| 2 | `value` | `uint32` | `optional` |  |  |
+| 3 | `playerid_1` | `sint32` | `optional` |  | default = -1 |
+| 4 | `playerid_2` | `sint32` | `optional` |  | default = -1 |
+| 5 | `playerid_3` | `sint32` | `optional` |  | default = -1 |
+| 6 | `playerid_4` | `sint32` | `optional` |  | default = -1 |
+| 7 | `playerid_5` | `sint32` | `optional` |  | default = -1 |
+| 8 | `playerid_6` | `sint32` | `optional` |  | default = -1 |
+| 9 | `value2` | `uint32` | `optional` |  |  |
+| 10 | `value3` | `uint32` | `optional` |  |  |
+| 11 | `time` | `float` | `optional` |  |  |
 
 </details>
 
@@ -84,10 +84,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `message` | `string` | `optional` | `` |  |
-| 4 | `target` | `string` | `optional` | `` |  |
-| 5 | `team_only` | `bool` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `message` | `string` | `optional` |  |  |
+| 4 | `target` | `string` | `optional` |  |  |
+| 5 | `team_only` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -99,10 +99,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `index` | `uint32` | `optional` | `` |  |
-| 2 | `time` | `int32` | `optional` | `` |  |
-| 3 | `world_pos` | `.CMsgVector2D` | `optional` | `` |  |
-| 4 | `health` | `int32` | `optional` | `` |  |
+| 1 | `index` | `uint32` | `optional` |  |  |
+| 2 | `time` | `int32` | `optional` |  |  |
+| 3 | `world_pos` | `.CMsgVector2D` | `optional` |  |  |
+| 4 | `health` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -114,11 +114,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `combat_entries` | `.CMsgDOTACombatLogEntry` | `repeated` | `` |  |
-| 2 | `timestamp` | `float` | `optional` | `` |  |
-| 3 | `duration` | `float` | `optional` | `` |  |
-| 4 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 5 | `request_time` | `float` | `optional` | `` |  |
+| 1 | `combat_entries` | `.CMsgDOTACombatLogEntry` | `repeated` |  |  |
+| 2 | `timestamp` | `float` | `optional` |  |  |
+| 3 | `duration` | `float` | `optional` |  |  |
+| 4 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 5 | `request_time` | `float` | `optional` |  |  |
 
 </details>
 
@@ -130,8 +130,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `control_point` | `int32` | `optional` | `` |  |
-| 2 | `vector` | `.CMsgVector` | `optional` | `` |  |
+| 1 | `control_point` | `int32` | `optional` |  |  |
+| 2 | `vector` | `.CMsgVector` | `optional` |  |  |
 
 </details>
 
@@ -143,9 +143,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `handle` | `int32` | `optional` | `` |  |
-| 2 | `control_point` | `int32` | `optional` | `` |  |
-| 3 | `vector` | `.CMsgVector` | `optional` | `` |  |
+| 1 | `handle` | `int32` | `optional` |  |  |
+| 2 | `control_point` | `int32` | `optional` |  |  |
+| 3 | `vector` | `.CMsgVector` | `optional` |  |  |
 
 </details>
 
@@ -157,7 +157,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `attackers` | `.CDOTAUserMsg_MiniKillCamInfo.Attacker` | `repeated` | `` |  |
+| 1 | `attackers` | `.CDOTAUserMsg_MiniKillCamInfo.Attacker` | `repeated` |  |  |
 
 </details>
 
@@ -169,10 +169,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `attacker` | `uint32` | `optional` | `` | default = 16777215 |
-| 2 | `total_damage` | `int32` | `optional` | `` |  |
-| 3 | `abilities` | `.CDOTAUserMsg_MiniKillCamInfo.Attacker.Ability` | `repeated` | `` |  |
-| 4 | `attacker_name` | `string` | `optional` | `` |  |
+| 1 | `attacker` | `uint32` | `optional` |  | default = 16777215 |
+| 2 | `total_damage` | `int32` | `optional` |  |  |
+| 3 | `abilities` | `.CDOTAUserMsg_MiniKillCamInfo.Attacker.Ability` | `repeated` |  |  |
+| 4 | `attacker_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -184,8 +184,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ability_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `damage` | `int32` | `optional` | `` |  |
+| 1 | `ability_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `damage` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -197,8 +197,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `color` | `uint32` | `optional` | `` |  |
-| 2 | `duration` | `float` | `optional` | `` |  |
+| 1 | `color` | `uint32` | `optional` |  |  |
+| 2 | `duration` | `float` | `optional` |  |  |
 
 </details>
 
@@ -210,8 +210,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `direction` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `duration` | `float` | `optional` | `` |  |
+| 1 | `direction` | `.CMsgVector` | `optional` |  |  |
+| 2 | `duration` | `float` | `optional` |  |  |
 
 </details>
 
@@ -223,8 +223,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `location_ping` | `.CDOTAMsg_LocationPing` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `location_ping` | `.CDOTAMsg_LocationPing` | `optional` |  |  |
 
 </details>
 
@@ -236,10 +236,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id_of_original_pinger` | `int32` | `optional` | `` | default = -1 |
-| 2 | `entity_index` | `uint32` | `optional` | `` |  |
-| 3 | `icon_type` | `uint32` | `optional` | `` |  |
-| 4 | `location` | `.CMsgVector` | `optional` | `` |  |
+| 1 | `player_id_of_original_pinger` | `int32` | `optional` |  | default = -1 |
+| 2 | `entity_index` | `uint32` | `optional` |  |  |
+| 3 | `icon_type` | `uint32` | `optional` |  |  |
+| 4 | `location` | `.CMsgVector` | `optional` |  |  |
 
 </details>
 
@@ -251,8 +251,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `item_alert` | `.CDOTAMsg_ItemAlert` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `item_alert` | `.CDOTAMsg_ItemAlert` | `optional` |  |  |
 
 </details>
 
@@ -264,14 +264,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `target_player_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `item_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 4 | `rune_type` | `int32` | `optional` | `` | default = -1 |
-| 5 | `entity_id` | `int32` | `optional` | `` |  |
-| 6 | `item_level` | `int32` | `optional` | `` | default = -1 |
-| 7 | `primary_charges` | `int32` | `optional` | `` | default = -1 |
-| 8 | `secondary_charges` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `target_player_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `item_ability_id` | `int32` | `optional` |  | default = -1 |
+| 4 | `rune_type` | `int32` | `optional` |  | default = -1 |
+| 5 | `entity_id` | `int32` | `optional` |  |  |
+| 6 | `item_level` | `int32` | `optional` |  | default = -1 |
+| 7 | `primary_charges` | `int32` | `optional` |  | default = -1 |
+| 8 | `secondary_charges` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -283,12 +283,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `class_name` | `string` | `optional` | `` |  |
-| 3 | `stack_count` | `uint32` | `optional` | `` |  |
-| 4 | `is_debuff` | `bool` | `optional` | `` |  |
-| 5 | `target_entindex` | `int32` | `optional` | `` | default = -1 |
-| 6 | `seconds_remaining` | `float` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `class_name` | `string` | `optional` |  |  |
+| 3 | `stack_count` | `uint32` | `optional` |  |  |
+| 4 | `is_debuff` | `bool` | `optional` |  |  |
+| 5 | `target_entindex` | `int32` | `optional` |  | default = -1 |
+| 6 | `seconds_remaining` | `float` | `optional` |  |  |
 
 </details>
 
@@ -300,9 +300,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `target_entindex` | `int32` | `optional` | `` | default = -1 |
-| 3 | `show_raw_values` | `bool` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `target_entindex` | `int32` | `optional` |  | default = -1 |
+| 3 | `show_raw_values` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -314,13 +314,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `spawner_entindex` | `int32` | `optional` | `` | default = -1 |
-| 3 | `unit_entindex` | `int32` | `optional` | `` | default = -1 |
-| 4 | `stack_count` | `int32` | `optional` | `` |  |
-| 5 | `camp_type` | `int32` | `optional` | `` |  |
-| 6 | `stack_request` | `bool` | `optional` | `` |  |
-| 7 | `stack_intention` | `bool` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `spawner_entindex` | `int32` | `optional` |  | default = -1 |
+| 3 | `unit_entindex` | `int32` | `optional` |  | default = -1 |
+| 4 | `stack_count` | `int32` | `optional` |  |  |
+| 5 | `camp_type` | `int32` | `optional` |  |  |
+| 6 | `stack_request` | `bool` | `optional` |  |  |
+| 7 | `stack_intention` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -332,8 +332,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `negative` | `bool` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `negative` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -345,8 +345,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `negative` | `bool` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `negative` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -358,8 +358,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `negative` | `bool` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `negative` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -371,8 +371,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `negative` | `bool` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `negative` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -384,10 +384,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `gold_remaining` | `uint32` | `optional` | `` |  |
-| 4 | `suggestion_player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `item_ability_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `gold_remaining` | `uint32` | `optional` |  |  |
+| 4 | `suggestion_player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -399,9 +399,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `source_player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `target_player_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `cooldown_seconds` | `int32` | `optional` | `` |  |
+| 1 | `source_player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `target_player_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `cooldown_seconds` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -413,9 +413,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `source_ehandle` | `uint32` | `optional` | `` | default = 16777215 |
-| 2 | `target_ehandle` | `uint32` | `optional` | `` | default = 16777215 |
-| 3 | `warrior_index` | `int32` | `optional` | `` |  |
+| 1 | `source_ehandle` | `uint32` | `optional` |  | default = 16777215 |
+| 2 | `target_ehandle` | `uint32` | `optional` |  | default = 16777215 |
+| 3 | `warrior_index` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -427,7 +427,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -439,11 +439,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `item_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `gold_cost` | `int32` | `optional` | `` |  |
-| 4 | `item_cooldown_seconds` | `int32` | `optional` | `` |  |
-| 5 | `show_buyback` | `bool` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `item_ability_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `gold_cost` | `int32` | `optional` |  |  |
+| 4 | `item_cooldown_seconds` | `int32` | `optional` |  |  |
+| 5 | `show_buyback` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -455,13 +455,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team` | `uint32` | `optional` | `` |  |
-| 2 | `gold_value` | `uint32` | `optional` | `` |  |
-| 3 | `entity_handle` | `uint32` | `optional` | `` | default = 16777215 |
-| 4 | `timestamp` | `int32` | `optional` | `` |  |
-| 5 | `lost_items` | `.CDOTAUserMsg_CourierKilledAlert.LostItem` | `repeated` | `` |  |
-| 6 | `killer_player_id` | `int32` | `optional` | `` | default = -1 |
-| 7 | `owning_player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `team` | `uint32` | `optional` |  |  |
+| 2 | `gold_value` | `uint32` | `optional` |  |  |
+| 3 | `entity_handle` | `uint32` | `optional` |  | default = 16777215 |
+| 4 | `timestamp` | `int32` | `optional` |  |  |
+| 5 | `lost_items` | `.CDOTAUserMsg_CourierKilledAlert.LostItem` | `repeated` |  |  |
+| 6 | `killer_player_id` | `int32` | `optional` |  | default = -1 |
+| 7 | `owning_player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -473,8 +473,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `quantity` | `uint32` | `optional` | `` |  |
+| 1 | `item_ability_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `quantity` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -486,12 +486,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_type` | `int32` | `optional` | `` |  |
-| 2 | `entity_handle` | `uint32` | `optional` | `` | default = 16777215 |
-| 3 | `x` | `int32` | `optional` | `` |  |
-| 4 | `y` | `int32` | `optional` | `` |  |
-| 5 | `duration` | `int32` | `optional` | `` |  |
-| 6 | `target_entity_handle` | `uint32` | `optional` | `` | default = 16777215 |
+| 1 | `event_type` | `int32` | `optional` |  |  |
+| 2 | `entity_handle` | `uint32` | `optional` |  | default = 16777215 |
+| 3 | `x` | `int32` | `optional` |  |  |
+| 4 | `y` | `int32` | `optional` |  |  |
+| 5 | `duration` | `int32` | `optional` |  |  |
+| 6 | `target_entity_handle` | `uint32` | `optional` |  | default = 16777215 |
 
 </details>
 
@@ -503,8 +503,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `mapline` | `.CDOTAMsg_MapLine` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `mapline` | `.CDOTAMsg_MapLine` | `optional` |  |  |
 
 </details>
 
@@ -516,11 +516,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `location` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `color` | `uint32` | `optional` | `` |  |
-| 3 | `size` | `int32` | `optional` | `` |  |
-| 4 | `duration` | `float` | `optional` | `` |  |
-| 5 | `index` | `int32` | `optional` | `` |  |
+| 1 | `location` | `.CMsgVector` | `optional` |  |  |
+| 2 | `color` | `uint32` | `optional` |  |  |
+| 3 | `size` | `int32` | `optional` |  |  |
+| 4 | `duration` | `float` | `optional` |  |  |
+| 5 | `index` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -532,18 +532,18 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `origin` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `velocity` | `.CMsgVector2D` | `optional` | `` |  |
-| 4 | `entindex` | `int32` | `optional` | `` | default = -1 |
-| 5 | `particle_index` | `uint64` | `optional` | `` |  |
-| 6 | `handle` | `int32` | `optional` | `` |  |
-| 7 | `acceleration` | `.CMsgVector2D` | `optional` | `` |  |
-| 8 | `max_speed` | `float` | `optional` | `` |  |
-| 9 | `fow_radius` | `float` | `optional` | `` |  |
-| 10 | `sticky_fow_reveal` | `bool` | `optional` | `` |  |
-| 11 | `distance` | `float` | `optional` | `` |  |
-| 12 | `colorgemcolor` | `fixed32` | `optional` | `` |  |
-| 13 | `particle_cp_data` | `.CDOTAUserMsg_ProjectileParticleCPData` | `repeated` | `` |  |
+| 1 | `origin` | `.CMsgVector` | `optional` |  |  |
+| 2 | `velocity` | `.CMsgVector2D` | `optional` |  |  |
+| 4 | `entindex` | `int32` | `optional` |  | default = -1 |
+| 5 | `particle_index` | `uint64` | `optional` |  |  |
+| 6 | `handle` | `int32` | `optional` |  |  |
+| 7 | `acceleration` | `.CMsgVector2D` | `optional` |  |  |
+| 8 | `max_speed` | `float` | `optional` |  |  |
+| 9 | `fow_radius` | `float` | `optional` |  |  |
+| 10 | `sticky_fow_reveal` | `bool` | `optional` |  |  |
+| 11 | `distance` | `float` | `optional` |  |  |
+| 12 | `colorgemcolor` | `fixed32` | `optional` |  |  |
+| 13 | `particle_cp_data` | `.CDOTAUserMsg_ProjectileParticleCPData` | `repeated` |  |  |
 
 </details>
 
@@ -555,7 +555,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `handle` | `int32` | `optional` | `` |  |
+| 1 | `handle` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -567,8 +567,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `entindex` | `int32` | `optional` | `` | default = -1 |
-| 2 | `attacks_only` | `bool` | `optional` | `` |  |
+| 1 | `entindex` | `int32` | `optional` |  | default = -1 |
+| 2 | `attacks_only` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -580,9 +580,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `entindex` | `int32` | `optional` | `` | default = -1 |
-| 2 | `order_type` | `int32` | `optional` | `` |  |
-| 3 | `target_index` | `int32` | `optional` | `` | default = 0 |
+| 1 | `entindex` | `int32` | `optional` |  | default = -1 |
+| 2 | `order_type` | `int32` | `optional` |  |  |
+| 3 | `target_index` | `int32` | `optional` |  | default = 0 |
 
 </details>
 
@@ -594,17 +594,17 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `entindex` | `int32` | `optional` | `` | default = -1 |
-| 2 | `order_type` | `int32` | `optional` | `` |  |
-| 3 | `units` | `int32` | `repeated` | `` |  |
-| 4 | `target_index` | `int32` | `optional` | `` | default = 0 |
-| 5 | `ability_id` | `int32` | `optional` | `` | default = -1 |
-| 6 | `position` | `.CMsgVector` | `optional` | `` |  |
-| 7 | `queue` | `bool` | `optional` | `` |  |
-| 8 | `sequence_number` | `int32` | `optional` | `` |  |
-| 9 | `flags` | `uint32` | `optional` | `` |  |
-| 10 | `last_order_latency` | `uint32` | `optional` | `` |  |
-| 11 | `ping` | `uint32` | `optional` | `` |  |
+| 1 | `entindex` | `int32` | `optional` |  | default = -1 |
+| 2 | `order_type` | `int32` | `optional` |  |  |
+| 3 | `units` | `int32` | `repeated` |  |  |
+| 4 | `target_index` | `int32` | `optional` |  | default = 0 |
+| 5 | `ability_id` | `int32` | `optional` |  | default = -1 |
+| 6 | `position` | `.CMsgVector` | `optional` |  |  |
+| 7 | `queue` | `bool` | `optional` |  |  |
+| 8 | `sequence_number` | `int32` | `optional` |  |  |
+| 9 | `flags` | `uint32` | `optional` |  |  |
+| 10 | `last_order_latency` | `uint32` | `optional` |  |  |
+| 11 | `ping` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -616,10 +616,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `entity_handle` | `uint32` | `optional` | `` | default = 16777215 |
-| 2 | `lines` | `int32` | `optional` | `` |  |
-| 3 | `origin` | `.CMsgVector` | `optional` | `` |  |
-| 4 | `reverse` | `bool` | `optional` | `` |  |
+| 1 | `entity_handle` | `uint32` | `optional` |  | default = 16777215 |
+| 2 | `lines` | `int32` | `optional` |  |  |
+| 3 | `origin` | `.CMsgVector` | `optional` |  |  |
+| 4 | `reverse` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -631,8 +631,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `message` | `string` | `optional` | `` |  |
-| 2 | `sequence_number` | `int32` | `optional` | `` |  |
+| 1 | `message` | `string` | `optional` |  |  |
+| 2 | `sequence_number` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -644,8 +644,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `order_id` | `int32` | `optional` | `` |  |
-| 2 | `sequence_number` | `int32` | `optional` | `` |  |
+| 1 | `order_id` | `int32` | `optional` |  |  |
+| 2 | `sequence_number` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -657,10 +657,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `entindex` | `int32` | `optional` | `` | default = -1 |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `cooldown` | `float` | `optional` | `` |  |
-| 4 | `name_index` | `int32` | `optional` | `` |  |
+| 1 | `entindex` | `int32` | `optional` |  | default = -1 |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `cooldown` | `float` | `optional` |  |  |
+| 4 | `name_index` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -672,7 +672,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -684,9 +684,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_defs` | `uint32` | `repeated` | `` |  |
-| 2 | `player_ids` | `int32` | `repeated` | `` |  |
-| 3 | `prize_list` | `uint32` | `optional` | `` |  |
+| 1 | `item_defs` | `uint32` | `repeated` |  |  |
+| 2 | `player_ids` | `int32` | `repeated` |  |  |
+| 3 | `prize_list` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -698,7 +698,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `owning_player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `owning_player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -710,7 +710,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `facts` | `.CDOTAResponseQuerySerialized.Fact` | `repeated` | `` |  |
+| 1 | `facts` | `.CDOTAResponseQuerySerialized.Fact` | `repeated` |  |  |
 
 </details>
 
@@ -722,12 +722,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key` | `int32` | `optional` | `` |  |
-| 2 | `valtype` | `.CDOTAResponseQuerySerialized.Fact.ValueType` | `optional` | `` | default = NUMERIC |
-| 3 | `val_numeric` | `float` | `optional` | `` |  |
-| 4 | `val_string` | `string` | `optional` | `` |  |
-| 5 | `val_stringtable_index` | `int32` | `optional` | `` |  |
-| 6 | `val_int_numeric` | `sint32` | `optional` | `` |  |
+| 1 | `key` | `int32` | `optional` |  |  |
+| 2 | `valtype` | `.CDOTAResponseQuerySerialized.Fact.ValueType` | `optional` |  | default = NUMERIC |
+| 3 | `val_numeric` | `float` | `optional` |  |  |
+| 4 | `val_string` | `string` | `optional` |  |  |
+| 5 | `val_stringtable_index` | `int32` | `optional` |  |  |
+| 6 | `val_int_numeric` | `sint32` | `optional` |  |  |
 
 </details>
 
@@ -739,10 +739,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `speech_concept` | `int32` | `optional` | `` |  |
-| 2 | `recipient_type` | `int32` | `optional` | `` |  |
-| 3 | `responsequery` | `.CDOTAResponseQuerySerialized` | `optional` | `` |  |
-| 4 | `randomseed` | `sfixed32` | `optional` | `` | default = 0 |
+| 1 | `speech_concept` | `int32` | `optional` |  |  |
+| 2 | `recipient_type` | `int32` | `optional` |  |  |
+| 3 | `responsequery` | `.CDOTAResponseQuerySerialized` | `optional` |  |  |
+| 4 | `randomseed` | `sfixed32` | `optional` |  | default = 0 |
 
 </details>
 
@@ -754,15 +754,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `msg_type` | `.EDotaEntityMessages` | `optional` | `` | default = DOTA_UNIT_SPEECH |
-| 2 | `entity_index` | `int32` | `optional` | `` |  |
-| 3 | `speech` | `.CDOTAUserMsg_UnitEvent.Speech` | `optional` | `` |  |
-| 4 | `speech_mute` | `.CDOTAUserMsg_UnitEvent.SpeechMute` | `optional` | `` |  |
-| 5 | `add_gesture` | `.CDOTAUserMsg_UnitEvent.AddGesture` | `optional` | `` |  |
-| 6 | `remove_gesture` | `.CDOTAUserMsg_UnitEvent.RemoveGesture` | `optional` | `` |  |
-| 7 | `blood_impact` | `.CDOTAUserMsg_UnitEvent.BloodImpact` | `optional` | `` |  |
-| 8 | `fade_gesture` | `.CDOTAUserMsg_UnitEvent.FadeGesture` | `optional` | `` |  |
-| 9 | `speech_match_on_client` | `.CDOTASpeechMatchOnClient` | `optional` | `` |  |
+| 1 | `msg_type` | `.EDotaEntityMessages` | `optional` |  | default = DOTA_UNIT_SPEECH |
+| 2 | `entity_index` | `int32` | `optional` |  |  |
+| 3 | `speech` | `.CDOTAUserMsg_UnitEvent.Speech` | `optional` |  |  |
+| 4 | `speech_mute` | `.CDOTAUserMsg_UnitEvent.SpeechMute` | `optional` |  |  |
+| 5 | `add_gesture` | `.CDOTAUserMsg_UnitEvent.AddGesture` | `optional` |  |  |
+| 6 | `remove_gesture` | `.CDOTAUserMsg_UnitEvent.RemoveGesture` | `optional` |  |  |
+| 7 | `blood_impact` | `.CDOTAUserMsg_UnitEvent.BloodImpact` | `optional` |  |  |
+| 8 | `fade_gesture` | `.CDOTAUserMsg_UnitEvent.FadeGesture` | `optional` |  |  |
+| 9 | `speech_match_on_client` | `.CDOTASpeechMatchOnClient` | `optional` |  |  |
 
 </details>
 
@@ -774,8 +774,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `start` | `float` | `optional` | `` |  |
-| 2 | `range` | `float` | `optional` | `` |  |
+| 1 | `start` | `float` | `optional` |  |  |
+| 2 | `range` | `float` | `optional` |  |  |
 
 </details>
 
@@ -787,13 +787,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `speech_concept` | `int32` | `optional` | `` |  |
-| 2 | `response` | `string` | `optional` | `` |  |
-| 3 | `recipient_type` | `int32` | `optional` | `` |  |
-| 5 | `muteable` | `bool` | `optional` | `` | default = false |
-| 6 | `predelay` | `.CDOTAUserMsg_UnitEvent.Interval` | `optional` | `` |  |
-| 7 | `flags` | `uint32` | `optional` | `` |  |
-| 8 | `response_type` | `int32` | `optional` | `` |  |
+| 1 | `speech_concept` | `int32` | `optional` |  |  |
+| 2 | `response` | `string` | `optional` |  |  |
+| 3 | `recipient_type` | `int32` | `optional` |  |  |
+| 5 | `muteable` | `bool` | `optional` |  | default = false |
+| 6 | `predelay` | `.CDOTAUserMsg_UnitEvent.Interval` | `optional` |  |  |
+| 7 | `flags` | `uint32` | `optional` |  |  |
+| 8 | `response_type` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -805,7 +805,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `delay` | `float` | `optional` | `` | default = 0.5 |
+| 1 | `delay` | `float` | `optional` |  | default = 0.5 |
 
 </details>
 
@@ -817,12 +817,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `activity` | `int32` | `optional` | `` |  |
-| 2 | `slot` | `int32` | `optional` | `` |  |
-| 3 | `fade_in` | `float` | `optional` | `` | default = 0 |
-| 4 | `fade_out` | `float` | `optional` | `` | default = 0.1 |
-| 5 | `playback_rate` | `float` | `optional` | `` | default = 1 |
-| 6 | `sequence_variant` | `int32` | `optional` | `` |  |
+| 1 | `activity` | `int32` | `optional` |  |  |
+| 2 | `slot` | `int32` | `optional` |  |  |
+| 3 | `fade_in` | `float` | `optional` |  | default = 0 |
+| 4 | `fade_out` | `float` | `optional` |  | default = 0.1 |
+| 5 | `playback_rate` | `float` | `optional` |  | default = 1 |
+| 6 | `sequence_variant` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -834,7 +834,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `activity` | `int32` | `optional` | `` |  |
+| 1 | `activity` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -846,9 +846,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `scale` | `int32` | `optional` | `` |  |
-| 2 | `x_normal` | `int32` | `optional` | `` |  |
-| 3 | `y_normal` | `int32` | `optional` | `` |  |
+| 1 | `scale` | `int32` | `optional` |  |  |
+| 2 | `x_normal` | `int32` | `optional` |  |  |
+| 3 | `y_normal` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -860,7 +860,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `activity` | `int32` | `optional` | `` |  |
+| 1 | `activity` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -872,8 +872,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `from_combine` | `bool` | `optional` | `` |  |
+| 1 | `item_ability_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `from_combine` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -885,7 +885,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_ability_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `item_ability_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -897,11 +897,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player` | `int32` | `optional` | `` | default = -1 |
-| 2 | `quality` | `int32` | `optional` | `` |  |
-| 3 | `rarity` | `int32` | `optional` | `` |  |
-| 4 | `method` | `int32` | `optional` | `` |  |
-| 5 | `itemdef` | `uint32` | `optional` | `` |  |
+| 1 | `player` | `int32` | `optional` |  | default = -1 |
+| 2 | `quality` | `int32` | `optional` |  |  |
+| 3 | `rarity` | `int32` | `optional` |  |  |
+| 4 | `method` | `int32` | `optional` |  |  |
+| 5 | `itemdef` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -913,11 +913,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `message_type` | `.DOTA_OVERHEAD_ALERT` | `optional` | `` | default = OVERHEAD_ALERT_GOLD |
-| 2 | `value` | `int32` | `optional` | `` |  |
-| 3 | `target_player_entindex` | `int32` | `optional` | `` | default = -1 |
-| 4 | `target_entindex` | `int32` | `optional` | `` | default = -1 |
-| 5 | `source_player_entindex` | `int32` | `optional` | `` | default = -1 |
+| 1 | `message_type` | `.DOTA_OVERHEAD_ALERT` | `optional` |  | default = OVERHEAD_ALERT_GOLD |
+| 2 | `value` | `int32` | `optional` |  |  |
+| 3 | `target_player_entindex` | `int32` | `optional` |  | default = -1 |
+| 4 | `target_entindex` | `int32` | `optional` |  | default = -1 |
+| 5 | `source_player_entindex` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -929,8 +929,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `progress` | `int32` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `progress` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -942,10 +942,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `heading` | `string` | `optional` | `` |  |
-| 2 | `emblem` | `string` | `optional` | `` |  |
-| 3 | `body` | `string` | `optional` | `` |  |
-| 4 | `success` | `bool` | `optional` | `` |  |
+| 1 | `heading` | `string` | `optional` |  |  |
+| 2 | `emblem` | `string` | `optional` |  |  |
+| 3 | `body` | `string` | `optional` |  |  |
+| 4 | `success` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -969,10 +969,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `title` | `string` | `optional` | `` |  |
-| 2 | `text` | `string` | `optional` | `` |  |
-| 3 | `entindex` | `int32` | `optional` | `` |  |
-| 4 | `close` | `bool` | `optional` | `` |  |
+| 1 | `title` | `string` | `optional` |  |  |
+| 2 | `text` | `string` | `optional` |  |  |
+| 3 | `entindex` | `int32` | `optional` |  |  |
+| 4 | `close` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -984,8 +984,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `worldline` | `.CDOTAMsg_WorldLine` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `worldline` | `.CDOTAMsg_WorldLine` | `optional` |  |  |
 
 </details>
 
@@ -997,11 +997,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `chat_message_id` | `uint32` | `optional` | `` | default = 4294967295 |
-| 2 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `account_id` | `uint32` | `optional` | `` |  |
-| 4 | `param_hero_id` | `int32` | `optional` | `` |  |
-| 5 | `emoticon_id` | `uint32` | `optional` | `` |  |
+| 1 | `chat_message_id` | `uint32` | `optional` |  | default = 4294967295 |
+| 2 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `account_id` | `uint32` | `optional` |  |  |
+| 4 | `param_hero_id` | `int32` | `optional` |  |  |
+| 5 | `emoticon_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1013,9 +1013,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `item_name` | `string` | `optional` | `` |  |
-| 3 | `inventory_slot` | `int32` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `item_name` | `string` | `optional` |  |  |
+| 3 | `inventory_slot` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1027,12 +1027,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `survey_id` | `int32` | `optional` | `` |  |
-| 2 | `match_id` | `uint64` | `optional` | `` |  |
-| 3 | `response_style` | `string` | `optional` | `` |  |
-| 4 | `teammate_hero_id` | `int32` | `optional` | `` |  |
-| 5 | `teammate_name` | `string` | `optional` | `` |  |
-| 6 | `teammate_account_id` | `uint32` | `optional` | `` |  |
+| 1 | `survey_id` | `int32` | `optional` |  |  |
+| 2 | `match_id` | `uint64` | `optional` |  |  |
+| 3 | `response_style` | `string` | `optional` |  |  |
+| 4 | `teammate_hero_id` | `int32` | `optional` |  |  |
+| 5 | `teammate_name` | `string` | `optional` |  |  |
+| 6 | `teammate_account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1044,7 +1044,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `slot_type` | `int32` | `optional` | `` |  |
+| 1 | `slot_type` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1068,7 +1068,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tgt_alpha` | `int32` | `optional` | `` |  |
+| 1 | `tgt_alpha` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1080,11 +1080,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `pos_x` | `float` | `optional` | `` |  |
-| 3 | `pos_y` | `float` | `optional` | `` |  |
-| 4 | `pos_z` | `float` | `optional` | `` |  |
-| 5 | `entity_index` | `int32` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `pos_x` | `float` | `optional` |  |  |
+| 3 | `pos_y` | `float` | `optional` |  |  |
+| 4 | `pos_z` | `float` | `optional` |  |  |
+| 5 | `entity_index` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1096,7 +1096,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `state` | `uint32` | `optional` | `` |  |
+| 1 | `state` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1108,8 +1108,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `npc_name` | `string` | `optional` | `` |  |
-| 2 | `npc_dialog` | `string` | `optional` | `` |  |
+| 1 | `npc_name` | `string` | `optional` |  |  |
+| 2 | `npc_dialog` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1121,8 +1121,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `statpopup` | `.CDOTAMsg_SendStatPopup` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `statpopup` | `.CDOTAMsg_SendStatPopup` | `optional` |  |  |
 
 </details>
 
@@ -1134,7 +1134,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `dismissallmsg` | `.CDOTAMsg_DismissAllStatPopups` | `optional` | `` |  |
+| 1 | `dismissallmsg` | `.CDOTAMsg_DismissAllStatPopups` | `optional` |  |  |
 
 </details>
 
@@ -1146,9 +1146,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `phase` | `.DOTA_ROSHAN_PHASE` | `optional` | `` | default = k_SRSP_ROSHAN_ALIVE |
-| 2 | `phase_start_time` | `int32` | `optional` | `` |  |
-| 3 | `phase_length` | `int32` | `optional` | `` |  |
+| 1 | `phase` | `.DOTA_ROSHAN_PHASE` | `optional` |  | default = k_SRSP_ROSHAN_ALIVE |
+| 2 | `phase_start_time` | `int32` | `optional` |  |  |
+| 3 | `phase_length` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1160,8 +1160,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `reclaimed` | `bool` | `optional` | `` |  |
-| 2 | `gametime` | `int32` | `optional` | `` |  |
+| 1 | `reclaimed` | `bool` | `optional` |  |  |
+| 2 | `gametime` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1173,8 +1173,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `reliable_gold` | `uint32` | `repeated` | `` |  |
-| 2 | `unreliable_gold` | `uint32` | `repeated` | `` |  |
+| 1 | `reliable_gold` | `uint32` | `repeated` |  |  |
+| 2 | `unreliable_gold` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -1186,9 +1186,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `message` | `string` | `optional` | `` |  |
-| 2 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `value` | `int32` | `optional` | `` |  |
+| 1 | `message` | `string` | `optional` |  |  |
+| 2 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `value` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1200,8 +1200,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `hud_ping` | `.CDOTAMsg_CoachHUDPing` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `hud_ping` | `.CDOTAMsg_CoachHUDPing` | `optional` |  |  |
 
 </details>
 
@@ -1225,24 +1225,24 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `source` | `uint32` | `optional` | `` | default = 16777215 |
-| 2 | `target` | `uint32` | `optional` | `` | default = 16777215 |
-| 3 | `move_speed` | `int32` | `optional` | `` |  |
-| 4 | `source_attachment` | `int32` | `optional` | `` |  |
-| 5 | `particle_system_handle` | `int64` | `optional` | `` |  |
-| 6 | `dodgeable` | `bool` | `optional` | `` |  |
-| 7 | `is_attack` | `bool` | `optional` | `` |  |
-| 9 | `expire_time` | `float` | `optional` | `` |  |
-| 10 | `maximpacttime` | `float` | `optional` | `` |  |
-| 11 | `colorgemcolor` | `fixed32` | `optional` | `` |  |
-| 12 | `launch_tick` | `int32` | `optional` | `` |  |
-| 13 | `handle` | `int32` | `optional` | `` |  |
-| 14 | `target_loc` | `.CMsgVector` | `optional` | `` |  |
-| 15 | `particle_cp_data` | `.CDOTAUserMsg_ProjectileParticleCPData` | `repeated` | `` |  |
-| 16 | `additional_particle_system_handle` | `int64` | `optional` | `` |  |
-| 17 | `original_move_speed` | `int32` | `optional` | `` |  |
-| 18 | `ability` | `uint32` | `optional` | `` | default = 16777215 |
-| 19 | `target_projectile_handle` | `int32` | `optional` | `` |  |
+| 1 | `source` | `uint32` | `optional` |  | default = 16777215 |
+| 2 | `target` | `uint32` | `optional` |  | default = 16777215 |
+| 3 | `move_speed` | `int32` | `optional` |  |  |
+| 4 | `source_attachment` | `int32` | `optional` |  |  |
+| 5 | `particle_system_handle` | `int64` | `optional` |  |  |
+| 6 | `dodgeable` | `bool` | `optional` |  |  |
+| 7 | `is_attack` | `bool` | `optional` |  |  |
+| 9 | `expire_time` | `float` | `optional` |  |  |
+| 10 | `maximpacttime` | `float` | `optional` |  |  |
+| 11 | `colorgemcolor` | `fixed32` | `optional` |  |  |
+| 12 | `launch_tick` | `int32` | `optional` |  |  |
+| 13 | `handle` | `int32` | `optional` |  |  |
+| 14 | `target_loc` | `.CMsgVector` | `optional` |  |  |
+| 15 | `particle_cp_data` | `.CDOTAUserMsg_ProjectileParticleCPData` | `repeated` |  |  |
+| 16 | `additional_particle_system_handle` | `int64` | `optional` |  |  |
+| 17 | `original_move_speed` | `int32` | `optional` |  |  |
+| 18 | `ability` | `uint32` | `optional` |  | default = 16777215 |
+| 19 | `target_projectile_handle` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1254,22 +1254,22 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `source_loc` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `target` | `uint32` | `optional` | `` | default = 16777215 |
-| 3 | `move_speed` | `int32` | `optional` | `` |  |
-| 4 | `particle_system_handle` | `int64` | `optional` | `` |  |
-| 5 | `dodgeable` | `bool` | `optional` | `` |  |
-| 6 | `is_attack` | `bool` | `optional` | `` |  |
-| 9 | `expire_time` | `float` | `optional` | `` |  |
-| 10 | `target_loc` | `.CMsgVector` | `optional` | `` |  |
-| 11 | `colorgemcolor` | `fixed32` | `optional` | `` |  |
-| 12 | `launch_tick` | `int32` | `optional` | `` |  |
-| 13 | `handle` | `int32` | `optional` | `` |  |
-| 14 | `source` | `uint32` | `optional` | `` | default = 16777215 |
-| 15 | `source_attachment` | `int32` | `optional` | `` |  |
-| 16 | `particle_cp_data` | `.CDOTAUserMsg_ProjectileParticleCPData` | `repeated` | `` |  |
-| 17 | `additional_particle_system_handle` | `int64` | `optional` | `` |  |
-| 18 | `original_move_speed` | `int32` | `optional` | `` |  |
+| 1 | `source_loc` | `.CMsgVector` | `optional` |  |  |
+| 2 | `target` | `uint32` | `optional` |  | default = 16777215 |
+| 3 | `move_speed` | `int32` | `optional` |  |  |
+| 4 | `particle_system_handle` | `int64` | `optional` |  |  |
+| 5 | `dodgeable` | `bool` | `optional` |  |  |
+| 6 | `is_attack` | `bool` | `optional` |  |  |
+| 9 | `expire_time` | `float` | `optional` |  |  |
+| 10 | `target_loc` | `.CMsgVector` | `optional` |  |  |
+| 11 | `colorgemcolor` | `fixed32` | `optional` |  |  |
+| 12 | `launch_tick` | `int32` | `optional` |  |  |
+| 13 | `handle` | `int32` | `optional` |  |  |
+| 14 | `source` | `uint32` | `optional` |  | default = 16777215 |
+| 15 | `source_attachment` | `int32` | `optional` |  |  |
+| 16 | `particle_cp_data` | `.CDOTAUserMsg_ProjectileParticleCPData` | `repeated` |  |  |
+| 17 | `additional_particle_system_handle` | `int64` | `optional` |  |  |
+| 18 | `original_move_speed` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1281,7 +1281,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `handle` | `int32` | `optional` | `` |  |
+| 1 | `handle` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1293,10 +1293,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `entity` | `uint32` | `optional` | `` | default = 16777215 |
-| 2 | `scale` | `float` | `optional` | `` |  |
-| 3 | `xnormal` | `float` | `optional` | `` |  |
-| 4 | `ynormal` | `float` | `optional` | `` |  |
+| 1 | `entity` | `uint32` | `optional` |  | default = 16777215 |
+| 2 | `scale` | `float` | `optional` |  |  |
+| 3 | `xnormal` | `float` | `optional` |  |  |
+| 4 | `ynormal` | `float` | `optional` |  |  |
 
 </details>
 
@@ -1308,19 +1308,19 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `ability_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `type` | `.DOTA_ABILITY_PING_TYPE` | `optional` | `` | default = ABILITY_PING_READY |
-| 4 | `cooldown_seconds` | `uint32` | `optional` | `` |  |
-| 5 | `level` | `uint32` | `optional` | `` |  |
-| 6 | `passive` | `bool` | `optional` | `` |  |
-| 7 | `mana_needed` | `uint32` | `optional` | `` |  |
-| 8 | `entity_id` | `uint32` | `optional` | `` |  |
-| 9 | `primary_charges` | `int32` | `optional` | `` |  |
-| 10 | `secondary_charges` | `int32` | `optional` | `` |  |
-| 12 | `ctrl_held` | `bool` | `optional` | `` |  |
-| 13 | `reclaim_time` | `float` | `optional` | `` |  |
-| 14 | `owner_entity` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `ability_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `type` | `.DOTA_ABILITY_PING_TYPE` | `optional` |  | default = ABILITY_PING_READY |
+| 4 | `cooldown_seconds` | `uint32` | `optional` |  |  |
+| 5 | `level` | `uint32` | `optional` |  |  |
+| 6 | `passive` | `bool` | `optional` |  |  |
+| 7 | `mana_needed` | `uint32` | `optional` |  |  |
+| 8 | `entity_id` | `uint32` | `optional` |  |  |
+| 9 | `primary_charges` | `int32` | `optional` |  |  |
+| 10 | `secondary_charges` | `int32` | `optional` |  |  |
+| 12 | `ctrl_held` | `bool` | `optional` |  |  |
+| 13 | `reclaim_time` | `float` | `optional` |  |  |
+| 14 | `owner_entity` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -1332,13 +1332,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `entity` | `uint32` | `optional` | `` | default = 16777215 |
-| 2 | `sequence_variant` | `int32` | `optional` | `` |  |
-| 3 | `playbackrate` | `float` | `optional` | `` |  |
-| 4 | `castpoint` | `float` | `optional` | `` |  |
-| 5 | `type` | `int32` | `optional` | `` |  |
-| 6 | `activity` | `int32` | `optional` | `` |  |
-| 7 | `lag_compensation_time` | `float` | `optional` | `` |  |
+| 1 | `entity` | `uint32` | `optional` |  | default = 16777215 |
+| 2 | `sequence_variant` | `int32` | `optional` |  |  |
+| 3 | `playbackrate` | `float` | `optional` |  |  |
+| 4 | `castpoint` | `float` | `optional` |  |  |
+| 5 | `type` | `int32` | `optional` |  |  |
+| 6 | `activity` | `int32` | `optional` |  |  |
+| 7 | `lag_compensation_time` | `float` | `optional` |  |  |
 
 </details>
 
@@ -1350,8 +1350,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `entity` | `uint32` | `optional` | `` | default = 16777215 |
-| 2 | `snap` | `bool` | `optional` | `` |  |
+| 1 | `entity` | `uint32` | `optional` |  | default = 16777215 |
+| 2 | `snap` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1363,12 +1363,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `header` | `string` | `optional` | `` |  |
-| 2 | `body` | `string` | `optional` | `` |  |
-| 3 | `param1` | `string` | `optional` | `` |  |
-| 4 | `param2` | `string` | `optional` | `` |  |
-| 5 | `tint_screen` | `bool` | `optional` | `` |  |
-| 6 | `show_no_other_dialogs` | `bool` | `optional` | `` |  |
+| 1 | `header` | `string` | `optional` |  |  |
+| 2 | `body` | `string` | `optional` |  |  |
+| 3 | `param1` | `string` | `optional` |  |  |
+| 4 | `param2` | `string` | `optional` |  |  |
+| 5 | `tint_screen` | `bool` | `optional` |  |  |
+| 6 | `show_no_other_dialogs` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1380,10 +1380,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `title` | `string` | `optional` | `` |  |
-| 2 | `duration` | `float` | `optional` | `` |  |
-| 3 | `choice_count` | `int32` | `optional` | `` |  |
-| 4 | `choices` | `string` | `repeated` | `` |  |
+| 1 | `title` | `string` | `optional` |  |  |
+| 2 | `duration` | `float` | `optional` |  |  |
+| 3 | `choice_count` | `int32` | `optional` |  |  |
+| 4 | `choices` | `string` | `repeated` |  |  |
 
 </details>
 
@@ -1395,7 +1395,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `choice_counts` | `int32` | `repeated` | `` |  |
+| 1 | `choice_counts` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -1407,7 +1407,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `selected_choice` | `int32` | `optional` | `` |  |
+| 1 | `selected_choice` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1419,11 +1419,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `bonus` | `float` | `optional` | `` |  |
-| 3 | `event_bonus` | `float` | `optional` | `` |  |
-| 4 | `bonus_item_id` | `uint32` | `optional` | `` |  |
-| 5 | `event_bonus_item_id` | `uint32` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `bonus` | `float` | `optional` |  |  |
+| 3 | `event_bonus` | `float` | `optional` |  |  |
+| 4 | `bonus_item_id` | `uint32` | `optional` |  |  |
+| 5 | `event_bonus_item_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1435,7 +1435,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `boosted_players` | `.CDOTAUserMsg_BoosterStatePlayer` | `repeated` | `` |  |
+| 1 | `boosted_players` | `.CDOTAUserMsg_BoosterStatePlayer` | `repeated` |  |  |
 
 </details>
 
@@ -1447,9 +1447,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `ability_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `ability_level` | `uint32` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `ability_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `ability_level` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1461,10 +1461,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `hero_id` | `int32` | `optional` | `` |  |
-| 3 | `hero_name` | `string` | `optional` | `` |  |
-| 4 | `persona` | `string` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `hero_id` | `int32` | `optional` |  |  |
+| 3 | `hero_name` | `string` | `optional` |  |  |
+| 4 | `persona` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1476,8 +1476,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `average_position` | `float` | `optional` | `` |  |
-| 2 | `position_details` | `.CDOTAUserMsg_StatsHeroPositionInfo.PositionPair` | `repeated` | `` |  |
+| 1 | `average_position` | `float` | `optional` |  |  |
+| 2 | `position_details` | `.CDOTAUserMsg_StatsHeroPositionInfo.PositionPair` | `repeated` |  |  |
 
 </details>
 
@@ -1489,8 +1489,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `position_category` | `.DOTA_POSITION_CATEGORY` | `optional` | `` | default = DOTA_POSITION_NONE |
-| 2 | `position_count` | `uint32` | `optional` | `` |  |
+| 1 | `position_category` | `.DOTA_POSITION_CATEGORY` | `optional` |  | default = DOTA_POSITION_NONE |
+| 2 | `position_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1502,21 +1502,21 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `last_hits` | `uint32` | `optional` | `` |  |
-| 2 | `hero_kills` | `uint32` | `optional` | `` |  |
-| 3 | `hero_damage` | `uint32` | `optional` | `` |  |
-| 4 | `tower_damage` | `uint32` | `optional` | `` |  |
-| 5 | `position_info` | `.CDOTAUserMsg_StatsHeroPositionInfo` | `optional` | `` |  |
-| 6 | `total_xp` | `uint32` | `optional` | `` |  |
-| 7 | `net_worth` | `uint32` | `optional` | `` |  |
-| 8 | `harvested_creep_gold` | `uint32` | `optional` | `` |  |
-| 9 | `claimed_farm` | `uint32` | `optional` | `` |  |
-| 10 | `wards_placed` | `uint32` | `optional` | `` |  |
-| 11 | `runes_collected` | `uint32` | `optional` | `` |  |
-| 12 | `tps_used` | `uint32` | `optional` | `` |  |
-| 13 | `mana_spent` | `uint32` | `repeated` | `` |  |
-| 14 | `damage_absorbed` | `uint32` | `repeated` | `` |  |
-| 15 | `damage_done` | `uint32` | `repeated` | `` |  |
+| 1 | `last_hits` | `uint32` | `optional` |  |  |
+| 2 | `hero_kills` | `uint32` | `optional` |  |  |
+| 3 | `hero_damage` | `uint32` | `optional` |  |  |
+| 4 | `tower_damage` | `uint32` | `optional` |  |  |
+| 5 | `position_info` | `.CDOTAUserMsg_StatsHeroPositionInfo` | `optional` |  |  |
+| 6 | `total_xp` | `uint32` | `optional` |  |  |
+| 7 | `net_worth` | `uint32` | `optional` |  |  |
+| 8 | `harvested_creep_gold` | `uint32` | `optional` |  |  |
+| 9 | `claimed_farm` | `uint32` | `optional` |  |  |
+| 10 | `wards_placed` | `uint32` | `optional` |  |  |
+| 11 | `runes_collected` | `uint32` | `optional` |  |  |
+| 12 | `tps_used` | `uint32` | `optional` |  |  |
+| 13 | `mana_spent` | `uint32` | `repeated` |  |  |
+| 14 | `damage_absorbed` | `uint32` | `repeated` |  |  |
+| 15 | `damage_done` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -1528,16 +1528,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_stats` | `.CDOTAUserMsg_StatsHeroMinuteDetails` | `repeated` | `` |  |
-| 2 | `tower_kills` | `uint32` | `optional` | `` |  |
-| 3 | `barrack_kills` | `uint32` | `optional` | `` |  |
-| 4 | `available_lane_creep_gold` | `uint32` | `optional` | `` |  |
-| 5 | `balance_kill_value` | `uint32` | `optional` | `` |  |
-| 6 | `balance_tower_value` | `uint32` | `optional` | `` |  |
-| 7 | `balance_barracks_value` | `uint32` | `optional` | `` |  |
-| 8 | `balance_gold_value` | `uint32` | `optional` | `` |  |
-| 9 | `balance_xp_value` | `uint32` | `optional` | `` |  |
-| 10 | `lane_performance` | `.CDOTAUserMsg_StatsTeamMinuteDetails.LocationPerformance` | `repeated` | `` |  |
+| 1 | `player_stats` | `.CDOTAUserMsg_StatsHeroMinuteDetails` | `repeated` |  |  |
+| 2 | `tower_kills` | `uint32` | `optional` |  |  |
+| 3 | `barrack_kills` | `uint32` | `optional` |  |  |
+| 4 | `available_lane_creep_gold` | `uint32` | `optional` |  |  |
+| 5 | `balance_kill_value` | `uint32` | `optional` |  |  |
+| 6 | `balance_tower_value` | `uint32` | `optional` |  |  |
+| 7 | `balance_barracks_value` | `uint32` | `optional` |  |  |
+| 8 | `balance_gold_value` | `uint32` | `optional` |  |  |
+| 9 | `balance_xp_value` | `uint32` | `optional` |  |  |
+| 10 | `lane_performance` | `.CDOTAUserMsg_StatsTeamMinuteDetails.LocationPerformance` | `repeated` |  |  |
 
 </details>
 
@@ -1549,9 +1549,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `location_category` | `uint32` | `optional` | `` |  |
-| 2 | `stat_type` | `uint32` | `optional` | `` |  |
-| 3 | `value` | `uint32` | `optional` | `` |  |
+| 1 | `location_category` | `uint32` | `optional` |  |  |
+| 2 | `stat_type` | `uint32` | `optional` |  |  |
+| 3 | `value` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1563,12 +1563,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `kill_share_percent` | `float` | `optional` | `` |  |
-| 3 | `player_loc_x` | `float` | `optional` | `` |  |
-| 4 | `player_loc_y` | `float` | `optional` | `` |  |
-| 5 | `health_percent` | `float` | `optional` | `` |  |
-| 6 | `mana_percent` | `float` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `kill_share_percent` | `float` | `optional` |  |  |
+| 3 | `player_loc_x` | `float` | `optional` |  |  |
+| 4 | `player_loc_y` | `float` | `optional` |  |  |
+| 5 | `health_percent` | `float` | `optional` |  |  |
+| 6 | `mana_percent` | `float` | `optional` |  |  |
 
 </details>
 
@@ -1580,12 +1580,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `victim_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `kill_shares` | `.CDOTAUserMsg_StatsPlayerKillShare` | `repeated` | `` |  |
-| 3 | `damage_to_kill` | `uint32` | `optional` | `` |  |
-| 4 | `effective_health` | `uint32` | `optional` | `` |  |
-| 5 | `death_time` | `float` | `optional` | `` |  |
-| 6 | `killer_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `victim_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `kill_shares` | `.CDOTAUserMsg_StatsPlayerKillShare` | `repeated` |  |  |
+| 3 | `damage_to_kill` | `uint32` | `optional` |  |  |
+| 4 | `effective_health` | `uint32` | `optional` |  |  |
+| 5 | `death_time` | `float` | `optional` |  |  |
+| 6 | `killer_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -1597,12 +1597,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_lookup` | `.CDOTAUserMsg_StatsHeroLookup` | `repeated` | `` |  |
-| 2 | `radiant_stats` | `.CDOTAUserMsg_StatsTeamMinuteDetails` | `repeated` | `` |  |
-| 3 | `dire_stats` | `.CDOTAUserMsg_StatsTeamMinuteDetails` | `repeated` | `` |  |
-| 4 | `radiant_kills` | `.CDOTAUserMsg_StatsKillDetails` | `repeated` | `` |  |
-| 5 | `dire_kills` | `.CDOTAUserMsg_StatsKillDetails` | `repeated` | `` |  |
-| 6 | `fight_details` | `.CDOTAUserMsg_StatsMatchDetails.CDOTAUserMsg_StatsFightDetails` | `repeated` | `` |  |
+| 1 | `hero_lookup` | `.CDOTAUserMsg_StatsHeroLookup` | `repeated` |  |  |
+| 2 | `radiant_stats` | `.CDOTAUserMsg_StatsTeamMinuteDetails` | `repeated` |  |  |
+| 3 | `dire_stats` | `.CDOTAUserMsg_StatsTeamMinuteDetails` | `repeated` |  |  |
+| 4 | `radiant_kills` | `.CDOTAUserMsg_StatsKillDetails` | `repeated` |  |  |
+| 5 | `dire_kills` | `.CDOTAUserMsg_StatsKillDetails` | `repeated` |  |  |
+| 6 | `fight_details` | `.CDOTAUserMsg_StatsMatchDetails.CDOTAUserMsg_StatsFightDetails` | `repeated` |  |  |
 
 </details>
 
@@ -1614,10 +1614,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `participants` | `int32` | `repeated` | `` |  |
-| 2 | `deaths` | `int32` | `repeated` | `` |  |
-| 3 | `gold_delta` | `uint32` | `optional` | `` |  |
-| 4 | `xp_delta` | `uint32` | `optional` | `` |  |
+| 1 | `participants` | `int32` | `repeated` |  |  |
+| 2 | `deaths` | `int32` | `repeated` |  |  |
+| 3 | `gold_delta` | `uint32` | `optional` |  |  |
+| 4 | `xp_delta` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1629,10 +1629,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `start_time` | `float` | `optional` | `` |  |
-| 2 | `end_time` | `float` | `optional` | `` |  |
-| 3 | `radiant_fight_details` | `.CDOTAUserMsg_StatsMatchDetails.CDOTAUserMsg_StatsFightTeamDetails` | `optional` | `` |  |
-| 4 | `dire_fight_details` | `.CDOTAUserMsg_StatsMatchDetails.CDOTAUserMsg_StatsFightTeamDetails` | `optional` | `` |  |
+| 1 | `start_time` | `float` | `optional` |  |  |
+| 2 | `end_time` | `float` | `optional` |  |  |
+| 3 | `radiant_fight_details` | `.CDOTAUserMsg_StatsMatchDetails.CDOTAUserMsg_StatsFightTeamDetails` | `optional` |  |  |
+| 4 | `dire_fight_details` | `.CDOTAUserMsg_StatsMatchDetails.CDOTAUserMsg_StatsFightTeamDetails` | `optional` |  |  |
 
 </details>
 
@@ -1644,7 +1644,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `taunting_player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `taunting_player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -1656,7 +1656,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `destroy_all` | `bool` | `optional` | `` |  |
+| 1 | `destroy_all` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1668,10 +1668,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `duration` | `float` | `optional` | `` |  |
-| 3 | `message` | `string` | `optional` | `` |  |
-| 4 | `value` | `int32` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `duration` | `float` | `optional` |  |  |
+| 3 | `message` | `string` | `optional` |  |  |
+| 4 | `value` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1683,9 +1683,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `stat_type` | `.EHeroStatType` | `optional` | `` | default = k_EHeroStatType_None |
-| 2 | `int_value` | `int32` | `optional` | `` |  |
-| 3 | `float_value` | `float` | `optional` | `` |  |
+| 1 | `stat_type` | `.EHeroStatType` | `optional` |  | default = k_EHeroStatType_None |
+| 2 | `int_value` | `int32` | `optional` |  |  |
+| 3 | `float_value` | `float` | `optional` |  |  |
 
 </details>
 
@@ -1697,8 +1697,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `hero_ability_stats` | `.CMsgHeroAbilityStat` | `repeated` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `hero_ability_stats` | `.CMsgHeroAbilityStat` | `repeated` |  |  |
 
 </details>
 
@@ -1710,8 +1710,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `player_stats` | `.CMsgCombatAnalyzerPlayerStat` | `repeated` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `player_stats` | `.CMsgCombatAnalyzerPlayerStat` | `repeated` |  |  |
 
 </details>
 
@@ -1723,10 +1723,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team` | `uint32` | `optional` | `` |  |
-| 2 | `format` | `string` | `optional` | `` |  |
-| 3 | `message` | `string` | `optional` | `` |  |
-| 4 | `target` | `string` | `optional` | `` |  |
+| 1 | `team` | `uint32` | `optional` |  |  |
+| 2 | `format` | `string` | `optional` |  |  |
+| 3 | `message` | `string` | `optional` |  |  |
+| 4 | `target` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1738,9 +1738,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `element_id` | `string` | `optional` | `` |  |
-| 2 | `layout_filename` | `string` | `optional` | `` |  |
-| 3 | `data` | `bytes` | `optional` | `` |  |
+| 1 | `element_id` | `string` | `optional` |  |  |
+| 2 | `layout_filename` | `string` | `optional` |  |  |
+| 3 | `data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -1752,9 +1752,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `element_id` | `string` | `optional` | `` |  |
-| 2 | `modify_visible` | `bool` | `optional` | `` |  |
-| 3 | `data` | `bytes` | `optional` | `` |  |
+| 1 | `element_id` | `string` | `optional` |  |  |
+| 2 | `modify_visible` | `bool` | `optional` |  |  |
+| 3 | `data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -1766,7 +1766,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `element_id` | `string` | `optional` | `` |  |
+| 1 | `element_id` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1778,8 +1778,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `level` | `uint32` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `level` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1791,7 +1791,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `compendium_players` | `.CDOTAUserMsg_CompendiumStatePlayer` | `repeated` | `` |  |
+| 1 | `compendium_players` | `.CDOTAUserMsg_CompendiumStatePlayer` | `repeated` |  |  |
 
 </details>
 
@@ -1803,14 +1803,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ability_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `caster_ent_index` | `int32` | `optional` | `` | default = -1 |
-| 3 | `caster_team` | `int32` | `optional` | `` |  |
-| 4 | `channel_end` | `bool` | `optional` | `` |  |
-| 5 | `origin` | `.CMsgVector` | `optional` | `` |  |
-| 6 | `track_caster_only` | `bool` | `optional` | `` |  |
-| 7 | `end_time` | `float` | `optional` | `` |  |
-| 8 | `victim_ent_index` | `int32` | `optional` | `` | default = -1 |
+| 1 | `ability_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `caster_ent_index` | `int32` | `optional` |  | default = -1 |
+| 3 | `caster_team` | `int32` | `optional` |  |  |
+| 4 | `channel_end` | `bool` | `optional` |  |  |
+| 5 | `origin` | `.CMsgVector` | `optional` |  |  |
+| 6 | `track_caster_only` | `bool` | `optional` |  |  |
+| 7 | `end_time` | `float` | `optional` |  |  |
+| 8 | `victim_ent_index` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -1822,8 +1822,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `.EProjectionEvent` | `optional` | `` | default = ePE_FirstBlood |
-| 2 | `team` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `.EProjectionEvent` | `optional` |  | default = ePE_FirstBlood |
+| 2 | `team` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1835,8 +1835,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `target_entindex` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `target_entindex` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -1848,11 +1848,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `target_entindex` | `int32` | `optional` | `` | default = -1 |
-| 3 | `ability_id` | `int32` | `optional` | `` | default = -1 |
-| 4 | `slot` | `int32` | `optional` | `` |  |
-| 5 | `learned` | `bool` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `target_entindex` | `int32` | `optional` |  | default = -1 |
+| 3 | `ability_id` | `int32` | `optional` |  | default = -1 |
+| 4 | `slot` | `int32` | `optional` |  |  |
+| 5 | `learned` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1876,14 +1876,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `quest_id` | `uint32` | `optional` | `` |  |
-| 3 | `challenge_id` | `uint32` | `optional` | `` |  |
-| 4 | `progress` | `uint32` | `optional` | `` |  |
-| 5 | `goal` | `uint32` | `optional` | `` |  |
-| 6 | `query` | `uint32` | `optional` | `` |  |
-| 7 | `fail_gametime` | `float` | `optional` | `` |  |
-| 8 | `item_ability_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `quest_id` | `uint32` | `optional` |  |  |
+| 3 | `challenge_id` | `uint32` | `optional` |  |  |
+| 4 | `progress` | `uint32` | `optional` |  |  |
+| 5 | `goal` | `uint32` | `optional` |  |  |
+| 6 | `query` | `uint32` | `optional` |  |  |
+| 7 | `fail_gametime` | `float` | `optional` |  |  |
+| 8 | `item_ability_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -1895,10 +1895,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `hero_id` | `int32` | `optional` | `` |  |
-| 3 | `ban` | `bool` | `optional` | `` |  |
-| 4 | `facet_id` | `uint32` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `hero_id` | `int32` | `optional` |  |  |
+| 3 | `ban` | `bool` | `optional` |  |  |
+| 4 | `facet_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1910,8 +1910,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `hero_role` | `string` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `hero_role` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1923,12 +1923,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `damage_taken` | `uint32` | `optional` | `` |  |
-| 3 | `item_type` | `uint32` | `optional` | `` |  |
-| 4 | `item_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 5 | `hero_name` | `string` | `optional` | `` |  |
-| 6 | `damage_color` | `string` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `damage_taken` | `uint32` | `optional` |  |  |
+| 3 | `item_type` | `uint32` | `optional` |  |  |
+| 4 | `item_ability_id` | `int32` | `optional` |  | default = -1 |
+| 5 | `hero_name` | `string` | `optional` |  |  |
+| 6 | `damage_color` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1940,8 +1940,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `cost` | `sint32` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `cost` | `sint32` | `optional` |  |  |
 
 </details>
 
@@ -1953,11 +1953,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `channel_type` | `uint32` | `optional` | `` |  |
-| 3 | `roll_min` | `uint32` | `optional` | `` |  |
-| 4 | `roll_max` | `uint32` | `optional` | `` |  |
-| 5 | `result` | `uint32` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `channel_type` | `uint32` | `optional` |  |  |
+| 3 | `roll_min` | `uint32` | `optional` |  |  |
+| 4 | `roll_max` | `uint32` | `optional` |  |  |
+| 5 | `result` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1969,9 +1969,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `channel_type` | `uint32` | `optional` | `` |  |
-| 3 | `result` | `bool` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `channel_type` | `uint32` | `optional` |  |  |
+| 3 | `result` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1983,7 +1983,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -1995,8 +1995,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team` | `uint32` | `optional` | `` |  |
-| 2 | `captain_player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `team` | `uint32` | `optional` |  |  |
+| 2 | `captain_player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -2008,8 +2008,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `message_id` | `uint32` | `optional` | `` | default = 4294967295 |
-| 2 | `cooldown_remaining` | `float` | `optional` | `` |  |
+| 1 | `message_id` | `uint32` | `optional` |  | default = 4294967295 |
+| 2 | `cooldown_remaining` | `float` | `optional` |  |  |
 
 </details>
 
@@ -2021,11 +2021,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hero_relic_type` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `uint32` | `optional` | `` |  |
-| 3 | `ehandle` | `uint32` | `optional` | `` | default = 16777215 |
-| 4 | `event_id` | `uint32` | `optional` | `` |  |
-| 5 | `value_display` | `float` | `optional` | `` |  |
+| 1 | `hero_relic_type` | `uint32` | `optional` |  |  |
+| 2 | `value` | `uint32` | `optional` |  |  |
+| 3 | `ehandle` | `uint32` | `optional` |  | default = 16777215 |
+| 4 | `event_id` | `uint32` | `optional` |  |  |
+| 5 | `value_display` | `float` | `optional` |  |  |
 
 </details>
 
@@ -2037,11 +2037,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `requested_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `ctrl_is_down` | `bool` | `optional` | `` |  |
-| 4 | `requested_hero_id` | `int32` | `optional` | `` |  |
-| 5 | `requested_facet_key` | `uint64` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `requested_ability_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `ctrl_is_down` | `bool` | `optional` |  |  |
+| 4 | `requested_hero_id` | `int32` | `optional` |  |  |
+| 5 | `requested_facet_key` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -2053,11 +2053,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `target_hero_id` | `int32` | `optional` | `` |  |
-| 3 | `source_hero_id` | `int32` | `optional` | `` |  |
-| 4 | `damage_amount` | `int32` | `optional` | `` |  |
-| 5 | `broadcast` | `bool` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `target_hero_id` | `int32` | `optional` |  |  |
+| 3 | `source_hero_id` | `int32` | `optional` |  |  |
+| 4 | `damage_amount` | `int32` | `optional` |  |  |
+| 5 | `broadcast` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2069,12 +2069,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `source_player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `target_player_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `tip_amount` | `uint32` | `optional` | `` |  |
-| 4 | `event_id` | `uint32` | `optional` | `` |  |
-| 5 | `custom_tip_style` | `string` | `optional` | `` |  |
-| 6 | `num_recent_tips` | `uint32` | `optional` | `` |  |
+| 1 | `source_player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `target_player_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `tip_amount` | `uint32` | `optional` |  |  |
+| 4 | `event_id` | `uint32` | `optional` |  |  |
+| 5 | `custom_tip_style` | `string` | `optional` |  |  |
+| 6 | `num_recent_tips` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2086,9 +2086,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `source_player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `target_player_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `gift_item_def_index` | `uint32` | `optional` | `` |  |
+| 1 | `source_player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `target_player_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `gift_item_def_index` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2100,8 +2100,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `tip_text` | `string` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `tip_text` | `string` | `optional` |  |  |
 
 </details>
 
@@ -2113,9 +2113,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `source_entindex` | `int32` | `optional` | `` | default = -1 |
-| 3 | `target_entindex` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `source_entindex` | `int32` | `optional` |  | default = -1 |
+| 3 | `target_entindex` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -2127,9 +2127,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ehandle` | `uint32` | `optional` | `` | default = 16777215 |
-| 2 | `combo_count` | `uint32` | `optional` | `` |  |
-| 3 | `arcana_level` | `uint32` | `optional` | `` |  |
+| 1 | `ehandle` | `uint32` | `optional` |  | default = 16777215 |
+| 2 | `combo_count` | `uint32` | `optional` |  |  |
+| 3 | `arcana_level` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2141,9 +2141,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ehandle` | `uint32` | `optional` | `` | default = 16777215 |
-| 2 | `combo_count` | `uint32` | `optional` | `` |  |
-| 3 | `damage_amount` | `uint32` | `optional` | `` |  |
+| 1 | `ehandle` | `uint32` | `optional` |  | default = 16777215 |
+| 2 | `combo_count` | `uint32` | `optional` |  |  |
+| 3 | `damage_amount` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2155,10 +2155,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ehandle` | `uint32` | `optional` | `` | default = 16777215 |
-| 2 | `multicast_amount` | `uint32` | `optional` | `` |  |
-| 3 | `arcana_level` | `uint32` | `optional` | `` |  |
-| 4 | `multicast_chance` | `uint32` | `optional` | `` |  |
+| 1 | `ehandle` | `uint32` | `optional` |  | default = 16777215 |
+| 2 | `multicast_amount` | `uint32` | `optional` |  |  |
+| 3 | `arcana_level` | `uint32` | `optional` |  |  |
+| 4 | `multicast_chance` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2170,10 +2170,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id_1` | `int32` | `optional` | `` | default = -1 |
-| 2 | `player_id_2` | `int32` | `optional` | `` | default = -1 |
-| 3 | `special_high_five` | `bool` | `optional` | `` |  |
-| 4 | `special_entindex` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_id_1` | `int32` | `optional` |  | default = -1 |
+| 2 | `player_id_2` | `int32` | `optional` |  | default = -1 |
+| 3 | `special_high_five` | `bool` | `optional` |  |  |
+| 4 | `special_entindex` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -2185,7 +2185,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -2197,10 +2197,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `all_chat` | `bool` | `optional` | `` |  |
-| 3 | `locstring` | `string` | `optional` | `` |  |
-| 4 | `quantity` | `uint32` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `all_chat` | `bool` | `optional` |  |  |
+| 3 | `locstring` | `string` | `optional` |  |  |
+| 4 | `quantity` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2212,11 +2212,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `source_player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `target_player_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `point_amount` | `uint32` | `optional` | `` |  |
-| 4 | `event_id` | `uint32` | `optional` | `` |  |
-| 5 | `player_scores` | `.CDOTAUserMsg_AllStarEvent.PlayerScore` | `repeated` | `` |  |
+| 1 | `source_player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `target_player_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `point_amount` | `uint32` | `optional` |  |  |
+| 4 | `event_id` | `uint32` | `optional` |  |  |
+| 5 | `player_scores` | `.CDOTAUserMsg_AllStarEvent.PlayerScore` | `repeated` |  |  |
 
 </details>
 
@@ -2228,8 +2228,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `score_sans_kda` | `uint32` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `score_sans_kda` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2241,7 +2241,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `unit_order_sequence` | `uint32` | `repeated` | `` |  |
+| 1 | `unit_order_sequence` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -2253,13 +2253,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `challenge_type` | `uint32` | `optional` | `` |  |
-| 2 | `challenge_query_id` | `uint32` | `optional` | `` |  |
-| 3 | `event_id` | `uint32` | `optional` | `` |  |
-| 4 | `instance_id` | `uint32` | `optional` | `` |  |
-| 5 | `challenge_var_0` | `uint32` | `optional` | `` |  |
-| 6 | `challenge_var_1` | `uint32` | `optional` | `` |  |
-| 7 | `challenge_max_rank` | `uint32` | `optional` | `` |  |
+| 1 | `challenge_type` | `uint32` | `optional` |  |  |
+| 2 | `challenge_query_id` | `uint32` | `optional` |  |  |
+| 3 | `event_id` | `uint32` | `optional` |  |  |
+| 4 | `instance_id` | `uint32` | `optional` |  |  |
+| 5 | `challenge_var_0` | `uint32` | `optional` |  |  |
+| 6 | `challenge_var_1` | `uint32` | `optional` |  |  |
+| 7 | `challenge_max_rank` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2271,13 +2271,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `item_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `item_tier` | `uint32` | `optional` | `` |  |
-| 4 | `tier_item_count` | `uint32` | `optional` | `` |  |
-| 5 | `enhancement_ability_id` | `int32` | `optional` | `` | default = -1 |
-| 6 | `enhancement_level` | `int32` | `optional` | `` |  |
-| 7 | `trinket_level` | `int32` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `item_ability_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `item_tier` | `uint32` | `optional` |  |  |
+| 4 | `tier_item_count` | `uint32` | `optional` |  |  |
+| 5 | `enhancement_ability_id` | `int32` | `optional` |  | default = -1 |
+| 6 | `enhancement_level` | `int32` | `optional` |  |  |
+| 7 | `trinket_level` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -2289,8 +2289,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `outpost_entindex` | `int32` | `optional` | `` | default = -1 |
-| 2 | `team_id` | `uint32` | `optional` | `` |  |
+| 1 | `outpost_entindex` | `int32` | `optional` |  | default = -1 |
+| 2 | `team_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2302,8 +2302,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `team_id` | `uint32` | `optional` | `` |  |
-| 2 | `xp_amount` | `uint32` | `optional` | `` |  |
+| 1 | `team_id` | `uint32` | `optional` |  |  |
+| 2 | `xp_amount` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2315,7 +2315,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `unit_ehandle` | `uint32` | `optional` | `` | default = 16777215 |
+| 1 | `unit_ehandle` | `uint32` | `optional` |  | default = 16777215 |
 
 </details>
 
@@ -2327,7 +2327,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data_bits` | `.CDOTAUserMsg_PauseMinigameData.DataBit` | `repeated` | `` |  |
+| 1 | `data_bits` | `.CDOTAUserMsg_PauseMinigameData.DataBit` | `repeated` |  |  |
 
 </details>
 
@@ -2339,9 +2339,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `index` | `uint32` | `optional` | `` |  |
-| 2 | `data` | `int32` | `optional` | `` |  |
-| 3 | `data_extra` | `int64` | `optional` | `` |  |
+| 1 | `index` | `uint32` | `optional` |  |  |
+| 2 | `data` | `int32` | `optional` |  |  |
+| 3 | `data_extra` | `int64` | `optional` |  |  |
 
 </details>
 
@@ -2353,11 +2353,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `behavior` | `.EDOTAVersusScenePlayerBehavior` | `optional` | `` | default = VS_PLAYER_BEHAVIOR_PLAY_ACTIVITY |
-| 3 | `play_activity` | `.VersusScene_PlayActivity` | `optional` | `` |  |
-| 4 | `chat_wheel` | `.VersusScene_ChatWheel` | `optional` | `` |  |
-| 5 | `playback_rate` | `.VersusScene_PlaybackRate` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `behavior` | `.EDOTAVersusScenePlayerBehavior` | `optional` |  | default = VS_PLAYER_BEHAVIOR_PLAY_ACTIVITY |
+| 3 | `play_activity` | `.VersusScene_PlayActivity` | `optional` |  |  |
+| 4 | `chat_wheel` | `.VersusScene_ChatWheel` | `optional` |  |  |
+| 5 | `playback_rate` | `.VersusScene_PlaybackRate` | `optional` |  |  |
 
 </details>
 
@@ -2369,10 +2369,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ehandle` | `uint32` | `optional` | `` | default = 16777215 |
-| 2 | `arcana_level` | `uint32` | `optional` | `` |  |
-| 3 | `players_hit` | `uint32` | `optional` | `` |  |
-| 4 | `players_killed` | `uint32` | `optional` | `` |  |
+| 1 | `ehandle` | `uint32` | `optional` |  | default = 16777215 |
+| 2 | `arcana_level` | `uint32` | `optional` |  |  |
+| 3 | `players_hit` | `uint32` | `optional` |  |  |
+| 4 | `players_killed` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2384,8 +2384,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id_1` | `int32` | `optional` | `` | default = -1 |
-| 2 | `player_id_2` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_id_1` | `int32` | `optional` |  | default = -1 |
+| 2 | `player_id_2` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -2397,7 +2397,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -2409,9 +2409,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ehandle` | `uint32` | `optional` | `` | default = 16777215 |
-| 2 | `arcana_level` | `uint32` | `optional` | `` |  |
-| 3 | `hero_id` | `int32` | `optional` | `` |  |
+| 1 | `ehandle` | `uint32` | `optional` |  | default = 16777215 |
+| 2 | `arcana_level` | `uint32` | `optional` |  |  |
+| 3 | `hero_id` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -2423,13 +2423,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_progress` | `.CDOTAUserMsg_GuildChallenge_Progress.PlayerProgress` | `repeated` | `` |  |
-| 2 | `guild_id` | `uint32` | `optional` | `` |  |
-| 3 | `challenge_instance_id` | `uint32` | `optional` | `` |  |
-| 4 | `challenge_parameter` | `uint32` | `optional` | `` |  |
-| 5 | `challenge_type` | `.CDOTAUserMsg_GuildChallenge_Progress.EChallengeType` | `optional` | `` | default = k_EChallengeType_Invalid |
-| 7 | `challenge_progress_at_start` | `uint32` | `optional` | `` |  |
-| 8 | `complete` | `bool` | `optional` | `` |  |
+| 1 | `player_progress` | `.CDOTAUserMsg_GuildChallenge_Progress.PlayerProgress` | `repeated` |  |  |
+| 2 | `guild_id` | `uint32` | `optional` |  |  |
+| 3 | `challenge_instance_id` | `uint32` | `optional` |  |  |
+| 4 | `challenge_parameter` | `uint32` | `optional` |  |  |
+| 5 | `challenge_type` | `.CDOTAUserMsg_GuildChallenge_Progress.EChallengeType` | `optional` |  | default = k_EChallengeType_Invalid |
+| 7 | `challenge_progress_at_start` | `uint32` | `optional` |  |  |
+| 8 | `complete` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2441,8 +2441,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 6 | `progress` | `uint32` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 6 | `progress` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2454,13 +2454,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ehandle` | `uint32` | `optional` | `` | default = 16777215 |
-| 2 | `target_ehandle` | `uint32` | `optional` | `` | default = 16777215 |
-| 3 | `arrows_landed` | `uint32` | `optional` | `` |  |
-| 4 | `damage_dealt` | `uint32` | `optional` | `` |  |
-| 5 | `target_hp` | `uint32` | `optional` | `` |  |
-| 6 | `target_max_hp` | `uint32` | `optional` | `` |  |
-| 7 | `arcana_level` | `uint32` | `optional` | `` |  |
+| 1 | `ehandle` | `uint32` | `optional` |  | default = 16777215 |
+| 2 | `target_ehandle` | `uint32` | `optional` |  | default = 16777215 |
+| 3 | `arrows_landed` | `uint32` | `optional` |  |  |
+| 4 | `damage_dealt` | `uint32` | `optional` |  |  |
+| 5 | `target_hp` | `uint32` | `optional` |  |  |
+| 6 | `target_max_hp` | `uint32` | `optional` |  |  |
+| 7 | `arcana_level` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -2472,14 +2472,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ehandle` | `uint32` | `optional` | `` | default = 16777215 |
-| 2 | `target_ehandle` | `uint32` | `optional` | `` | default = 16777215 |
-| 3 | `arrows_landed` | `uint32` | `optional` | `` |  |
-| 4 | `damage_dealt` | `uint32` | `optional` | `` |  |
-| 5 | `target_hp` | `uint32` | `optional` | `` |  |
-| 6 | `target_max_hp` | `uint32` | `optional` | `` |  |
-| 7 | `arcana_level` | `uint32` | `optional` | `` |  |
-| 8 | `success` | `bool` | `optional` | `` |  |
+| 1 | `ehandle` | `uint32` | `optional` |  | default = 16777215 |
+| 2 | `target_ehandle` | `uint32` | `optional` |  | default = 16777215 |
+| 3 | `arrows_landed` | `uint32` | `optional` |  |  |
+| 4 | `damage_dealt` | `uint32` | `optional` |  |  |
+| 5 | `target_hp` | `uint32` | `optional` |  |  |
+| 6 | `target_max_hp` | `uint32` | `optional` |  |  |
+| 7 | `arcana_level` | `uint32` | `optional` |  |  |
+| 8 | `success` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2491,10 +2491,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `source_player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `target_player_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `slot_index` | `int32` | `optional` | `` |  |
-| 4 | `cooldown_seconds` | `int32` | `optional` | `` |  |
+| 1 | `source_player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `target_player_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `slot_index` | `int32` | `optional` |  |  |
+| 4 | `cooldown_seconds` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -2506,12 +2506,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `source_player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `target_player_id` | `int32` | `optional` | `` | default = -1 |
-| 3 | `target_entindex` | `int32` | `optional` | `` | default = -1 |
-| 4 | `alert_type` | `uint32` | `optional` | `` |  |
-| 5 | `has_scepter` | `bool` | `optional` | `` |  |
-| 6 | `has_shard` | `bool` | `optional` | `` |  |
+| 1 | `source_player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `target_player_id` | `int32` | `optional` |  | default = -1 |
+| 3 | `target_entindex` | `int32` | `optional` |  | default = -1 |
+| 4 | `alert_type` | `uint32` | `optional` |  |  |
+| 5 | `has_scepter` | `bool` | `optional` |  |  |
+| 6 | `has_shard` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2523,8 +2523,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `text_muted_player_ids` | `int32` | `repeated` | `` |  |
-| 2 | `voice_muted_player_ids` | `int32` | `repeated` | `` |  |
+| 1 | `text_muted_player_ids` | `int32` | `repeated` |  |  |
+| 2 | `voice_muted_player_ids` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -2536,21 +2536,21 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tip_id` | `int32` | `optional` | `` |  |
-| 2 | `referenced_abilities` | `string` | `repeated` | `` |  |
-| 3 | `referenced_units` | `string` | `repeated` | `` |  |
-| 4 | `panorama_classes` | `string` | `repeated` | `` |  |
-| 5 | `force_annotation` | `bool` | `optional` | `` |  |
-| 6 | `variant` | `int32` | `optional` | `` |  |
-| 7 | `int_param` | `int32` | `optional` | `` |  |
-| 8 | `int_param2` | `int32` | `optional` | `` |  |
-| 9 | `float_param` | `float` | `optional` | `` |  |
-| 10 | `float_param2` | `float` | `optional` | `` |  |
-| 11 | `string_param` | `string` | `optional` | `` |  |
-| 12 | `string_param2` | `string` | `optional` | `` |  |
-| 13 | `tip_text_override` | `string` | `optional` | `` |  |
-| 14 | `tip_annotation_override` | `string` | `optional` | `` |  |
-| 15 | `panorama_snippet` | `string` | `optional` | `` |  |
+| 1 | `tip_id` | `int32` | `optional` |  |  |
+| 2 | `referenced_abilities` | `string` | `repeated` |  |  |
+| 3 | `referenced_units` | `string` | `repeated` |  |  |
+| 4 | `panorama_classes` | `string` | `repeated` |  |  |
+| 5 | `force_annotation` | `bool` | `optional` |  |  |
+| 6 | `variant` | `int32` | `optional` |  |  |
+| 7 | `int_param` | `int32` | `optional` |  |  |
+| 8 | `int_param2` | `int32` | `optional` |  |  |
+| 9 | `float_param` | `float` | `optional` |  |  |
+| 10 | `float_param2` | `float` | `optional` |  |  |
+| 11 | `string_param` | `string` | `optional` |  |  |
+| 12 | `string_param2` | `string` | `optional` |  |  |
+| 13 | `tip_text_override` | `string` | `optional` |  |  |
+| 14 | `tip_annotation_override` | `string` | `optional` |  |  |
+| 15 | `panorama_snippet` | `string` | `optional` |  |  |
 
 </details>
 
@@ -2562,9 +2562,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `source_player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `channel_type` | `uint32` | `optional` | `` |  |
-| 3 | `message_text` | `string` | `optional` | `` |  |
+| 1 | `source_player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `channel_type` | `uint32` | `optional` |  |  |
+| 3 | `message_text` | `string` | `optional` |  |  |
 
 </details>
 
@@ -2576,8 +2576,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id_source` | `int32` | `optional` | `` | default = -1 |
-| 2 | `player_id_target` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_id_source` | `int32` | `optional` |  | default = -1 |
+| 2 | `player_id_target` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -2589,10 +2589,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id_1` | `int32` | `optional` | `` | default = -1 |
-| 2 | `player_id_2` | `int32` | `optional` | `` | default = -1 |
-| 3 | `player_1_choice` | `int32` | `optional` | `` |  |
-| 4 | `player_2_choice` | `int32` | `optional` | `` |  |
+| 1 | `player_id_1` | `int32` | `optional` |  | default = -1 |
+| 2 | `player_id_2` | `int32` | `optional` |  | default = -1 |
+| 3 | `player_1_choice` | `int32` | `optional` |  |  |
+| 4 | `player_2_choice` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -2604,8 +2604,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id_winner` | `int32` | `optional` | `` |  |
-| 2 | `player_id_loser` | `int32` | `optional` | `` |  |
+| 1 | `player_id_winner` | `int32` | `optional` |  |  |
+| 2 | `player_id_loser` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -2617,8 +2617,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id_1` | `int32` | `optional` | `` |  |
-| 2 | `player_id_2` | `int32` | `optional` | `` |  |
+| 1 | `player_id_1` | `int32` | `optional` |  |  |
+| 2 | `player_id_2` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -2630,7 +2630,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id_requestor` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_id_requestor` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -2642,11 +2642,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id_killer` | `int32` | `optional` | `` | default = -1 |
-| 2 | `player_id_target` | `int32` | `optional` | `` | default = -1 |
-| 3 | `points` | `int32` | `optional` | `` |  |
-| 4 | `points_total` | `int32` | `optional` | `` |  |
-| 5 | `last_hit` | `bool` | `optional` | `` |  |
+| 1 | `player_id_killer` | `int32` | `optional` |  | default = -1 |
+| 2 | `player_id_target` | `int32` | `optional` |  | default = -1 |
+| 3 | `points` | `int32` | `optional` |  |  |
+| 4 | `points_total` | `int32` | `optional` |  |  |
+| 5 | `last_hit` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2658,8 +2658,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `suggestion_player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `suggestion_player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -2671,9 +2671,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id_captain` | `int32` | `optional` | `` | default = -1 |
-| 2 | `player_id_target` | `int32` | `optional` | `` | default = -1 |
-| 3 | `team` | `int32` | `optional` | `` |  |
+| 1 | `player_id_captain` | `int32` | `optional` |  | default = -1 |
+| 2 | `player_id_target` | `int32` | `optional` |  | default = -1 |
+| 3 | `team` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -2685,10 +2685,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `facet_strhash` | `uint32` | `optional` | `` |  |
-| 3 | `entity_id` | `uint32` | `optional` | `` |  |
-| 4 | `all_chat` | `bool` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `facet_strhash` | `uint32` | `optional` |  |  |
+| 3 | `entity_id` | `uint32` | `optional` |  |  |
+| 4 | `all_chat` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2700,9 +2700,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `entity_id` | `uint32` | `optional` | `` |  |
-| 3 | `all_chat` | `bool` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `entity_id` | `uint32` | `optional` |  |  |
+| 3 | `all_chat` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2726,8 +2726,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `timer_alert_type` | `.ETimerAlertType` | `optional` | `` | default = k_TimerAlertType_PowerRune |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `timer_alert_type` | `.ETimerAlertType` | `optional` |  | default = k_TimerAlertType_PowerRune |
 
 </details>
 
@@ -2739,11 +2739,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `target_entindex` | `int32` | `optional` | `` | default = -1 |
-| 3 | `tier` | `int32` | `optional` | `` |  |
-| 4 | `madstone_alert_type` | `.CDOTAUserMsg_MadstoneAlert.EMadstoneAlertType` | `optional` | `` | default = CraftAvailable |
-| 5 | `value` | `int32` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `target_entindex` | `int32` | `optional` |  | default = -1 |
+| 3 | `tier` | `int32` | `optional` |  |  |
+| 4 | `madstone_alert_type` | `.CDOTAUserMsg_MadstoneAlert.EMadstoneAlertType` | `optional` |  | default = CraftAvailable |
+| 5 | `value` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -2755,7 +2755,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `investigations` | `.CMsgMonsterHunterInvestigation` | `repeated` | `` |  |
+| 1 | `investigations` | `.CMsgMonsterHunterInvestigation` | `repeated` |  |  |
 
 </details>
 
@@ -2767,8 +2767,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `investigation_game_state` | `.CMsgMonsterHunterInvestigationGameState` | `optional` | `` |  |
-| 2 | `investigations_locked` | `bool` | `optional` | `` |  |
+| 1 | `investigation_game_state` | `.CMsgMonsterHunterInvestigationGameState` | `optional` |  |  |
+| 2 | `investigations_locked` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -2780,11 +2780,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_id` | `int32` | `optional` | `` | default = -1 |
-| 2 | `hero_id` | `int32` | `optional` | `` |  |
-| 3 | `hunt_alert_type` | `.CDOTAUserMsg_MonsterHunter_HuntAlert.EHuntAlertType` | `optional` | `` | default = MainObjective |
-| 4 | `hunt_status_type` | `.CDOTAUserMsg_MonsterHunter_HuntAlert.EHuntStatusType` | `optional` | `` | default = Pending |
-| 5 | `index` | `int32` | `optional` | `` |  |
+| 1 | `player_id` | `int32` | `optional` |  | default = -1 |
+| 2 | `hero_id` | `int32` | `optional` |  |  |
+| 3 | `hunt_alert_type` | `.CDOTAUserMsg_MonsterHunter_HuntAlert.EHuntAlertType` | `optional` |  | default = MainObjective |
+| 4 | `hunt_status_type` | `.CDOTAUserMsg_MonsterHunter_HuntAlert.EHuntStatusType` | `optional` |  | default = Pending |
+| 5 | `index` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -2796,8 +2796,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `victim_ent_index` | `int32` | `optional` | `` | default = -1 |
-| 2 | `killer_player_id` | `int32` | `optional` | `` | default = -1 |
+| 1 | `victim_ent_index` | `int32` | `optional` |  | default = -1 |
+| 2 | `killer_player_id` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -2809,10 +2809,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `giver_ent_index` | `uint32` | `optional` | `` | default = 16777215 |
-| 2 | `receiver_ent_index` | `uint32` | `optional` | `` | default = 16777215 |
-| 3 | `item_ent_index` | `uint32` | `optional` | `` | default = 16777215 |
-| 4 | `give_status` | `.CDOTAUserMsg_GiveItem.EGiveStatus` | `optional` | `` | default = Start |
+| 1 | `giver_ent_index` | `uint32` | `optional` |  | default = 16777215 |
+| 2 | `receiver_ent_index` | `uint32` | `optional` |  | default = 16777215 |
+| 3 | `item_ent_index` | `uint32` | `optional` |  | default = 16777215 |
+| 4 | `give_status` | `.CDOTAUserMsg_GiveItem.EGiveStatus` | `optional` |  | default = Start |
 
 </details>
 

--- a/docs/cookbook/proto-fields/econ-gcmessages.md
+++ b/docs/cookbook/proto-fields/econ-gcmessages.md
@@ -26,8 +26,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `autograph_item_id` | `uint64` | `optional` | `` |  |
-| 2 | `item_item_id` | `uint64` | `optional` | `` |  |
+| 1 | `autograph_item_id` | `uint64` | `optional` |  |  |
+| 2 | `item_item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -39,10 +39,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `uint64` | `optional` | `` |  |
-| 2 | `new_class` | `uint32` | `optional` | `` |  |
-| 3 | `new_slot` | `uint32` | `optional` | `` |  |
-| 4 | `style_index` | `uint32` | `optional` | `` | default = 255 |
+| 1 | `item_id` | `uint64` | `optional` |  |  |
+| 2 | `new_class` | `uint32` | `optional` |  |  |
+| 3 | `new_slot` | `uint32` | `optional` |  |  |
+| 4 | `style_index` | `uint32` | `optional` |  | default = 255 |
 
 </details>
 
@@ -54,9 +54,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `strange_count_adjustments` | `.CMsgEconPlayerStrangeCountAdjustment.CStrangeCountAdjustment` | `repeated` | `` |  |
-| 3 | `turbo_mode` | `bool` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `strange_count_adjustments` | `.CMsgEconPlayerStrangeCountAdjustment.CStrangeCountAdjustment` | `repeated` |  |  |
+| 3 | `turbo_mode` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -68,9 +68,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_type` | `uint32` | `optional` | `` |  |
-| 2 | `item_id` | `uint64` | `optional` | `` |  |
-| 3 | `adjustment` | `uint32` | `optional` | `` |  |
+| 1 | `event_type` | `uint32` | `optional` |  |  |
+| 2 | `item_id` | `uint64` | `optional` |  |  |
+| 3 | `adjustment` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -82,7 +82,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_ids` | `uint64` | `repeated` | `` |  |
+| 1 | `item_ids` | `uint64` | `repeated` |  |  |
 
 </details>
 
@@ -94,8 +94,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `version` | `uint32` | `optional` | `` |  |
-| 2 | `currency` | `uint32` | `optional` | `` |  |
+| 1 | `version` | `uint32` | `optional` |  |  |
+| 2 | `currency` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -107,9 +107,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `sale_price` | `.CMsgGCRequestStoreSalesDataResponse.Price` | `repeated` | `` |  |
-| 2 | `version` | `uint32` | `optional` | `` |  |
-| 3 | `expiration_time` | `uint32` | `optional` | `` |  |
+| 1 | `sale_price` | `.CMsgGCRequestStoreSalesDataResponse.Price` | `repeated` |  |  |
+| 2 | `version` | `uint32` | `optional` |  |  |
+| 3 | `expiration_time` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -121,8 +121,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def` | `uint32` | `optional` | `` |  |
-| 2 | `price` | `uint32` | `optional` | `` |  |
+| 1 | `item_def` | `uint32` | `optional` |  |  |
+| 2 | `price` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -134,8 +134,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `version` | `uint32` | `optional` | `` |  |
-| 2 | `expiration_time` | `uint32` | `optional` | `` |  |
+| 1 | `version` | `uint32` | `optional` |  |  |
+| 2 | `expiration_time` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -171,7 +171,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -183,8 +183,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `server_steam_id` | `fixed64` | `optional` | `` |  |
-| 2 | `is_online` | `bool` | `optional` | `` |  |
+| 1 | `server_steam_id` | `fixed64` | `optional` |  |  |
+| 2 | `is_online` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -196,8 +196,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `max_spectators` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `max_spectators` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -209,7 +209,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `member_account_id` | `uint32` | `repeated` | `` |  |
+| 1 | `member_account_id` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -221,7 +221,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `accountids` | `uint32` | `repeated` | `` | packed = true |
+| 1 | `accountids` | `uint32` | `repeated` |  | packed = true |
 
 </details>
 
@@ -233,7 +233,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `accounts` | `.CMsgLookupMultipleAccountNamesResponse.Account` | `repeated` | `` |  |
+| 1 | `accounts` | `.CMsgLookupMultipleAccountNamesResponse.Account` | `repeated` |  |  |
 
 </details>
 
@@ -245,8 +245,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `accountid` | `uint32` | `optional` | `` |  |
-| 2 | `persona` | `string` | `optional` | `` |  |
+| 1 | `accountid` | `uint32` | `optional` |  |  |
+| 2 | `persona` | `string` | `optional` |  |  |
 
 </details>
 
@@ -258,7 +258,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `crate_item_def` | `uint32` | `optional` | `` |  |
+| 1 | `crate_item_def` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -270,10 +270,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `uint32` | `optional` | `` |  |
-| 2 | `item_defs` | `uint32` | `repeated` | `` |  |
-| 3 | `peek_item_defs` | `uint32` | `repeated` | `` |  |
-| 4 | `peek_items` | `.CSOEconItem` | `repeated` | `` |  |
+| 1 | `response` | `uint32` | `optional` |  |  |
+| 2 | `item_defs` | `uint32` | `repeated` |  |  |
+| 3 | `peek_item_defs` | `uint32` | `repeated` |  |  |
+| 4 | `peek_items` | `.CSOEconItem` | `repeated` |  |  |
 
 </details>
 
@@ -285,7 +285,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `crate_item_def` | `uint32` | `optional` | `` |  |
+| 1 | `crate_item_def` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -297,11 +297,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `uint32` | `optional` | `` |  |
-| 2 | `escalation_level0` | `uint32` | `optional` | `` |  |
-| 3 | `escalation_level1` | `uint32` | `optional` | `` |  |
-| 4 | `escalation_level2` | `uint32` | `optional` | `` |  |
-| 5 | `escalation_level3` | `uint32` | `optional` | `` |  |
+| 1 | `response` | `uint32` | `optional` |  |  |
+| 2 | `escalation_level0` | `uint32` | `optional` |  |  |
+| 3 | `escalation_level1` | `uint32` | `optional` |  |  |
+| 4 | `escalation_level2` | `uint32` | `optional` |  |  |
+| 5 | `escalation_level3` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -313,11 +313,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `drop_rate_bonus` | `float` | `optional` | `` |  |
-| 3 | `booster_type` | `uint32` | `optional` | `` |  |
-| 4 | `exclusive_item_def` | `uint32` | `optional` | `` |  |
-| 5 | `allow_equal_rate` | `bool` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `drop_rate_bonus` | `float` | `optional` |  |  |
+| 3 | `booster_type` | `uint32` | `optional` |  |  |
+| 4 | `exclusive_item_def` | `uint32` | `optional` |  |  |
+| 5 | `allow_equal_rate` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -329,13 +329,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `item_id` | `uint64` | `optional` | `` |  |
-| 3 | `item_def` | `uint32` | `optional` | `` |  |
-| 4 | `drop_rate_bonus` | `float` | `optional` | `` |  |
-| 5 | `booster_type` | `uint32` | `optional` | `` |  |
-| 6 | `seconds_duration` | `uint32` | `optional` | `` |  |
-| 7 | `end_time_stamp` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `item_id` | `uint64` | `optional` |  |  |
+| 3 | `item_def` | `uint32` | `optional` |  |  |
+| 4 | `drop_rate_bonus` | `float` | `optional` |  |  |
+| 5 | `booster_type` | `uint32` | `optional` |  |  |
+| 6 | `seconds_duration` | `uint32` | `optional` |  |  |
+| 7 | `end_time_stamp` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -347,10 +347,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `item_def` | `uint32` | `optional` | `` |  |
-| 3 | `bonus_to_add` | `float` | `optional` | `` |  |
-| 4 | `booster_type` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `item_def` | `uint32` | `optional` |  |  |
+| 3 | `bonus_to_add` | `float` | `optional` |  |  |
+| 4 | `booster_type` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -362,8 +362,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `reload` | `bool` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `reload` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -375,9 +375,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `matching_subscription_def_indexes` | `uint32` | `repeated` | `` |  |
-| 3 | `additional_seconds` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `matching_subscription_def_indexes` | `uint32` | `repeated` |  |  |
+| 3 | `additional_seconds` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -389,10 +389,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `items` | `.CMsgGCToGCGrantAccountRolledItems.Item` | `repeated` | `` |  |
-| 3 | `audit_action` | `uint32` | `optional` | `` |  |
-| 4 | `audit_data` | `uint64` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `items` | `.CMsgGCToGCGrantAccountRolledItems.Item` | `repeated` |  |  |
+| 3 | `audit_action` | `uint32` | `optional` |  |  |
+| 4 | `audit_data` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -404,14 +404,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def` | `uint32` | `optional` | `` |  |
-| 2 | `loot_lists` | `string` | `repeated` | `` |  |
-| 3 | `ignore_limit` | `bool` | `optional` | `` |  |
-| 4 | `origin` | `uint32` | `optional` | `` |  |
-| 5 | `dynamic_attributes` | `.CMsgGCToGCGrantAccountRolledItems.Item.DynamicAttribute` | `repeated` | `` |  |
-| 6 | `additional_audit_entries` | `.CMsgGCToGCGrantAccountRolledItems.Item.AdditionalAuditEntry` | `repeated` | `` |  |
-| 7 | `inventory_token` | `uint32` | `optional` | `` |  |
-| 8 | `quality` | `int32` | `optional` | `` | default = -1 |
+| 1 | `item_def` | `uint32` | `optional` |  |  |
+| 2 | `loot_lists` | `string` | `repeated` |  |  |
+| 3 | `ignore_limit` | `bool` | `optional` |  |  |
+| 4 | `origin` | `uint32` | `optional` |  |  |
+| 5 | `dynamic_attributes` | `.CMsgGCToGCGrantAccountRolledItems.Item.DynamicAttribute` | `repeated` |  |  |
+| 6 | `additional_audit_entries` | `.CMsgGCToGCGrantAccountRolledItems.Item.AdditionalAuditEntry` | `repeated` |  |  |
+| 7 | `inventory_token` | `uint32` | `optional` |  |  |
+| 8 | `quality` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -423,10 +423,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `value_uint32` | `uint32` | `optional` | `` |  |
-| 3 | `value_float` | `float` | `optional` | `` |  |
-| 4 | `value_string` | `string` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `value_uint32` | `uint32` | `optional` |  |  |
+| 3 | `value_float` | `float` | `optional` |  |  |
+| 4 | `value_string` | `string` | `optional` |  |  |
 
 </details>
 
@@ -438,9 +438,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `owner_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `audit_action` | `uint32` | `optional` | `` |  |
-| 3 | `audit_data` | `uint64` | `optional` | `` |  |
+| 1 | `owner_account_id` | `uint32` | `optional` |  |  |
+| 2 | `audit_action` | `uint32` | `optional` |  |  |
+| 3 | `audit_data` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -452,9 +452,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `item_ids` | `uint64` | `repeated` | `` |  |
-| 3 | `item_defs` | `uint32` | `repeated` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `item_ids` | `uint64` | `repeated` |  |  |
+| 3 | `item_defs` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -466,8 +466,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def_index` | `uint32` | `optional` | `` |  |
-| 2 | `accountid` | `uint32` | `optional` | `` |  |
+| 1 | `item_def_index` | `uint32` | `optional` |  |  |
+| 2 | `accountid` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -479,9 +479,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `crate_item_id` | `uint64` | `optional` | `` |  |
-| 3 | `key_item_id` | `uint64` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `crate_item_id` | `uint64` | `optional` |  |  |
+| 3 | `key_item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -493,12 +493,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `uint64` | `optional` | `` |  |
-| 2 | `target_steam_id` | `fixed64` | `optional` | `` |  |
-| 3 | `gift__potential_targets` | `uint32` | `repeated` | `` |  |
-| 4 | `duel__class_lock` | `uint32` | `optional` | `` |  |
-| 5 | `initiator_steam_id` | `uint64` | `optional` | `` |  |
-| 6 | `itempack__ack_immediately` | `bool` | `optional` | `` |  |
+| 1 | `item_id` | `uint64` | `optional` |  |  |
+| 2 | `target_steam_id` | `fixed64` | `optional` |  |  |
+| 3 | `gift__potential_targets` | `uint32` | `repeated` |  |  |
+| 4 | `duel__class_lock` | `uint32` | `optional` |  |  |
+| 5 | `initiator_steam_id` | `uint64` | `optional` |  |  |
+| 6 | `itempack__ack_immediately` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -510,8 +510,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `initiator_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `use_item_msg` | `.CMsgUseItem` | `optional` | `` |  |
+| 1 | `initiator_account_id` | `uint32` | `optional` |  |  |
+| 2 | `use_item_msg` | `.CMsgUseItem` | `optional` |  |  |
 
 </details>
 
@@ -523,7 +523,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_ids` | `uint64` | `repeated` | `` |  |
+| 1 | `item_ids` | `uint64` | `repeated` |  |  |
 
 </details>
 
@@ -535,8 +535,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def_id` | `uint32` | `optional` | `` |  |
-| 2 | `quantity` | `uint32` | `optional` | `` |  |
+| 1 | `item_def_id` | `uint32` | `optional` |  |  |
+| 2 | `quantity` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -548,11 +548,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `deleted_item_id` | `uint64` | `optional` | `` |  |
-| 3 | `old_audit_action` | `uint32` | `optional` | `` |  |
-| 4 | `new_audit_action` | `uint32` | `optional` | `` |  |
-| 5 | `expected_audit_action` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `deleted_item_id` | `uint64` | `optional` |  |  |
+| 3 | `old_audit_action` | `uint32` | `optional` |  |  |
+| 4 | `new_audit_action` | `uint32` | `optional` |  |  |
+| 5 | `expected_audit_action` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -564,12 +564,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `heroid` | `uint32` | `optional` | `` |  |
-| 2 | `sequencename` | `string` | `optional` | `` |  |
-| 3 | `cycle` | `float` | `optional` | `` |  |
-| 4 | `description` | `string` | `optional` | `` |  |
-| 5 | `pedestal_itemdef` | `uint32` | `optional` | `` |  |
-| 6 | `toolid` | `uint64` | `optional` | `` |  |
+| 1 | `heroid` | `uint32` | `optional` |  |  |
+| 2 | `sequencename` | `string` | `optional` |  |  |
+| 3 | `cycle` | `float` | `optional` |  |  |
+| 4 | `description` | `string` | `optional` |  |  |
+| 5 | `pedestal_itemdef` | `uint32` | `optional` |  |  |
+| 6 | `toolid` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -581,7 +581,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `code` | `string` | `optional` | `` |  |
+| 1 | `code` | `string` | `optional` |  |  |
 
 </details>
 
@@ -593,8 +593,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `uint32` | `optional` | `` |  |
-| 2 | `item_id` | `uint64` | `optional` | `` |  |
+| 1 | `response` | `uint32` | `optional` |  |  |
+| 2 | `item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -606,11 +606,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 3 | `item_def_name` | `string` | `optional` | `` |  |
-| 4 | `loot_list_name` | `string` | `optional` | `` |  |
-| 5 | `attr_def_name` | `string` | `repeated` | `` |  |
-| 6 | `attr_value` | `string` | `repeated` | `` |  |
-| 7 | `item_quality` | `uint32` | `optional` | `` |  |
+| 3 | `item_def_name` | `string` | `optional` |  |  |
+| 4 | `loot_list_name` | `string` | `optional` |  |  |
+| 5 | `attr_def_name` | `string` | `repeated` |  |  |
+| 6 | `attr_value` | `string` | `repeated` |  |  |
+| 7 | `item_quality` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -622,7 +622,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `success` | `bool` | `optional` | `` |  |
+| 1 | `success` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -634,7 +634,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `uint64` | `optional` | `` |  |
+| 1 | `item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -646,7 +646,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `success` | `bool` | `optional` | `` |  |
+| 1 | `success` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -658,7 +658,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -670,7 +670,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `def_index` | `uint32` | `optional` | `` |  |
+| 1 | `def_index` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -682,11 +682,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `gifter_account_id` | `uint32` | `optional` | `` |  |
-| 2 | `receiver_account_id` | `uint32` | `optional` | `` |  |
-| 3 | `wrapped_item` | `.CSOEconItem` | `optional` | `` |  |
-| 4 | `gift_message` | `string` | `optional` | `` |  |
-| 5 | `is_wallet_cash_trusted` | `bool` | `optional` | `` |  |
+| 1 | `gifter_account_id` | `uint32` | `optional` |  |  |
+| 2 | `receiver_account_id` | `uint32` | `optional` |  |  |
+| 3 | `wrapped_item` | `.CSOEconItem` | `optional` |  |  |
+| 4 | `gift_message` | `string` | `optional` |  |  |
+| 5 | `is_wallet_cash_trusted` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -698,9 +698,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `uint64` | `optional` | `` |  |
-| 2 | `give_to_account_id` | `uint32` | `optional` | `` |  |
-| 3 | `gift_message` | `string` | `optional` | `` |  |
+| 1 | `item_id` | `uint64` | `optional` |  |  |
+| 2 | `give_to_account_id` | `uint32` | `optional` |  |  |
+| 3 | `gift_message` | `string` | `optional` |  |  |
 
 </details>
 
@@ -712,8 +712,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 4 | `sent_item_id` | `uint64` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 4 | `sent_item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -725,13 +725,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.EGCMsgResponse` | `optional` | `` | default = k_EGCMsgResponseOK |
-| 2 | `gifting_charge_uses` | `uint32` | `optional` | `` |  |
-| 3 | `gifting_charge_max` | `int32` | `optional` | `` |  |
-| 4 | `gifting_uses` | `uint32` | `optional` | `` |  |
-| 5 | `gifting_max` | `int32` | `optional` | `` |  |
-| 6 | `gifting_window_hours` | `uint32` | `optional` | `` |  |
-| 7 | `trade_restriction` | `.EGCMsgInitiateTradeResponse` | `optional` | `` | default = k_EGCMsgInitiateTradeResponse_Accepted |
+| 1 | `response` | `.EGCMsgResponse` | `optional` |  | default = k_EGCMsgResponseOK |
+| 2 | `gifting_charge_uses` | `uint32` | `optional` |  |  |
+| 3 | `gifting_charge_max` | `int32` | `optional` |  |  |
+| 4 | `gifting_uses` | `uint32` | `optional` |  |  |
+| 5 | `gifting_max` | `int32` | `optional` |  |  |
+| 6 | `gifting_window_hours` | `uint32` | `optional` |  |  |
+| 7 | `trade_restriction` | `.EGCMsgInitiateTradeResponse` | `optional` |  | default = k_EGCMsgInitiateTradeResponse_Accepted |
 
 </details>
 
@@ -743,7 +743,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `uint64` | `optional` | `` |  |
+| 1 | `item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -767,12 +767,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `is_unlimited` | `bool` | `optional` | `` |  |
-| 3 | `has_two_factor` | `bool` | `optional` | `` |  |
-| 6 | `sender_permission` | `.EGCMsgInitiateTradeResponse` | `optional` | `` | default = k_EGCMsgInitiateTradeResponse_Accepted |
-| 7 | `friendship_age_requirement` | `uint32` | `optional` | `` |  |
-| 8 | `friendship_age_requirement_two_factor` | `uint32` | `optional` | `` |  |
-| 9 | `friend_permissions` | `.CMsgClientToGCGetGiftPermissionsResponse.FriendPermission` | `repeated` | `` |  |
+| 1 | `is_unlimited` | `bool` | `optional` |  |  |
+| 3 | `has_two_factor` | `bool` | `optional` |  |  |
+| 6 | `sender_permission` | `.EGCMsgInitiateTradeResponse` | `optional` |  | default = k_EGCMsgInitiateTradeResponse_Accepted |
+| 7 | `friendship_age_requirement` | `uint32` | `optional` |  |  |
+| 8 | `friendship_age_requirement_two_factor` | `uint32` | `optional` |  |  |
+| 9 | `friend_permissions` | `.CMsgClientToGCGetGiftPermissionsResponse.FriendPermission` | `repeated` |  |  |
 
 </details>
 
@@ -784,8 +784,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `permission` | `.EGCMsgInitiateTradeResponse` | `optional` | `` | default = k_EGCMsgInitiateTradeResponse_Accepted |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `permission` | `.EGCMsgInitiateTradeResponse` | `optional` |  | default = k_EGCMsgInitiateTradeResponse_Accepted |
 
 </details>
 
@@ -797,7 +797,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `uint64` | `optional` | `` |  |
+| 1 | `item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -809,9 +809,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `unpacked_item_ids` | `uint64` | `repeated` | `` |  |
-| 2 | `response` | `.CMsgClientToGCUnpackBundleResponse.EUnpackBundle` | `optional` | `` | default = k_UnpackBundle_Succeeded |
-| 3 | `unpacked_item_def_indexes` | `uint32` | `repeated` | `` |  |
+| 1 | `unpacked_item_ids` | `uint64` | `repeated` |  |  |
+| 2 | `response` | `.CMsgClientToGCUnpackBundleResponse.EUnpackBundle` | `optional` |  | default = k_UnpackBundle_Succeeded |
+| 3 | `unpacked_item_def_indexes` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -823,8 +823,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_ids` | `uint64` | `repeated` | `` |  |
-| 2 | `bundle_item_def_index` | `uint32` | `optional` | `` |  |
+| 1 | `item_ids` | `uint64` | `repeated` |  |  |
+| 2 | `bundle_item_def_index` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -836,8 +836,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `uint64` | `optional` | `` |  |
-| 2 | `response` | `.CMsgClientToGCPackBundleResponse.EPackBundle` | `optional` | `` | default = k_PackBundle_Succeeded |
+| 1 | `item_id` | `uint64` | `optional` |  |  |
+| 2 | `response` | `.CMsgClientToGCPackBundleResponse.EPackBundle` | `optional` |  | default = k_PackBundle_Succeeded |
 
 </details>
 
@@ -849,8 +849,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `txn_id` | `uint64` | `optional` | `` |  |
-| 2 | `item_ids` | `uint64` | `repeated` | `` |  |
+| 1 | `txn_id` | `uint64` | `optional` |  |  |
+| 2 | `item_ids` | `uint64` | `repeated` |  |  |
 
 </details>
 
@@ -862,7 +862,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `equips` | `.CMsgAdjustItemEquippedState` | `repeated` | `` |  |
+| 1 | `equips` | `.CMsgAdjustItemEquippedState` | `repeated` |  |  |
 
 </details>
 
@@ -874,7 +874,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `so_cache_version_id` | `fixed64` | `optional` | `` |  |
+| 1 | `so_cache_version_id` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -886,8 +886,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `uint64` | `optional` | `` |  |
-| 2 | `style_index` | `uint32` | `optional` | `` | default = 255 |
+| 1 | `item_id` | `uint64` | `optional` |  |  |
+| 2 | `style_index` | `uint32` | `optional` |  | default = 255 |
 
 </details>
 
@@ -899,7 +899,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCSetItemStyleResponse.ESetStyle` | `optional` | `` | default = k_SetStyle_Succeeded |
+| 1 | `response` | `.CMsgClientToGCSetItemStyleResponse.ESetStyle` | `optional` |  | default = k_SetStyle_Succeeded |
 
 </details>
 
@@ -911,9 +911,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_to_unlock` | `uint64` | `optional` | `` |  |
-| 2 | `style_index` | `uint32` | `optional` | `` | default = 255 |
-| 3 | `consumable_item_ids` | `uint64` | `repeated` | `` |  |
+| 1 | `item_to_unlock` | `uint64` | `optional` |  |  |
+| 2 | `style_index` | `uint32` | `optional` |  | default = 255 |
+| 3 | `consumable_item_ids` | `uint64` | `repeated` |  |  |
 
 </details>
 
@@ -925,10 +925,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCUnlockItemStyleResponse.EUnlockStyle` | `optional` | `` | default = k_UnlockStyle_Succeeded |
-| 2 | `item_id` | `uint64` | `optional` | `` |  |
-| 3 | `style_index` | `uint32` | `optional` | `` | default = 255 |
-| 4 | `style_prereq` | `uint32` | `optional` | `` | default = 255 |
+| 1 | `response` | `.CMsgClientToGCUnlockItemStyleResponse.EUnlockStyle` | `optional` |  | default = k_UnlockStyle_Succeeded |
+| 2 | `item_id` | `uint64` | `optional` |  |  |
+| 3 | `style_index` | `uint32` | `optional` |  | default = 255 |
+| 4 | `style_prereq` | `uint32` | `optional` |  | default = 255 |
 
 </details>
 
@@ -940,10 +940,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_ids` | `uint64` | `repeated` | `` |  |
-| 2 | `set_to_value` | `uint32` | `optional` | `` |  |
-| 3 | `remove_categories` | `uint32` | `optional` | `` |  |
-| 4 | `add_categories` | `uint32` | `optional` | `` |  |
+| 1 | `item_ids` | `uint64` | `repeated` |  |  |
+| 2 | `set_to_value` | `uint32` | `optional` |  |  |
+| 3 | `remove_categories` | `uint32` | `optional` |  |  |
+| 4 | `add_categories` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -955,8 +955,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `crate_item_id` | `uint64` | `optional` | `` |  |
-| 2 | `key_item_id` | `uint64` | `optional` | `` |  |
+| 1 | `crate_item_id` | `uint64` | `optional` |  |  |
+| 2 | `key_item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -968,8 +968,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.EGCMsgResponse` | `optional` | `` | default = k_EGCMsgResponseOK |
-| 2 | `granted_items` | `.CMsgClientToGCUnlockCrateResponse.Item` | `repeated` | `` |  |
+| 1 | `result` | `.EGCMsgResponse` | `optional` |  | default = k_EGCMsgResponseOK |
+| 2 | `granted_items` | `.CMsgClientToGCUnlockCrateResponse.Item` | `repeated` |  |  |
 
 </details>
 
@@ -981,8 +981,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `uint64` | `optional` | `` |  |
-| 2 | `def_index` | `uint32` | `optional` | `` |  |
+| 1 | `item_id` | `uint64` | `optional` |  |  |
+| 2 | `def_index` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -994,7 +994,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `uint64` | `optional` | `` |  |
+| 1 | `item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -1006,8 +1006,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCRemoveItemAttributeResponse.ERemoveItemAttribute` | `optional` | `` | default = k_RemoveItemAttribute_Succeeded |
-| 2 | `item_id` | `uint64` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCRemoveItemAttributeResponse.ERemoveItemAttribute` | `optional` |  | default = k_RemoveItemAttribute_Succeeded |
+| 2 | `item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -1019,9 +1019,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `subject_item_id` | `uint64` | `optional` | `` |  |
-| 2 | `tool_item_id` | `uint64` | `optional` | `` |  |
-| 3 | `name` | `string` | `optional` | `` |  |
+| 1 | `subject_item_id` | `uint64` | `optional` |  |  |
+| 2 | `tool_item_id` | `uint64` | `optional` |  |  |
+| 3 | `name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1033,8 +1033,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCNameItemResponse.ENameItem` | `optional` | `` | default = k_NameItem_Succeeded |
-| 2 | `item_id` | `uint64` | `optional` | `` |  |
+| 1 | `response` | `.CMsgClientToGCNameItemResponse.ENameItem` | `optional` |  | default = k_NameItem_Succeeded |
+| 2 | `item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -1046,8 +1046,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `uint64` | `optional` | `` |  |
-| 2 | `new_position` | `uint32` | `optional` | `` |  |
+| 1 | `item_id` | `uint64` | `optional` |  |  |
+| 2 | `new_position` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1059,16 +1059,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def` | `uint32` | `optional` | `` |  |
-| 2 | `item_quality` | `uint32` | `optional` | `` |  |
-| 3 | `item_flags` | `uint32` | `optional` | `` |  |
-| 4 | `attributes_string` | `string` | `optional` | `` |  |
-| 5 | `item_count` | `uint32` | `optional` | `` |  |
-| 6 | `items_fulfilled` | `uint32` | `optional` | `` |  |
-| 7 | `item_rarity` | `uint32` | `optional` | `` |  |
-| 8 | `lootlist` | `string` | `optional` | `` |  |
-| 9 | `fulfilled_item_id` | `uint64` | `optional` | `` |  |
-| 10 | `associated_item_def` | `uint32` | `optional` | `` |  |
+| 1 | `item_def` | `uint32` | `optional` |  |  |
+| 2 | `item_quality` | `uint32` | `optional` |  |  |
+| 3 | `item_flags` | `uint32` | `optional` |  |  |
+| 4 | `attributes_string` | `string` | `optional` |  |  |
+| 5 | `item_count` | `uint32` | `optional` |  |  |
+| 6 | `items_fulfilled` | `uint32` | `optional` |  |  |
+| 7 | `item_rarity` | `uint32` | `optional` |  |  |
+| 8 | `lootlist` | `string` | `optional` |  |  |
+| 9 | `fulfilled_item_id` | `uint64` | `optional` |  |  |
+| 10 | `associated_item_def` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1080,13 +1080,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `uint64` | `optional` | `` |  |
-| 2 | `attr_def_index` | `uint32` | `optional` | `` |  |
-| 3 | `required_type` | `uint32` | `optional` | `` |  |
-| 4 | `required_hero` | `string` | `optional` | `` |  |
-| 5 | `gem_def_index` | `uint32` | `optional` | `` |  |
-| 6 | `not_tradable` | `bool` | `optional` | `` |  |
-| 7 | `required_item_slot` | `string` | `optional` | `` |  |
+| 1 | `item_id` | `uint64` | `optional` |  |  |
+| 2 | `attr_def_index` | `uint32` | `optional` |  |  |
+| 3 | `required_type` | `uint32` | `optional` |  |  |
+| 4 | `required_hero` | `string` | `optional` |  |  |
+| 5 | `gem_def_index` | `uint32` | `optional` |  |  |
+| 6 | `not_tradable` | `bool` | `optional` |  |  |
+| 7 | `required_item_slot` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1098,7 +1098,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `socket` | `.CProtoItemSocket` | `optional` | `` |  |
+| 1 | `socket` | `.CProtoItemSocket` | `optional` |  |  |
 
 </details>
 
@@ -1110,8 +1110,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `socket` | `.CProtoItemSocket` | `optional` | `` |  |
-| 2 | `effect` | `uint32` | `optional` | `` |  |
+| 1 | `socket` | `.CProtoItemSocket` | `optional` |  |  |
+| 2 | `effect` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1123,10 +1123,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `socket` | `.CProtoItemSocket` | `optional` | `` |  |
-| 2 | `red` | `uint32` | `optional` | `` |  |
-| 3 | `green` | `uint32` | `optional` | `` |  |
-| 4 | `blue` | `uint32` | `optional` | `` |  |
+| 1 | `socket` | `.CProtoItemSocket` | `optional` |  |  |
+| 2 | `red` | `uint32` | `optional` |  |  |
+| 3 | `green` | `uint32` | `optional` |  |  |
+| 4 | `blue` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1138,9 +1138,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `socket` | `.CProtoItemSocket` | `optional` | `` |  |
-| 2 | `strange_type` | `uint32` | `optional` | `` |  |
-| 3 | `strange_value` | `uint32` | `optional` | `` |  |
+| 1 | `socket` | `.CProtoItemSocket` | `optional` |  |  |
+| 2 | `strange_type` | `uint32` | `optional` |  |  |
+| 3 | `strange_value` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1152,10 +1152,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `socket` | `.CProtoItemSocket` | `optional` | `` |  |
-| 2 | `strange_type` | `uint32` | `optional` | `` |  |
-| 3 | `strange_value` | `uint32` | `optional` | `` |  |
-| 4 | `ability_effect` | `uint32` | `optional` | `` |  |
+| 1 | `socket` | `.CProtoItemSocket` | `optional` |  |  |
+| 2 | `strange_type` | `uint32` | `optional` |  |  |
+| 3 | `strange_value` | `uint32` | `optional` |  |  |
+| 4 | `ability_effect` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1167,11 +1167,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `socket` | `.CProtoItemSocket` | `optional` | `` |  |
-| 2 | `games_viewed` | `uint32` | `optional` | `` |  |
-| 3 | `corporation_id` | `uint32` | `optional` | `` |  |
-| 4 | `league_id` | `uint32` | `optional` | `` |  |
-| 5 | `team_id` | `uint32` | `optional` | `` |  |
+| 1 | `socket` | `.CProtoItemSocket` | `optional` |  |  |
+| 2 | `games_viewed` | `uint32` | `optional` |  |  |
+| 3 | `corporation_id` | `uint32` | `optional` |  |  |
+| 4 | `league_id` | `uint32` | `optional` |  |  |
+| 5 | `team_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1183,8 +1183,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `socket` | `.CProtoItemSocket` | `optional` | `` |  |
-| 2 | `asset_modifier` | `uint32` | `optional` | `` |  |
+| 1 | `socket` | `.CProtoItemSocket` | `optional` |  |  |
+| 2 | `asset_modifier` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1196,10 +1196,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `socket` | `.CProtoItemSocket` | `optional` | `` |  |
-| 2 | `asset_modifier` | `uint32` | `optional` | `` |  |
-| 3 | `anim_modifier` | `uint32` | `optional` | `` |  |
-| 4 | `ability_effect` | `uint32` | `optional` | `` |  |
+| 1 | `socket` | `.CProtoItemSocket` | `optional` |  |  |
+| 2 | `asset_modifier` | `uint32` | `optional` |  |  |
+| 3 | `anim_modifier` | `uint32` | `optional` |  |  |
+| 4 | `ability_effect` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1211,10 +1211,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `socket` | `.CProtoItemSocket` | `optional` | `` |  |
-| 2 | `autograph` | `string` | `optional` | `` |  |
-| 3 | `autograph_id` | `uint32` | `optional` | `` |  |
-| 4 | `autograph_score` | `uint32` | `optional` | `` |  |
+| 1 | `socket` | `.CProtoItemSocket` | `optional` |  |  |
+| 2 | `autograph` | `string` | `optional` |  |  |
+| 3 | `autograph_id` | `uint32` | `optional` |  |  |
+| 4 | `autograph_score` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1226,7 +1226,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `socket` | `.CProtoItemSocket` | `optional` | `` |  |
+| 1 | `socket` | `.CProtoItemSocket` | `optional` |  |  |
 
 </details>
 
@@ -1238,7 +1238,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `value` | `string` | `optional` | `` |  |
+| 1 | `value` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1250,10 +1250,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` |  |
-| 2 | `item_id` | `uint32` | `optional` | `` |  |
-| 3 | `date_start` | `uint32` | `optional` | `` |  |
-| 4 | `date_end` | `uint32` | `optional` | `` |  |
+| 1 | `appid` | `uint32` | `optional` |  |  |
+| 2 | `item_id` | `uint32` | `optional` |  |  |
+| 3 | `date_start` | `uint32` | `optional` |  |  |
+| 4 | `date_end` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1265,7 +1265,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `country_revenue` | `.CWorkshop_GetItemDailyRevenue_Response.CountryDailyRevenue` | `repeated` | `` |  |
+| 1 | `country_revenue` | `.CWorkshop_GetItemDailyRevenue_Response.CountryDailyRevenue` | `repeated` |  |  |
 
 </details>
 
@@ -1277,10 +1277,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `country_code` | `string` | `optional` | `` |  |
-| 2 | `date` | `uint32` | `optional` | `` |  |
-| 3 | `revenue_usd` | `int64` | `optional` | `` |  |
-| 4 | `units` | `int32` | `optional` | `` |  |
+| 1 | `country_code` | `string` | `optional` |  |  |
+| 2 | `date` | `uint32` | `optional` |  |  |
+| 3 | `revenue_usd` | `int64` | `optional` |  |  |
+| 4 | `units` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1292,9 +1292,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `packageid` | `uint32` | `optional` | `` |  |
-| 2 | `date_start` | `uint32` | `optional` | `` |  |
-| 3 | `date_end` | `uint32` | `optional` | `` |  |
+| 1 | `packageid` | `uint32` | `optional` |  |  |
+| 2 | `date_start` | `uint32` | `optional` |  |  |
+| 3 | `date_end` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1306,7 +1306,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `country_revenue` | `.CWorkshop_GetPackageDailyRevenue_Response.CountryDailyRevenue` | `repeated` | `` |  |
+| 1 | `country_revenue` | `.CWorkshop_GetPackageDailyRevenue_Response.CountryDailyRevenue` | `repeated` |  |  |
 
 </details>
 
@@ -1318,10 +1318,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `country_code` | `string` | `optional` | `` |  |
-| 2 | `date` | `uint32` | `optional` | `` |  |
-| 3 | `revenue_usd` | `int64` | `optional` | `` |  |
-| 4 | `units` | `int32` | `optional` | `` |  |
+| 1 | `country_code` | `string` | `optional` |  |  |
+| 2 | `date` | `uint32` | `optional` |  |  |
+| 3 | `revenue_usd` | `int64` | `optional` |  |  |
+| 4 | `units` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1333,8 +1333,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `add_slots` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `add_slots` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1346,7 +1346,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1358,8 +1358,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `account_name` | `string` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `account_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1371,8 +1371,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `items` | `.CMsgClientToGCCreateStaticRecipe.Item` | `repeated` | `` |  |
-| 2 | `recipe_def_index` | `uint32` | `optional` | `` |  |
+| 1 | `items` | `.CMsgClientToGCCreateStaticRecipe.Item` | `repeated` |  |  |
+| 2 | `recipe_def_index` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1384,8 +1384,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `uint64` | `optional` | `` |  |
-| 2 | `slot_id` | `uint32` | `optional` | `` |  |
+| 1 | `item_id` | `uint64` | `optional` |  |  |
+| 2 | `slot_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1397,10 +1397,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `response` | `.CMsgClientToGCCreateStaticRecipeResponse.EResponse` | `optional` | `` | default = eResponse_Success |
-| 2 | `output_items` | `.CMsgClientToGCCreateStaticRecipeResponse.OutputItem` | `repeated` | `` |  |
-| 3 | `input_errors` | `.CMsgClientToGCCreateStaticRecipeResponse.InputError` | `repeated` | `` |  |
-| 4 | `additional_outputs` | `.CMsgClientToGCCreateStaticRecipeResponse.AdditionalOutput` | `repeated` | `` |  |
+| 1 | `response` | `.CMsgClientToGCCreateStaticRecipeResponse.EResponse` | `optional` |  | default = eResponse_Success |
+| 2 | `output_items` | `.CMsgClientToGCCreateStaticRecipeResponse.OutputItem` | `repeated` |  |  |
+| 3 | `input_errors` | `.CMsgClientToGCCreateStaticRecipeResponse.InputError` | `repeated` |  |  |
+| 4 | `additional_outputs` | `.CMsgClientToGCCreateStaticRecipeResponse.AdditionalOutput` | `repeated` |  |  |
 
 </details>
 
@@ -1412,9 +1412,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `def_index` | `uint32` | `optional` | `` |  |
-| 2 | `item_id` | `uint64` | `optional` | `` |  |
-| 3 | `slot_id` | `uint32` | `optional` | `` |  |
+| 1 | `def_index` | `uint32` | `optional` |  |  |
+| 2 | `item_id` | `uint64` | `optional` |  |  |
+| 3 | `slot_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1426,8 +1426,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `slot_id` | `uint32` | `optional` | `` |  |
-| 2 | `error` | `.CMsgClientToGCCreateStaticRecipeResponse.EResponse` | `optional` | `` | default = eResponse_Success |
+| 1 | `slot_id` | `uint32` | `optional` |  |  |
+| 2 | `error` | `.CMsgClientToGCCreateStaticRecipeResponse.EResponse` | `optional` |  | default = eResponse_Success |
 
 </details>
 
@@ -1439,8 +1439,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `slot_id` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `uint64` | `optional` | `` |  |
+| 1 | `slot_id` | `uint32` | `optional` |  |  |
+| 2 | `value` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -1452,15 +1452,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `txn_id` | `uint64` | `optional` | `` |  |
-| 2 | `steam_txn_id` | `uint64` | `optional` | `` |  |
-| 3 | `partner_txn_id` | `uint64` | `optional` | `` |  |
-| 4 | `steam_id` | `fixed64` | `optional` | `` |  |
-| 5 | `time_stamp` | `uint32` | `optional` | `` |  |
-| 6 | `watermark` | `uint64` | `optional` | `` |  |
-| 7 | `purchase_report_status` | `int32` | `optional` | `` |  |
-| 8 | `currency` | `uint32` | `optional` | `` |  |
-| 9 | `items` | `.CMsgProcessTransactionOrder.Item` | `repeated` | `` |  |
+| 1 | `txn_id` | `uint64` | `optional` |  |  |
+| 2 | `steam_txn_id` | `uint64` | `optional` |  |  |
+| 3 | `partner_txn_id` | `uint64` | `optional` |  |  |
+| 4 | `steam_id` | `fixed64` | `optional` |  |  |
+| 5 | `time_stamp` | `uint32` | `optional` |  |  |
+| 6 | `watermark` | `uint64` | `optional` |  |  |
+| 7 | `purchase_report_status` | `int32` | `optional` |  |  |
+| 8 | `currency` | `uint32` | `optional` |  |  |
+| 9 | `items` | `.CMsgProcessTransactionOrder.Item` | `repeated` |  |  |
 
 </details>
 
@@ -1472,16 +1472,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def_index` | `uint32` | `optional` | `` |  |
-| 2 | `item_price` | `uint32` | `optional` | `` |  |
-| 3 | `quantity` | `uint32` | `optional` | `` |  |
-| 4 | `category_desc` | `string` | `optional` | `` |  |
-| 5 | `store_purchase_type` | `uint32` | `optional` | `` |  |
-| 6 | `source_reference_id` | `uint64` | `optional` | `` |  |
-| 7 | `parent_stack_index` | `int32` | `optional` | `` |  |
-| 8 | `default_price` | `bool` | `optional` | `` |  |
-| 9 | `is_user_facing` | `bool` | `optional` | `` |  |
-| 11 | `price_index` | `int32` | `optional` | `` |  |
+| 1 | `item_def_index` | `uint32` | `optional` |  |  |
+| 2 | `item_price` | `uint32` | `optional` |  |  |
+| 3 | `quantity` | `uint32` | `optional` |  |  |
+| 4 | `category_desc` | `string` | `optional` |  |  |
+| 5 | `store_purchase_type` | `uint32` | `optional` |  |  |
+| 6 | `source_reference_id` | `uint64` | `optional` |  |  |
+| 7 | `parent_stack_index` | `int32` | `optional` |  |  |
+| 8 | `default_price` | `bool` | `optional` |  |  |
+| 9 | `is_user_facing` | `bool` | `optional` |  |  |
+| 11 | `price_index` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1493,9 +1493,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `order` | `.CMsgProcessTransactionOrder` | `optional` | `` |  |
-| 2 | `reason_code` | `uint32` | `optional` | `` |  |
-| 3 | `partner` | `uint32` | `optional` | `` |  |
+| 1 | `order` | `.CMsgProcessTransactionOrder` | `optional` |  |  |
+| 2 | `reason_code` | `uint32` | `optional` |  |  |
+| 3 | `partner` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1507,7 +1507,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `success` | `bool` | `optional` | `` |  |
+| 1 | `success` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1519,7 +1519,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `order` | `.CMsgProcessTransactionOrder` | `optional` | `` |  |
+| 1 | `order` | `.CMsgProcessTransactionOrder` | `optional` |  |  |
 
 </details>
 
@@ -1531,7 +1531,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `success` | `bool` | `optional` | `` |  |
+| 1 | `success` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1543,11 +1543,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `con_command` | `string` | `optional` | `` |  |
-| 2 | `report_output` | `bool` | `optional` | `` |  |
-| 3 | `sending_gc` | `int32` | `optional` | `` | default = -1 |
-| 4 | `output_initiator` | `string` | `optional` | `` |  |
-| 5 | `sender_source` | `string` | `optional` | `` |  |
+| 1 | `con_command` | `string` | `optional` |  |  |
+| 2 | `report_output` | `bool` | `optional` |  |  |
+| 3 | `sending_gc` | `int32` | `optional` |  | default = -1 |
+| 4 | `output_initiator` | `string` | `optional` |  |  |
+| 5 | `sender_source` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1559,10 +1559,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `initiator` | `string` | `optional` | `` |  |
-| 2 | `sending_gc` | `int32` | `optional` | `` | default = -1 |
-| 3 | `msgs` | `.CMsgGCToGCConsoleOutput.OutputLine` | `repeated` | `` |  |
-| 4 | `is_last_for_source_job` | `bool` | `optional` | `` |  |
+| 1 | `initiator` | `string` | `optional` |  |  |
+| 2 | `sending_gc` | `int32` | `optional` |  | default = -1 |
+| 3 | `msgs` | `.CMsgGCToGCConsoleOutput.OutputLine` | `repeated` |  |  |
+| 4 | `is_last_for_source_job` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1574,8 +1574,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `text` | `string` | `optional` | `` |  |
-| 2 | `spew_level` | `uint32` | `optional` | `` |  |
+| 1 | `text` | `string` | `optional` |  |  |
+| 2 | `spew_level` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1587,7 +1587,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `max_item_id_timestamps` | `.CMsgItemAges.MaxItemIDTimestamp` | `repeated` | `` |  |
+| 1 | `max_item_id_timestamps` | `.CMsgItemAges.MaxItemIDTimestamp` | `repeated` |  |  |
 
 </details>
 
@@ -1599,8 +1599,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `timestamp` | `uint32` | `optional` | `` |  |
-| 2 | `max_item_id` | `uint64` | `optional` | `` |  |
+| 1 | `timestamp` | `uint32` | `optional` |  |  |
+| 2 | `max_item_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -1612,13 +1612,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `sending_gc` | `int32` | `optional` | `` | default = -1 |
-| 2 | `sender_id` | `fixed64` | `optional` | `` |  |
-| 3 | `context` | `uint32` | `optional` | `` |  |
-| 4 | `message_id` | `uint32` | `optional` | `` |  |
-| 5 | `message_body` | `bytes` | `optional` | `` |  |
-| 6 | `job_id_source` | `fixed64` | `optional` | `` |  |
-| 7 | `job_id_target` | `fixed64` | `optional` | `` |  |
+| 1 | `sending_gc` | `int32` | `optional` |  | default = -1 |
+| 2 | `sender_id` | `fixed64` | `optional` |  |  |
+| 3 | `context` | `uint32` | `optional` |  |  |
+| 4 | `message_id` | `uint32` | `optional` |  |  |
+| 5 | `message_body` | `bytes` | `optional` |  |  |
+| 6 | `job_id_source` | `fixed64` | `optional` |  |  |
+| 7 | `job_id_target` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -1630,11 +1630,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `client_min_allowed_version` | `uint32` | `optional` | `` |  |
-| 2 | `client_active_version` | `uint32` | `optional` | `` |  |
-| 3 | `server_active_version` | `uint32` | `optional` | `` |  |
-| 4 | `server_deployed_version` | `uint32` | `optional` | `` |  |
-| 5 | `what_changed` | `uint32` | `optional` | `` |  |
+| 1 | `client_min_allowed_version` | `uint32` | `optional` |  |  |
+| 2 | `client_active_version` | `uint32` | `optional` |  |  |
+| 3 | `server_active_version` | `uint32` | `optional` |  |  |
+| 4 | `server_deployed_version` | `uint32` | `optional` |  |  |
+| 5 | `what_changed` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1646,10 +1646,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `msg_id` | `uint32` | `optional` | `` |  |
-| 2 | `serialized_msg` | `bytes` | `optional` | `` |  |
-| 3 | `account_id_list` | `uint32` | `repeated` | `` | packed = true |
-| 4 | `steam_id_list` | `fixed64` | `repeated` | `` | packed = true |
+| 1 | `msg_id` | `uint32` | `optional` |  |  |
+| 2 | `serialized_msg` | `bytes` | `optional` |  |  |
+| 3 | `account_id_list` | `uint32` | `repeated` |  | packed = true |
+| 4 | `steam_id_list` | `fixed64` | `repeated` |  | packed = true |
 
 </details>
 
@@ -1661,8 +1661,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `price_key` | `uint64` | `repeated` | `` | packed = true |
-| 2 | `currencies` | `.CMsgGCToClientCurrencyPricePoints.Currency` | `repeated` | `` |  |
+| 1 | `price_key` | `uint64` | `repeated` |  | packed = true |
+| 2 | `currencies` | `.CMsgGCToClientCurrencyPricePoints.Currency` | `repeated` |  |  |
 
 </details>
 
@@ -1674,8 +1674,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `currency_id` | `uint32` | `optional` | `` |  |
-| 2 | `currency_price` | `uint64` | `repeated` | `` | packed = true |
+| 1 | `currency_id` | `uint32` | `optional` |  |  |
+| 2 | `currency_price` | `uint64` | `repeated` |  | packed = true |
 
 </details>
 
@@ -1687,8 +1687,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `version` | `uint32` | `optional` | `` |  |
-| 2 | `banned_words` | `string` | `repeated` | `` |  |
+| 1 | `version` | `uint32` | `optional` |  |  |
+| 2 | `banned_words` | `string` | `repeated` |  |  |
 
 </details>
 
@@ -1700,7 +1700,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `keys` | `.CMsgGCToGCFlushSteamInventoryCache.Key` | `repeated` | `` |  |
+| 1 | `keys` | `.CMsgGCToGCFlushSteamInventoryCache.Key` | `repeated` |  |  |
 
 </details>
 
@@ -1712,8 +1712,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `uint64` | `optional` | `` |  |
-| 2 | `contextid` | `uint64` | `optional` | `` |  |
+| 1 | `steamid` | `uint64` | `optional` |  |  |
+| 2 | `contextid` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -1725,8 +1725,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `always_notify` | `bool` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `always_notify` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1738,7 +1738,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `sample_id` | `uint32` | `optional` | `` |  |
+| 1 | `sample_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1762,11 +1762,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `stat_ids` | `fixed32` | `repeated` | `` | packed = true |
-| 2 | `stat_total` | `uint64` | `repeated` | `` | packed = true |
-| 3 | `stat_samples` | `uint32` | `repeated` | `` | packed = true |
-| 4 | `stat_max` | `uint32` | `repeated` | `` | packed = true |
-| 5 | `sample_duration_ms` | `uint32` | `optional` | `` |  |
+| 1 | `stat_ids` | `fixed32` | `repeated` |  | packed = true |
+| 2 | `stat_total` | `uint64` | `repeated` |  | packed = true |
+| 3 | `stat_samples` | `uint32` | `repeated` |  | packed = true |
+| 4 | `stat_max` | `uint32` | `repeated` |  | packed = true |
+| 5 | `sample_duration_ms` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1790,7 +1790,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def` | `uint32` | `optional` | `` |  |
+| 1 | `item_def` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1802,8 +1802,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCGetLimitedItemPurchaseQuantityResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `quantity_purchased` | `uint32` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCGetLimitedItemPurchaseQuantityResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `quantity_purchased` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1815,7 +1815,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def` | `uint32` | `optional` | `` |  |
+| 1 | `item_def` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1827,8 +1827,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCGetInFlightItemChargesResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `charges_in_flight` | `uint32` | `optional` | `` |  |
+| 1 | `result` | `.CMsgClientToGCGetInFlightItemChargesResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `charges_in_flight` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1840,8 +1840,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `items` | `.CMsgClientToGCPurchaseChargeCostItems.Item` | `repeated` | `` |  |
-| 2 | `currency` | `uint32` | `optional` | `` |  |
+| 1 | `items` | `.CMsgClientToGCPurchaseChargeCostItems.Item` | `repeated` |  |  |
+| 2 | `currency` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1853,10 +1853,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def_index` | `uint32` | `optional` | `` |  |
-| 2 | `quantity` | `uint32` | `optional` | `` |  |
-| 3 | `source_reference_id` | `uint64` | `optional` | `` |  |
-| 4 | `price_index` | `int32` | `optional` | `` |  |
+| 1 | `item_def_index` | `uint32` | `optional` |  |  |
+| 2 | `quantity` | `uint32` | `optional` |  |  |
+| 3 | `source_reference_id` | `uint64` | `optional` |  |  |
+| 4 | `price_index` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1868,8 +1868,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.CMsgClientToGCPurchaseChargeCostItemsResponse.EResponse` | `optional` | `` | default = k_eInternalError |
-| 2 | `item_ids` | `uint64` | `repeated` | `` |  |
+| 1 | `result` | `.CMsgClientToGCPurchaseChargeCostItemsResponse.EResponse` | `optional` |  | default = k_eInternalError |
+| 2 | `item_ids` | `uint64` | `repeated` |  |  |
 
 </details>
 
@@ -1881,7 +1881,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `in_flight_charges` | `.CMsgGCToClientInFlightChargesUpdated.ItemCharges` | `repeated` | `` |  |
+| 2 | `in_flight_charges` | `.CMsgGCToClientInFlightChargesUpdated.ItemCharges` | `repeated` |  |  |
 
 </details>
 
@@ -1893,8 +1893,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_def` | `uint32` | `optional` | `` |  |
-| 2 | `charges_in_flight` | `uint32` | `optional` | `` |  |
+| 1 | `item_def` | `uint32` | `optional` |  |  |
+| 2 | `charges_in_flight` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1906,7 +1906,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `unused` | `uint32` | `optional` | `` |  |
+| 1 | `unused` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1918,7 +1918,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `uint32` | `optional` | `` |  |
+| 1 | `result` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1930,9 +1930,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `server` | `bool` | `optional` | `` |  |
-| 2 | `new_msg` | `.CExtraMsgBlock` | `optional` | `` |  |
-| 3 | `broadcast` | `bool` | `optional` | `` |  |
+| 1 | `server` | `bool` | `optional` |  |  |
+| 2 | `new_msg` | `.CExtraMsgBlock` | `optional` |  |  |
+| 3 | `broadcast` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1944,7 +1944,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `items` | `.CMsgClientToGCRecycleMultipleItems.Item` | `repeated` | `` |  |
+| 1 | `items` | `.CMsgClientToGCRecycleMultipleItems.Item` | `repeated` |  |  |
 
 </details>
 
@@ -1956,9 +1956,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item_id` | `uint64` | `optional` | `` |  |
-| 2 | `slot_id` | `uint32` | `optional` | `` |  |
-| 3 | `recipe_def_index` | `uint32` | `optional` | `` |  |
+| 1 | `item_id` | `uint64` | `optional` |  |  |
+| 2 | `slot_id` | `uint32` | `optional` |  |  |
+| 3 | `recipe_def_index` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1970,7 +1970,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `responses` | `.CMsgClientToGCCreateStaticRecipeResponse` | `repeated` | `` |  |
+| 1 | `responses` | `.CMsgClientToGCCreateStaticRecipeResponse` | `repeated` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/econ-shared-enums.md
+++ b/docs/cookbook/proto-fields/econ-shared-enums.md
@@ -19,8 +19,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `eresult` | `uint32` | `optional` | `` | default = 2 |
-| 2 | `debug_message` | `string` | `optional` | `` |  |
+| 1 | `eresult` | `uint32` | `optional` |  | default = 2 |
+| 2 | `debug_message` | `string` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/engine-gcmessages.md
+++ b/docs/cookbook/proto-fields/engine-gcmessages.md
@@ -23,16 +23,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `match_id` | `uint64` | `optional` | `` |  |
-| 2 | `instance_id` | `uint32` | `optional` | `` |  |
-| 3 | `signupfragment` | `uint32` | `optional` | `` |  |
-| 4 | `currentfragment` | `uint32` | `optional` | `` |  |
-| 5 | `tickrate` | `float` | `optional` | `` |  |
-| 6 | `tick` | `uint32` | `optional` | `` |  |
-| 8 | `rtdelay` | `float` | `optional` | `` |  |
-| 9 | `rcvage` | `float` | `optional` | `` |  |
-| 10 | `keyframe_interval` | `float` | `optional` | `` |  |
-| 11 | `cdndelay` | `uint32` | `optional` | `` |  |
+| 1 | `match_id` | `uint64` | `optional` |  |  |
+| 2 | `instance_id` | `uint32` | `optional` |  |  |
+| 3 | `signupfragment` | `uint32` | `optional` |  |  |
+| 4 | `currentfragment` | `uint32` | `optional` |  |  |
+| 5 | `tickrate` | `float` | `optional` |  |  |
+| 6 | `tick` | `uint32` | `optional` |  |  |
+| 8 | `rtdelay` | `float` | `optional` |  |  |
+| 9 | `rcvage` | `float` | `optional` |  |  |
+| 10 | `keyframe_interval` | `float` | `optional` |  |  |
+| 11 | `cdndelay` | `uint32` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/gameevents.md
+++ b/docs/cookbook/proto-fields/gameevents.md
@@ -23,8 +23,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `clientid` | `int32` | `optional` | `` |  |
-| 2 | `gamesessionid` | `string` | `optional` | `` |  |
+| 1 | `clientid` | `int32` | `optional` |  |  |
+| 2 | `gamesessionid` | `string` | `optional` |  |  |
 
 </details>
 
@@ -36,20 +36,20 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `position` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `normal` | `.CMsgVector` | `optional` | `` |  |
-| 3 | `saxis` | `.CMsgVector` | `optional` | `` |  |
-| 4 | `boneindex` | `int32` | `optional` | `` |  |
-| 5 | `flags` | `uint32` | `optional` | `` |  |
-| 6 | `color` | `fixed32` | `optional` | `` |  |
-| 7 | `random_seed` | `int32` | `optional` | `` |  |
-| 8 | `decal_group_name` | `uint32` | `optional` | `` |  |
-| 9 | `size_override` | `float` | `optional` | `` |  |
-| 10 | `entityhandle` | `uint32` | `optional` | `` | default = 16777215 |
-| 11 | `material_id` | `uint64` | `optional` | `` |  |
-| 12 | `sequence_name` | `uint32` | `optional` | `` |  |
-| 13 | `triangleindex` | `int32` | `optional` | `` |  |
-| 14 | `position_objectspace` | `.CMsgVector` | `optional` | `` |  |
+| 1 | `position` | `.CMsgVector` | `optional` |  |  |
+| 2 | `normal` | `.CMsgVector` | `optional` |  |  |
+| 3 | `saxis` | `.CMsgVector` | `optional` |  |  |
+| 4 | `boneindex` | `int32` | `optional` |  |  |
+| 5 | `flags` | `uint32` | `optional` |  |  |
+| 6 | `color` | `fixed32` | `optional` |  |  |
+| 7 | `random_seed` | `int32` | `optional` |  |  |
+| 8 | `decal_group_name` | `uint32` | `optional` |  |  |
+| 9 | `size_override` | `float` | `optional` |  |  |
+| 10 | `entityhandle` | `uint32` | `optional` |  | default = 16777215 |
+| 11 | `material_id` | `uint64` | `optional` |  |  |
+| 12 | `sequence_name` | `uint32` | `optional` |  |  |
+| 13 | `triangleindex` | `int32` | `optional` |  |  |
+| 14 | `position_objectspace` | `.CMsgVector` | `optional` |  |  |
 
 </details>
 
@@ -61,7 +61,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `flagstoclear` | `uint32` | `optional` | `` |  |
+| 1 | `flagstoclear` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -73,7 +73,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `flagstoclear` | `uint32` | `optional` | `` |  |
+| 1 | `flagstoclear` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -85,8 +85,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `flagstoclear` | `uint32` | `optional` | `` |  |
-| 2 | `entityhandle` | `uint32` | `optional` | `` | default = 16777215 |
+| 1 | `flagstoclear` | `uint32` | `optional` |  |  |
+| 2 | `entityhandle` | `uint32` | `optional` |  | default = 16777215 |
 
 </details>
 
@@ -98,7 +98,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `descriptors` | `.CMsgSource1LegacyGameEventList.descriptor_t` | `repeated` | `` |  |
+| 1 | `descriptors` | `.CMsgSource1LegacyGameEventList.descriptor_t` | `repeated` |  |  |
 
 </details>
 
@@ -110,8 +110,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `type` | `int32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
+| 1 | `type` | `int32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -123,9 +123,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `eventid` | `int32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `keys` | `.CMsgSource1LegacyGameEventList.key_t` | `repeated` | `` |  |
+| 1 | `eventid` | `int32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `keys` | `.CMsgSource1LegacyGameEventList.key_t` | `repeated` |  |  |
 
 </details>
 
@@ -137,8 +137,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `playerslot` | `int32` | `optional` | `` |  |
-| 2 | `eventarraybits` | `uint32` | `repeated` | `` |  |
+| 1 | `playerslot` | `int32` | `optional` |  |  |
+| 2 | `eventarraybits` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -150,11 +150,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_name` | `string` | `optional` | `` |  |
-| 2 | `eventid` | `int32` | `optional` | `` |  |
-| 3 | `keys` | `.CMsgSource1LegacyGameEvent.key_t` | `repeated` | `` |  |
-| 4 | `server_tick` | `int32` | `optional` | `` |  |
-| 5 | `passthrough` | `int32` | `optional` | `` |  |
+| 1 | `event_name` | `string` | `optional` |  |  |
+| 2 | `eventid` | `int32` | `optional` |  |  |
+| 3 | `keys` | `.CMsgSource1LegacyGameEvent.key_t` | `repeated` |  |  |
+| 4 | `server_tick` | `int32` | `optional` |  |  |
+| 5 | `passthrough` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -166,14 +166,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `type` | `int32` | `optional` | `` |  |
-| 2 | `val_string` | `string` | `optional` | `` |  |
-| 3 | `val_float` | `float` | `optional` | `` |  |
-| 4 | `val_long` | `int32` | `optional` | `` |  |
-| 5 | `val_short` | `int32` | `optional` | `` |  |
-| 6 | `val_byte` | `int32` | `optional` | `` |  |
-| 7 | `val_bool` | `bool` | `optional` | `` |  |
-| 8 | `val_uint64` | `uint64` | `optional` | `` |  |
+| 1 | `type` | `int32` | `optional` |  |  |
+| 2 | `val_string` | `string` | `optional` |  |  |
+| 3 | `val_float` | `float` | `optional` |  |  |
+| 4 | `val_long` | `int32` | `optional` |  |  |
+| 5 | `val_short` | `int32` | `optional` |  |  |
+| 6 | `val_byte` | `int32` | `optional` |  |  |
+| 7 | `val_bool` | `bool` | `optional` |  |  |
+| 8 | `val_uint64` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -185,12 +185,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `soundevent_guid` | `int32` | `optional` | `` |  |
-| 2 | `soundevent_hash` | `fixed32` | `optional` | `` |  |
-| 3 | `source_entity_index` | `int32` | `optional` | `` | default = -1 |
-| 4 | `seed` | `int32` | `optional` | `` |  |
-| 5 | `packed_params` | `bytes` | `optional` | `` |  |
-| 6 | `start_time` | `float` | `optional` | `` |  |
+| 1 | `soundevent_guid` | `int32` | `optional` |  |  |
+| 2 | `soundevent_hash` | `fixed32` | `optional` |  |  |
+| 3 | `source_entity_index` | `int32` | `optional` |  | default = -1 |
+| 4 | `seed` | `int32` | `optional` |  |  |
+| 5 | `packed_params` | `bytes` | `optional` |  |  |
+| 6 | `start_time` | `float` | `optional` |  |  |
 
 </details>
 
@@ -202,7 +202,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `soundevent_guid` | `int32` | `optional` | `` |  |
+| 1 | `soundevent_guid` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -214,8 +214,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `soundevent_hash` | `fixed32` | `optional` | `` |  |
-| 2 | `source_entity_index` | `int32` | `optional` | `` | default = -1 |
+| 1 | `soundevent_hash` | `fixed32` | `optional` |  |  |
+| 2 | `source_entity_index` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -227,8 +227,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `soundevent_guid` | `int32` | `optional` | `` |  |
-| 5 | `packed_params` | `bytes` | `optional` | `` |  |
+| 1 | `soundevent_guid` | `int32` | `optional` |  |  |
+| 5 | `packed_params` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -240,8 +240,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `stack_hash` | `fixed32` | `optional` | `` |  |
-| 5 | `packed_fields` | `bytes` | `optional` | `` |  |
+| 1 | `stack_hash` | `fixed32` | `optional` |  |  |
+| 5 | `packed_fields` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -253,12 +253,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `source_entity_index` | `int32` | `optional` | `` | default = -1 |
-| 2 | `vertex_set_hash` | `int32` | `optional` | `` |  |
-| 3 | `intensity` | `float` | `optional` | `` |  |
-| 4 | `length` | `float` | `optional` | `` |  |
-| 5 | `speed_in` | `float` | `optional` | `` |  |
-| 6 | `speed_out` | `float` | `optional` | `` |  |
+| 1 | `source_entity_index` | `int32` | `optional` |  | default = -1 |
+| 2 | `vertex_set_hash` | `int32` | `optional` |  |  |
+| 3 | `intensity` | `float` | `optional` |  |  |
+| 4 | `length` | `float` | `optional` |  |  |
+| 5 | `speed_in` | `float` | `optional` |  |  |
+| 6 | `speed_out` | `float` | `optional` |  |  |
 
 </details>
 
@@ -270,12 +270,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `source_entity_index` | `int32` | `optional` | `` | default = -1 |
-| 2 | `effect_name_hash` | `int32` | `optional` | `` |  |
-| 3 | `operation` | `int32` | `optional` | `` |  |
-| 4 | `flags` | `int32` | `optional` | `` |  |
-| 5 | `tags` | `string` | `optional` | `` |  |
-| 6 | `pte` | `.CMsgVector` | `optional` | `` |  |
+| 1 | `source_entity_index` | `int32` | `optional` |  | default = -1 |
+| 2 | `effect_name_hash` | `int32` | `optional` |  |  |
+| 3 | `operation` | `int32` | `optional` |  |  |
+| 4 | `flags` | `int32` | `optional` |  |  |
+| 5 | `tags` | `string` | `optional` |  |  |
+| 6 | `pte` | `.CMsgVector` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/gcsdk-gcmessages.md
+++ b/docs/cookbook/proto-fields/gcsdk-gcmessages.md
@@ -25,10 +25,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `msg_type` | `uint32` | `optional` | `` |  |
-| 2 | `contents` | `bytes` | `optional` | `` | (debugprint_visibility) = k_EProtoDebugVisibility_Never |
-| 3 | `msg_key` | `uint64` | `optional` | `` |  |
-| 4 | `is_compressed` | `bool` | `optional` | `` |  |
+| 1 | `msg_type` | `uint32` | `optional` |  |  |
+| 2 | `contents` | `bytes` | `optional` |  | (debugprint_visibility) = k_EProtoDebugVisibility_Never |
+| 3 | `msg_key` | `uint64` | `optional` |  |  |
+| 4 | `is_compressed` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -40,8 +40,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 4 | `access_tokens` | `.CMsgSteamLearnAccessTokens` | `optional` | `` |  |
-| 5 | `project_infos` | `.CMsgSteamLearnServerInfo.ProjectInfo` | `repeated` | `` |  |
+| 4 | `access_tokens` | `.CMsgSteamLearnAccessTokens` | `optional` |  |  |
+| 5 | `project_infos` | `.CMsgSteamLearnServerInfo.ProjectInfo` | `repeated` |  |  |
 
 </details>
 
@@ -53,11 +53,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `project_id` | `uint32` | `optional` | `` |  |
-| 2 | `snapshot_published_version` | `uint32` | `optional` | `` |  |
-| 3 | `inference_published_version` | `uint32` | `optional` | `` |  |
-| 6 | `snapshot_percentage` | `uint32` | `optional` | `` |  |
-| 7 | `snapshot_enabled` | `bool` | `optional` | `` |  |
+| 1 | `project_id` | `uint32` | `optional` |  |  |
+| 2 | `snapshot_published_version` | `uint32` | `optional` |  |  |
+| 3 | `inference_published_version` | `uint32` | `optional` |  |  |
+| 6 | `snapshot_percentage` | `uint32` | `optional` |  |  |
+| 7 | `snapshot_enabled` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -69,8 +69,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `message_type` | `string` | `optional` | `` |  |
-| 2 | `message_data` | `bytes` | `optional` | `` |  |
+| 1 | `message_type` | `string` | `optional` |  |  |
+| 2 | `message_data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -82,7 +82,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `command` | `string` | `optional` | `` |  |
+| 1 | `command` | `string` | `optional` |  |  |
 
 </details>
 
@@ -94,8 +94,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `sdo_type` | `int32` | `optional` | `` |  |
-| 2 | `requests` | `.CMsgSDOAssert.Request` | `repeated` | `` |  |
+| 1 | `sdo_type` | `int32` | `optional` |  |  |
+| 2 | `requests` | `.CMsgSDOAssert.Request` | `repeated` |  |  |
 
 </details>
 
@@ -107,8 +107,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key` | `uint64` | `repeated` | `` |  |
-| 2 | `requesting_job` | `string` | `optional` | `` |  |
+| 1 | `key` | `uint64` | `repeated` |  |  |
+| 2 | `requesting_job` | `string` | `optional` |  |  |
 
 </details>
 
@@ -120,8 +120,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `type` | `uint32` | `optional` | `` |  |
-| 2 | `id` | `uint64` | `optional` | `` |  |
+| 1 | `type` | `uint32` | `optional` |  |  |
+| 2 | `id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -133,11 +133,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `type_id` | `int32` | `optional` | `` |  |
-| 3 | `object_data` | `bytes` | `optional` | `` |  |
-| 4 | `version` | `fixed64` | `optional` | `` |  |
-| 5 | `owner_soid` | `.CMsgSOIDOwner` | `optional` | `` |  |
-| 6 | `service_id` | `uint32` | `optional` | `` |  |
+| 2 | `type_id` | `int32` | `optional` |  |  |
+| 3 | `object_data` | `bytes` | `optional` |  |  |
+| 4 | `version` | `fixed64` | `optional` |  |  |
+| 5 | `owner_soid` | `.CMsgSOIDOwner` | `optional` |  |  |
+| 6 | `service_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -149,12 +149,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `objects_modified` | `.CMsgSOMultipleObjects.SingleObject` | `repeated` | `` |  |
-| 3 | `version` | `fixed64` | `optional` | `` |  |
-| 4 | `objects_added` | `.CMsgSOMultipleObjects.SingleObject` | `repeated` | `` |  |
-| 5 | `objects_removed` | `.CMsgSOMultipleObjects.SingleObject` | `repeated` | `` |  |
-| 6 | `owner_soid` | `.CMsgSOIDOwner` | `optional` | `` |  |
-| 7 | `service_id` | `uint32` | `optional` | `` |  |
+| 2 | `objects_modified` | `.CMsgSOMultipleObjects.SingleObject` | `repeated` |  |  |
+| 3 | `version` | `fixed64` | `optional` |  |  |
+| 4 | `objects_added` | `.CMsgSOMultipleObjects.SingleObject` | `repeated` |  |  |
+| 5 | `objects_removed` | `.CMsgSOMultipleObjects.SingleObject` | `repeated` |  |  |
+| 6 | `owner_soid` | `.CMsgSOIDOwner` | `optional` |  |  |
+| 7 | `service_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -166,8 +166,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `type_id` | `int32` | `optional` | `` |  |
-| 2 | `object_data` | `bytes` | `optional` | `` |  |
+| 1 | `type_id` | `int32` | `optional` |  |  |
+| 2 | `object_data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -179,12 +179,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `objects` | `.CMsgSOCacheSubscribed.SubscribedType` | `repeated` | `` |  |
-| 3 | `version` | `fixed64` | `optional` | `` |  |
-| 4 | `owner_soid` | `.CMsgSOIDOwner` | `optional` | `` |  |
-| 5 | `service_id` | `uint32` | `optional` | `` |  |
-| 6 | `service_list` | `uint32` | `repeated` | `` |  |
-| 7 | `sync_version` | `fixed64` | `optional` | `` |  |
+| 2 | `objects` | `.CMsgSOCacheSubscribed.SubscribedType` | `repeated` |  |  |
+| 3 | `version` | `fixed64` | `optional` |  |  |
+| 4 | `owner_soid` | `.CMsgSOIDOwner` | `optional` |  |  |
+| 5 | `service_id` | `uint32` | `optional` |  |  |
+| 6 | `service_list` | `uint32` | `repeated` |  |  |
+| 7 | `sync_version` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -196,8 +196,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `type_id` | `int32` | `optional` | `` |  |
-| 2 | `object_data` | `bytes` | `repeated` | `` |  |
+| 1 | `type_id` | `int32` | `optional` |  |  |
+| 2 | `object_data` | `bytes` | `repeated` |  |  |
 
 </details>
 
@@ -209,11 +209,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `version` | `fixed64` | `optional` | `` |  |
-| 2 | `owner_soid` | `.CMsgSOIDOwner` | `optional` | `` |  |
-| 3 | `service_id` | `uint32` | `optional` | `` |  |
-| 4 | `service_list` | `uint32` | `repeated` | `` |  |
-| 5 | `sync_version` | `fixed64` | `optional` | `` |  |
+| 1 | `version` | `fixed64` | `optional` |  |  |
+| 2 | `owner_soid` | `.CMsgSOIDOwner` | `optional` |  |  |
+| 3 | `service_id` | `uint32` | `optional` |  |  |
+| 4 | `service_list` | `uint32` | `repeated` |  |  |
+| 5 | `sync_version` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -225,7 +225,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `owner_soid` | `.CMsgSOIDOwner` | `optional` | `` |  |
+| 2 | `owner_soid` | `.CMsgSOIDOwner` | `optional` |  |  |
 
 </details>
 
@@ -237,11 +237,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `version` | `fixed64` | `optional` | `` |  |
-| 3 | `owner_soid` | `.CMsgSOIDOwner` | `optional` | `` |  |
-| 4 | `service_id` | `uint32` | `optional` | `` |  |
-| 5 | `service_list` | `uint32` | `repeated` | `` |  |
-| 6 | `sync_version` | `fixed64` | `optional` | `` |  |
+| 2 | `version` | `fixed64` | `optional` |  |  |
+| 3 | `owner_soid` | `.CMsgSOIDOwner` | `optional` |  |  |
+| 4 | `service_id` | `uint32` | `optional` |  |  |
+| 5 | `service_list` | `uint32` | `repeated` |  |  |
+| 6 | `sync_version` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -253,7 +253,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `owner_soid` | `.CMsgSOIDOwner` | `optional` | `` |  |
+| 2 | `owner_soid` | `.CMsgSOIDOwner` | `optional` |  |  |
 
 </details>
 
@@ -265,7 +265,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `version` | `fixed64` | `optional` | `` |  |
+| 1 | `version` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -277,9 +277,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `msgtype` | `uint32` | `optional` | `` |  |
-| 2 | `payload` | `bytes` | `optional` | `` |  |
-| 3 | `steamids` | `fixed64` | `repeated` | `` |  |
+| 1 | `msgtype` | `uint32` | `optional` |  |  |
+| 2 | `payload` | `bytes` | `optional` |  |  |
+| 3 | `steamids` | `fixed64` | `repeated` |  |  |
 
 </details>
 
@@ -291,7 +291,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `dir_index` | `int32` | `optional` | `` | default = -1 |
+| 1 | `dir_index` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -303,10 +303,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `dir_index` | `int32` | `optional` | `` | default = -1 |
-| 3 | `machine_name` | `string` | `optional` | `` |  |
-| 4 | `process_name` | `string` | `optional` | `` |  |
-| 6 | `directory` | `.CGCToGCMsgMasterAck.Process` | `repeated` | `` |  |
+| 1 | `dir_index` | `int32` | `optional` |  | default = -1 |
+| 3 | `machine_name` | `string` | `optional` |  |  |
+| 4 | `process_name` | `string` | `optional` |  |  |
+| 6 | `directory` | `.CGCToGCMsgMasterAck.Process` | `repeated` |  |  |
 
 </details>
 
@@ -318,8 +318,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `dir_index` | `int32` | `optional` | `` | default = -1 |
-| 2 | `type_instances` | `uint32` | `repeated` | `` |  |
+| 1 | `dir_index` | `int32` | `optional` |  | default = -1 |
+| 2 | `type_instances` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -331,7 +331,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `eresult` | `int32` | `optional` | `` | default = 2 |
+| 1 | `eresult` | `int32` | `optional` |  | default = 2 |
 
 </details>
 
@@ -343,7 +343,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `is_initial_startup` | `bool` | `optional` | `` |  |
+| 1 | `is_initial_startup` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -355,7 +355,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `eresult` | `int32` | `optional` | `` |  |
+| 1 | `eresult` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -367,7 +367,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `gc_info` | `.CGCToGCMsgMasterStartupComplete.GCInfo` | `repeated` | `` |  |
+| 1 | `gc_info` | `.CGCToGCMsgMasterStartupComplete.GCInfo` | `repeated` |  |  |
 
 </details>
 
@@ -379,8 +379,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `dir_index` | `int32` | `optional` | `` | default = -1 |
-| 2 | `machine_name` | `string` | `optional` | `` |  |
+| 1 | `dir_index` | `int32` | `optional` |  | default = -1 |
+| 2 | `machine_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -392,9 +392,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `msg_type` | `uint32` | `optional` | `` |  |
-| 2 | `sender_id` | `fixed64` | `optional` | `` |  |
-| 3 | `net_message` | `bytes` | `optional` | `` |  |
+| 1 | `msg_type` | `uint32` | `optional` |  |  |
+| 2 | `sender_id` | `fixed64` | `optional` |  |  |
+| 3 | `net_message` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -406,8 +406,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `msg_type` | `uint32` | `optional` | `` |  |
-| 2 | `net_message` | `bytes` | `optional` | `` |  |
+| 1 | `msg_type` | `uint32` | `optional` |  |  |
+| 2 | `net_message` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -419,7 +419,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `updates` | `.CMsgGCUpdateSubGCSessionInfo.CMsgUpdate` | `repeated` | `` |  |
+| 1 | `updates` | `.CMsgGCUpdateSubGCSessionInfo.CMsgUpdate` | `repeated` |  |  |
 
 </details>
 
@@ -431,9 +431,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `optional` | `` |  |
-| 2 | `ip` | `fixed32` | `optional` | `` |  |
-| 3 | `trusted` | `bool` | `optional` | `` |  |
+| 1 | `steamid` | `fixed64` | `optional` |  |  |
+| 2 | `ip` | `fixed32` | `optional` |  |  |
+| 3 | `trusted` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -445,7 +445,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `optional` | `` |  |
+| 1 | `steamid` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -457,10 +457,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ip` | `fixed32` | `optional` | `` |  |
-| 2 | `trusted` | `bool` | `optional` | `` |  |
-| 3 | `port` | `uint32` | `optional` | `` |  |
-| 4 | `success` | `bool` | `optional` | `` |  |
+| 1 | `ip` | `fixed32` | `optional` |  |  |
+| 2 | `trusted` | `bool` | `optional` |  |  |
+| 3 | `port` | `uint32` | `optional` |  |  |
+| 4 | `success` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -472,10 +472,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `soid` | `.CMsgSOIDOwner` | `optional` | `` |  |
-| 2 | `version` | `fixed64` | `optional` | `` |  |
-| 3 | `service_id` | `uint32` | `optional` | `` |  |
-| 4 | `cached_file_version` | `uint32` | `optional` | `` |  |
+| 1 | `soid` | `.CMsgSOIDOwner` | `optional` |  |  |
+| 2 | `version` | `fixed64` | `optional` |  |  |
+| 3 | `service_id` | `uint32` | `optional` |  |  |
+| 4 | `cached_file_version` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -487,29 +487,29 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `version` | `uint32` | `optional` | `` |  |
-| 2 | `socache_have_versions` | `.CMsgSOCacheHaveVersion` | `repeated` | `` |  |
-| 3 | `client_session_need` | `uint32` | `optional` | `` |  |
-| 4 | `client_launcher` | `.PartnerAccountType` | `optional` | `` | default = PARTNER_NONE |
-| 5 | `secret_key` | `string` | `optional` | `` |  |
-| 6 | `client_language` | `uint32` | `optional` | `` |  |
-| 7 | `engine` | `.ESourceEngine` | `optional` | `` | default = k_ESE_Source1 |
-| 8 | `steamdatagram_login` | `bytes` | `optional` | `` |  |
-| 9 | `platform_id` | `uint32` | `optional` | `` |  |
-| 10 | `game_msg` | `bytes` | `optional` | `` |  |
-| 11 | `os_type` | `int32` | `optional` | `` |  |
-| 12 | `render_system` | `uint32` | `optional` | `` |  |
-| 13 | `render_system_req` | `uint32` | `optional` | `` |  |
-| 14 | `screen_width` | `uint32` | `optional` | `` |  |
-| 15 | `screen_height` | `uint32` | `optional` | `` |  |
-| 16 | `screen_refresh` | `uint32` | `optional` | `` |  |
-| 17 | `render_width` | `uint32` | `optional` | `` |  |
-| 18 | `render_height` | `uint32` | `optional` | `` |  |
-| 19 | `swap_width` | `uint32` | `optional` | `` |  |
-| 20 | `swap_height` | `uint32` | `optional` | `` |  |
-| 22 | `is_steam_china` | `bool` | `optional` | `` |  |
-| 23 | `platform_name` | `string` | `optional` | `` |  |
-| 24 | `is_steam_china_client` | `bool` | `optional` | `` |  |
+| 1 | `version` | `uint32` | `optional` |  |  |
+| 2 | `socache_have_versions` | `.CMsgSOCacheHaveVersion` | `repeated` |  |  |
+| 3 | `client_session_need` | `uint32` | `optional` |  |  |
+| 4 | `client_launcher` | `.PartnerAccountType` | `optional` |  | default = PARTNER_NONE |
+| 5 | `secret_key` | `string` | `optional` |  |  |
+| 6 | `client_language` | `uint32` | `optional` |  |  |
+| 7 | `engine` | `.ESourceEngine` | `optional` |  | default = k_ESE_Source1 |
+| 8 | `steamdatagram_login` | `bytes` | `optional` |  |  |
+| 9 | `platform_id` | `uint32` | `optional` |  |  |
+| 10 | `game_msg` | `bytes` | `optional` |  |  |
+| 11 | `os_type` | `int32` | `optional` |  |  |
+| 12 | `render_system` | `uint32` | `optional` |  |  |
+| 13 | `render_system_req` | `uint32` | `optional` |  |  |
+| 14 | `screen_width` | `uint32` | `optional` |  |  |
+| 15 | `screen_height` | `uint32` | `optional` |  |  |
+| 16 | `screen_refresh` | `uint32` | `optional` |  |  |
+| 17 | `render_width` | `uint32` | `optional` |  |  |
+| 18 | `render_height` | `uint32` | `optional` |  |  |
+| 19 | `swap_width` | `uint32` | `optional` |  |  |
+| 20 | `swap_height` | `uint32` | `optional` |  |  |
+| 22 | `is_steam_china` | `bool` | `optional` |  |  |
+| 23 | `platform_name` | `string` | `optional` |  |  |
+| 24 | `is_steam_china_client` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -521,22 +521,22 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `version` | `uint32` | `optional` | `` |  |
-| 2 | `game_data` | `bytes` | `optional` | `` |  |
-| 3 | `outofdate_subscribed_caches` | `.CMsgSOCacheSubscribed` | `repeated` | `` |  |
-| 4 | `uptodate_subscribed_caches` | `.CMsgSOCacheSubscriptionCheck` | `repeated` | `` |  |
-| 5 | `location` | `.CMsgClientWelcome.Location` | `optional` | `` |  |
-| 9 | `gc_socache_file_version` | `uint32` | `optional` | `` |  |
-| 10 | `txn_country_code` | `string` | `optional` | `` |  |
-| 11 | `game_data2` | `bytes` | `optional` | `` |  |
-| 12 | `rtime32_gc_welcome_timestamp` | `uint32` | `optional` | `` |  |
-| 13 | `currency` | `uint32` | `optional` | `` |  |
-| 14 | `balance` | `uint32` | `optional` | `` |  |
-| 15 | `balance_url` | `string` | `optional` | `` |  |
-| 16 | `has_accepted_china_ssa` | `bool` | `optional` | `` |  |
-| 17 | `is_banned_steam_china` | `bool` | `optional` | `` |  |
-| 18 | `additional_welcome_msgs` | `.CExtraMsgBlock` | `optional` | `` |  |
-| 20 | `steam_learn_server_info` | `.CMsgSteamLearnServerInfo` | `optional` | `` |  |
+| 1 | `version` | `uint32` | `optional` |  |  |
+| 2 | `game_data` | `bytes` | `optional` |  |  |
+| 3 | `outofdate_subscribed_caches` | `.CMsgSOCacheSubscribed` | `repeated` |  |  |
+| 4 | `uptodate_subscribed_caches` | `.CMsgSOCacheSubscriptionCheck` | `repeated` |  |  |
+| 5 | `location` | `.CMsgClientWelcome.Location` | `optional` |  |  |
+| 9 | `gc_socache_file_version` | `uint32` | `optional` |  |  |
+| 10 | `txn_country_code` | `string` | `optional` |  |  |
+| 11 | `game_data2` | `bytes` | `optional` |  |  |
+| 12 | `rtime32_gc_welcome_timestamp` | `uint32` | `optional` |  |  |
+| 13 | `currency` | `uint32` | `optional` |  |  |
+| 14 | `balance` | `uint32` | `optional` |  |  |
+| 15 | `balance_url` | `string` | `optional` |  |  |
+| 16 | `has_accepted_china_ssa` | `bool` | `optional` |  |  |
+| 17 | `is_banned_steam_china` | `bool` | `optional` |  |  |
+| 18 | `additional_welcome_msgs` | `.CExtraMsgBlock` | `optional` |  |  |
+| 20 | `steam_learn_server_info` | `.CMsgSteamLearnServerInfo` | `optional` |  |  |
 
 </details>
 
@@ -548,9 +548,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `latitude` | `float` | `optional` | `` |  |
-| 2 | `longitude` | `float` | `optional` | `` |  |
-| 3 | `country` | `string` | `optional` | `` |  |
+| 1 | `latitude` | `float` | `optional` |  |  |
+| 2 | `longitude` | `float` | `optional` |  |  |
+| 3 | `country` | `string` | `optional` |  |  |
 
 </details>
 
@@ -562,12 +562,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `status` | `.GCConnectionStatus` | `optional` | `` | default = GCConnectionStatus_HAVE_SESSION |
-| 2 | `client_session_need` | `uint32` | `optional` | `` |  |
-| 3 | `queue_position` | `int32` | `optional` | `` |  |
-| 4 | `queue_size` | `int32` | `optional` | `` |  |
-| 5 | `wait_seconds` | `int32` | `optional` | `` |  |
-| 6 | `estimated_wait_seconds_remaining` | `int32` | `optional` | `` |  |
+| 1 | `status` | `.GCConnectionStatus` | `optional` |  | default = GCConnectionStatus_HAVE_SESSION |
+| 2 | `client_session_need` | `uint32` | `optional` |  |  |
+| 3 | `queue_position` | `int32` | `optional` |  |  |
+| 4 | `queue_size` | `int32` | `optional` |  |  |
+| 5 | `wait_seconds` | `int32` | `optional` |  |  |
+| 6 | `estimated_wait_seconds_remaining` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -579,11 +579,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `subscriber` | `fixed64` | `optional` | `` |  |
-| 2 | `subscribe_to_id` | `fixed64` | `optional` | `` |  |
-| 3 | `sync_version` | `fixed64` | `optional` | `` |  |
-| 4 | `have_versions` | `.CMsgGCToGCSOCacheSubscribe.CMsgHaveVersions` | `repeated` | `` |  |
-| 5 | `subscribe_to_type` | `uint32` | `optional` | `` |  |
+| 1 | `subscriber` | `fixed64` | `optional` |  |  |
+| 2 | `subscribe_to_id` | `fixed64` | `optional` |  |  |
+| 3 | `sync_version` | `fixed64` | `optional` |  |  |
+| 4 | `have_versions` | `.CMsgGCToGCSOCacheSubscribe.CMsgHaveVersions` | `repeated` |  |  |
+| 5 | `subscribe_to_type` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -595,8 +595,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `service_id` | `uint32` | `optional` | `` |  |
-| 2 | `version` | `uint64` | `optional` | `` |  |
+| 1 | `service_id` | `uint32` | `optional` |  |  |
+| 2 | `version` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -608,9 +608,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `subscriber` | `fixed64` | `optional` | `` |  |
-| 2 | `unsubscribe_from_id` | `fixed64` | `optional` | `` |  |
-| 3 | `unsubscribe_from_type` | `uint32` | `optional` | `` |  |
+| 1 | `subscriber` | `fixed64` | `optional` |  |  |
+| 2 | `unsubscribe_from_id` | `fixed64` | `optional` |  |  |
+| 3 | `unsubscribe_from_type` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -634,9 +634,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `optional` | `` |  |
-| 2 | `account_details` | `.CGCSystemMsg_GetAccountDetails_Response` | `optional` | `` |  |
-| 3 | `age_seconds` | `uint32` | `optional` | `` |  |
+| 1 | `steamid` | `fixed64` | `optional` |  |  |
+| 2 | `account_details` | `.CGCSystemMsg_GetAccountDetails_Response` | `optional` |  |  |
+| 3 | `age_seconds` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -648,8 +648,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `forward_account_details` | `.CMsgGCToGCForwardAccountDetails` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `forward_account_details` | `.CMsgGCToGCForwardAccountDetails` | `optional` |  |  |
 
 </details>
 
@@ -673,9 +673,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `user_sessions` | `uint32` | `optional` | `` |  |
-| 2 | `server_sessions` | `uint32` | `optional` | `` |  |
-| 3 | `in_logon_surge` | `bool` | `optional` | `` |  |
+| 1 | `user_sessions` | `uint32` | `optional` |  |  |
+| 2 | `server_sessions` | `uint32` | `optional` |  |  |
+| 3 | `in_logon_surge` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -699,8 +699,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` |  |
-| 2 | `languages` | `.CWorkshop_PopulateItemDescriptions_Request.ItemDescriptionsLanguageBlock` | `repeated` | `` |  |
+| 1 | `appid` | `uint32` | `optional` |  |  |
+| 2 | `languages` | `.CWorkshop_PopulateItemDescriptions_Request.ItemDescriptionsLanguageBlock` | `repeated` |  |  |
 
 </details>
 
@@ -712,8 +712,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `gameitemid` | `uint32` | `optional` | `` |  |
-| 2 | `item_description` | `string` | `optional` | `` |  |
+| 1 | `gameitemid` | `uint32` | `optional` |  |  |
+| 2 | `item_description` | `string` | `optional` |  |  |
 
 </details>
 
@@ -725,8 +725,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `language` | `string` | `optional` | `` |  |
-| 2 | `descriptions` | `.CWorkshop_PopulateItemDescriptions_Request.SingleItemDescription` | `repeated` | `` |  |
+| 1 | `language` | `string` | `optional` |  |  |
+| 2 | `descriptions` | `.CWorkshop_PopulateItemDescriptions_Request.SingleItemDescription` | `repeated` |  |  |
 
 </details>
 
@@ -738,8 +738,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` |  |
-| 2 | `gameitemid` | `uint32` | `optional` | `` |  |
+| 1 | `appid` | `uint32` | `optional` |  |  |
+| 2 | `gameitemid` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -751,7 +751,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `contributors` | `fixed64` | `repeated` | `` |  |
+| 1 | `contributors` | `fixed64` | `repeated` |  |  |
 
 </details>
 
@@ -763,13 +763,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` |  |
-| 2 | `gameitemid` | `uint32` | `optional` | `` |  |
-| 3 | `associated_workshop_files` | `.CWorkshop_SetItemPaymentRules_Request.WorkshopItemPaymentRule` | `repeated` | `` |  |
-| 4 | `partner_accounts` | `.CWorkshop_SetItemPaymentRules_Request.PartnerItemPaymentRule` | `repeated` | `` |  |
-| 5 | `validate_only` | `bool` | `optional` | `` |  |
-| 6 | `make_workshop_files_subscribable` | `bool` | `optional` | `` |  |
-| 7 | `associated_workshop_file_for_direct_payments` | `.CWorkshop_SetItemPaymentRules_Request.WorkshopDirectPaymentRule` | `optional` | `` |  |
+| 1 | `appid` | `uint32` | `optional` |  |  |
+| 2 | `gameitemid` | `uint32` | `optional` |  |  |
+| 3 | `associated_workshop_files` | `.CWorkshop_SetItemPaymentRules_Request.WorkshopItemPaymentRule` | `repeated` |  |  |
+| 4 | `partner_accounts` | `.CWorkshop_SetItemPaymentRules_Request.PartnerItemPaymentRule` | `repeated` |  |  |
+| 5 | `validate_only` | `bool` | `optional` |  |  |
+| 6 | `make_workshop_files_subscribable` | `bool` | `optional` |  |  |
+| 7 | `associated_workshop_file_for_direct_payments` | `.CWorkshop_SetItemPaymentRules_Request.WorkshopDirectPaymentRule` | `optional` |  |  |
 
 </details>
 
@@ -781,10 +781,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `workshop_file_id` | `uint64` | `optional` | `` |  |
-| 2 | `revenue_percentage` | `float` | `optional` | `` |  |
-| 3 | `rule_description` | `string` | `optional` | `` |  |
-| 4 | `rule_type` | `uint32` | `optional` | `` | default = 1 |
+| 1 | `workshop_file_id` | `uint64` | `optional` |  |  |
+| 2 | `revenue_percentage` | `float` | `optional` |  |  |
+| 3 | `rule_description` | `string` | `optional` |  |  |
+| 4 | `rule_type` | `uint32` | `optional` |  | default = 1 |
 
 </details>
 
@@ -796,8 +796,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `workshop_file_id` | `uint64` | `optional` | `` |  |
-| 2 | `rule_description` | `string` | `optional` | `` |  |
+| 1 | `workshop_file_id` | `uint64` | `optional` |  |  |
+| 2 | `rule_description` | `string` | `optional` |  |  |
 
 </details>
 
@@ -809,9 +809,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `account_id` | `uint32` | `optional` | `` |  |
-| 2 | `revenue_percentage` | `float` | `optional` | `` |  |
-| 3 | `rule_description` | `string` | `optional` | `` |  |
+| 1 | `account_id` | `uint32` | `optional` |  |  |
+| 2 | `revenue_percentage` | `float` | `optional` |  |  |
+| 3 | `rule_description` | `string` | `optional` |  |  |
 
 </details>
 
@@ -823,7 +823,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `validation_errors` | `string` | `repeated` | `` |  |
+| 1 | `validation_errors` | `string` | `repeated` |  |  |
 
 </details>
 
@@ -835,18 +835,18 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `gid` | `uint64` | `optional` | `` |  |
-| 2 | `clanid` | `uint64` | `optional` | `` |  |
-| 3 | `posterid` | `uint64` | `optional` | `` |  |
-| 4 | `headline` | `string` | `optional` | `` |  |
-| 5 | `posttime` | `uint32` | `optional` | `` |  |
-| 6 | `updatetime` | `uint32` | `optional` | `` |  |
-| 7 | `body` | `string` | `optional` | `` |  |
-| 8 | `commentcount` | `int32` | `optional` | `` |  |
-| 9 | `tags` | `string` | `repeated` | `` |  |
-| 10 | `language` | `int32` | `optional` | `` |  |
-| 11 | `hidden` | `bool` | `optional` | `` |  |
-| 12 | `forum_topic_id` | `fixed64` | `optional` | `` |  |
+| 1 | `gid` | `uint64` | `optional` |  |  |
+| 2 | `clanid` | `uint64` | `optional` |  |  |
+| 3 | `posterid` | `uint64` | `optional` |  |  |
+| 4 | `headline` | `string` | `optional` |  |  |
+| 5 | `posttime` | `uint32` | `optional` |  |  |
+| 6 | `updatetime` | `uint32` | `optional` |  |  |
+| 7 | `body` | `string` | `optional` |  |  |
+| 8 | `commentcount` | `int32` | `optional` |  |  |
+| 9 | `tags` | `string` | `repeated` |  |  |
+| 10 | `language` | `int32` | `optional` |  |  |
+| 11 | `hidden` | `bool` | `optional` |  |  |
+| 12 | `forum_topic_id` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -858,19 +858,19 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `uint64` | `optional` | `` |  |
-| 2 | `offset` | `uint32` | `optional` | `` |  |
-| 3 | `count` | `uint32` | `optional` | `` |  |
-| 4 | `maxchars` | `uint32` | `optional` | `` |  |
-| 5 | `strip_html` | `bool` | `optional` | `` |  |
-| 6 | `required_tags` | `string` | `repeated` | `` |  |
-| 7 | `require_no_tags` | `bool` | `optional` | `` |  |
-| 8 | `language_preference` | `uint32` | `repeated` | `` |  |
-| 9 | `hidden_only` | `bool` | `optional` | `` |  |
-| 10 | `only_gid` | `bool` | `optional` | `` |  |
-| 11 | `rtime_oldest_date` | `uint32` | `optional` | `` |  |
-| 12 | `include_hidden` | `bool` | `optional` | `` |  |
-| 13 | `include_partner_events` | `bool` | `optional` | `` |  |
+| 1 | `steamid` | `uint64` | `optional` |  |  |
+| 2 | `offset` | `uint32` | `optional` |  |  |
+| 3 | `count` | `uint32` | `optional` |  |  |
+| 4 | `maxchars` | `uint32` | `optional` |  |  |
+| 5 | `strip_html` | `bool` | `optional` |  |  |
+| 6 | `required_tags` | `string` | `repeated` |  |  |
+| 7 | `require_no_tags` | `bool` | `optional` |  |  |
+| 8 | `language_preference` | `uint32` | `repeated` |  |  |
+| 9 | `hidden_only` | `bool` | `optional` |  |  |
+| 10 | `only_gid` | `bool` | `optional` |  |  |
+| 11 | `rtime_oldest_date` | `uint32` | `optional` |  |  |
+| 12 | `include_hidden` | `bool` | `optional` |  |  |
+| 13 | `include_partner_events` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -882,9 +882,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `maxchars` | `uint32` | `optional` | `` |  |
-| 2 | `strip_html` | `bool` | `optional` | `` |  |
-| 3 | `announcements` | `.CCommunity_ClanAnnouncementInfo` | `repeated` | `` |  |
+| 1 | `maxchars` | `uint32` | `optional` |  |  |
+| 2 | `strip_html` | `bool` | `optional` |  |  |
+| 3 | `announcements` | `.CCommunity_ClanAnnouncementInfo` | `repeated` |  |  |
 
 </details>
 
@@ -896,10 +896,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` |  |
-| 2 | `steamid` | `fixed64` | `optional` | `` |  |
-| 3 | `broadcast_id` | `fixed64` | `optional` | `` |  |
-| 4 | `frame_data` | `bytes` | `optional` | `` |  |
+| 1 | `appid` | `uint32` | `optional` |  |  |
+| 2 | `steamid` | `fixed64` | `optional` |  |  |
+| 3 | `broadcast_id` | `fixed64` | `optional` |  |  |
+| 4 | `frame_data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -911,9 +911,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `file_version` | `uint32` | `optional` | `` |  |
-| 2 | `caches` | `.CMsgSerializedSOCache.Cache` | `repeated` | `` |  |
-| 3 | `gc_socache_file_version` | `uint32` | `optional` | `` |  |
+| 1 | `file_version` | `uint32` | `optional` |  |  |
+| 2 | `caches` | `.CMsgSerializedSOCache.Cache` | `repeated` |  |  |
+| 3 | `gc_socache_file_version` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -925,9 +925,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `type` | `uint32` | `optional` | `` |  |
-| 2 | `objects` | `bytes` | `repeated` | `` |  |
-| 3 | `service_id` | `uint32` | `optional` | `` |  |
+| 1 | `type` | `uint32` | `optional` |  |  |
+| 2 | `objects` | `bytes` | `repeated` |  |  |
+| 3 | `service_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -939,10 +939,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `type` | `uint32` | `optional` | `` |  |
-| 2 | `id` | `uint64` | `optional` | `` |  |
-| 3 | `versions` | `.CMsgSerializedSOCache.Cache.Version` | `repeated` | `` |  |
-| 4 | `type_caches` | `.CMsgSerializedSOCache.TypeCache` | `repeated` | `` |  |
+| 1 | `type` | `uint32` | `optional` |  |  |
+| 2 | `id` | `uint64` | `optional` |  |  |
+| 3 | `versions` | `.CMsgSerializedSOCache.Cache.Version` | `repeated` |  |  |
+| 4 | `type_caches` | `.CMsgSerializedSOCache.TypeCache` | `repeated` |  |  |
 
 </details>
 
@@ -954,8 +954,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `service` | `uint32` | `optional` | `` |  |
-| 2 | `version` | `uint64` | `optional` | `` |  |
+| 1 | `service` | `uint32` | `optional` |  |  |
+| 2 | `version` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -967,8 +967,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `convar_name` | `string` | `optional` | `` |  |
-| 2 | `poll_id` | `uint32` | `optional` | `` |  |
+| 1 | `convar_name` | `string` | `optional` |  |  |
+| 2 | `poll_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -980,8 +980,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `poll_id` | `uint32` | `optional` | `` |  |
-| 2 | `convar_value` | `string` | `optional` | `` |  |
+| 1 | `poll_id` | `uint32` | `optional` |  |  |
+| 2 | `convar_value` | `string` | `optional` |  |  |
 
 </details>
 
@@ -993,8 +993,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `msg_id` | `uint32` | `optional` | `` |  |
-| 2 | `compressed_msg` | `bytes` | `optional` | `` |  |
+| 1 | `msg_id` | `uint32` | `optional` |  |  |
+| 2 | `compressed_msg` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -1006,12 +1006,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `users_per_second` | `uint32` | `optional` | `` |  |
-| 2 | `send_to_users` | `bool` | `optional` | `` |  |
-| 3 | `send_to_servers` | `bool` | `optional` | `` |  |
-| 4 | `msg_id` | `uint32` | `optional` | `` |  |
-| 5 | `msg_data` | `bytes` | `optional` | `` |  |
-| 6 | `trusted_servers_only` | `bool` | `optional` | `` |  |
+| 1 | `users_per_second` | `uint32` | `optional` |  |  |
+| 2 | `send_to_users` | `bool` | `optional` |  |  |
+| 3 | `send_to_servers` | `bool` | `optional` |  |  |
+| 4 | `msg_id` | `uint32` | `optional` |  |  |
+| 5 | `msg_data` | `bytes` | `optional` |  |  |
+| 6 | `trusted_servers_only` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1023,10 +1023,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `soid_type` | `uint32` | `optional` | `` |  |
-| 2 | `soid_id` | `fixed64` | `optional` | `` |  |
-| 3 | `account_ids` | `uint32` | `repeated` | `` |  |
-| 4 | `steam_ids` | `fixed64` | `repeated` | `` |  |
+| 1 | `soid_type` | `uint32` | `optional` |  |  |
+| 2 | `soid_id` | `fixed64` | `optional` |  |  |
+| 3 | `account_ids` | `uint32` | `repeated` |  |  |
+| 4 | `steam_ids` | `fixed64` | `repeated` |  |  |
 
 </details>
 
@@ -1050,7 +1050,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `subscribe_msg` | `.CMsgGCToGCMasterSubscribeToCache` | `optional` | `` |  |
+| 1 | `subscribe_msg` | `.CMsgGCToGCMasterSubscribeToCache` | `optional` |  |  |
 
 </details>
 
@@ -1062,10 +1062,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `soid_type` | `uint32` | `optional` | `` |  |
-| 2 | `soid_id` | `fixed64` | `optional` | `` |  |
-| 3 | `account_ids` | `uint32` | `repeated` | `` |  |
-| 4 | `steam_ids` | `fixed64` | `repeated` | `` |  |
+| 1 | `soid_type` | `uint32` | `optional` |  |  |
+| 2 | `soid_id` | `fixed64` | `optional` |  |  |
+| 3 | `account_ids` | `uint32` | `repeated` |  |  |
+| 4 | `steam_ids` | `fixed64` | `repeated` |  |  |
 
 </details>
 
@@ -1077,8 +1077,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `soid_type` | `uint32` | `optional` | `` |  |
-| 2 | `soid_id` | `fixed64` | `optional` | `` |  |
+| 1 | `soid_type` | `uint32` | `optional` |  |  |
+| 2 | `soid_id` | `fixed64` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/netmessages.md
+++ b/docs/cookbook/proto-fields/netmessages.md
@@ -24,11 +24,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `send_table_crc` | `fixed32` | `optional` | `` |  |
-| 2 | `server_count` | `uint32` | `optional` | `` |  |
-| 3 | `is_hltv` | `bool` | `optional` | `` |  |
-| 5 | `friends_id` | `uint32` | `optional` | `` |  |
-| 6 | `friends_name` | `string` | `optional` | `` |  |
+| 1 | `send_table_crc` | `fixed32` | `optional` |  |  |
+| 2 | `server_count` | `uint32` | `optional` |  |  |
+| 3 | `is_hltv` | `bool` | `optional` |  |  |
+| 5 | `friends_id` | `uint32` | `optional` |  |  |
+| 6 | `friends_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -40,8 +40,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 3 | `data` | `bytes` | `optional` | `` |  |
-| 4 | `last_command_number` | `uint32` | `optional` | `` |  |
+| 3 | `data` | `bytes` | `optional` |  |  |
+| 4 | `last_command_number` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -53,15 +53,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `format` | `.VoiceDataFormat_t` | `optional` | `` | default = VOICEDATA_FORMAT_STEAM |
-| 2 | `voice_data` | `bytes` | `optional` | `` |  |
-| 3 | `sequence_bytes` | `int32` | `optional` | `` |  |
-| 4 | `section_number` | `uint32` | `optional` | `` |  |
-| 5 | `sample_rate` | `uint32` | `optional` | `` |  |
-| 6 | `uncompressed_sample_offset` | `uint32` | `optional` | `` |  |
-| 7 | `num_packets` | `uint32` | `optional` | `` |  |
-| 8 | `packet_offsets` | `uint32` | `repeated` | `` | packed = true |
-| 9 | `voice_level` | `float` | `optional` | `` |  |
+| 1 | `format` | `.VoiceDataFormat_t` | `optional` |  | default = VOICEDATA_FORMAT_STEAM |
+| 2 | `voice_data` | `bytes` | `optional` |  |  |
+| 3 | `sequence_bytes` | `int32` | `optional` |  |  |
+| 4 | `section_number` | `uint32` | `optional` |  |  |
+| 5 | `sample_rate` | `uint32` | `optional` |  |  |
+| 6 | `uncompressed_sample_offset` | `uint32` | `optional` |  |  |
+| 7 | `num_packets` | `uint32` | `optional` |  |  |
+| 8 | `packet_offsets` | `uint32` | `repeated` |  | packed = true |
+| 9 | `voice_level` | `float` | `optional` |  |  |
 
 </details>
 
@@ -73,9 +73,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `audio` | `.CMsgVoiceAudio` | `optional` | `` |  |
-| 2 | `xuid` | `fixed64` | `optional` | `` |  |
-| 3 | `tick` | `uint32` | `optional` | `` |  |
+| 1 | `audio` | `.CMsgVoiceAudio` | `optional` |  |  |
+| 2 | `xuid` | `fixed64` | `optional` |  |  |
+| 3 | `tick` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -87,8 +87,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `baseline_tick` | `int32` | `optional` | `` |  |
-| 2 | `baseline_nr` | `int32` | `optional` | `` |  |
+| 1 | `baseline_tick` | `int32` | `optional` |  |  |
+| 2 | `baseline_nr` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -100,7 +100,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_mask` | `fixed32` | `repeated` | `` |  |
+| 1 | `event_mask` | `fixed32` | `repeated` |  |  |
 
 </details>
 
@@ -112,10 +112,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cookie` | `int32` | `optional` | `` |  |
-| 2 | `status_code` | `int32` | `optional` | `` |  |
-| 3 | `name` | `string` | `optional` | `` |  |
-| 4 | `value` | `string` | `optional` | `` |  |
+| 1 | `cookie` | `int32` | `optional` |  |  |
+| 2 | `status_code` | `int32` | `optional` |  |  |
+| 3 | `name` | `string` | `optional` |  |  |
+| 4 | `value` | `string` | `optional` |  |  |
 
 </details>
 
@@ -127,7 +127,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `progress` | `int32` | `optional` | `` |  |
+| 1 | `progress` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -139,7 +139,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `playername` | `string` | `optional` | `` |  |
+| 1 | `playername` | `string` | `optional` |  |  |
 
 </details>
 
@@ -151,7 +151,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `slot` | `int32` | `optional` | `` |  |
+| 1 | `slot` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -163,7 +163,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `simplified` | `bool` | `optional` | `` |  |
+| 1 | `simplified` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -175,8 +175,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `pause_type` | `.RequestPause_t` | `optional` | `` | default = RP_PAUSE |
-| 2 | `pause_group` | `int32` | `optional` | `` |  |
+| 1 | `pause_type` | `.RequestPause_t` | `optional` |  | default = RP_PAUSE |
+| 2 | `pause_group` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -188,7 +188,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data` | `bytes` | `optional` | `` |  |
+| 1 | `data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -200,7 +200,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `token` | `bytes` | `optional` | `` |  |
+| 1 | `token` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -212,11 +212,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `system_specs` | `.CMsgSource2SystemSpecs` | `optional` | `` |  |
-| 2 | `vprof_report` | `.CMsgSource2VProfLiteReport` | `optional` | `` |  |
-| 3 | `downstream_flow` | `.CMsgSource2NetworkFlowQuality` | `optional` | `` |  |
-| 4 | `upstream_flow` | `.CMsgSource2NetworkFlowQuality` | `optional` | `` |  |
-| 5 | `perf_samples` | `.CMsgSource2PerfIntervalSample` | `repeated` | `` |  |
+| 1 | `system_specs` | `.CMsgSource2SystemSpecs` | `optional` |  |  |
+| 2 | `vprof_report` | `.CMsgSource2VProfLiteReport` | `optional` |  |  |
+| 3 | `downstream_flow` | `.CMsgSource2NetworkFlowQuality` | `optional` |  |  |
+| 4 | `upstream_flow` | `.CMsgSource2NetworkFlowQuality` | `optional` |  |  |
+| 5 | `perf_samples` | `.CMsgSource2PerfIntervalSample` | `repeated` |  |  |
 
 </details>
 
@@ -228,22 +228,22 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `protocol` | `int32` | `optional` | `` |  |
-| 2 | `server_count` | `int32` | `optional` | `` |  |
-| 3 | `is_dedicated` | `bool` | `optional` | `` |  |
-| 4 | `is_hltv` | `bool` | `optional` | `` |  |
-| 6 | `c_os` | `int32` | `optional` | `` |  |
-| 10 | `max_clients` | `int32` | `optional` | `` |  |
-| 11 | `max_classes` | `int32` | `optional` | `` |  |
-| 12 | `player_slot` | `int32` | `optional` | `` | default = -1 |
-| 13 | `tick_interval` | `float` | `optional` | `` |  |
-| 14 | `game_dir` | `string` | `optional` | `` |  |
-| 15 | `map_name` | `string` | `optional` | `` |  |
-| 16 | `sky_name` | `string` | `optional` | `` |  |
-| 17 | `host_name` | `string` | `optional` | `` |  |
-| 18 | `addon_name` | `string` | `optional` | `` |  |
-| 19 | `game_session_config` | `.CSVCMsg_GameSessionConfiguration` | `optional` | `` |  |
-| 20 | `game_session_manifest` | `bytes` | `optional` | `` |  |
+| 1 | `protocol` | `int32` | `optional` |  |  |
+| 2 | `server_count` | `int32` | `optional` |  |  |
+| 3 | `is_dedicated` | `bool` | `optional` |  |  |
+| 4 | `is_hltv` | `bool` | `optional` |  |  |
+| 6 | `c_os` | `int32` | `optional` |  |  |
+| 10 | `max_clients` | `int32` | `optional` |  |  |
+| 11 | `max_classes` | `int32` | `optional` |  |  |
+| 12 | `player_slot` | `int32` | `optional` |  | default = -1 |
+| 13 | `tick_interval` | `float` | `optional` |  |  |
+| 14 | `game_dir` | `string` | `optional` |  |  |
+| 15 | `map_name` | `string` | `optional` |  |  |
+| 16 | `sky_name` | `string` | `optional` |  |  |
+| 17 | `host_name` | `string` | `optional` |  |  |
+| 18 | `addon_name` | `string` | `optional` |  |  |
+| 19 | `game_session_config` | `.CSVCMsg_GameSessionConfiguration` | `optional` |  |  |
+| 20 | `game_session_manifest` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -255,8 +255,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `create_on_client` | `bool` | `optional` | `` |  |
-| 2 | `classes` | `.CSVCMsg_ClassInfo.class_t` | `repeated` | `` |  |
+| 1 | `create_on_client` | `bool` | `optional` |  |  |
+| 2 | `classes` | `.CSVCMsg_ClassInfo.class_t` | `repeated` |  |  |
 
 </details>
 
@@ -268,8 +268,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `class_id` | `int32` | `optional` | `` |  |
-| 3 | `class_name` | `string` | `optional` | `` |  |
+| 1 | `class_id` | `int32` | `optional` |  |  |
+| 3 | `class_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -281,7 +281,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `paused` | `bool` | `optional` | `` |  |
+| 1 | `paused` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -293,9 +293,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `quality` | `int32` | `optional` | `` |  |
-| 2 | `codec` | `string` | `optional` | `` |  |
-| 3 | `version` | `int32` | `optional` | `` | default = 0 |
+| 1 | `quality` | `int32` | `optional` |  |  |
+| 2 | `codec` | `string` | `optional` |  |  |
+| 3 | `version` | `int32` | `optional` |  | default = 0 |
 
 </details>
 
@@ -307,7 +307,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `text` | `string` | `optional` | `` |  |
+| 1 | `text` | `string` | `optional` |  |  |
 
 </details>
 
@@ -319,8 +319,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `reliable_sound` | `bool` | `optional` | `` |  |
-| 2 | `sounds` | `.CSVCMsg_Sounds.sounddata_t` | `repeated` | `` |  |
+| 1 | `reliable_sound` | `bool` | `optional` |  |  |
+| 2 | `sounds` | `.CSVCMsg_Sounds.sounddata_t` | `repeated` |  |  |
 
 </details>
 
@@ -332,25 +332,25 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `origin_x` | `sint32` | `optional` | `` |  |
-| 2 | `origin_y` | `sint32` | `optional` | `` |  |
-| 3 | `origin_z` | `sint32` | `optional` | `` |  |
-| 4 | `volume` | `uint32` | `optional` | `` |  |
-| 5 | `delay_value` | `float` | `optional` | `` |  |
-| 6 | `sequence_number` | `int32` | `optional` | `` |  |
-| 7 | `entity_index` | `int32` | `optional` | `` | default = -1 |
-| 8 | `channel` | `int32` | `optional` | `` |  |
-| 9 | `pitch` | `int32` | `optional` | `` |  |
-| 10 | `flags` | `int32` | `optional` | `` |  |
-| 11 | `sound_num` | `uint32` | `optional` | `` |  |
-| 12 | `sound_num_handle` | `fixed32` | `optional` | `` |  |
-| 13 | `speaker_entity` | `int32` | `optional` | `` |  |
-| 14 | `random_seed` | `int32` | `optional` | `` |  |
-| 15 | `sound_level` | `int32` | `optional` | `` |  |
-| 16 | `is_sentence` | `bool` | `optional` | `` |  |
-| 17 | `is_ambient` | `bool` | `optional` | `` |  |
-| 18 | `guid` | `uint32` | `optional` | `` |  |
-| 19 | `sound_resource_id` | `fixed64` | `optional` | `` |  |
+| 1 | `origin_x` | `sint32` | `optional` |  |  |
+| 2 | `origin_y` | `sint32` | `optional` |  |  |
+| 3 | `origin_z` | `sint32` | `optional` |  |  |
+| 4 | `volume` | `uint32` | `optional` |  |  |
+| 5 | `delay_value` | `float` | `optional` |  |  |
+| 6 | `sequence_number` | `int32` | `optional` |  |  |
+| 7 | `entity_index` | `int32` | `optional` |  | default = -1 |
+| 8 | `channel` | `int32` | `optional` |  |  |
+| 9 | `pitch` | `int32` | `optional` |  |  |
+| 10 | `flags` | `int32` | `optional` |  |  |
+| 11 | `sound_num` | `uint32` | `optional` |  |  |
+| 12 | `sound_num_handle` | `fixed32` | `optional` |  |  |
+| 13 | `speaker_entity` | `int32` | `optional` |  |  |
+| 14 | `random_seed` | `int32` | `optional` |  |  |
+| 15 | `sound_level` | `int32` | `optional` |  |  |
+| 16 | `is_sentence` | `bool` | `optional` |  |  |
+| 17 | `is_ambient` | `bool` | `optional` |  |  |
+| 18 | `guid` | `uint32` | `optional` |  |  |
+| 19 | `sound_resource_id` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -362,8 +362,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `sound_index` | `int32` | `optional` | `` |  |
-| 2 | `resource_type` | `.PrefetchType` | `optional` | `` | default = PFT_SOUND |
+| 1 | `sound_index` | `int32` | `optional` |  |  |
+| 2 | `resource_type` | `.PrefetchType` | `optional` |  | default = PFT_SOUND |
 
 </details>
 
@@ -375,8 +375,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `entity_index` | `int32` | `optional` | `` | default = -1 |
-| 2 | `slot` | `int32` | `optional` | `` | default = -1 |
+| 1 | `entity_index` | `int32` | `optional` |  | default = -1 |
+| 2 | `slot` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -388,8 +388,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `relative` | `bool` | `optional` | `` |  |
-| 2 | `angle` | `.CMsgQAngle` | `optional` | `` |  |
+| 1 | `relative` | `bool` | `optional` |  |  |
+| 2 | `angle` | `.CMsgQAngle` | `optional` |  |  |
 
 </details>
 
@@ -401,7 +401,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `angle` | `.CMsgQAngle` | `optional` | `` |  |
+| 1 | `angle` | `.CMsgQAngle` | `optional` |  |  |
 
 </details>
 
@@ -413,11 +413,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `pos` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `decal_texture_index` | `int32` | `optional` | `` |  |
-| 3 | `entity_index` | `int32` | `optional` | `` | default = -1 |
-| 4 | `model_index` | `int32` | `optional` | `` |  |
-| 5 | `low_priority` | `bool` | `optional` | `` |  |
+| 1 | `pos` | `.CMsgVector` | `optional` |  |  |
+| 2 | `decal_texture_index` | `int32` | `optional` |  |  |
+| 3 | `entity_index` | `int32` | `optional` |  | default = -1 |
+| 4 | `model_index` | `int32` | `optional` |  |  |
+| 5 | `low_priority` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -429,9 +429,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `type` | `.ESplitScreenMessageType` | `optional` | `` | default = MSG_SPLITSCREEN_ADDUSER |
-| 2 | `slot` | `int32` | `optional` | `` |  |
-| 3 | `player_index` | `int32` | `optional` | `` | default = -1 |
+| 1 | `type` | `.ESplitScreenMessageType` | `optional` |  | default = MSG_SPLITSCREEN_ADDUSER |
+| 2 | `slot` | `int32` | `optional` |  |  |
+| 3 | `player_index` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -443,8 +443,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cookie` | `int32` | `optional` | `` |  |
-| 2 | `cvar_name` | `string` | `optional` | `` |  |
+| 1 | `cookie` | `int32` | `optional` |  |  |
+| 2 | `cvar_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -456,8 +456,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `dialog_type` | `int32` | `optional` | `` |  |
-| 2 | `menu_key_values` | `bytes` | `optional` | `` |  |
+| 1 | `dialog_type` | `int32` | `optional` |  |  |
+| 2 | `menu_key_values` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -469,9 +469,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `msg_type` | `int32` | `optional` | `` |  |
-| 2 | `msg_data` | `bytes` | `optional` | `` |  |
-| 3 | `passthrough` | `int32` | `optional` | `` |  |
+| 1 | `msg_type` | `int32` | `optional` |  |  |
+| 2 | `msg_data` | `bytes` | `optional` |  |  |
+| 3 | `passthrough` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -483,10 +483,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `is_end` | `bool` | `optional` | `` |  |
-| 2 | `net_table_name` | `string` | `optional` | `` |  |
-| 3 | `needs_decoder` | `bool` | `optional` | `` |  |
-| 4 | `props` | `.CSVCMsg_SendTable.sendprop_t` | `repeated` | `` |  |
+| 1 | `is_end` | `bool` | `optional` |  |  |
+| 2 | `net_table_name` | `string` | `optional` |  |  |
+| 3 | `needs_decoder` | `bool` | `optional` |  |  |
+| 4 | `props` | `.CSVCMsg_SendTable.sendprop_t` | `repeated` |  |  |
 
 </details>
 
@@ -498,15 +498,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `type` | `int32` | `optional` | `` |  |
-| 2 | `var_name` | `string` | `optional` | `` |  |
-| 3 | `flags` | `int32` | `optional` | `` |  |
-| 4 | `priority` | `int32` | `optional` | `` |  |
-| 5 | `dt_name` | `string` | `optional` | `` |  |
-| 6 | `num_elements` | `int32` | `optional` | `` |  |
-| 7 | `low_value` | `float` | `optional` | `` |  |
-| 8 | `high_value` | `float` | `optional` | `` |  |
-| 9 | `num_bits` | `int32` | `optional` | `` |  |
+| 1 | `type` | `int32` | `optional` |  |  |
+| 2 | `var_name` | `string` | `optional` |  |  |
+| 3 | `flags` | `int32` | `optional` |  |  |
+| 4 | `priority` | `int32` | `optional` |  |  |
+| 5 | `dt_name` | `string` | `optional` |  |  |
+| 6 | `num_elements` | `int32` | `optional` |  |  |
+| 7 | `low_value` | `float` | `optional` |  |  |
+| 8 | `high_value` | `float` | `optional` |  |  |
+| 9 | `num_bits` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -518,7 +518,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `descriptors` | `.CSVCMsg_GameEventList.descriptor_t` | `repeated` | `` |  |
+| 1 | `descriptors` | `.CSVCMsg_GameEventList.descriptor_t` | `repeated` |  |  |
 
 </details>
 
@@ -530,8 +530,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `type` | `int32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
+| 1 | `type` | `int32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -543,9 +543,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `eventid` | `int32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `keys` | `.CSVCMsg_GameEventList.key_t` | `repeated` | `` |  |
+| 1 | `eventid` | `int32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `keys` | `.CSVCMsg_GameEventList.key_t` | `repeated` |  |  |
 
 </details>
 
@@ -557,28 +557,28 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `max_entries` | `int32` | `optional` | `` |  |
-| 2 | `updated_entries` | `int32` | `optional` | `` |  |
-| 3 | `legacy_is_delta` | `bool` | `optional` | `` |  |
-| 4 | `update_baseline` | `bool` | `optional` | `` |  |
-| 5 | `baseline` | `int32` | `optional` | `` |  |
-| 6 | `delta_from` | `int32` | `optional` | `` |  |
-| 7 | `entity_data` | `bytes` | `optional` | `` |  |
-| 8 | `pending_full_frame` | `bool` | `optional` | `` |  |
-| 9 | `active_spawngroup_handle` | `uint32` | `optional` | `` |  |
-| 10 | `max_spawngroup_creationsequence` | `uint32` | `optional` | `` |  |
-| 11 | `last_cmd_number_executed` | `uint32` | `optional` | `` |  |
-| 12 | `server_tick` | `uint32` | `optional` | `` |  |
-| 13 | `serialized_entities` | `bytes` | `optional` | `` |  |
-| 15 | `alternate_baselines` | `.CSVCMsg_PacketEntities.alternate_baseline_t` | `repeated` | `` |  |
-| 16 | `has_pvs_vis_bits_deprecated` | `uint32` | `optional` | `` |  |
-| 17 | `last_cmd_number_recv_delta` | `sint32` | `optional` | `` |  |
-| 19 | `non_transmitted_entities` | `.CSVCMsg_PacketEntities.non_transmitted_entities_t` | `optional` | `` |  |
-| 20 | `cq_starved_command_ticks` | `uint32` | `optional` | `` |  |
-| 21 | `cq_discarded_command_ticks` | `uint32` | `optional` | `` |  |
-| 22 | `cmd_recv_status` | `sint32` | `repeated` | `` | packed = true |
-| 23 | `outofpvs_entity_updates` | `.CSVCMsg_PacketEntities.outofpvs_entity_updates_t` | `optional` | `` |  |
-| 999 | `dev_padding` | `bytes` | `optional` | `` |  |
+| 1 | `max_entries` | `int32` | `optional` |  |  |
+| 2 | `updated_entries` | `int32` | `optional` |  |  |
+| 3 | `legacy_is_delta` | `bool` | `optional` |  |  |
+| 4 | `update_baseline` | `bool` | `optional` |  |  |
+| 5 | `baseline` | `int32` | `optional` |  |  |
+| 6 | `delta_from` | `int32` | `optional` |  |  |
+| 7 | `entity_data` | `bytes` | `optional` |  |  |
+| 8 | `pending_full_frame` | `bool` | `optional` |  |  |
+| 9 | `active_spawngroup_handle` | `uint32` | `optional` |  |  |
+| 10 | `max_spawngroup_creationsequence` | `uint32` | `optional` |  |  |
+| 11 | `last_cmd_number_executed` | `uint32` | `optional` |  |  |
+| 12 | `server_tick` | `uint32` | `optional` |  |  |
+| 13 | `serialized_entities` | `bytes` | `optional` |  |  |
+| 15 | `alternate_baselines` | `.CSVCMsg_PacketEntities.alternate_baseline_t` | `repeated` |  |  |
+| 16 | `has_pvs_vis_bits_deprecated` | `uint32` | `optional` |  |  |
+| 17 | `last_cmd_number_recv_delta` | `sint32` | `optional` |  |  |
+| 19 | `non_transmitted_entities` | `.CSVCMsg_PacketEntities.non_transmitted_entities_t` | `optional` |  |  |
+| 20 | `cq_starved_command_ticks` | `uint32` | `optional` |  |  |
+| 21 | `cq_discarded_command_ticks` | `uint32` | `optional` |  |  |
+| 22 | `cmd_recv_status` | `sint32` | `repeated` |  | packed = true |
+| 23 | `outofpvs_entity_updates` | `.CSVCMsg_PacketEntities.outofpvs_entity_updates_t` | `optional` |  |  |
+| 999 | `dev_padding` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -590,8 +590,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `entity_index` | `int32` | `optional` | `` |  |
-| 2 | `baseline_index` | `int32` | `optional` | `` |  |
+| 1 | `entity_index` | `int32` | `optional` |  |  |
+| 2 | `baseline_index` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -603,8 +603,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `header_count` | `int32` | `optional` | `` |  |
-| 2 | `data` | `bytes` | `optional` | `` |  |
+| 1 | `header_count` | `int32` | `optional` |  |  |
+| 2 | `data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -616,8 +616,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `count` | `int32` | `optional` | `` |  |
-| 2 | `data` | `bytes` | `optional` | `` |  |
+| 1 | `count` | `int32` | `optional` |  |  |
+| 2 | `data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -629,9 +629,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `reliable` | `bool` | `optional` | `` |  |
-| 2 | `num_entries` | `int32` | `optional` | `` |  |
-| 3 | `entity_data` | `bytes` | `optional` | `` |  |
+| 1 | `reliable` | `bool` | `optional` |  |  |
+| 2 | `num_entries` | `int32` | `optional` |  |  |
+| 3 | `entity_data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -643,16 +643,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `num_entries` | `int32` | `optional` | `` |  |
-| 3 | `user_data_fixed_size` | `bool` | `optional` | `` |  |
-| 4 | `user_data_size` | `int32` | `optional` | `` |  |
-| 5 | `user_data_size_bits` | `int32` | `optional` | `` |  |
-| 6 | `flags` | `int32` | `optional` | `` |  |
-| 7 | `string_data` | `bytes` | `optional` | `` |  |
-| 8 | `uncompressed_size` | `int32` | `optional` | `` |  |
-| 9 | `data_compressed` | `bool` | `optional` | `` |  |
-| 10 | `using_varint_bitcounts` | `bool` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `num_entries` | `int32` | `optional` |  |  |
+| 3 | `user_data_fixed_size` | `bool` | `optional` |  |  |
+| 4 | `user_data_size` | `int32` | `optional` |  |  |
+| 5 | `user_data_size_bits` | `int32` | `optional` |  |  |
+| 6 | `flags` | `int32` | `optional` |  |  |
+| 7 | `string_data` | `bytes` | `optional` |  |  |
+| 8 | `uncompressed_size` | `int32` | `optional` |  |  |
+| 9 | `data_compressed` | `bool` | `optional` |  |  |
+| 10 | `using_varint_bitcounts` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -664,9 +664,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `table_id` | `int32` | `optional` | `` |  |
-| 2 | `num_changed_entries` | `int32` | `optional` | `` |  |
-| 3 | `string_data` | `bytes` | `optional` | `` |  |
+| 1 | `table_id` | `int32` | `optional` |  |  |
+| 2 | `num_changed_entries` | `int32` | `optional` |  |  |
+| 3 | `string_data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -678,13 +678,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `audio` | `.CMsgVoiceAudio` | `optional` | `` |  |
-| 2 | `client` | `int32` | `optional` | `` | default = -1 |
-| 3 | `proximity` | `bool` | `optional` | `` |  |
-| 4 | `xuid` | `fixed64` | `optional` | `` |  |
-| 5 | `audible_mask` | `int32` | `optional` | `` |  |
-| 6 | `tick` | `uint32` | `optional` | `` |  |
-| 7 | `passthrough` | `int32` | `optional` | `` |  |
+| 1 | `audio` | `.CMsgVoiceAudio` | `optional` |  |  |
+| 2 | `client` | `int32` | `optional` |  | default = -1 |
+| 3 | `proximity` | `bool` | `optional` |  |  |
+| 4 | `xuid` | `fixed64` | `optional` |  |  |
+| 5 | `audible_mask` | `int32` | `optional` |  |  |
+| 6 | `tick` | `uint32` | `optional` |  |  |
+| 7 | `passthrough` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -696,9 +696,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tick` | `int32` | `optional` | `` |  |
-| 2 | `messagessize` | `int32` | `optional` | `` |  |
-| 3 | `state` | `bool` | `optional` | `` |  |
+| 1 | `tick` | `int32` | `optional` |  |  |
+| 2 | `messagessize` | `int32` | `optional` |  |  |
+| 3 | `state` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -710,10 +710,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tick` | `int32` | `optional` | `` |  |
-| 2 | `section` | `int32` | `optional` | `` |  |
-| 3 | `total` | `int32` | `optional` | `` |  |
-| 4 | `data` | `bytes` | `optional` | `` |  |
+| 1 | `tick` | `int32` | `optional` |  |  |
+| 2 | `section` | `int32` | `optional` |  |  |
+| 3 | `total` | `int32` | `optional` |  |  |
+| 4 | `data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -725,10 +725,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `master` | `string` | `optional` | `` |  |
-| 2 | `clients` | `int32` | `optional` | `` |  |
-| 3 | `slots` | `int32` | `optional` | `` |  |
-| 4 | `proxies` | `int32` | `optional` | `` |  |
+| 1 | `master` | `string` | `optional` |  |  |
+| 2 | `clients` | `int32` | `optional` |  |  |
+| 3 | `slots` | `int32` | `optional` |  |  |
+| 4 | `proxies` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -740,7 +740,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steam_id` | `uint64` | `optional` | `` |  |
+| 1 | `steam_id` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -752,7 +752,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data` | `bytes` | `optional` | `` |  |
+| 1 | `data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -764,8 +764,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `token` | `bytes` | `optional` | `` |  |
-| 2 | `details` | `string` | `optional` | `` |  |
+| 1 | `token` | `bytes` | `optional` |  |  |
+| 2 | `details` | `string` | `optional` |  |  |
 
 </details>
 
@@ -777,8 +777,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `computer_guid` | `fixed64` | `optional` | `` |  |
-| 2 | `process_id` | `uint32` | `optional` | `` |  |
+| 1 | `computer_guid` | `fixed64` | `optional` |  |  |
+| 2 | `process_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -790,12 +790,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_slot` | `int32` | `optional` | `` | default = -1 |
-| 2 | `steamid` | `fixed64` | `optional` | `` |  |
-| 3 | `ipc` | `.CMsgIPCAddress` | `optional` | `` |  |
-| 4 | `they_hear_you` | `bool` | `optional` | `` |  |
-| 5 | `you_hear_them` | `bool` | `optional` | `` |  |
-| 6 | `is_listenserver_host` | `bool` | `optional` | `` |  |
+| 1 | `player_slot` | `int32` | `optional` |  | default = -1 |
+| 2 | `steamid` | `fixed64` | `optional` |  |  |
+| 3 | `ipc` | `.CMsgIPCAddress` | `optional` |  |  |
+| 4 | `they_hear_you` | `bool` | `optional` |  |  |
+| 5 | `you_hear_them` | `bool` | `optional` |  |  |
+| 6 | `is_listenserver_host` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -807,7 +807,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `peer` | `.CMsgServerPeer` | `repeated` | `` |  |
+| 1 | `peer` | `.CMsgServerPeer` | `repeated` |  |  |
 
 </details>
 
@@ -819,8 +819,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `mapname` | `string` | `optional` | `` |  |
-| 3 | `create_tables_skipped` | `bool` | `optional` | `` |  |
+| 1 | `mapname` | `string` | `optional` |  |  |
+| 3 | `create_tables_skipped` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -832,18 +832,18 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `var_type_sym` | `int32` | `optional` | `` |  |
-| 2 | `var_name_sym` | `int32` | `optional` | `` |  |
-| 3 | `bit_count` | `int32` | `optional` | `` |  |
-| 4 | `low_value` | `float` | `optional` | `` |  |
-| 5 | `high_value` | `float` | `optional` | `` |  |
-| 6 | `encode_flags` | `int32` | `optional` | `` |  |
-| 7 | `field_serializer_name_sym` | `int32` | `optional` | `` |  |
-| 8 | `field_serializer_version` | `int32` | `optional` | `` |  |
-| 9 | `send_node_sym` | `int32` | `optional` | `` |  |
-| 10 | `var_encoder_sym` | `int32` | `optional` | `` |  |
-| 11 | `polymorphic_types` | `.ProtoFlattenedSerializerField_t.polymorphic_field_t` | `repeated` | `` |  |
-| 12 | `var_serializer_sym` | `int32` | `optional` | `` |  |
+| 1 | `var_type_sym` | `int32` | `optional` |  |  |
+| 2 | `var_name_sym` | `int32` | `optional` |  |  |
+| 3 | `bit_count` | `int32` | `optional` |  |  |
+| 4 | `low_value` | `float` | `optional` |  |  |
+| 5 | `high_value` | `float` | `optional` |  |  |
+| 6 | `encode_flags` | `int32` | `optional` |  |  |
+| 7 | `field_serializer_name_sym` | `int32` | `optional` |  |  |
+| 8 | `field_serializer_version` | `int32` | `optional` |  |  |
+| 9 | `send_node_sym` | `int32` | `optional` |  |  |
+| 10 | `var_encoder_sym` | `int32` | `optional` |  |  |
+| 11 | `polymorphic_types` | `.ProtoFlattenedSerializerField_t.polymorphic_field_t` | `repeated` |  |  |
+| 12 | `var_serializer_sym` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -855,8 +855,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `polymorphic_field_serializer_name_sym` | `int32` | `optional` | `` |  |
-| 2 | `polymorphic_field_serializer_version` | `int32` | `optional` | `` |  |
+| 1 | `polymorphic_field_serializer_name_sym` | `int32` | `optional` |  |  |
+| 2 | `polymorphic_field_serializer_version` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -868,9 +868,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `serializer_name_sym` | `int32` | `optional` | `` |  |
-| 2 | `serializer_version` | `int32` | `optional` | `` |  |
-| 3 | `fields_index` | `int32` | `repeated` | `` |  |
+| 1 | `serializer_name_sym` | `int32` | `optional` |  |  |
+| 2 | `serializer_version` | `int32` | `optional` |  |  |
+| 3 | `fields_index` | `int32` | `repeated` |  |  |
 
 </details>
 
@@ -882,9 +882,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `serializers` | `.ProtoFlattenedSerializer_t` | `repeated` | `` |  |
-| 2 | `symbols` | `string` | `repeated` | `` |  |
-| 3 | `fields` | `.ProtoFlattenedSerializerField_t` | `repeated` | `` |  |
+| 1 | `serializers` | `.ProtoFlattenedSerializer_t` | `repeated` |  |  |
+| 2 | `symbols` | `string` | `repeated` |  |  |
+| 3 | `fields` | `.ProtoFlattenedSerializerField_t` | `repeated` |  |  |
 
 </details>
 
@@ -896,7 +896,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `guid` | `fixed32` | `optional` | `` |  |
+| 1 | `guid` | `fixed32` | `optional` |  |  |
 
 </details>
 
@@ -908,10 +908,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `posttoserver` | `bool` | `optional` | `` |  |
-| 2 | `buftype` | `int32` | `optional` | `` |  |
-| 3 | `clientbitcount` | `uint32` | `optional` | `` |  |
-| 4 | `receivingclients` | `uint64` | `optional` | `` |  |
+| 1 | `posttoserver` | `bool` | `optional` |  |  |
+| 2 | `buftype` | `int32` | `optional` |  |  |
+| 3 | `clientbitcount` | `uint32` | `optional` |  |  |
+| 4 | `receivingclients` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -923,7 +923,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `eventsource` | `int32` | `optional` | `` |  |
+| 1 | `eventsource` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -935,10 +935,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_id` | `uint32` | `optional` | `` |  |
-| 2 | `event_data` | `bytes` | `optional` | `` |  |
-| 3 | `sync_type` | `uint32` | `optional` | `` |  |
-| 4 | `sync_val_uint32` | `uint32` | `optional` | `` |  |
+| 1 | `event_id` | `uint32` | `optional` |  |  |
+| 2 | `event_data` | `bytes` | `optional` |  |  |
+| 3 | `sync_type` | `uint32` | `optional` |  |  |
+| 4 | `sync_val_uint32` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -950,31 +950,31 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `dedicated` | `bool` | `optional` | `` |  |
-| 2 | `cpu_usage` | `int32` | `optional` | `` |  |
-| 3 | `memory_used_mb` | `int32` | `optional` | `` |  |
-| 4 | `memory_free_mb` | `int32` | `optional` | `` |  |
-| 5 | `uptime` | `int32` | `optional` | `` |  |
-| 6 | `spawn_count` | `int32` | `optional` | `` |  |
-| 8 | `num_clients` | `int32` | `optional` | `` |  |
-| 9 | `num_bots` | `int32` | `optional` | `` |  |
-| 10 | `num_spectators` | `int32` | `optional` | `` |  |
-| 11 | `num_tv_relays` | `int32` | `optional` | `` |  |
-| 12 | `fps` | `float` | `optional` | `` |  |
-| 17 | `ports` | `.CMsgServerNetworkStats.Port` | `repeated` | `` |  |
-| 18 | `avg_ping_ms` | `float` | `optional` | `` |  |
-| 19 | `avg_engine_latency_out` | `float` | `optional` | `` |  |
-| 20 | `avg_packets_out` | `float` | `optional` | `` |  |
-| 21 | `avg_packets_in` | `float` | `optional` | `` |  |
-| 22 | `avg_loss_out` | `float` | `optional` | `` |  |
-| 23 | `avg_loss_in` | `float` | `optional` | `` |  |
-| 24 | `avg_data_out` | `float` | `optional` | `` |  |
-| 25 | `avg_data_in` | `float` | `optional` | `` |  |
-| 26 | `total_data_in` | `uint64` | `optional` | `` |  |
-| 27 | `total_packets_in` | `uint64` | `optional` | `` |  |
-| 28 | `total_data_out` | `uint64` | `optional` | `` |  |
-| 29 | `total_packets_out` | `uint64` | `optional` | `` |  |
-| 30 | `players` | `.CMsgServerNetworkStats.Player` | `repeated` | `` |  |
+| 1 | `dedicated` | `bool` | `optional` |  |  |
+| 2 | `cpu_usage` | `int32` | `optional` |  |  |
+| 3 | `memory_used_mb` | `int32` | `optional` |  |  |
+| 4 | `memory_free_mb` | `int32` | `optional` |  |  |
+| 5 | `uptime` | `int32` | `optional` |  |  |
+| 6 | `spawn_count` | `int32` | `optional` |  |  |
+| 8 | `num_clients` | `int32` | `optional` |  |  |
+| 9 | `num_bots` | `int32` | `optional` |  |  |
+| 10 | `num_spectators` | `int32` | `optional` |  |  |
+| 11 | `num_tv_relays` | `int32` | `optional` |  |  |
+| 12 | `fps` | `float` | `optional` |  |  |
+| 17 | `ports` | `.CMsgServerNetworkStats.Port` | `repeated` |  |  |
+| 18 | `avg_ping_ms` | `float` | `optional` |  |  |
+| 19 | `avg_engine_latency_out` | `float` | `optional` |  |  |
+| 20 | `avg_packets_out` | `float` | `optional` |  |  |
+| 21 | `avg_packets_in` | `float` | `optional` |  |  |
+| 22 | `avg_loss_out` | `float` | `optional` |  |  |
+| 23 | `avg_loss_in` | `float` | `optional` |  |  |
+| 24 | `avg_data_out` | `float` | `optional` |  |  |
+| 25 | `avg_data_in` | `float` | `optional` |  |  |
+| 26 | `total_data_in` | `uint64` | `optional` |  |  |
+| 27 | `total_packets_in` | `uint64` | `optional` |  |  |
+| 28 | `total_data_out` | `uint64` | `optional` |  |  |
+| 29 | `total_packets_out` | `uint64` | `optional` |  |  |
+| 30 | `players` | `.CMsgServerNetworkStats.Player` | `repeated` |  |  |
 
 </details>
 
@@ -986,8 +986,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `port` | `int32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
+| 1 | `port` | `int32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -999,14 +999,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `uint64` | `optional` | `` |  |
-| 2 | `remote_addr` | `string` | `optional` | `` |  |
-| 4 | `ping_avg_ms` | `int32` | `optional` | `` |  |
-| 5 | `packet_loss_pct` | `float` | `optional` | `` |  |
-| 6 | `is_bot` | `bool` | `optional` | `` |  |
-| 7 | `loss_in` | `float` | `optional` | `` |  |
-| 8 | `loss_out` | `float` | `optional` | `` |  |
-| 9 | `engine_latency_ms` | `int32` | `optional` | `` |  |
+| 1 | `steamid` | `uint64` | `optional` |  |  |
+| 2 | `remote_addr` | `string` | `optional` |  |  |
+| 4 | `ping_avg_ms` | `int32` | `optional` |  |  |
+| 5 | `packet_loss_pct` | `float` | `optional` |  |  |
+| 6 | `is_bot` | `bool` | `optional` |  |  |
+| 7 | `loss_in` | `float` | `optional` |  |  |
+| 8 | `loss_out` | `float` | `optional` |  |  |
+| 9 | `engine_latency_ms` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1018,14 +1018,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `delay` | `int32` | `optional` | `` |  |
-| 2 | `primary_target` | `int32` | `optional` | `` | default = -1 |
-| 3 | `replay_stop_at` | `int32` | `optional` | `` |  |
-| 4 | `replay_start_at` | `int32` | `optional` | `` |  |
-| 5 | `replay_slowdown_begin` | `int32` | `optional` | `` |  |
-| 6 | `replay_slowdown_end` | `int32` | `optional` | `` |  |
-| 7 | `replay_slowdown_rate` | `float` | `optional` | `` |  |
-| 8 | `reason` | `int32` | `optional` | `` |  |
+| 1 | `delay` | `int32` | `optional` |  |  |
+| 2 | `primary_target` | `int32` | `optional` |  | default = -1 |
+| 3 | `replay_stop_at` | `int32` | `optional` |  |  |
+| 4 | `replay_start_at` | `int32` | `optional` |  |  |
+| 5 | `replay_slowdown_begin` | `int32` | `optional` |  |  |
+| 6 | `replay_slowdown_end` | `int32` | `optional` |  |  |
+| 7 | `replay_slowdown_rate` | `float` | `optional` |  |  |
+| 8 | `reason` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1037,11 +1037,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `request` | `int32` | `optional` | `` |  |
-| 2 | `slowdown_length` | `float` | `optional` | `` |  |
-| 3 | `slowdown_rate` | `float` | `optional` | `` |  |
-| 4 | `primary_target` | `int32` | `optional` | `` | default = -1 |
-| 5 | `event_time` | `float` | `optional` | `` |  |
+| 1 | `request` | `int32` | `optional` |  |  |
+| 2 | `slowdown_length` | `float` | `optional` |  |  |
+| 3 | `slowdown_rate` | `float` | `optional` |  |  |
+| 4 | `primary_target` | `int32` | `optional` |  | default = -1 |
+| 5 | `event_time` | `float` | `optional` |  |  |
 
 </details>
 
@@ -1053,7 +1053,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cmd` | `string` | `optional` | `` |  |
+| 1 | `cmd` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1065,14 +1065,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tick` | `int32` | `optional` | `` |  |
-| 2 | `props_data` | `bytes` | `optional` | `` |  |
-| 3 | `origin` | `.CMsgVector` | `optional` | `` |  |
-| 4 | `eye_angles` | `.CMsgQAngle` | `optional` | `` |  |
-| 5 | `observer_mode` | `int32` | `optional` | `` |  |
-| 6 | `cameraman_scoreboard` | `bool` | `optional` | `` |  |
-| 7 | `observer_target` | `int32` | `optional` | `` |  |
-| 8 | `view_offset` | `.CMsgVector` | `optional` | `` |  |
+| 1 | `tick` | `int32` | `optional` |  |  |
+| 2 | `props_data` | `bytes` | `optional` |  |  |
+| 3 | `origin` | `.CMsgVector` | `optional` |  |  |
+| 4 | `eye_angles` | `.CMsgQAngle` | `optional` |  |  |
+| 5 | `observer_mode` | `int32` | `optional` |  |  |
+| 6 | `cameraman_scoreboard` | `bool` | `optional` |  |  |
+| 7 | `observer_target` | `int32` | `optional` |  |  |
+| 8 | `view_offset` | `.CMsgVector` | `optional` |  |  |
 
 </details>
 
@@ -1084,8 +1084,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `mode` | `uint32` | `optional` | `` |  |
-| 2 | `override_operator_name` | `string` | `optional` | `` |  |
+| 1 | `mode` | `uint32` | `optional` |  |  |
+| 2 | `override_operator_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1097,11 +1097,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data` | `bytes` | `optional` | `` |  |
-| 2 | `cmd_number` | `int32` | `optional` | `` |  |
-| 3 | `player_slot` | `int32` | `optional` | `` | default = -1 |
-| 4 | `server_tick_executed` | `int32` | `optional` | `` |  |
-| 5 | `client_tick` | `int32` | `optional` | `` |  |
+| 1 | `data` | `bytes` | `optional` |  |  |
+| 2 | `cmd_number` | `int32` | `optional` |  |  |
+| 3 | `player_slot` | `int32` | `optional` |  | default = -1 |
+| 4 | `server_tick_executed` | `int32` | `optional` |  |  |
+| 5 | `client_tick` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1113,7 +1113,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `commands` | `.CMsgServerUserCmd` | `repeated` | `` |  |
+| 1 | `commands` | `.CMsgServerUserCmd` | `repeated` |  |  |
 
 </details>
 
@@ -1125,8 +1125,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `predicted_by_player_slot` | `int32` | `optional` | `` | default = -1 |
-| 2 | `message_type_id` | `uint32` | `optional` | `` |  |
+| 1 | `predicted_by_player_slot` | `int32` | `optional` |  | default = -1 |
+| 2 | `message_type_id` | `uint32` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/networkbasetypes.md
+++ b/docs/cookbook/proto-fields/networkbasetypes.md
@@ -24,10 +24,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `x` | `float` | `optional` | `` |  |
-| 2 | `y` | `float` | `optional` | `` |  |
-| 3 | `z` | `float` | `optional` | `` |  |
-| 4 | `w` | `float` | `optional` | `` |  |
+| 1 | `x` | `float` | `optional` |  |  |
+| 2 | `y` | `float` | `optional` |  |  |
+| 3 | `z` | `float` | `optional` |  |  |
+| 4 | `w` | `float` | `optional` |  |  |
 
 </details>
 
@@ -39,8 +39,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `x` | `float` | `optional` | `` |  |
-| 2 | `y` | `float` | `optional` | `` |  |
+| 1 | `x` | `float` | `optional` |  |  |
+| 2 | `y` | `float` | `optional` |  |  |
 
 </details>
 
@@ -52,9 +52,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `x` | `float` | `optional` | `` |  |
-| 2 | `y` | `float` | `optional` | `` |  |
-| 3 | `z` | `float` | `optional` | `` |  |
+| 1 | `x` | `float` | `optional` |  |  |
+| 2 | `y` | `float` | `optional` |  |  |
+| 3 | `z` | `float` | `optional` |  |  |
 
 </details>
 
@@ -66,10 +66,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `x` | `float` | `optional` | `` |  |
-| 2 | `y` | `float` | `optional` | `` |  |
-| 3 | `z` | `float` | `optional` | `` |  |
-| 4 | `w` | `float` | `optional` | `` |  |
+| 1 | `x` | `float` | `optional` |  |  |
+| 2 | `y` | `float` | `optional` |  |  |
+| 3 | `z` | `float` | `optional` |  |  |
+| 4 | `w` | `float` | `optional` |  |  |
 
 </details>
 
@@ -81,9 +81,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `position` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `scale` | `float` | `optional` | `` |  |
-| 3 | `orientation` | `.CMsgQuaternion` | `optional` | `` |  |
+| 1 | `position` | `.CMsgVector` | `optional` |  |  |
+| 2 | `scale` | `float` | `optional` |  |  |
+| 3 | `orientation` | `.CMsgQuaternion` | `optional` |  |  |
 
 </details>
 
@@ -95,10 +95,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `r` | `int32` | `optional` | `` |  |
-| 2 | `g` | `int32` | `optional` | `` |  |
-| 3 | `b` | `int32` | `optional` | `` |  |
-| 4 | `a` | `int32` | `optional` | `` |  |
+| 1 | `r` | `int32` | `optional` |  |  |
+| 2 | `g` | `int32` | `optional` |  |  |
+| 3 | `b` | `int32` | `optional` |  |  |
+| 4 | `a` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -110,12 +110,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `xuid` | `fixed64` | `optional` | `` |  |
-| 3 | `userid` | `int32` | `optional` | `` |  |
-| 4 | `steamid` | `fixed64` | `optional` | `` |  |
-| 5 | `fakeplayer` | `bool` | `optional` | `` |  |
-| 6 | `ishltv` | `bool` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `xuid` | `fixed64` | `optional` |  |  |
+| 3 | `userid` | `int32` | `optional` |  |  |
+| 4 | `steamid` | `fixed64` | `optional` |  |  |
+| 5 | `fakeplayer` | `bool` | `optional` |  |  |
+| 6 | `ishltv` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -127,7 +127,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_entity` | `uint32` | `optional` | `` | default = 16777215 |
+| 1 | `target_entity` | `uint32` | `optional` |  | default = 16777215 |
 
 </details>
 
@@ -139,7 +139,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cvars` | `.CMsg_CVars.CVar` | `repeated` | `` |  |
+| 1 | `cvars` | `.CMsg_CVars.CVar` | `repeated` |  |  |
 
 </details>
 
@@ -151,8 +151,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `value` | `string` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `value` | `string` | `optional` |  |  |
 
 </details>
 
@@ -176,7 +176,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `slot` | `int32` | `optional` | `` |  |
+| 1 | `slot` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -188,16 +188,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tick` | `uint32` | `optional` | `` |  |
-| 4 | `host_computationtime` | `uint32` | `optional` | `` |  |
-| 5 | `host_computationtime_std_deviation` | `uint32` | `optional` | `` |  |
-| 7 | `legacy_host_loss` | `uint32` | `optional` | `` |  |
-| 8 | `host_unfiltered_frametime` | `uint32` | `optional` | `` |  |
-| 9 | `hltv_replay_flags` | `uint32` | `optional` | `` |  |
-| 10 | `expected_long_tick` | `uint32` | `optional` | `` |  |
-| 11 | `expected_long_tick_reason` | `string` | `optional` | `` |  |
-| 12 | `host_frame_dropped_pct_x10` | `uint32` | `optional` | `` |  |
-| 13 | `host_frame_irregular_arrival_pct_x10` | `uint32` | `optional` | `` |  |
+| 1 | `tick` | `uint32` | `optional` |  |  |
+| 4 | `host_computationtime` | `uint32` | `optional` |  |  |
+| 5 | `host_computationtime_std_deviation` | `uint32` | `optional` |  |  |
+| 7 | `legacy_host_loss` | `uint32` | `optional` |  |  |
+| 8 | `host_unfiltered_frametime` | `uint32` | `optional` |  |  |
+| 9 | `hltv_replay_flags` | `uint32` | `optional` |  |  |
+| 10 | `expected_long_tick` | `uint32` | `optional` |  |  |
+| 11 | `expected_long_tick_reason` | `string` | `optional` |  |  |
+| 12 | `host_frame_dropped_pct_x10` | `uint32` | `optional` |  |  |
+| 13 | `host_frame_irregular_arrival_pct_x10` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -209,8 +209,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `command` | `string` | `optional` | `` |  |
-| 2 | `prediction_sync` | `uint32` | `optional` | `` |  |
+| 1 | `command` | `string` | `optional` |  |  |
+| 2 | `prediction_sync` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -222,7 +222,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `convars` | `.CMsg_CVars` | `optional` | `` |  |
+| 1 | `convars` | `.CMsg_CVars` | `optional` |  |  |
 
 </details>
 
@@ -234,12 +234,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `signon_state` | `.SignonState_t` | `optional` | `` | default = SIGNONSTATE_NONE |
-| 2 | `spawn_count` | `uint32` | `optional` | `` |  |
-| 3 | `num_server_players` | `uint32` | `optional` | `` |  |
-| 4 | `players_networkids` | `string` | `repeated` | `` |  |
-| 5 | `map_name` | `string` | `optional` | `` |  |
-| 6 | `addons` | `string` | `optional` | `` |  |
+| 1 | `signon_state` | `.SignonState_t` | `optional` |  | default = SIGNONSTATE_NONE |
+| 2 | `spawn_count` | `uint32` | `optional` |  |  |
+| 3 | `num_server_players` | `uint32` | `optional` |  |  |
+| 4 | `players_networkids` | `string` | `repeated` |  |  |
+| 5 | `map_name` | `string` | `optional` |  |  |
+| 6 | `addons` | `string` | `optional` |  |  |
 
 </details>
 
@@ -251,9 +251,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_name` | `string` | `optional` | `` |  |
-| 2 | `eventid` | `int32` | `optional` | `` |  |
-| 3 | `keys` | `.CSVCMsg_GameEvent.key_t` | `repeated` | `` |  |
+| 1 | `event_name` | `string` | `optional` |  |  |
+| 2 | `eventid` | `int32` | `optional` |  |  |
+| 3 | `keys` | `.CSVCMsg_GameEvent.key_t` | `repeated` |  |  |
 
 </details>
 
@@ -265,14 +265,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `type` | `int32` | `optional` | `` |  |
-| 2 | `val_string` | `string` | `optional` | `` |  |
-| 3 | `val_float` | `float` | `optional` | `` |  |
-| 4 | `val_long` | `int32` | `optional` | `` |  |
-| 5 | `val_short` | `int32` | `optional` | `` |  |
-| 6 | `val_byte` | `int32` | `optional` | `` |  |
-| 7 | `val_bool` | `bool` | `optional` | `` |  |
-| 8 | `val_uint64` | `uint64` | `optional` | `` |  |
+| 1 | `type` | `int32` | `optional` |  |  |
+| 2 | `val_string` | `string` | `optional` |  |  |
+| 3 | `val_float` | `float` | `optional` |  |  |
+| 4 | `val_long` | `int32` | `optional` |  |  |
+| 5 | `val_short` | `int32` | `optional` |  |  |
+| 6 | `val_byte` | `int32` | `optional` |  |  |
+| 7 | `val_bool` | `bool` | `optional` |  |  |
+| 8 | `val_uint64` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -284,7 +284,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `events` | `.CSVCMsgList_GameEvents.event_t` | `repeated` | `` |  |
+| 1 | `events` | `.CSVCMsgList_GameEvents.event_t` | `repeated` |  |  |
 
 </details>
 
@@ -296,8 +296,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tick` | `int32` | `optional` | `` |  |
-| 2 | `event` | `.CSVCMsg_GameEvent` | `optional` | `` |  |
+| 1 | `tick` | `int32` | `optional` |  |  |
+| 2 | `event` | `.CSVCMsg_GameEvent` | `optional` |  |  |
 
 </details>
 
@@ -309,26 +309,26 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `worldname` | `string` | `optional` | `` |  |
-| 2 | `entitylumpname` | `string` | `optional` | `` |  |
-| 3 | `entityfiltername` | `string` | `optional` | `` |  |
-| 4 | `spawngrouphandle` | `uint32` | `optional` | `` |  |
-| 5 | `spawngroupownerhandle` | `uint32` | `optional` | `` |  |
-| 6 | `world_offset_pos` | `.CMsgVector` | `optional` | `` |  |
-| 7 | `world_offset_angle` | `.CMsgQAngle` | `optional` | `` |  |
-| 8 | `spawngroupmanifest` | `bytes` | `optional` | `` |  |
-| 9 | `flags` | `uint32` | `optional` | `` |  |
-| 10 | `tickcount` | `int32` | `optional` | `` |  |
-| 11 | `manifestincomplete` | `bool` | `optional` | `` |  |
-| 12 | `localnamefixup` | `string` | `optional` | `` |  |
-| 13 | `parentnamefixup` | `string` | `optional` | `` |  |
-| 14 | `manifestloadpriority` | `int32` | `optional` | `` |  |
-| 15 | `worldgroupid` | `uint32` | `optional` | `` |  |
-| 16 | `creationsequence` | `uint32` | `optional` | `` |  |
-| 17 | `savegamefilename` | `string` | `optional` | `` |  |
-| 18 | `spawngroupparenthandle` | `uint32` | `optional` | `` |  |
-| 19 | `leveltransition` | `bool` | `optional` | `` |  |
-| 20 | `worldgroupname` | `string` | `optional` | `` |  |
+| 1 | `worldname` | `string` | `optional` |  |  |
+| 2 | `entitylumpname` | `string` | `optional` |  |  |
+| 3 | `entityfiltername` | `string` | `optional` |  |  |
+| 4 | `spawngrouphandle` | `uint32` | `optional` |  |  |
+| 5 | `spawngroupownerhandle` | `uint32` | `optional` |  |  |
+| 6 | `world_offset_pos` | `.CMsgVector` | `optional` |  |  |
+| 7 | `world_offset_angle` | `.CMsgQAngle` | `optional` |  |  |
+| 8 | `spawngroupmanifest` | `bytes` | `optional` |  |  |
+| 9 | `flags` | `uint32` | `optional` |  |  |
+| 10 | `tickcount` | `int32` | `optional` |  |  |
+| 11 | `manifestincomplete` | `bool` | `optional` |  |  |
+| 12 | `localnamefixup` | `string` | `optional` |  |  |
+| 13 | `parentnamefixup` | `string` | `optional` |  |  |
+| 14 | `manifestloadpriority` | `int32` | `optional` |  |  |
+| 15 | `worldgroupid` | `uint32` | `optional` |  |  |
+| 16 | `creationsequence` | `uint32` | `optional` |  |  |
+| 17 | `savegamefilename` | `string` | `optional` |  |  |
+| 18 | `spawngroupparenthandle` | `uint32` | `optional` |  |  |
+| 19 | `leveltransition` | `bool` | `optional` |  |  |
+| 20 | `worldgroupname` | `string` | `optional` |  |  |
 
 </details>
 
@@ -340,9 +340,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `spawngrouphandle` | `uint32` | `optional` | `` |  |
-| 2 | `spawngroupmanifest` | `bytes` | `optional` | `` |  |
-| 3 | `manifestincomplete` | `bool` | `optional` | `` |  |
+| 1 | `spawngrouphandle` | `uint32` | `optional` |  |  |
+| 2 | `spawngroupmanifest` | `bytes` | `optional` |  |  |
+| 3 | `manifestincomplete` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -354,9 +354,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `spawngrouphandle` | `uint32` | `optional` | `` |  |
-| 2 | `tickcount` | `int32` | `optional` | `` |  |
-| 3 | `creationsequence` | `uint32` | `optional` | `` |  |
+| 1 | `spawngrouphandle` | `uint32` | `optional` |  |  |
+| 2 | `tickcount` | `int32` | `optional` |  |  |
+| 3 | `creationsequence` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -368,9 +368,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `spawngrouphandle` | `uint32` | `optional` | `` |  |
-| 2 | `flags` | `uint32` | `optional` | `` |  |
-| 3 | `tickcount` | `int32` | `optional` | `` |  |
+| 1 | `spawngrouphandle` | `uint32` | `optional` |  |  |
+| 2 | `flags` | `uint32` | `optional` |  |  |
+| 3 | `tickcount` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -382,7 +382,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `spawngrouphandle` | `uint32` | `optional` | `` |  |
+| 1 | `spawngrouphandle` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -394,25 +394,25 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `is_multiplayer` | `bool` | `optional` | `` |  |
-| 2 | `is_loadsavegame` | `bool` | `optional` | `` |  |
-| 3 | `is_background_map` | `bool` | `optional` | `` |  |
-| 4 | `is_headless` | `bool` | `optional` | `` |  |
-| 5 | `min_client_limit` | `uint32` | `optional` | `` |  |
-| 6 | `max_client_limit` | `uint32` | `optional` | `` |  |
-| 7 | `max_clients` | `uint32` | `optional` | `` |  |
-| 8 | `tick_interval` | `fixed32` | `optional` | `` |  |
-| 9 | `hostname` | `string` | `optional` | `` |  |
-| 10 | `savegamename` | `string` | `optional` | `` |  |
-| 11 | `s1_mapname` | `string` | `optional` | `` |  |
-| 12 | `gamemode` | `string` | `optional` | `` |  |
-| 13 | `server_ip_address` | `string` | `optional` | `` |  |
-| 14 | `data` | `bytes` | `optional` | `` |  |
-| 15 | `is_localonly` | `bool` | `optional` | `` |  |
-| 16 | `is_transition` | `bool` | `optional` | `` |  |
-| 17 | `previouslevel` | `string` | `optional` | `` |  |
-| 18 | `landmarkname` | `string` | `optional` | `` |  |
-| 19 | `no_steam_server` | `bool` | `optional` | `` |  |
+| 1 | `is_multiplayer` | `bool` | `optional` |  |  |
+| 2 | `is_loadsavegame` | `bool` | `optional` |  |  |
+| 3 | `is_background_map` | `bool` | `optional` |  |  |
+| 4 | `is_headless` | `bool` | `optional` |  |  |
+| 5 | `min_client_limit` | `uint32` | `optional` |  |  |
+| 6 | `max_client_limit` | `uint32` | `optional` |  |  |
+| 7 | `max_clients` | `uint32` | `optional` |  |  |
+| 8 | `tick_interval` | `fixed32` | `optional` |  |  |
+| 9 | `hostname` | `string` | `optional` |  |  |
+| 10 | `savegamename` | `string` | `optional` |  |  |
+| 11 | `s1_mapname` | `string` | `optional` |  |  |
+| 12 | `gamemode` | `string` | `optional` |  |  |
+| 13 | `server_ip_address` | `string` | `optional` |  |  |
+| 14 | `data` | `bytes` | `optional` |  |  |
+| 15 | `is_localonly` | `bool` | `optional` |  |  |
+| 16 | `is_transition` | `bool` | `optional` |  |  |
+| 17 | `previouslevel` | `string` | `optional` |  |  |
+| 18 | `landmarkname` | `string` | `optional` |  |  |
+| 19 | `no_steam_server` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -424,14 +424,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `etype` | `int32` | `optional` | `` |  |
-| 2 | `vectors` | `.CMsgVector` | `repeated` | `` |  |
-| 3 | `colors` | `.CMsgRGBA` | `repeated` | `` |  |
-| 4 | `dimensions` | `float` | `repeated` | `` |  |
-| 5 | `times` | `float` | `repeated` | `` |  |
-| 6 | `bools` | `bool` | `repeated` | `` |  |
-| 7 | `uint64s` | `uint64` | `repeated` | `` |  |
-| 8 | `strings` | `string` | `repeated` | `` |  |
+| 1 | `etype` | `int32` | `optional` |  |  |
+| 2 | `vectors` | `.CMsgVector` | `repeated` |  |  |
+| 3 | `colors` | `.CMsgRGBA` | `repeated` |  |  |
+| 4 | `dimensions` | `float` | `repeated` |  |  |
+| 5 | `times` | `float` | `repeated` |  |  |
+| 6 | `bools` | `bool` | `repeated` |  |  |
+| 7 | `uint64s` | `uint64` | `repeated` |  |  |
+| 8 | `strings` | `string` | `repeated` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/networksystem-protomessages.md
+++ b/docs/cookbook/proto-fields/networksystem-protomessages.md
@@ -19,7 +19,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `slot` | `uint32` | `optional` | `` |  |
+| 1 | `slot` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -31,8 +31,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `reason` | `uint32` | `optional` | `` |  |
-| 2 | `message` | `string` | `optional` | `` |  |
+| 1 | `reason` | `uint32` | `optional` |  |  |
+| 2 | `message` | `string` | `optional` |  |  |
 
 </details>
 
@@ -44,8 +44,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `reason` | `uint32` | `optional` | `` |  |
-| 2 | `message` | `string` | `optional` | `` |  |
+| 1 | `reason` | `uint32` | `optional` |  |  |
+| 2 | `message` | `string` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/prediction-events.md
+++ b/docs/cookbook/proto-fields/prediction-events.md
@@ -23,9 +23,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `origin` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `angles` | `.CMsgQAngle` | `optional` | `` |  |
-| 3 | `drop_to_ground_range` | `float` | `optional` | `` |  |
+| 1 | `origin` | `.CMsgVector` | `optional` |  |  |
+| 2 | `angles` | `.CMsgQAngle` | `optional` |  |  |
+| 3 | `drop_to_ground_range` | `float` | `optional` |  |  |
 
 </details>
 
@@ -37,7 +37,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `command` | `string` | `optional` | `` |  |
+| 1 | `command` | `string` | `optional` |  |  |
 
 </details>
 
@@ -49,10 +49,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `uint32` | `optional` | `` |  |
-| 2 | `requested_sync` | `uint32` | `optional` | `` |  |
-| 3 | `requested_player_index` | `uint32` | `optional` | `` |  |
-| 4 | `execution_sync` | `uint32` | `repeated` | `` |  |
+| 1 | `id` | `uint32` | `optional` |  |  |
+| 2 | `requested_sync` | `uint32` | `optional` |  |  |
+| 3 | `requested_player_index` | `uint32` | `optional` |  |  |
+| 4 | `execution_sync` | `uint32` | `repeated` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/source2-steam-stats.md
+++ b/docs/cookbook/proto-fields/source2-steam-stats.md
@@ -19,20 +19,20 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cpu_id` | `string` | `optional` | `` |  |
-| 2 | `cpu_brand` | `string` | `optional` | `` |  |
-| 3 | `cpu_model` | `uint32` | `optional` | `` |  |
-| 4 | `cpu_num_physical` | `uint32` | `optional` | `` |  |
-| 21 | `ram_physical_total_mb` | `uint32` | `optional` | `` |  |
-| 41 | `gpu_rendersystem_dll_name` | `string` | `optional` | `` |  |
-| 42 | `gpu_vendor_id` | `uint32` | `optional` | `` |  |
-| 43 | `gpu_driver_name` | `string` | `optional` | `` |  |
-| 44 | `gpu_driver_version_high` | `uint32` | `optional` | `` |  |
-| 45 | `gpu_driver_version_low` | `uint32` | `optional` | `` |  |
-| 46 | `gpu_dx_support_level` | `uint32` | `optional` | `` |  |
-| 47 | `gpu_texture_memory_size_mb` | `uint32` | `optional` | `` |  |
-| 51 | `backbuffer_width` | `uint32` | `optional` | `` |  |
-| 52 | `backbuffer_height` | `uint32` | `optional` | `` |  |
+| 1 | `cpu_id` | `string` | `optional` |  |  |
+| 2 | `cpu_brand` | `string` | `optional` |  |  |
+| 3 | `cpu_model` | `uint32` | `optional` |  |  |
+| 4 | `cpu_num_physical` | `uint32` | `optional` |  |  |
+| 21 | `ram_physical_total_mb` | `uint32` | `optional` |  |  |
+| 41 | `gpu_rendersystem_dll_name` | `string` | `optional` |  |  |
+| 42 | `gpu_vendor_id` | `uint32` | `optional` |  |  |
+| 43 | `gpu_driver_name` | `string` | `optional` |  |  |
+| 44 | `gpu_driver_version_high` | `uint32` | `optional` |  |  |
+| 45 | `gpu_driver_version_low` | `uint32` | `optional` |  |  |
+| 46 | `gpu_dx_support_level` | `uint32` | `optional` |  |  |
+| 47 | `gpu_texture_memory_size_mb` | `uint32` | `optional` |  |  |
+| 51 | `backbuffer_width` | `uint32` | `optional` |  |  |
+| 52 | `backbuffer_height` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -44,24 +44,24 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `active_samples` | `uint32` | `optional` | `` |  |
-| 3 | `usec_max` | `uint32` | `optional` | `` |  |
-| 4 | `active_samples_1secmax` | `uint32` | `optional` | `` |  |
-| 11 | `usec_avg_active` | `uint32` | `optional` | `` |  |
-| 12 | `usec_p50_active` | `uint32` | `optional` | `` |  |
-| 13 | `usec_p99_active` | `uint32` | `optional` | `` |  |
-| 21 | `usec_avg_all` | `uint32` | `optional` | `` |  |
-| 22 | `usec_p50_all` | `uint32` | `optional` | `` |  |
-| 23 | `usec_p99_all` | `uint32` | `optional` | `` |  |
-| 31 | `usec_1secmax_avg_active` | `uint32` | `optional` | `` |  |
-| 32 | `usec_1secmax_p50_active` | `uint32` | `optional` | `` |  |
-| 33 | `usec_1secmax_p95_active` | `uint32` | `optional` | `` |  |
-| 34 | `usec_1secmax_p99_active` | `uint32` | `optional` | `` |  |
-| 41 | `usec_1secmax_avg_all` | `uint32` | `optional` | `` |  |
-| 42 | `usec_1secmax_p50_all` | `uint32` | `optional` | `` |  |
-| 43 | `usec_1secmax_p95_all` | `uint32` | `optional` | `` |  |
-| 44 | `usec_1secmax_p99_all` | `uint32` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `active_samples` | `uint32` | `optional` |  |  |
+| 3 | `usec_max` | `uint32` | `optional` |  |  |
+| 4 | `active_samples_1secmax` | `uint32` | `optional` |  |  |
+| 11 | `usec_avg_active` | `uint32` | `optional` |  |  |
+| 12 | `usec_p50_active` | `uint32` | `optional` |  |  |
+| 13 | `usec_p99_active` | `uint32` | `optional` |  |  |
+| 21 | `usec_avg_all` | `uint32` | `optional` |  |  |
+| 22 | `usec_p50_all` | `uint32` | `optional` |  |  |
+| 23 | `usec_p99_all` | `uint32` | `optional` |  |  |
+| 31 | `usec_1secmax_avg_active` | `uint32` | `optional` |  |  |
+| 32 | `usec_1secmax_p50_active` | `uint32` | `optional` |  |  |
+| 33 | `usec_1secmax_p95_active` | `uint32` | `optional` |  |  |
+| 34 | `usec_1secmax_p99_active` | `uint32` | `optional` |  |  |
+| 41 | `usec_1secmax_avg_all` | `uint32` | `optional` |  |  |
+| 42 | `usec_1secmax_p50_all` | `uint32` | `optional` |  |  |
+| 43 | `usec_1secmax_p95_all` | `uint32` | `optional` |  |  |
+| 44 | `usec_1secmax_p99_all` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -73,9 +73,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `total` | `.CMsgSource2VProfLiteReportItem` | `optional` | `` |  |
-| 2 | `items` | `.CMsgSource2VProfLiteReportItem` | `repeated` | `` |  |
-| 3 | `discarded_frames` | `uint32` | `optional` | `` |  |
+| 1 | `total` | `.CMsgSource2VProfLiteReportItem` | `optional` |  |  |
+| 2 | `items` | `.CMsgSource2VProfLiteReportItem` | `repeated` |  |  |
+| 3 | `discarded_frames` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -87,50 +87,50 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `duration` | `uint32` | `optional` | `` |  |
-| 5 | `bytes_total` | `uint64` | `optional` | `` |  |
-| 6 | `bytes_total_reliable` | `uint64` | `optional` | `` |  |
-| 7 | `bytes_total_voice` | `uint64` | `optional` | `` |  |
-| 10 | `bytes_sec_p95` | `uint32` | `optional` | `` |  |
-| 11 | `bytes_sec_p99` | `uint32` | `optional` | `` |  |
-| 20 | `enginemsgs_total` | `uint32` | `optional` | `` |  |
-| 21 | `enginemsgs_sec_p95` | `uint32` | `optional` | `` |  |
-| 22 | `enginemsgs_sec_p99` | `uint32` | `optional` | `` |  |
-| 30 | `netframes_total` | `uint32` | `optional` | `` |  |
-| 31 | `netframes_dropped` | `uint32` | `optional` | `` |  |
-| 32 | `netframes_outoforder` | `uint32` | `optional` | `` |  |
-| 34 | `netframes_size_exceeds_mtu` | `uint32` | `optional` | `` |  |
-| 35 | `netframes_size_p95` | `uint32` | `optional` | `` |  |
-| 36 | `netframes_size_p99` | `uint32` | `optional` | `` |  |
-| 40 | `ticks_total` | `uint32` | `optional` | `` |  |
-| 41 | `ticks_good` | `uint32` | `optional` | `` |  |
-| 42 | `ticks_good_almost_late` | `uint32` | `optional` | `` |  |
-| 43 | `ticks_fixed_dropped` | `uint32` | `optional` | `` |  |
-| 44 | `ticks_fixed_late` | `uint32` | `optional` | `` |  |
-| 45 | `ticks_bad_dropped` | `uint32` | `optional` | `` |  |
-| 46 | `ticks_bad_late` | `uint32` | `optional` | `` |  |
-| 47 | `ticks_bad_other` | `uint32` | `optional` | `` |  |
-| 50 | `tick_missrate_samples_total` | `uint32` | `optional` | `` |  |
-| 51 | `tick_missrate_samples_perfect` | `uint32` | `optional` | `` |  |
-| 52 | `tick_missrate_samples_perfectnet` | `uint32` | `optional` | `` |  |
-| 53 | `tick_missratenet_p75_x10` | `uint32` | `optional` | `` |  |
-| 54 | `tick_missratenet_p95_x10` | `uint32` | `optional` | `` |  |
-| 55 | `tick_missratenet_p99_x10` | `uint32` | `optional` | `` |  |
-| 61 | `recvmargin_p1` | `sint32` | `optional` | `` |  |
-| 62 | `recvmargin_p5` | `sint32` | `optional` | `` |  |
-| 63 | `recvmargin_p25` | `sint32` | `optional` | `` |  |
-| 64 | `recvmargin_p50` | `sint32` | `optional` | `` |  |
-| 65 | `recvmargin_p75` | `sint32` | `optional` | `` |  |
-| 66 | `recvmargin_p95` | `sint32` | `optional` | `` |  |
-| 70 | `netframe_jitter_p50` | `uint32` | `optional` | `` |  |
-| 71 | `netframe_jitter_p99` | `uint32` | `optional` | `` |  |
-| 72 | `interval_peakjitter_p50` | `uint32` | `optional` | `` |  |
-| 73 | `interval_peakjitter_p95` | `uint32` | `optional` | `` |  |
-| 74 | `packet_misdelivery_rate_p50_x4` | `uint32` | `optional` | `` |  |
-| 75 | `packet_misdelivery_rate_p95_x4` | `uint32` | `optional` | `` |  |
-| 80 | `net_ping_p5` | `uint32` | `optional` | `` |  |
-| 81 | `net_ping_p50` | `uint32` | `optional` | `` |  |
-| 82 | `net_ping_p95` | `uint32` | `optional` | `` |  |
+| 1 | `duration` | `uint32` | `optional` |  |  |
+| 5 | `bytes_total` | `uint64` | `optional` |  |  |
+| 6 | `bytes_total_reliable` | `uint64` | `optional` |  |  |
+| 7 | `bytes_total_voice` | `uint64` | `optional` |  |  |
+| 10 | `bytes_sec_p95` | `uint32` | `optional` |  |  |
+| 11 | `bytes_sec_p99` | `uint32` | `optional` |  |  |
+| 20 | `enginemsgs_total` | `uint32` | `optional` |  |  |
+| 21 | `enginemsgs_sec_p95` | `uint32` | `optional` |  |  |
+| 22 | `enginemsgs_sec_p99` | `uint32` | `optional` |  |  |
+| 30 | `netframes_total` | `uint32` | `optional` |  |  |
+| 31 | `netframes_dropped` | `uint32` | `optional` |  |  |
+| 32 | `netframes_outoforder` | `uint32` | `optional` |  |  |
+| 34 | `netframes_size_exceeds_mtu` | `uint32` | `optional` |  |  |
+| 35 | `netframes_size_p95` | `uint32` | `optional` |  |  |
+| 36 | `netframes_size_p99` | `uint32` | `optional` |  |  |
+| 40 | `ticks_total` | `uint32` | `optional` |  |  |
+| 41 | `ticks_good` | `uint32` | `optional` |  |  |
+| 42 | `ticks_good_almost_late` | `uint32` | `optional` |  |  |
+| 43 | `ticks_fixed_dropped` | `uint32` | `optional` |  |  |
+| 44 | `ticks_fixed_late` | `uint32` | `optional` |  |  |
+| 45 | `ticks_bad_dropped` | `uint32` | `optional` |  |  |
+| 46 | `ticks_bad_late` | `uint32` | `optional` |  |  |
+| 47 | `ticks_bad_other` | `uint32` | `optional` |  |  |
+| 50 | `tick_missrate_samples_total` | `uint32` | `optional` |  |  |
+| 51 | `tick_missrate_samples_perfect` | `uint32` | `optional` |  |  |
+| 52 | `tick_missrate_samples_perfectnet` | `uint32` | `optional` |  |  |
+| 53 | `tick_missratenet_p75_x10` | `uint32` | `optional` |  |  |
+| 54 | `tick_missratenet_p95_x10` | `uint32` | `optional` |  |  |
+| 55 | `tick_missratenet_p99_x10` | `uint32` | `optional` |  |  |
+| 61 | `recvmargin_p1` | `sint32` | `optional` |  |  |
+| 62 | `recvmargin_p5` | `sint32` | `optional` |  |  |
+| 63 | `recvmargin_p25` | `sint32` | `optional` |  |  |
+| 64 | `recvmargin_p50` | `sint32` | `optional` |  |  |
+| 65 | `recvmargin_p75` | `sint32` | `optional` |  |  |
+| 66 | `recvmargin_p95` | `sint32` | `optional` |  |  |
+| 70 | `netframe_jitter_p50` | `uint32` | `optional` |  |  |
+| 71 | `netframe_jitter_p99` | `uint32` | `optional` |  |  |
+| 72 | `interval_peakjitter_p50` | `uint32` | `optional` |  |  |
+| 73 | `interval_peakjitter_p95` | `uint32` | `optional` |  |  |
+| 74 | `packet_misdelivery_rate_p50_x4` | `uint32` | `optional` |  |  |
+| 75 | `packet_misdelivery_rate_p95_x4` | `uint32` | `optional` |  |  |
+| 80 | `net_ping_p5` | `uint32` | `optional` |  |  |
+| 81 | `net_ping_p50` | `uint32` | `optional` |  |  |
+| 82 | `net_ping_p95` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -142,12 +142,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `frame_time_max_ms` | `float` | `optional` | `` |  |
-| 2 | `frame_time_avg_ms` | `float` | `optional` | `` |  |
-| 3 | `frame_time_min_ms` | `float` | `optional` | `` |  |
-| 4 | `frame_count` | `int32` | `optional` | `` |  |
-| 5 | `frame_time_total_ms` | `float` | `optional` | `` |  |
-| 6 | `tags` | `.CMsgSource2PerfIntervalSample.Tag` | `repeated` | `` |  |
+| 1 | `frame_time_max_ms` | `float` | `optional` |  |  |
+| 2 | `frame_time_avg_ms` | `float` | `optional` |  |  |
+| 3 | `frame_time_min_ms` | `float` | `optional` |  |  |
+| 4 | `frame_count` | `int32` | `optional` |  |  |
+| 5 | `frame_time_total_ms` | `float` | `optional` |  |  |
+| 6 | `tags` | `.CMsgSource2PerfIntervalSample.Tag` | `repeated` |  |  |
 
 </details>
 
@@ -159,8 +159,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tag` | `string` | `optional` | `` |  |
-| 2 | `max_value` | `uint32` | `optional` | `` |  |
+| 1 | `tag` | `string` | `optional` |  |  |
+| 2 | `max_value` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -172,13 +172,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` |  |
-| 2 | `game_mode` | `string` | `optional` | `` |  |
-| 3 | `server_build_id` | `uint32` | `optional` | `` |  |
-| 4 | `server_popid` | `fixed32` | `optional` | `` |  |
-| 10 | `server_profile` | `.CMsgSource2VProfLiteReport` | `optional` | `` |  |
-| 11 | `clients` | `.CSource2Metrics_MatchPerfSummary_Notification.Client` | `repeated` | `` |  |
-| 20 | `map` | `string` | `optional` | `` |  |
+| 1 | `appid` | `uint32` | `optional` |  |  |
+| 2 | `game_mode` | `string` | `optional` |  |  |
+| 3 | `server_build_id` | `uint32` | `optional` |  |  |
+| 4 | `server_popid` | `fixed32` | `optional` |  |  |
+| 10 | `server_profile` | `.CMsgSource2VProfLiteReport` | `optional` |  |  |
+| 11 | `clients` | `.CSource2Metrics_MatchPerfSummary_Notification.Client` | `repeated` |  |  |
+| 20 | `map` | `string` | `optional` |  |  |
 
 </details>
 
@@ -190,13 +190,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `system_specs` | `.CMsgSource2SystemSpecs` | `optional` | `` |  |
-| 2 | `profile` | `.CMsgSource2VProfLiteReport` | `optional` | `` |  |
-| 3 | `build_id` | `uint32` | `optional` | `` |  |
-| 4 | `downstream_flow` | `.CMsgSource2NetworkFlowQuality` | `optional` | `` |  |
-| 5 | `upstream_flow` | `.CMsgSource2NetworkFlowQuality` | `optional` | `` |  |
-| 10 | `steamid` | `fixed64` | `optional` | `` |  |
-| 11 | `perf_samples` | `.CMsgSource2PerfIntervalSample` | `repeated` | `` |  |
+| 1 | `system_specs` | `.CMsgSource2SystemSpecs` | `optional` |  |  |
+| 2 | `profile` | `.CMsgSource2VProfLiteReport` | `optional` |  |  |
+| 3 | `build_id` | `uint32` | `optional` |  |  |
+| 4 | `downstream_flow` | `.CMsgSource2NetworkFlowQuality` | `optional` |  |  |
+| 5 | `upstream_flow` | `.CMsgSource2NetworkFlowQuality` | `optional` |  |  |
+| 10 | `steamid` | `fixed64` | `optional` |  |  |
+| 11 | `perf_samples` | `.CMsgSource2PerfIntervalSample` | `repeated` |  |  |
 
 </details>
 
@@ -208,25 +208,25 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `record_name` | `string` | `optional` | `` |  |
-| 2 | `field_defs` | `.CMsgSource2PlayStatsPackedRecordList.FieldDef` | `repeated` | `` |  |
-| 3 | `record_count` | `uint32` | `optional` | `` |  |
-| 4 | `uint64_vals` | `uint64` | `repeated` | `` | packed = true |
-| 5 | `uint32_vals` | `uint32` | `repeated` | `` | packed = true |
-| 6 | `uint16_vals` | `uint32` | `repeated` | `` | packed = true |
-| 7 | `uint8_vals` | `uint32` | `repeated` | `` | packed = true |
-| 8 | `int64_vals` | `int64` | `repeated` | `` | packed = true |
-| 9 | `int32_vals` | `int32` | `repeated` | `` | packed = true |
-| 10 | `int16_vals` | `int32` | `repeated` | `` | packed = true |
-| 11 | `int8_vals` | `int32` | `repeated` | `` | packed = true |
-| 12 | `float64_vals` | `double` | `repeated` | `` | packed = true |
-| 13 | `float32_vals` | `float` | `repeated` | `` | packed = true |
-| 14 | `bool_vals` | `bool` | `repeated` | `` | packed = true |
-| 15 | `string_vals` | `string` | `repeated` | `` |  |
-| 16 | `low_cardinality_string_vals` | `string` | `repeated` | `` |  |
-| 17 | `utcdatetime_vals` | `fixed32` | `repeated` | `` | packed = true |
-| 18 | `steamidtrustbucket_vals` | `fixed64` | `repeated` | `` | packed = true |
-| 19 | `trustbucket_vals` | `.CMsgSource2PlayStatsPackedRecordList.SteamIDList` | `repeated` | `` |  |
+| 1 | `record_name` | `string` | `optional` |  |  |
+| 2 | `field_defs` | `.CMsgSource2PlayStatsPackedRecordList.FieldDef` | `repeated` |  |  |
+| 3 | `record_count` | `uint32` | `optional` |  |  |
+| 4 | `uint64_vals` | `uint64` | `repeated` |  | packed = true |
+| 5 | `uint32_vals` | `uint32` | `repeated` |  | packed = true |
+| 6 | `uint16_vals` | `uint32` | `repeated` |  | packed = true |
+| 7 | `uint8_vals` | `uint32` | `repeated` |  | packed = true |
+| 8 | `int64_vals` | `int64` | `repeated` |  | packed = true |
+| 9 | `int32_vals` | `int32` | `repeated` |  | packed = true |
+| 10 | `int16_vals` | `int32` | `repeated` |  | packed = true |
+| 11 | `int8_vals` | `int32` | `repeated` |  | packed = true |
+| 12 | `float64_vals` | `double` | `repeated` |  | packed = true |
+| 13 | `float32_vals` | `float` | `repeated` |  | packed = true |
+| 14 | `bool_vals` | `bool` | `repeated` |  | packed = true |
+| 15 | `string_vals` | `string` | `repeated` |  |  |
+| 16 | `low_cardinality_string_vals` | `string` | `repeated` |  |  |
+| 17 | `utcdatetime_vals` | `fixed32` | `repeated` |  | packed = true |
+| 18 | `steamidtrustbucket_vals` | `fixed64` | `repeated` |  | packed = true |
+| 19 | `trustbucket_vals` | `.CMsgSource2PlayStatsPackedRecordList.SteamIDList` | `repeated` |  |  |
 
 </details>
 
@@ -238,8 +238,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `field_name` | `string` | `optional` | `` |  |
-| 2 | `field_type` | `.ESource2PlayStatsFieldType` | `optional` | `` | default = Source2PlayStats_Invalid |
+| 1 | `field_name` | `string` | `optional` |  |  |
+| 2 | `field_type` | `.ESource2PlayStatsFieldType` | `optional` |  | default = Source2PlayStats_Invalid |
 
 </details>
 
@@ -251,7 +251,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `repeated` | `` | packed = true |
+| 1 | `steamid` | `fixed64` | `repeated` |  | packed = true |
 
 </details>
 
@@ -263,8 +263,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `record_types` | `.CMsgSource2PlayStatsPackedRecordList` | `repeated` | `` |  |
-| 2 | `appid` | `uint32` | `optional` | `` |  |
+| 1 | `record_types` | `.CMsgSource2PlayStatsPackedRecordList` | `repeated` |  |  |
+| 2 | `appid` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -276,12 +276,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` |  |
-| 2 | `map_name` | `string` | `optional` | `` |  |
-| 3 | `game_type` | `uint32` | `optional` | `` |  |
-| 4 | `game_mode` | `uint32` | `optional` | `` |  |
-| 5 | `param` | `string` | `optional` | `` |  |
-| 6 | `time_span` | `uint32` | `optional` | `` |  |
+| 1 | `appid` | `uint32` | `optional` |  |  |
+| 2 | `map_name` | `string` | `optional` |  |  |
+| 3 | `game_type` | `uint32` | `optional` |  |  |
+| 4 | `game_mode` | `uint32` | `optional` |  |  |
+| 5 | `param` | `string` | `optional` |  |  |
+| 6 | `time_span` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -293,7 +293,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `results` | `.CSource2Metrics_FetchMapData_Response.MapData` | `repeated` | `` |  |
+| 1 | `results` | `.CSource2Metrics_FetchMapData_Response.MapData` | `repeated` |  |  |
 
 </details>
 
@@ -305,9 +305,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `type` | `string` | `optional` | `` |  |
-| 3 | `data` | `string` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `type` | `string` | `optional` |  |  |
+| 3 | `data` | `string` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/steamdatagram-messages-auth.md
+++ b/docs/cookbook/proto-fields/steamdatagram-messages-auth.md
@@ -23,19 +23,19 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `time_expiry` | `fixed32` | `optional` | `` |  |
-| 2 | `legacy_authorized_steam_id` | `fixed64` | `optional` | `` |  |
-| 3 | `authorized_public_ip` | `fixed32` | `optional` | `` |  |
-| 4 | `legacy_gameserver_steam_id` | `fixed64` | `optional` | `` |  |
-| 7 | `app_id` | `uint32` | `optional` | `` |  |
-| 8 | `extra_fields` | `.CMsgSteamDatagramRelayAuthTicket.ExtraField` | `repeated` | `` |  |
-| 9 | `legacy_gameserver_pop_id` | `fixed32` | `optional` | `` |  |
-| 10 | `virtual_port` | `uint32` | `optional` | `` |  |
-| 11 | `gameserver_address` | `bytes` | `optional` | `` |  |
-| 12 | `legacy_authorized_client_identity_binary` | `bytes` | `optional` | `` |  |
-| 13 | `legacy_gameserver_identity_binary` | `bytes` | `optional` | `` |  |
-| 14 | `authorized_client_identity_string` | `string` | `optional` | `` |  |
-| 15 | `gameserver_identity_string` | `string` | `optional` | `` |  |
+| 1 | `time_expiry` | `fixed32` | `optional` |  |  |
+| 2 | `legacy_authorized_steam_id` | `fixed64` | `optional` |  |  |
+| 3 | `authorized_public_ip` | `fixed32` | `optional` |  |  |
+| 4 | `legacy_gameserver_steam_id` | `fixed64` | `optional` |  |  |
+| 7 | `app_id` | `uint32` | `optional` |  |  |
+| 8 | `extra_fields` | `.CMsgSteamDatagramRelayAuthTicket.ExtraField` | `repeated` |  |  |
+| 9 | `legacy_gameserver_pop_id` | `fixed32` | `optional` |  |  |
+| 10 | `virtual_port` | `uint32` | `optional` |  |  |
+| 11 | `gameserver_address` | `bytes` | `optional` |  |  |
+| 12 | `legacy_authorized_client_identity_binary` | `bytes` | `optional` |  |  |
+| 13 | `legacy_gameserver_identity_binary` | `bytes` | `optional` |  |  |
+| 14 | `authorized_client_identity_string` | `string` | `optional` |  |  |
+| 15 | `gameserver_identity_string` | `string` | `optional` |  |  |
 
 </details>
 
@@ -47,10 +47,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `string_value` | `string` | `optional` | `` |  |
-| 3 | `int64_value` | `sint64` | `optional` | `` |  |
-| 5 | `fixed64_value` | `fixed64` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `string_value` | `string` | `optional` |  |  |
+| 3 | `int64_value` | `sint64` | `optional` |  |  |
+| 5 | `fixed64_value` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -62,11 +62,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `reserved_do_not_use` | `fixed64` | `optional` | `` |  |
-| 2 | `key_id` | `fixed64` | `optional` | `` |  |
-| 3 | `ticket` | `bytes` | `optional` | `` |  |
-| 4 | `signature` | `bytes` | `optional` | `` |  |
-| 5 | `certs` | `.CMsgSteamDatagramCertificateSigned` | `repeated` | `` |  |
+| 1 | `reserved_do_not_use` | `fixed64` | `optional` |  |  |
+| 2 | `key_id` | `fixed64` | `optional` |  |  |
+| 3 | `ticket` | `bytes` | `optional` |  |  |
+| 4 | `signature` | `bytes` | `optional` |  |  |
+| 5 | `certs` | `.CMsgSteamDatagramCertificateSigned` | `repeated` |  |  |
 
 </details>
 
@@ -78,9 +78,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `private_key` | `bytes` | `optional` | `` |  |
-| 2 | `cert` | `bytes` | `optional` | `` |  |
-| 3 | `relay_tickets` | `bytes` | `repeated` | `` |  |
+| 1 | `private_key` | `bytes` | `optional` |  |  |
+| 2 | `cert` | `bytes` | `optional` |  |  |
+| 3 | `relay_tickets` | `bytes` | `repeated` |  |  |
 
 </details>
 
@@ -92,13 +92,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `time_generated` | `uint32` | `optional` | `` |  |
-| 2 | `appid` | `uint32` | `optional` | `` |  |
-| 3 | `routing` | `bytes` | `optional` | `` |  |
-| 4 | `appdata` | `bytes` | `optional` | `` |  |
-| 5 | `legacy_identity_binary` | `bytes` | `optional` | `` |  |
-| 6 | `identity_string` | `string` | `optional` | `` |  |
-| 99 | `dummy_steam_id` | `fixed64` | `optional` | `` |  |
+| 1 | `time_generated` | `uint32` | `optional` |  |  |
+| 2 | `appid` | `uint32` | `optional` |  |  |
+| 3 | `routing` | `bytes` | `optional` |  |  |
+| 4 | `appdata` | `bytes` | `optional` |  |  |
+| 5 | `legacy_identity_binary` | `bytes` | `optional` |  |  |
+| 6 | `identity_string` | `string` | `optional` |  |  |
+| 99 | `dummy_steam_id` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -110,9 +110,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cert` | `.CMsgSteamDatagramCertificateSigned` | `optional` | `` |  |
-| 2 | `login` | `bytes` | `optional` | `` |  |
-| 3 | `signature` | `bytes` | `optional` | `` |  |
+| 1 | `cert` | `.CMsgSteamDatagramCertificateSigned` | `optional` |  |  |
+| 2 | `login` | `bytes` | `optional` |  |  |
+| 3 | `signature` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -124,11 +124,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ipv4` | `fixed32` | `optional` | `` |  |
-| 2 | `ipv6` | `bytes` | `optional` | `` |  |
-| 3 | `port` | `uint32` | `optional` | `` |  |
-| 4 | `routing_secret` | `fixed64` | `optional` | `` |  |
-| 5 | `protocol_version` | `uint32` | `optional` | `` |  |
+| 1 | `ipv4` | `fixed32` | `optional` |  |  |
+| 2 | `ipv6` | `bytes` | `optional` |  |  |
+| 3 | `port` | `uint32` | `optional` |  |  |
+| 4 | `routing_secret` | `fixed64` | `optional` |  |  |
+| 5 | `protocol_version` | `uint32` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/steamdatagram-messages-sdr.md
+++ b/docs/cookbook/proto-fields/steamdatagram-messages-sdr.md
@@ -24,8 +24,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `v4` | `fixed32` | `optional` | `` |  |
-| 2 | `v6` | `bytes` | `optional` | `` |  |
+| 1 | `v4` | `fixed32` | `optional` |  |  |
+| 2 | `v6` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -37,10 +37,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cert` | `.CMsgSteamDatagramCertificateSigned` | `optional` | `` |  |
-| 2 | `signed_data` | `bytes` | `optional` | `` |  |
-| 3 | `signature` | `bytes` | `optional` | `` |  |
-| 1023 | `dummy_pad` | `bytes` | `optional` | `` |  |
+| 1 | `cert` | `.CMsgSteamDatagramCertificateSigned` | `optional` |  |  |
+| 2 | `signed_data` | `bytes` | `optional` |  |  |
+| 3 | `signature` | `bytes` | `optional` |  |  |
+| 1023 | `dummy_pad` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -52,27 +52,27 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `client_timestamp` | `fixed32` | `optional` | `` |  |
-| 2 | `latency_datacenter_ids` | `fixed32` | `repeated` | `` | packed = true |
-| 3 | `latency_ping_ms` | `uint32` | `repeated` | `` | packed = true |
-| 4 | `your_public_ip` | `fixed32` | `optional` | `` |  |
-| 5 | `server_time` | `fixed32` | `optional` | `` |  |
-| 6 | `challenge` | `fixed64` | `optional` | `` |  |
-| 7 | `seconds_until_shutdown` | `uint32` | `optional` | `` |  |
-| 8 | `client_cookie` | `fixed32` | `optional` | `` |  |
-| 9 | `scoring_penalty_relay_cluster` | `uint32` | `optional` | `` |  |
-| 10 | `route_exceptions` | `.CMsgSteamDatagramRouterPingReply.RouteException` | `repeated` | `` |  |
-| 11 | `your_public_port` | `fixed32` | `optional` | `` |  |
-| 12 | `flags` | `uint32` | `optional` | `` |  |
-| 13 | `alt_addresses` | `.CMsgSteamDatagramRouterPingReply.AltAddress` | `repeated` | `` |  |
-| 14 | `latency_datacenter_ids_p2p` | `fixed32` | `repeated` | `` | packed = true |
-| 15 | `latency_ping_ms_p2p` | `uint32` | `repeated` | `` | packed = true |
-| 16 | `recv_tos` | `uint32` | `optional` | `` |  |
-| 17 | `echo_sent_tos` | `uint32` | `optional` | `` |  |
-| 18 | `sent_tos` | `uint32` | `optional` | `` |  |
-| 19 | `echo_request_reply_tos` | `uint32` | `optional` | `` |  |
-| 99 | `dummy_pad` | `bytes` | `optional` | `` |  |
-| 100 | `dummy_varint` | `uint64` | `optional` | `` |  |
+| 1 | `client_timestamp` | `fixed32` | `optional` |  |  |
+| 2 | `latency_datacenter_ids` | `fixed32` | `repeated` |  | packed = true |
+| 3 | `latency_ping_ms` | `uint32` | `repeated` |  | packed = true |
+| 4 | `your_public_ip` | `fixed32` | `optional` |  |  |
+| 5 | `server_time` | `fixed32` | `optional` |  |  |
+| 6 | `challenge` | `fixed64` | `optional` |  |  |
+| 7 | `seconds_until_shutdown` | `uint32` | `optional` |  |  |
+| 8 | `client_cookie` | `fixed32` | `optional` |  |  |
+| 9 | `scoring_penalty_relay_cluster` | `uint32` | `optional` |  |  |
+| 10 | `route_exceptions` | `.CMsgSteamDatagramRouterPingReply.RouteException` | `repeated` |  |  |
+| 11 | `your_public_port` | `fixed32` | `optional` |  |  |
+| 12 | `flags` | `uint32` | `optional` |  |  |
+| 13 | `alt_addresses` | `.CMsgSteamDatagramRouterPingReply.AltAddress` | `repeated` |  |  |
+| 14 | `latency_datacenter_ids_p2p` | `fixed32` | `repeated` |  | packed = true |
+| 15 | `latency_ping_ms_p2p` | `uint32` | `repeated` |  | packed = true |
+| 16 | `recv_tos` | `uint32` | `optional` |  |  |
+| 17 | `echo_sent_tos` | `uint32` | `optional` |  |  |
+| 18 | `sent_tos` | `uint32` | `optional` |  |  |
+| 19 | `echo_request_reply_tos` | `uint32` | `optional` |  |  |
+| 99 | `dummy_pad` | `bytes` | `optional` |  |  |
+| 100 | `dummy_varint` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -84,9 +84,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data_center_id` | `fixed32` | `optional` | `` |  |
-| 2 | `flags` | `uint32` | `optional` | `` |  |
-| 3 | `penalty` | `uint32` | `optional` | `` |  |
+| 1 | `data_center_id` | `fixed32` | `optional` |  |  |
+| 2 | `flags` | `uint32` | `optional` |  |  |
+| 3 | `penalty` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -98,11 +98,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ipv4` | `fixed32` | `optional` | `` |  |
-| 2 | `port` | `uint32` | `optional` | `` |  |
-| 3 | `penalty` | `uint32` | `optional` | `` |  |
-| 4 | `protocol` | `.CMsgSteamDatagramRouterPingReply.AltAddress.Protocol` | `optional` | `` | default = DefaultProtocol |
-| 5 | `id` | `string` | `optional` | `` |  |
+| 1 | `ipv4` | `fixed32` | `optional` |  |  |
+| 2 | `port` | `uint32` | `optional` |  |  |
+| 3 | `penalty` | `uint32` | `optional` |  |  |
+| 4 | `protocol` | `.CMsgSteamDatagramRouterPingReply.AltAddress.Protocol` | `optional` |  | default = DefaultProtocol |
+| 5 | `id` | `string` | `optional` |  |  |
 
 </details>
 
@@ -114,13 +114,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `relay_popid` | `fixed32` | `optional` | `` |  |
-| 2 | `your_public_ip` | `.CMsgSteamNetworkingIPAddress` | `optional` | `` |  |
-| 3 | `your_public_port` | `uint32` | `optional` | `` |  |
-| 4 | `relay_unix_time` | `uint64` | `optional` | `` |  |
-| 5 | `routing_secret` | `fixed64` | `optional` | `` |  |
-| 6 | `my_ips` | `.CMsgSteamNetworkingIPAddress` | `repeated` | `` |  |
-| 8 | `echo` | `bytes` | `optional` | `` |  |
+| 1 | `relay_popid` | `fixed32` | `optional` |  |  |
+| 2 | `your_public_ip` | `.CMsgSteamNetworkingIPAddress` | `optional` |  |  |
+| 3 | `your_public_port` | `uint32` | `optional` |  |  |
+| 4 | `relay_unix_time` | `uint64` | `optional` |  |  |
+| 5 | `routing_secret` | `fixed64` | `optional` |  |  |
+| 6 | `my_ips` | `.CMsgSteamNetworkingIPAddress` | `repeated` |  |  |
+| 8 | `echo` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -132,15 +132,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `legacy_your_public_ip` | `fixed32` | `optional` | `` |  |
-| 2 | `legacy_relay_unix_time` | `fixed32` | `optional` | `` |  |
-| 3 | `legacy_challenge` | `fixed64` | `optional` | `` |  |
-| 4 | `legacy_router_timestamp` | `fixed32` | `optional` | `` |  |
-| 5 | `legacy_your_public_port` | `fixed32` | `optional` | `` |  |
-| 6 | `cert` | `.CMsgSteamDatagramCertificateSigned` | `optional` | `` |  |
-| 7 | `signed_data` | `bytes` | `optional` | `` |  |
-| 8 | `signature` | `bytes` | `optional` | `` |  |
-| 1023 | `dummy_pad` | `bytes` | `optional` | `` |  |
+| 1 | `legacy_your_public_ip` | `fixed32` | `optional` |  |  |
+| 2 | `legacy_relay_unix_time` | `fixed32` | `optional` |  |  |
+| 3 | `legacy_challenge` | `fixed64` | `optional` |  |  |
+| 4 | `legacy_router_timestamp` | `fixed32` | `optional` |  |  |
+| 5 | `legacy_your_public_port` | `fixed32` | `optional` |  |  |
+| 6 | `cert` | `.CMsgSteamDatagramCertificateSigned` | `optional` |  |  |
+| 7 | `signed_data` | `bytes` | `optional` |  |  |
+| 8 | `signature` | `bytes` | `optional` |  |  |
+| 1023 | `dummy_pad` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -152,17 +152,17 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `echo_relay_unix_time` | `fixed32` | `optional` | `` |  |
-| 3 | `legacy_challenge` | `fixed64` | `optional` | `` |  |
-| 4 | `legacy_router_timestamp` | `fixed32` | `optional` | `` |  |
-| 5 | `data_center_id` | `fixed32` | `optional` | `` |  |
-| 6 | `appid` | `uint32` | `optional` | `` |  |
-| 7 | `protocol_version` | `uint32` | `optional` | `` |  |
-| 8 | `echo` | `bytes` | `optional` | `` |  |
-| 9 | `build` | `string` | `optional` | `` |  |
-| 10 | `network_config_version` | `uint64` | `optional` | `` |  |
-| 11 | `my_unix_time` | `fixed32` | `optional` | `` |  |
-| 12 | `routing_blob` | `bytes` | `optional` | `` |  |
+| 2 | `echo_relay_unix_time` | `fixed32` | `optional` |  |  |
+| 3 | `legacy_challenge` | `fixed64` | `optional` |  |  |
+| 4 | `legacy_router_timestamp` | `fixed32` | `optional` |  |  |
+| 5 | `data_center_id` | `fixed32` | `optional` |  |  |
+| 6 | `appid` | `uint32` | `optional` |  |  |
+| 7 | `protocol_version` | `uint32` | `optional` |  |  |
+| 8 | `echo` | `bytes` | `optional` |  |  |
+| 9 | `build` | `string` | `optional` |  |  |
+| 10 | `network_config_version` | `uint64` | `optional` |  |  |
+| 11 | `my_unix_time` | `fixed32` | `optional` |  |  |
+| 12 | `routing_blob` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -174,12 +174,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `your_public_ip` | `fixed32` | `optional` | `` |  |
-| 3 | `server_time` | `fixed32` | `optional` | `` |  |
-| 4 | `challenge` | `fixed64` | `optional` | `` |  |
-| 5 | `seconds_until_shutdown` | `uint32` | `optional` | `` |  |
-| 6 | `your_public_port` | `fixed32` | `optional` | `` |  |
-| 7 | `connection_id` | `fixed32` | `optional` | `` |  |
+| 2 | `your_public_ip` | `fixed32` | `optional` |  |  |
+| 3 | `server_time` | `fixed32` | `optional` |  |  |
+| 4 | `challenge` | `fixed64` | `optional` |  |  |
+| 5 | `seconds_until_shutdown` | `uint32` | `optional` |  |  |
+| 6 | `your_public_port` | `fixed32` | `optional` |  |  |
+| 7 | `connection_id` | `fixed32` | `optional` |  |  |
 
 </details>
 
@@ -191,10 +191,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `legacy_relay_session_id` | `uint32` | `optional` | `` |  |
-| 2 | `from_relay_session_id` | `fixed32` | `optional` | `` |  |
-| 7 | `from_connection_id` | `fixed32` | `optional` | `` |  |
-| 99 | `kludge_pad` | `fixed64` | `optional` | `` |  |
+| 1 | `legacy_relay_session_id` | `uint32` | `optional` |  |  |
+| 2 | `from_relay_session_id` | `fixed32` | `optional` |  |  |
+| 7 | `from_connection_id` | `fixed32` | `optional` |  |  |
+| 99 | `kludge_pad` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -206,9 +206,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `l4s_detect` | `string` | `optional` | `` |  |
-| 2 | `up_ecn1` | `string` | `optional` | `` |  |
-| 3 | `down_dscp45` | `string` | `optional` | `` |  |
+| 1 | `l4s_detect` | `string` | `optional` |  |  |
+| 2 | `up_ecn1` | `string` | `optional` |  |  |
+| 3 | `down_dscp45` | `string` | `optional` |  |  |
 
 </details>
 
@@ -220,7 +220,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `connection_id` | `fixed32` | `optional` | `` |  |
+| 1 | `connection_id` | `fixed32` | `optional` |  |  |
 
 </details>
 
@@ -232,11 +232,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `connection_id` | `fixed32` | `optional` | `` |  |
-| 2 | `pops` | `.CMsgSteamDatagramClientPingSampleReply.POP` | `repeated` | `` |  |
-| 3 | `legacy_data_centers` | `.CMsgSteamDatagramClientPingSampleReply.LegacyDataCenter` | `repeated` | `` |  |
-| 5 | `relay_override_active` | `bool` | `optional` | `` |  |
-| 6 | `tos` | `.CMsgTOSTreatment` | `optional` | `` |  |
+| 1 | `connection_id` | `fixed32` | `optional` |  |  |
+| 2 | `pops` | `.CMsgSteamDatagramClientPingSampleReply.POP` | `repeated` |  |  |
+| 3 | `legacy_data_centers` | `.CMsgSteamDatagramClientPingSampleReply.LegacyDataCenter` | `repeated` |  |  |
+| 5 | `relay_override_active` | `bool` | `optional` |  |  |
+| 6 | `tos` | `.CMsgTOSTreatment` | `optional` |  |  |
 
 </details>
 
@@ -248,22 +248,22 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `pop_id` | `fixed32` | `optional` | `` |  |
-| 2 | `default_front_ping_ms` | `uint32` | `optional` | `` |  |
-| 3 | `default_e2e_ping_ms` | `uint32` | `optional` | `` |  |
-| 4 | `cluster_penalty` | `uint32` | `optional` | `` |  |
-| 5 | `default_e2e_score` | `uint32` | `optional` | `` |  |
-| 6 | `p2p_via_peer_relay_pop_id` | `fixed32` | `optional` | `` |  |
-| 7 | `alt_addresses` | `.CMsgSteamDatagramClientPingSampleReply.POP.AltAddress` | `repeated` | `` |  |
-| 9 | `best_dc_ping_ms` | `uint32` | `optional` | `` |  |
-| 10 | `best_dc_score` | `uint32` | `optional` | `` |  |
-| 11 | `best_dc_via_relay_pop_id` | `fixed32` | `optional` | `` |  |
-| 12 | `default_dc_ping_ms` | `uint32` | `optional` | `` |  |
-| 13 | `default_dc_score` | `uint32` | `optional` | `` |  |
-| 14 | `default_dc_via_relay_pop_id` | `fixed32` | `optional` | `` |  |
-| 15 | `test_dc_ping_ms` | `uint32` | `optional` | `` |  |
-| 16 | `test_dc_score` | `uint32` | `optional` | `` |  |
-| 17 | `test_dc_via_relay_pop_id` | `fixed32` | `optional` | `` |  |
+| 1 | `pop_id` | `fixed32` | `optional` |  |  |
+| 2 | `default_front_ping_ms` | `uint32` | `optional` |  |  |
+| 3 | `default_e2e_ping_ms` | `uint32` | `optional` |  |  |
+| 4 | `cluster_penalty` | `uint32` | `optional` |  |  |
+| 5 | `default_e2e_score` | `uint32` | `optional` |  |  |
+| 6 | `p2p_via_peer_relay_pop_id` | `fixed32` | `optional` |  |  |
+| 7 | `alt_addresses` | `.CMsgSteamDatagramClientPingSampleReply.POP.AltAddress` | `repeated` |  |  |
+| 9 | `best_dc_ping_ms` | `uint32` | `optional` |  |  |
+| 10 | `best_dc_score` | `uint32` | `optional` |  |  |
+| 11 | `best_dc_via_relay_pop_id` | `fixed32` | `optional` |  |  |
+| 12 | `default_dc_ping_ms` | `uint32` | `optional` |  |  |
+| 13 | `default_dc_score` | `uint32` | `optional` |  |  |
+| 14 | `default_dc_via_relay_pop_id` | `fixed32` | `optional` |  |  |
+| 15 | `test_dc_ping_ms` | `uint32` | `optional` |  |  |
+| 16 | `test_dc_score` | `uint32` | `optional` |  |  |
+| 17 | `test_dc_via_relay_pop_id` | `fixed32` | `optional` |  |  |
 
 </details>
 
@@ -275,9 +275,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `string` | `optional` | `` |  |
-| 2 | `front_ping_ms` | `uint32` | `optional` | `` |  |
-| 3 | `penalty` | `uint32` | `optional` | `` |  |
+| 1 | `id` | `string` | `optional` |  |  |
+| 2 | `front_ping_ms` | `uint32` | `optional` |  |  |
+| 3 | `penalty` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -289,9 +289,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data_center_id` | `fixed32` | `optional` | `` |  |
-| 2 | `best_dc_via_relay_pop_id` | `fixed32` | `optional` | `` |  |
-| 3 | `best_dc_ping_ms` | `uint32` | `optional` | `` |  |
+| 1 | `data_center_id` | `fixed32` | `optional` |  |  |
+| 2 | `best_dc_via_relay_pop_id` | `fixed32` | `optional` |  |  |
+| 3 | `best_dc_ping_ms` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -303,18 +303,18 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `connection_id` | `fixed32` | `optional` | `` |  |
-| 2 | `from_ip` | `fixed32` | `optional` | `` |  |
-| 3 | `from_port` | `uint32` | `optional` | `` |  |
-| 4 | `from_router_cluster` | `fixed32` | `optional` | `` |  |
-| 5 | `from_active_time` | `uint32` | `optional` | `` |  |
-| 6 | `from_active_packets_recv` | `uint32` | `optional` | `` |  |
-| 7 | `from_dropped_reason` | `string` | `optional` | `` |  |
-| 8 | `gap_ms` | `uint32` | `optional` | `` |  |
-| 9 | `from_quality_now` | `.CMsgSteamDatagramClientSwitchedPrimary.RouterQuality` | `optional` | `` |  |
-| 10 | `to_quality_now` | `.CMsgSteamDatagramClientSwitchedPrimary.RouterQuality` | `optional` | `` |  |
-| 11 | `from_quality_then` | `.CMsgSteamDatagramClientSwitchedPrimary.RouterQuality` | `optional` | `` |  |
-| 12 | `to_quality_then` | `.CMsgSteamDatagramClientSwitchedPrimary.RouterQuality` | `optional` | `` |  |
+| 1 | `connection_id` | `fixed32` | `optional` |  |  |
+| 2 | `from_ip` | `fixed32` | `optional` |  |  |
+| 3 | `from_port` | `uint32` | `optional` |  |  |
+| 4 | `from_router_cluster` | `fixed32` | `optional` |  |  |
+| 5 | `from_active_time` | `uint32` | `optional` |  |  |
+| 6 | `from_active_packets_recv` | `uint32` | `optional` |  |  |
+| 7 | `from_dropped_reason` | `string` | `optional` |  |  |
+| 8 | `gap_ms` | `uint32` | `optional` |  |  |
+| 9 | `from_quality_now` | `.CMsgSteamDatagramClientSwitchedPrimary.RouterQuality` | `optional` |  |  |
+| 10 | `to_quality_now` | `.CMsgSteamDatagramClientSwitchedPrimary.RouterQuality` | `optional` |  |  |
+| 11 | `from_quality_then` | `.CMsgSteamDatagramClientSwitchedPrimary.RouterQuality` | `optional` |  |  |
+| 12 | `to_quality_then` | `.CMsgSteamDatagramClientSwitchedPrimary.RouterQuality` | `optional` |  |  |
 
 </details>
 
@@ -326,10 +326,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `score` | `uint32` | `optional` | `` |  |
-| 2 | `front_ping` | `uint32` | `optional` | `` |  |
-| 3 | `back_ping` | `uint32` | `optional` | `` |  |
-| 4 | `seconds_until_down` | `uint32` | `optional` | `` |  |
+| 1 | `score` | `uint32` | `optional` |  |  |
+| 2 | `front_ping` | `uint32` | `optional` |  |  |
+| 3 | `back_ping` | `uint32` | `optional` |  |  |
+| 4 | `seconds_until_down` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -341,15 +341,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `connection_id` | `fixed32` | `optional` | `` |  |
-| 2 | `gameserver_relay_session_id` | `uint32` | `optional` | `` |  |
-| 3 | `legacy_client_steam_id` | `fixed64` | `optional` | `` |  |
-| 4 | `my_timestamp` | `fixed64` | `optional` | `` |  |
-| 5 | `ping_est_ms` | `uint32` | `optional` | `` |  |
-| 6 | `crypt` | `.CMsgSteamDatagramSessionCryptInfoSigned` | `optional` | `` |  |
-| 7 | `cert` | `.CMsgSteamDatagramCertificateSigned` | `optional` | `` |  |
-| 9 | `virtual_port` | `uint32` | `optional` | `` |  |
-| 10 | `routing_secret` | `fixed64` | `optional` | `` |  |
+| 1 | `connection_id` | `fixed32` | `optional` |  |  |
+| 2 | `gameserver_relay_session_id` | `uint32` | `optional` |  |  |
+| 3 | `legacy_client_steam_id` | `fixed64` | `optional` |  |  |
+| 4 | `my_timestamp` | `fixed64` | `optional` |  |  |
+| 5 | `ping_est_ms` | `uint32` | `optional` |  |  |
+| 6 | `crypt` | `.CMsgSteamDatagramSessionCryptInfoSigned` | `optional` |  |  |
+| 7 | `cert` | `.CMsgSteamDatagramCertificateSigned` | `optional` |  |  |
+| 9 | `virtual_port` | `uint32` | `optional` |  |  |
+| 10 | `routing_secret` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -361,13 +361,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `client_connection_id` | `fixed32` | `optional` | `` |  |
-| 2 | `gameserver_relay_session_id` | `uint32` | `optional` | `` |  |
-| 3 | `your_timestamp` | `fixed64` | `optional` | `` |  |
-| 4 | `delay_time_usec` | `uint32` | `optional` | `` |  |
-| 5 | `crypt` | `.CMsgSteamDatagramSessionCryptInfoSigned` | `optional` | `` |  |
-| 6 | `cert` | `.CMsgSteamDatagramCertificateSigned` | `optional` | `` |  |
-| 7 | `server_connection_id` | `fixed32` | `optional` | `` |  |
+| 1 | `client_connection_id` | `fixed32` | `optional` |  |  |
+| 2 | `gameserver_relay_session_id` | `uint32` | `optional` |  |  |
+| 3 | `your_timestamp` | `fixed64` | `optional` |  |  |
+| 4 | `delay_time_usec` | `uint32` | `optional` |  |  |
+| 5 | `crypt` | `.CMsgSteamDatagramSessionCryptInfoSigned` | `optional` |  |  |
+| 6 | `cert` | `.CMsgSteamDatagramCertificateSigned` | `optional` |  |  |
+| 7 | `server_connection_id` | `fixed32` | `optional` |  |  |
 
 </details>
 
@@ -379,21 +379,21 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `initial_ping` | `uint32` | `optional` | `` |  |
-| 2 | `initial_ping_front_local` | `uint32` | `optional` | `` |  |
-| 3 | `initial_ping_front_remote` | `uint32` | `optional` | `` |  |
-| 4 | `initial_score` | `uint32` | `optional` | `` |  |
-| 5 | `initial_pop_local` | `fixed32` | `optional` | `` |  |
-| 6 | `initial_pop_remote` | `fixed32` | `optional` | `` |  |
-| 7 | `negotiation_ms` | `uint32` | `optional` | `` |  |
-| 8 | `selected_seconds` | `uint32` | `optional` | `` |  |
-| 11 | `best_ping` | `uint32` | `optional` | `` |  |
-| 12 | `best_ping_front_local` | `uint32` | `optional` | `` |  |
-| 13 | `best_ping_front_remote` | `uint32` | `optional` | `` |  |
-| 14 | `best_score` | `uint32` | `optional` | `` |  |
-| 15 | `best_pop_local` | `fixed32` | `optional` | `` |  |
-| 16 | `best_pop_remote` | `fixed32` | `optional` | `` |  |
-| 17 | `best_time` | `uint32` | `optional` | `` |  |
+| 1 | `initial_ping` | `uint32` | `optional` |  |  |
+| 2 | `initial_ping_front_local` | `uint32` | `optional` |  |  |
+| 3 | `initial_ping_front_remote` | `uint32` | `optional` |  |  |
+| 4 | `initial_score` | `uint32` | `optional` |  |  |
+| 5 | `initial_pop_local` | `fixed32` | `optional` |  |  |
+| 6 | `initial_pop_remote` | `fixed32` | `optional` |  |  |
+| 7 | `negotiation_ms` | `uint32` | `optional` |  |  |
+| 8 | `selected_seconds` | `uint32` | `optional` |  |  |
+| 11 | `best_ping` | `uint32` | `optional` |  |  |
+| 12 | `best_ping_front_local` | `uint32` | `optional` |  |  |
+| 13 | `best_ping_front_remote` | `uint32` | `optional` |  |  |
+| 14 | `best_score` | `uint32` | `optional` |  |  |
+| 15 | `best_pop_local` | `fixed32` | `optional` |  |  |
+| 16 | `best_pop_remote` | `fixed32` | `optional` |  |  |
+| 17 | `best_time` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -405,8 +405,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `ice` | `.CMsgSteamNetworkingICESessionSummary` | `optional` | `` |  |
-| 3 | `sdr` | `.CMsgSteamNetworkingP2PSDRRoutingSummary` | `optional` | `` |  |
+| 2 | `ice` | `.CMsgSteamNetworkingICESessionSummary` | `optional` |  |  |
+| 3 | `sdr` | `.CMsgSteamNetworkingP2PSDRRoutingSummary` | `optional` |  |  |
 
 </details>
 
@@ -418,26 +418,26 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `legacy_gameserver_relay_session_id` | `uint32` | `optional` | `` |  |
-| 3 | `legacy_from_steam_id` | `fixed64` | `optional` | `` |  |
-| 4 | `relay_mode` | `.CMsgSteamDatagramConnectionClosed.ERelayMode` | `optional` | `` | default = None |
-| 5 | `debug` | `string` | `optional` | `` |  |
-| 6 | `reason_code` | `uint32` | `optional` | `` |  |
-| 7 | `to_connection_id` | `fixed32` | `optional` | `` |  |
-| 8 | `from_connection_id` | `fixed32` | `optional` | `` |  |
-| 9 | `to_relay_session_id` | `fixed32` | `optional` | `` |  |
-| 10 | `from_relay_session_id` | `fixed32` | `optional` | `` |  |
-| 11 | `forward_target_relay_routing_token` | `bytes` | `optional` | `` |  |
-| 12 | `forward_target_revision` | `uint32` | `optional` | `` |  |
-| 13 | `legacy_from_identity_binary` | `.CMsgSteamNetworkingIdentityLegacyBinary` | `optional` | `` |  |
-| 14 | `routing_secret` | `fixed64` | `optional` | `` |  |
-| 15 | `from_identity_string` | `string` | `optional` | `` |  |
-| 16 | `not_primary_session` | `bool` | `optional` | `` |  |
-| 17 | `quality_relay` | `.CMsgSteamDatagramConnectionQuality` | `optional` | `` |  |
-| 18 | `quality_e2e` | `.CMsgSteamDatagramConnectionQuality` | `optional` | `` |  |
-| 19 | `not_primary_transport` | `bool` | `optional` | `` |  |
-| 21 | `p2p_routing_summary` | `.CMsgSteamDatagramP2PRoutingSummary` | `optional` | `` |  |
-| 22 | `relay_override_active` | `bool` | `optional` | `` |  |
+| 2 | `legacy_gameserver_relay_session_id` | `uint32` | `optional` |  |  |
+| 3 | `legacy_from_steam_id` | `fixed64` | `optional` |  |  |
+| 4 | `relay_mode` | `.CMsgSteamDatagramConnectionClosed.ERelayMode` | `optional` |  | default = None |
+| 5 | `debug` | `string` | `optional` |  |  |
+| 6 | `reason_code` | `uint32` | `optional` |  |  |
+| 7 | `to_connection_id` | `fixed32` | `optional` |  |  |
+| 8 | `from_connection_id` | `fixed32` | `optional` |  |  |
+| 9 | `to_relay_session_id` | `fixed32` | `optional` |  |  |
+| 10 | `from_relay_session_id` | `fixed32` | `optional` |  |  |
+| 11 | `forward_target_relay_routing_token` | `bytes` | `optional` |  |  |
+| 12 | `forward_target_revision` | `uint32` | `optional` |  |  |
+| 13 | `legacy_from_identity_binary` | `.CMsgSteamNetworkingIdentityLegacyBinary` | `optional` |  |  |
+| 14 | `routing_secret` | `fixed64` | `optional` |  |  |
+| 15 | `from_identity_string` | `string` | `optional` |  |  |
+| 16 | `not_primary_session` | `bool` | `optional` |  |  |
+| 17 | `quality_relay` | `.CMsgSteamDatagramConnectionQuality` | `optional` |  |  |
+| 18 | `quality_e2e` | `.CMsgSteamDatagramConnectionQuality` | `optional` |  |  |
+| 19 | `not_primary_transport` | `bool` | `optional` |  |  |
+| 21 | `p2p_routing_summary` | `.CMsgSteamDatagramP2PRoutingSummary` | `optional` |  |  |
+| 22 | `relay_override_active` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -449,22 +449,22 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `legacy_gameserver_relay_session_id` | `uint32` | `optional` | `` |  |
-| 3 | `legacy_from_steam_id` | `fixed64` | `optional` | `` |  |
-| 4 | `end_to_end` | `bool` | `optional` | `` |  |
-| 5 | `to_connection_id` | `fixed32` | `optional` | `` |  |
-| 6 | `from_connection_id` | `fixed32` | `optional` | `` |  |
-| 7 | `from_identity_string` | `string` | `optional` | `` |  |
-| 9 | `to_relay_session_id` | `fixed32` | `optional` | `` |  |
-| 10 | `from_relay_session_id` | `fixed32` | `optional` | `` |  |
-| 11 | `routing_secret` | `fixed64` | `optional` | `` |  |
-| 12 | `not_primary_session` | `bool` | `optional` | `` |  |
-| 13 | `quality_relay` | `.CMsgSteamDatagramConnectionQuality` | `optional` | `` |  |
-| 14 | `quality_e2e` | `.CMsgSteamDatagramConnectionQuality` | `optional` | `` |  |
-| 15 | `not_primary_transport` | `bool` | `optional` | `` |  |
-| 16 | `p2p_routing_summary` | `.CMsgSteamDatagramP2PRoutingSummary` | `optional` | `` |  |
-| 17 | `relay_override_active` | `bool` | `optional` | `` |  |
-| 1023 | `dummy_pad` | `fixed32` | `optional` | `` |  |
+| 2 | `legacy_gameserver_relay_session_id` | `uint32` | `optional` |  |  |
+| 3 | `legacy_from_steam_id` | `fixed64` | `optional` |  |  |
+| 4 | `end_to_end` | `bool` | `optional` |  |  |
+| 5 | `to_connection_id` | `fixed32` | `optional` |  |  |
+| 6 | `from_connection_id` | `fixed32` | `optional` |  |  |
+| 7 | `from_identity_string` | `string` | `optional` |  |  |
+| 9 | `to_relay_session_id` | `fixed32` | `optional` |  |  |
+| 10 | `from_relay_session_id` | `fixed32` | `optional` |  |  |
+| 11 | `routing_secret` | `fixed64` | `optional` |  |  |
+| 12 | `not_primary_session` | `bool` | `optional` |  |  |
+| 13 | `quality_relay` | `.CMsgSteamDatagramConnectionQuality` | `optional` |  |  |
+| 14 | `quality_e2e` | `.CMsgSteamDatagramConnectionQuality` | `optional` |  |  |
+| 15 | `not_primary_transport` | `bool` | `optional` |  |  |
+| 16 | `p2p_routing_summary` | `.CMsgSteamDatagramP2PRoutingSummary` | `optional` |  |  |
+| 17 | `relay_override_active` | `bool` | `optional` |  |  |
+| 1023 | `dummy_pad` | `fixed32` | `optional` |  |  |
 
 </details>
 
@@ -476,17 +476,17 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ticket` | `bytes` | `optional` | `` |  |
-| 3 | `challenge_time` | `fixed32` | `optional` | `` |  |
-| 4 | `challenge` | `fixed64` | `optional` | `` |  |
-| 5 | `client_connection_id` | `fixed32` | `optional` | `` |  |
-| 6 | `network_config_version` | `uint64` | `optional` | `` |  |
-| 7 | `protocol_version` | `uint32` | `optional` | `` |  |
-| 8 | `server_connection_id` | `fixed32` | `optional` | `` |  |
-| 9 | `platform` | `string` | `optional` | `` |  |
-| 10 | `build` | `string` | `optional` | `` |  |
-| 100 | `dev_gameserver_identity` | `string` | `optional` | `` |  |
-| 101 | `dev_client_cert` | `.CMsgSteamDatagramCertificateSigned` | `optional` | `` |  |
+| 1 | `ticket` | `bytes` | `optional` |  |  |
+| 3 | `challenge_time` | `fixed32` | `optional` |  |  |
+| 4 | `challenge` | `fixed64` | `optional` |  |  |
+| 5 | `client_connection_id` | `fixed32` | `optional` |  |  |
+| 6 | `network_config_version` | `uint64` | `optional` |  |  |
+| 7 | `protocol_version` | `uint32` | `optional` |  |  |
+| 8 | `server_connection_id` | `fixed32` | `optional` |  |  |
+| 9 | `platform` | `string` | `optional` |  |  |
+| 10 | `build` | `string` | `optional` |  |  |
+| 100 | `dev_gameserver_identity` | `string` | `optional` |  |  |
+| 101 | `dev_client_cert` | `.CMsgSteamDatagramCertificateSigned` | `optional` |  |  |
 
 </details>
 
@@ -498,12 +498,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `connection_id` | `fixed32` | `optional` | `` |  |
-| 2 | `gameserver_identity_string` | `string` | `optional` | `` |  |
-| 3 | `legacy_gameserver_steamid` | `fixed64` | `optional` | `` |  |
-| 4 | `seconds_until_shutdown` | `uint32` | `optional` | `` |  |
-| 6 | `seq_num_r2c` | `uint32` | `optional` | `` |  |
-| 7 | `dummy_legacy_identity_binary` | `bytes` | `optional` | `` |  |
+| 1 | `connection_id` | `fixed32` | `optional` |  |  |
+| 2 | `gameserver_identity_string` | `string` | `optional` |  |  |
+| 3 | `legacy_gameserver_steamid` | `fixed64` | `optional` |  |  |
+| 4 | `seconds_until_shutdown` | `uint32` | `optional` |  |  |
+| 6 | `seq_num_r2c` | `uint32` | `optional` |  |  |
+| 7 | `dummy_legacy_identity_binary` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -515,14 +515,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `quality_relay` | `.CMsgSteamDatagramConnectionQuality` | `optional` | `` |  |
-| 2 | `quality_e2e` | `.CMsgSteamDatagramConnectionQuality` | `optional` | `` |  |
-| 4 | `ack_relay` | `fixed32` | `repeated` | `` |  |
-| 5 | `legacy_ack_e2e` | `fixed32` | `repeated` | `` |  |
-| 6 | `flags` | `uint32` | `optional` | `` |  |
-| 8 | `client_connection_id` | `fixed32` | `optional` | `` |  |
-| 9 | `seq_num_c2r` | `uint32` | `optional` | `` |  |
-| 10 | `seq_num_e2e` | `uint32` | `optional` | `` |  |
+| 1 | `quality_relay` | `.CMsgSteamDatagramConnectionQuality` | `optional` |  |  |
+| 2 | `quality_e2e` | `.CMsgSteamDatagramConnectionQuality` | `optional` |  |  |
+| 4 | `ack_relay` | `fixed32` | `repeated` |  |  |
+| 5 | `legacy_ack_e2e` | `fixed32` | `repeated` |  |  |
+| 6 | `flags` | `uint32` | `optional` |  |  |
+| 8 | `client_connection_id` | `fixed32` | `optional` |  |  |
+| 9 | `seq_num_c2r` | `uint32` | `optional` |  |  |
+| 10 | `seq_num_e2e` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -534,18 +534,18 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `quality_relay` | `.CMsgSteamDatagramConnectionQuality` | `optional` | `` |  |
-| 2 | `quality_e2e` | `.CMsgSteamDatagramConnectionQuality` | `optional` | `` |  |
-| 6 | `seconds_until_shutdown` | `uint32` | `optional` | `` |  |
-| 7 | `client_connection_id` | `fixed32` | `optional` | `` |  |
-| 8 | `seq_num_r2c` | `uint32` | `optional` | `` |  |
-| 9 | `seq_num_e2e` | `uint32` | `optional` | `` |  |
-| 10 | `migrate_request_ip` | `fixed32` | `optional` | `` |  |
-| 11 | `migrate_request_port` | `uint32` | `optional` | `` |  |
-| 12 | `scoring_penalty_relay_cluster` | `uint32` | `optional` | `` |  |
-| 13 | `ack_relay` | `fixed32` | `repeated` | `` |  |
-| 14 | `legacy_ack_e2e` | `fixed32` | `repeated` | `` |  |
-| 15 | `flags` | `uint32` | `optional` | `` |  |
+| 1 | `quality_relay` | `.CMsgSteamDatagramConnectionQuality` | `optional` |  |  |
+| 2 | `quality_e2e` | `.CMsgSteamDatagramConnectionQuality` | `optional` |  |  |
+| 6 | `seconds_until_shutdown` | `uint32` | `optional` |  |  |
+| 7 | `client_connection_id` | `fixed32` | `optional` |  |  |
+| 8 | `seq_num_r2c` | `uint32` | `optional` |  |  |
+| 9 | `seq_num_e2e` | `uint32` | `optional` |  |  |
+| 10 | `migrate_request_ip` | `fixed32` | `optional` |  |  |
+| 11 | `migrate_request_port` | `uint32` | `optional` |  |  |
+| 12 | `scoring_penalty_relay_cluster` | `uint32` | `optional` |  |  |
+| 13 | `ack_relay` | `fixed32` | `repeated` |  |  |
+| 14 | `legacy_ack_e2e` | `fixed32` | `repeated` |  |  |
+| 15 | `flags` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -557,19 +557,19 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `quality_relay` | `.CMsgSteamDatagramConnectionQuality` | `optional` | `` |  |
-| 2 | `quality_e2e` | `.CMsgSteamDatagramConnectionQuality` | `optional` | `` |  |
-| 5 | `seq_num_r2s` | `uint32` | `optional` | `` |  |
-| 6 | `seq_num_e2e` | `uint32` | `optional` | `` |  |
-| 7 | `legacy_client_steam_id` | `fixed64` | `optional` | `` |  |
-| 8 | `relay_session_id` | `uint32` | `optional` | `` |  |
-| 9 | `client_connection_id` | `fixed32` | `optional` | `` |  |
-| 10 | `ack_relay` | `fixed32` | `repeated` | `` |  |
-| 11 | `legacy_ack_e2e` | `fixed32` | `repeated` | `` |  |
-| 12 | `flags` | `uint32` | `optional` | `` |  |
-| 13 | `server_connection_id` | `fixed32` | `optional` | `` |  |
-| 14 | `routing_secret` | `fixed64` | `optional` | `` |  |
-| 15 | `client_identity_string` | `string` | `optional` | `` |  |
+| 1 | `quality_relay` | `.CMsgSteamDatagramConnectionQuality` | `optional` |  |  |
+| 2 | `quality_e2e` | `.CMsgSteamDatagramConnectionQuality` | `optional` |  |  |
+| 5 | `seq_num_r2s` | `uint32` | `optional` |  |  |
+| 6 | `seq_num_e2e` | `uint32` | `optional` |  |  |
+| 7 | `legacy_client_steam_id` | `fixed64` | `optional` |  |  |
+| 8 | `relay_session_id` | `uint32` | `optional` |  |  |
+| 9 | `client_connection_id` | `fixed32` | `optional` |  |  |
+| 10 | `ack_relay` | `fixed32` | `repeated` |  |  |
+| 11 | `legacy_ack_e2e` | `fixed32` | `repeated` |  |  |
+| 12 | `flags` | `uint32` | `optional` |  |  |
+| 13 | `server_connection_id` | `fixed32` | `optional` |  |  |
+| 14 | `routing_secret` | `fixed64` | `optional` |  |  |
+| 15 | `client_identity_string` | `string` | `optional` |  |  |
 
 </details>
 
@@ -581,16 +581,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `quality_relay` | `.CMsgSteamDatagramConnectionQuality` | `optional` | `` |  |
-| 2 | `quality_e2e` | `.CMsgSteamDatagramConnectionQuality` | `optional` | `` |  |
-| 3 | `seq_num_s2r` | `uint32` | `optional` | `` |  |
-| 4 | `seq_num_e2e` | `uint32` | `optional` | `` |  |
-| 6 | `relay_session_id` | `uint32` | `optional` | `` |  |
-| 7 | `client_connection_id` | `fixed32` | `optional` | `` |  |
-| 8 | `ack_relay` | `fixed32` | `repeated` | `` |  |
-| 9 | `legacy_ack_e2e` | `fixed32` | `repeated` | `` |  |
-| 10 | `flags` | `uint32` | `optional` | `` |  |
-| 11 | `server_connection_id` | `fixed32` | `optional` | `` |  |
+| 1 | `quality_relay` | `.CMsgSteamDatagramConnectionQuality` | `optional` |  |  |
+| 2 | `quality_e2e` | `.CMsgSteamDatagramConnectionQuality` | `optional` |  |  |
+| 3 | `seq_num_s2r` | `uint32` | `optional` |  |  |
+| 4 | `seq_num_e2e` | `uint32` | `optional` |  |  |
+| 6 | `relay_session_id` | `uint32` | `optional` |  |  |
+| 7 | `client_connection_id` | `fixed32` | `optional` |  |  |
+| 8 | `ack_relay` | `fixed32` | `repeated` |  |  |
+| 9 | `legacy_ack_e2e` | `fixed32` | `repeated` |  |  |
+| 10 | `flags` | `uint32` | `optional` |  |  |
+| 11 | `server_connection_id` | `fixed32` | `optional` |  |  |
 
 </details>
 
@@ -602,19 +602,19 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `challenge_time` | `fixed32` | `optional` | `` |  |
-| 2 | `challenge` | `fixed64` | `optional` | `` |  |
-| 3 | `client_connection_id` | `fixed32` | `optional` | `` |  |
-| 4 | `legacy_peer_steam_id` | `fixed64` | `optional` | `` |  |
-| 5 | `peer_connection_id` | `fixed32` | `optional` | `` |  |
-| 8 | `protocol_version` | `uint32` | `optional` | `` |  |
-| 9 | `network_config_version` | `uint64` | `optional` | `` |  |
-| 11 | `peer_identity_string` | `string` | `optional` | `` |  |
-| 12 | `platform` | `string` | `optional` | `` |  |
-| 13 | `build` | `string` | `optional` | `` |  |
-| 14 | `encrypted_data` | `bytes` | `optional` | `` |  |
-| 15 | `encryption_your_public_key_lead_byte` | `uint32` | `optional` | `` |  |
-| 16 | `encryption_my_ephemeral_public_key` | `bytes` | `optional` | `` |  |
+| 1 | `challenge_time` | `fixed32` | `optional` |  |  |
+| 2 | `challenge` | `fixed64` | `optional` |  |  |
+| 3 | `client_connection_id` | `fixed32` | `optional` |  |  |
+| 4 | `legacy_peer_steam_id` | `fixed64` | `optional` |  |  |
+| 5 | `peer_connection_id` | `fixed32` | `optional` |  |  |
+| 8 | `protocol_version` | `uint32` | `optional` |  |  |
+| 9 | `network_config_version` | `uint64` | `optional` |  |  |
+| 11 | `peer_identity_string` | `string` | `optional` |  |  |
+| 12 | `platform` | `string` | `optional` |  |  |
+| 13 | `build` | `string` | `optional` |  |  |
+| 14 | `encrypted_data` | `bytes` | `optional` |  |  |
+| 15 | `encryption_your_public_key_lead_byte` | `uint32` | `optional` |  |  |
+| 16 | `encryption_my_ephemeral_public_key` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -626,7 +626,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `peer_identity_string` | `string` | `optional` | `` |  |
+| 1 | `peer_identity_string` | `string` | `optional` |  |  |
 
 </details>
 
@@ -638,9 +638,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cert` | `.CMsgSteamDatagramCertificateSigned` | `optional` | `` |  |
-| 2 | `body` | `bytes` | `optional` | `` |  |
-| 3 | `signature` | `bytes` | `optional` | `` |  |
+| 1 | `cert` | `.CMsgSteamDatagramCertificateSigned` | `optional` |  |  |
+| 2 | `body` | `bytes` | `optional` |  |  |
+| 3 | `signature` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -652,10 +652,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `connection_id` | `fixed32` | `optional` | `` |  |
-| 3 | `seconds_until_shutdown` | `uint32` | `optional` | `` |  |
-| 4 | `relay_routing_token` | `bytes` | `optional` | `` |  |
-| 5 | `seq_num_r2c` | `uint32` | `optional` | `` |  |
+| 1 | `connection_id` | `fixed32` | `optional` |  |  |
+| 3 | `seconds_until_shutdown` | `uint32` | `optional` |  |  |
+| 4 | `relay_routing_token` | `bytes` | `optional` |  |  |
+| 5 | `seq_num_r2c` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -667,19 +667,19 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `quality_relay` | `.CMsgSteamDatagramConnectionQuality` | `optional` | `` |  |
-| 2 | `quality_e2e` | `.CMsgSteamDatagramConnectionQuality` | `optional` | `` |  |
-| 3 | `ack_relay` | `fixed32` | `repeated` | `` |  |
-| 4 | `legacy_ack_e2e` | `fixed32` | `repeated` | `` |  |
-| 5 | `flags` | `uint32` | `optional` | `` |  |
-| 6 | `forward_target_relay_routing_token` | `bytes` | `optional` | `` |  |
-| 7 | `forward_target_revision` | `uint32` | `optional` | `` |  |
-| 8 | `routes` | `bytes` | `optional` | `` |  |
-| 9 | `ack_peer_routes_revision` | `uint32` | `optional` | `` |  |
-| 10 | `connection_id` | `fixed32` | `optional` | `` |  |
-| 11 | `seq_num_c2r` | `uint32` | `optional` | `` |  |
-| 12 | `seq_num_e2e` | `uint32` | `optional` | `` |  |
-| 14 | `p2p_routing_summary` | `.CMsgSteamDatagramP2PRoutingSummary` | `optional` | `` |  |
+| 1 | `quality_relay` | `.CMsgSteamDatagramConnectionQuality` | `optional` |  |  |
+| 2 | `quality_e2e` | `.CMsgSteamDatagramConnectionQuality` | `optional` |  |  |
+| 3 | `ack_relay` | `fixed32` | `repeated` |  |  |
+| 4 | `legacy_ack_e2e` | `fixed32` | `repeated` |  |  |
+| 5 | `flags` | `uint32` | `optional` |  |  |
+| 6 | `forward_target_relay_routing_token` | `bytes` | `optional` |  |  |
+| 7 | `forward_target_revision` | `uint32` | `optional` |  |  |
+| 8 | `routes` | `bytes` | `optional` |  |  |
+| 9 | `ack_peer_routes_revision` | `uint32` | `optional` |  |  |
+| 10 | `connection_id` | `fixed32` | `optional` |  |  |
+| 11 | `seq_num_c2r` | `uint32` | `optional` |  |  |
+| 12 | `seq_num_e2e` | `uint32` | `optional` |  |  |
+| 14 | `p2p_routing_summary` | `.CMsgSteamDatagramP2PRoutingSummary` | `optional` |  |  |
 
 </details>
 
@@ -691,21 +691,21 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `quality_relay` | `.CMsgSteamDatagramConnectionQuality` | `optional` | `` |  |
-| 2 | `quality_e2e` | `.CMsgSteamDatagramConnectionQuality` | `optional` | `` |  |
-| 3 | `seconds_until_shutdown` | `uint32` | `optional` | `` |  |
-| 4 | `migrate_request_ip` | `fixed32` | `optional` | `` |  |
-| 5 | `migrate_request_port` | `uint32` | `optional` | `` |  |
-| 6 | `scoring_penalty_relay_cluster` | `uint32` | `optional` | `` |  |
-| 7 | `ack_relay` | `fixed32` | `repeated` | `` |  |
-| 8 | `legacy_ack_e2e` | `fixed32` | `repeated` | `` |  |
-| 9 | `flags` | `uint32` | `optional` | `` |  |
-| 10 | `ack_forward_target_revision` | `uint32` | `optional` | `` |  |
-| 11 | `routes` | `bytes` | `optional` | `` |  |
-| 12 | `ack_peer_routes_revision` | `uint32` | `optional` | `` |  |
-| 13 | `connection_id` | `fixed32` | `optional` | `` |  |
-| 14 | `seq_num_r2c` | `uint32` | `optional` | `` |  |
-| 15 | `seq_num_e2e` | `uint32` | `optional` | `` |  |
+| 1 | `quality_relay` | `.CMsgSteamDatagramConnectionQuality` | `optional` |  |  |
+| 2 | `quality_e2e` | `.CMsgSteamDatagramConnectionQuality` | `optional` |  |  |
+| 3 | `seconds_until_shutdown` | `uint32` | `optional` |  |  |
+| 4 | `migrate_request_ip` | `fixed32` | `optional` |  |  |
+| 5 | `migrate_request_port` | `uint32` | `optional` |  |  |
+| 6 | `scoring_penalty_relay_cluster` | `uint32` | `optional` |  |  |
+| 7 | `ack_relay` | `fixed32` | `repeated` |  |  |
+| 8 | `legacy_ack_e2e` | `fixed32` | `repeated` |  |  |
+| 9 | `flags` | `uint32` | `optional` |  |  |
+| 10 | `ack_forward_target_revision` | `uint32` | `optional` |  |  |
+| 11 | `routes` | `bytes` | `optional` |  |  |
+| 12 | `ack_peer_routes_revision` | `uint32` | `optional` |  |  |
+| 13 | `connection_id` | `fixed32` | `optional` |  |  |
+| 14 | `seq_num_r2c` | `uint32` | `optional` |  |  |
+| 15 | `seq_num_e2e` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -717,10 +717,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `connection_id` | `fixed32` | `optional` | `` |  |
-| 2 | `failed_relay_routing_token` | `bytes` | `optional` | `` |  |
-| 3 | `ack_forward_target_revision` | `uint32` | `optional` | `` |  |
-| 99 | `kludge_pad` | `fixed64` | `optional` | `` |  |
+| 1 | `connection_id` | `fixed32` | `optional` |  |  |
+| 2 | `failed_relay_routing_token` | `bytes` | `optional` |  |  |
+| 3 | `ack_forward_target_revision` | `uint32` | `optional` |  |  |
+| 99 | `kludge_pad` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -732,9 +732,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `relay_clusters` | `.CMsgSteamDatagramP2PRoutes.RelayCluster` | `repeated` | `` |  |
-| 2 | `routes` | `.CMsgSteamDatagramP2PRoutes.Route` | `repeated` | `` |  |
-| 3 | `revision` | `uint32` | `optional` | `` |  |
+| 1 | `relay_clusters` | `.CMsgSteamDatagramP2PRoutes.RelayCluster` | `repeated` |  |  |
+| 2 | `routes` | `.CMsgSteamDatagramP2PRoutes.Route` | `repeated` |  |  |
+| 3 | `revision` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -746,10 +746,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `pop_id` | `fixed32` | `optional` | `` |  |
-| 2 | `ping_ms` | `uint32` | `optional` | `` |  |
-| 3 | `score_penalty` | `uint32` | `optional` | `` |  |
-| 4 | `session_relay_routing_token` | `bytes` | `optional` | `` |  |
+| 1 | `pop_id` | `fixed32` | `optional` |  |  |
+| 2 | `ping_ms` | `uint32` | `optional` |  |  |
+| 3 | `score_penalty` | `uint32` | `optional` |  |  |
+| 4 | `session_relay_routing_token` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -761,10 +761,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `my_pop_id` | `fixed32` | `optional` | `` |  |
-| 2 | `your_pop_id` | `fixed32` | `optional` | `` |  |
-| 3 | `legacy_score` | `uint32` | `optional` | `` |  |
-| 4 | `interior_score` | `uint32` | `optional` | `` |  |
+| 1 | `my_pop_id` | `fixed32` | `optional` |  |  |
+| 2 | `your_pop_id` | `fixed32` | `optional` |  |  |
+| 3 | `legacy_score` | `uint32` | `optional` |  |  |
+| 4 | `interior_score` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -776,12 +776,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `client_main_ip` | `fixed32` | `optional` | `` |  |
-| 2 | `client_main_port` | `fixed32` | `optional` | `` |  |
-| 3 | `client_connection_id` | `fixed32` | `optional` | `` |  |
-| 4 | `client_identity` | `string` | `optional` | `` |  |
-| 5 | `request_send_duplication` | `bool` | `optional` | `` |  |
-| 99 | `kludge_pad` | `bytes` | `optional` | `` |  |
+| 1 | `client_main_ip` | `fixed32` | `optional` |  |  |
+| 2 | `client_main_port` | `fixed32` | `optional` |  |  |
+| 3 | `client_connection_id` | `fixed32` | `optional` |  |  |
+| 4 | `client_identity` | `string` | `optional` |  |  |
+| 5 | `request_send_duplication` | `bool` | `optional` |  |  |
+| 99 | `kludge_pad` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -793,8 +793,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `success` | `bool` | `optional` | `` |  |
-| 2 | `message` | `string` | `optional` | `` |  |
+| 1 | `success` | `bool` | `optional` |  |  |
+| 2 | `message` | `string` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/steammessages-base.md
+++ b/docs/cookbook/proto-fields/steammessages-base.md
@@ -36,8 +36,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `original_ip_address` | `.CMsgIPAddress` | `optional` | `` |  |
-| 2 | `bucket` | `fixed64` | `optional` | `` |  |
+| 1 | `original_ip_address` | `.CMsgIPAddress` | `optional` |  |  |
+| 2 | `bucket` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -49,33 +49,33 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `optional` | `` |  |
-| 2 | `client_sessionid` | `int32` | `optional` | `` |  |
-| 3 | `routing_appid` | `uint32` | `optional` | `` |  |
-| 10 | `jobid_source` | `fixed64` | `optional` | `` | default = 18446744073709551615 |
-| 11 | `jobid_target` | `fixed64` | `optional` | `` | default = 18446744073709551615 |
-| 12 | `target_job_name` | `string` | `optional` | `` |  |
-| 13 | `eresult` | `int32` | `optional` | `` | default = 2 |
-| 14 | `error_message` | `string` | `optional` | `` |  |
+| 1 | `steamid` | `fixed64` | `optional` |  |  |
+| 2 | `client_sessionid` | `int32` | `optional` |  |  |
+| 3 | `routing_appid` | `uint32` | `optional` |  |  |
+| 10 | `jobid_source` | `fixed64` | `optional` |  | default = 18446744073709551615 |
+| 11 | `jobid_target` | `fixed64` | `optional` |  | default = 18446744073709551615 |
+| 12 | `target_job_name` | `string` | `optional` |  |  |
+| 13 | `eresult` | `int32` | `optional` |  | default = 2 |
+| 14 | `error_message` | `string` | `optional` |  |  |
 | 15 | `ip` | `uint32` | `oneof` | `ip_addr` |  |
-| 16 | `auth_account_flags` | `uint32` | `optional` | `` |  |
-| 17 | `transport_error` | `int32` | `optional` | `` | default = 1 |
-| 18 | `messageid` | `uint64` | `optional` | `` | default = 18446744073709551615 |
-| 19 | `publisher_group_id` | `uint32` | `optional` | `` |  |
-| 20 | `sysid` | `uint32` | `optional` | `` |  |
-| 21 | `trace_tag` | `uint64` | `optional` | `` |  |
-| 22 | `token_source` | `uint32` | `optional` | `` |  |
-| 23 | `admin_spoofing_user` | `bool` | `optional` | `` |  |
-| 24 | `seq_num` | `int32` | `optional` | `` |  |
-| 25 | `webapi_key_id` | `uint32` | `optional` | `` |  |
-| 26 | `is_from_external_source` | `bool` | `optional` | `` |  |
-| 27 | `forward_to_sysid` | `uint32` | `repeated` | `` |  |
-| 28 | `cm_sysid` | `uint32` | `optional` | `` |  |
+| 16 | `auth_account_flags` | `uint32` | `optional` |  |  |
+| 17 | `transport_error` | `int32` | `optional` |  | default = 1 |
+| 18 | `messageid` | `uint64` | `optional` |  | default = 18446744073709551615 |
+| 19 | `publisher_group_id` | `uint32` | `optional` |  |  |
+| 20 | `sysid` | `uint32` | `optional` |  |  |
+| 21 | `trace_tag` | `uint64` | `optional` |  |  |
+| 22 | `token_source` | `uint32` | `optional` |  |  |
+| 23 | `admin_spoofing_user` | `bool` | `optional` |  |  |
+| 24 | `seq_num` | `int32` | `optional` |  |  |
+| 25 | `webapi_key_id` | `uint32` | `optional` |  |  |
+| 26 | `is_from_external_source` | `bool` | `optional` |  |  |
+| 27 | `forward_to_sysid` | `uint32` | `repeated` |  |  |
+| 28 | `cm_sysid` | `uint32` | `optional` |  |  |
 | 29 | `ip_v6` | `bytes` | `oneof` | `ip_addr` |  |
-| 31 | `launcher_type` | `uint32` | `optional` | `` | default = 0 |
-| 32 | `realm` | `uint32` | `optional` | `` | default = 0 |
-| 33 | `timeout_ms` | `int32` | `optional` | `` | default = -1 |
-| 34 | `debug_source` | `string` | `optional` | `` |  |
+| 31 | `launcher_type` | `uint32` | `optional` |  | default = 0 |
+| 32 | `realm` | `uint32` | `optional` |  | default = 0 |
+| 33 | `timeout_ms` | `int32` | `optional` |  | default = -1 |
+| 34 | `debug_source` | `string` | `optional` |  |  |
 
 </details>
 
@@ -87,8 +87,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `size_unzipped` | `uint32` | `optional` | `` |  |
-| 2 | `message_body` | `bytes` | `optional` | `` |  |
+| 1 | `size_unzipped` | `uint32` | `optional` |  |  |
+| 2 | `message_body` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -100,7 +100,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `message_body` | `bytes` | `optional` | `` |  |
+| 1 | `message_body` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -112,13 +112,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `estate` | `uint32` | `optional` | `` |  |
-| 2 | `eresult` | `uint32` | `optional` | `` | default = 2 |
-| 3 | `steamid` | `fixed64` | `optional` | `` |  |
-| 4 | `gameid` | `fixed64` | `optional` | `` |  |
-| 5 | `h_steam_pipe` | `uint32` | `optional` | `` |  |
-| 6 | `ticket_crc` | `uint32` | `optional` | `` |  |
-| 7 | `ticket` | `bytes` | `optional` | `` |  |
+| 1 | `estate` | `uint32` | `optional` |  |  |
+| 2 | `eresult` | `uint32` | `optional` |  | default = 2 |
+| 3 | `steamid` | `fixed64` | `optional` |  |  |
+| 4 | `gameid` | `fixed64` | `optional` |  |  |
+| 5 | `h_steam_pipe` | `uint32` | `optional` |  |  |
+| 6 | `ticket_crc` | `uint32` | `optional` |  |  |
+| 7 | `ticket` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -130,18 +130,18 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `icon` | `string` | `optional` | `` |  |
-| 6 | `tool` | `bool` | `optional` | `` |  |
-| 7 | `demo` | `bool` | `optional` | `` |  |
-| 8 | `media` | `bool` | `optional` | `` |  |
-| 9 | `community_visible_stats` | `bool` | `optional` | `` |  |
-| 10 | `friendly_name` | `string` | `optional` | `` |  |
-| 11 | `propagation` | `string` | `optional` | `` |  |
-| 12 | `has_adult_content` | `bool` | `optional` | `` |  |
-| 13 | `is_visible_in_steam_china` | `bool` | `optional` | `` |  |
-| 14 | `app_type` | `uint32` | `optional` | `` |  |
+| 1 | `appid` | `uint32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `icon` | `string` | `optional` |  |  |
+| 6 | `tool` | `bool` | `optional` |  |  |
+| 7 | `demo` | `bool` | `optional` |  |  |
+| 8 | `media` | `bool` | `optional` |  |  |
+| 9 | `community_visible_stats` | `bool` | `optional` |  |  |
+| 10 | `friendly_name` | `string` | `optional` |  |  |
+| 11 | `propagation` | `string` | `optional` |  |  |
+| 12 | `has_adult_content` | `bool` | `optional` |  |  |
+| 13 | `is_visible_in_steam_china` | `bool` | `optional` |  |  |
+| 14 | `app_type` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -153,23 +153,23 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `edit_info` | `bool` | `optional` | `` |  |
-| 2 | `publish` | `bool` | `optional` | `` |  |
-| 3 | `view_error_data` | `bool` | `optional` | `` |  |
-| 4 | `download` | `bool` | `optional` | `` |  |
-| 5 | `upload_cdkeys` | `bool` | `optional` | `` |  |
-| 6 | `generate_cdkeys` | `bool` | `optional` | `` |  |
-| 7 | `view_financials` | `bool` | `optional` | `` |  |
-| 8 | `manage_ceg` | `bool` | `optional` | `` |  |
-| 9 | `manage_signing` | `bool` | `optional` | `` |  |
-| 10 | `manage_cdkeys` | `bool` | `optional` | `` |  |
-| 11 | `edit_marketing` | `bool` | `optional` | `` |  |
-| 12 | `economy_support` | `bool` | `optional` | `` |  |
-| 13 | `economy_support_supervisor` | `bool` | `optional` | `` |  |
-| 14 | `manage_pricing` | `bool` | `optional` | `` |  |
-| 15 | `broadcast_live` | `bool` | `optional` | `` |  |
-| 16 | `view_marketing_traffic` | `bool` | `optional` | `` |  |
-| 17 | `edit_store_display_content` | `bool` | `optional` | `` |  |
+| 1 | `edit_info` | `bool` | `optional` |  |  |
+| 2 | `publish` | `bool` | `optional` |  |  |
+| 3 | `view_error_data` | `bool` | `optional` |  |  |
+| 4 | `download` | `bool` | `optional` |  |  |
+| 5 | `upload_cdkeys` | `bool` | `optional` |  |  |
+| 6 | `generate_cdkeys` | `bool` | `optional` |  |  |
+| 7 | `view_financials` | `bool` | `optional` |  |  |
+| 8 | `manage_ceg` | `bool` | `optional` |  |  |
+| 9 | `manage_signing` | `bool` | `optional` |  |  |
+| 10 | `manage_cdkeys` | `bool` | `optional` |  |  |
+| 11 | `edit_marketing` | `bool` | `optional` |  |  |
+| 12 | `economy_support` | `bool` | `optional` |  |  |
+| 13 | `economy_support_supervisor` | `bool` | `optional` |  |  |
+| 14 | `manage_pricing` | `bool` | `optional` |  |  |
+| 15 | `broadcast_live` | `bool` | `optional` |  |  |
+| 16 | `view_marketing_traffic` | `bool` | `optional` |  |  |
+| 17 | `edit_store_display_content` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -181,20 +181,20 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `supported_languages` | `uint32` | `optional` | `` |  |
-| 2 | `platform_windows` | `bool` | `optional` | `` |  |
-| 3 | `platform_mac` | `bool` | `optional` | `` |  |
-| 4 | `platform_linux` | `bool` | `optional` | `` |  |
-| 5 | `vr_content` | `bool` | `optional` | `` |  |
-| 6 | `adult_content_violence` | `bool` | `optional` | `` |  |
-| 7 | `adult_content_sex` | `bool` | `optional` | `` |  |
-| 8 | `timestamp_updated` | `uint32` | `optional` | `` |  |
-| 9 | `tagids_curated` | `uint32` | `repeated` | `` |  |
-| 10 | `tagids_filtered` | `uint32` | `repeated` | `` |  |
-| 11 | `website_title` | `string` | `optional` | `` |  |
-| 12 | `website_url` | `string` | `optional` | `` |  |
-| 13 | `discussion_url` | `string` | `optional` | `` |  |
-| 14 | `show_broadcast` | `bool` | `optional` | `` |  |
+| 1 | `supported_languages` | `uint32` | `optional` |  |  |
+| 2 | `platform_windows` | `bool` | `optional` |  |  |
+| 3 | `platform_mac` | `bool` | `optional` |  |  |
+| 4 | `platform_linux` | `bool` | `optional` |  |  |
+| 5 | `vr_content` | `bool` | `optional` |  |  |
+| 6 | `adult_content_violence` | `bool` | `optional` |  |  |
+| 7 | `adult_content_sex` | `bool` | `optional` |  |  |
+| 8 | `timestamp_updated` | `uint32` | `optional` |  |  |
+| 9 | `tagids_curated` | `uint32` | `repeated` |  |  |
+| 10 | `tagids_filtered` | `uint32` | `repeated` |  |  |
+| 11 | `website_title` | `string` | `optional` |  |  |
+| 12 | `website_url` | `string` | `optional` |  |  |
+| 13 | `discussion_url` | `string` | `optional` |  |  |
+| 14 | `show_broadcast` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -206,8 +206,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `language` | `uint32` | `optional` | `` |  |
-| 2 | `localized_string` | `string` | `optional` | `` |  |
+| 1 | `language` | `uint32` | `optional` |  |  |
+| 2 | `localized_string` | `string` | `optional` |  |  |
 
 </details>
 
@@ -219,16 +219,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `clanid` | `uint32` | `optional` | `` |  |
-| 2 | `event_gid` | `fixed64` | `optional` | `` |  |
-| 3 | `announcement_gid` | `fixed64` | `optional` | `` |  |
-| 4 | `rtime_start` | `uint32` | `optional` | `` |  |
-| 5 | `rtime_end` | `uint32` | `optional` | `` |  |
-| 6 | `priority_score` | `uint32` | `optional` | `` |  |
-| 7 | `type` | `uint32` | `optional` | `` |  |
-| 8 | `clamp_range_slot` | `uint32` | `optional` | `` |  |
-| 9 | `appid` | `uint32` | `optional` | `` |  |
-| 10 | `rtime32_last_modified` | `uint32` | `optional` | `` |  |
+| 1 | `clanid` | `uint32` | `optional` |  |  |
+| 2 | `event_gid` | `fixed64` | `optional` |  |  |
+| 3 | `announcement_gid` | `fixed64` | `optional` |  |  |
+| 4 | `rtime_start` | `uint32` | `optional` |  |  |
+| 5 | `rtime_end` | `uint32` | `optional` |  |  |
+| 6 | `priority_score` | `uint32` | `optional` |  |  |
+| 7 | `type` | `uint32` | `optional` |  |  |
+| 8 | `clamp_range_slot` | `uint32` | `optional` |  |  |
+| 9 | `appid` | `uint32` | `optional` |  |  |
+| 10 | `rtime32_last_modified` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -240,10 +240,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `rtime_before` | `uint32` | `optional` | `` |  |
-| 2 | `rtime_after` | `uint32` | `optional` | `` |  |
-| 3 | `qualified` | `uint32` | `optional` | `` |  |
-| 4 | `events` | `.CClanEventUserNewsTuple` | `repeated` | `` |  |
+| 1 | `rtime_before` | `uint32` | `optional` |  |  |
+| 2 | `rtime_after` | `uint32` | `optional` |  |  |
+| 3 | `qualified` | `uint32` | `optional` |  |  |
+| 4 | `events` | `.CClanEventUserNewsTuple` | `repeated` |  |  |
 
 </details>
 
@@ -255,22 +255,22 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `gid` | `uint64` | `optional` | `` |  |
-| 2 | `clanid` | `uint64` | `optional` | `` |  |
-| 3 | `posterid` | `uint64` | `optional` | `` |  |
-| 4 | `headline` | `string` | `optional` | `` |  |
-| 5 | `posttime` | `uint32` | `optional` | `` |  |
-| 6 | `updatetime` | `uint32` | `optional` | `` |  |
-| 7 | `body` | `string` | `optional` | `` |  |
-| 8 | `commentcount` | `int32` | `optional` | `` |  |
-| 9 | `tags` | `string` | `repeated` | `` |  |
-| 10 | `language` | `int32` | `optional` | `` |  |
-| 11 | `hidden` | `bool` | `optional` | `` |  |
-| 12 | `forum_topic_id` | `fixed64` | `optional` | `` |  |
-| 13 | `event_gid` | `fixed64` | `optional` | `` |  |
-| 14 | `voteupcount` | `int32` | `optional` | `` |  |
-| 15 | `votedowncount` | `int32` | `optional` | `` |  |
-| 16 | `ban_check_result` | `.EBanContentCheckResult` | `optional` | `` | default = k_EBanContentCheckResult_NotScanned |
+| 1 | `gid` | `uint64` | `optional` |  |  |
+| 2 | `clanid` | `uint64` | `optional` |  |  |
+| 3 | `posterid` | `uint64` | `optional` |  |  |
+| 4 | `headline` | `string` | `optional` |  |  |
+| 5 | `posttime` | `uint32` | `optional` |  |  |
+| 6 | `updatetime` | `uint32` | `optional` |  |  |
+| 7 | `body` | `string` | `optional` |  |  |
+| 8 | `commentcount` | `int32` | `optional` |  |  |
+| 9 | `tags` | `string` | `repeated` |  |  |
+| 10 | `language` | `int32` | `optional` |  |  |
+| 11 | `hidden` | `bool` | `optional` |  |  |
+| 12 | `forum_topic_id` | `fixed64` | `optional` |  |  |
+| 13 | `event_gid` | `fixed64` | `optional` |  |  |
+| 14 | `voteupcount` | `int32` | `optional` |  |  |
+| 15 | `votedowncount` | `int32` | `optional` |  |  |
+| 16 | `ban_check_result` | `.EBanContentCheckResult` | `optional` |  | default = k_EBanContentCheckResult_NotScanned |
 
 </details>
 
@@ -282,36 +282,36 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `gid` | `fixed64` | `optional` | `` |  |
-| 2 | `clan_steamid` | `fixed64` | `optional` | `` |  |
-| 3 | `event_name` | `string` | `optional` | `` |  |
-| 4 | `event_type` | `.EProtoClanEventType` | `optional` | `` | default = k_EClanOtherEvent |
-| 5 | `appid` | `uint32` | `optional` | `` |  |
-| 6 | `server_address` | `string` | `optional` | `` |  |
-| 7 | `server_password` | `string` | `optional` | `` |  |
-| 8 | `rtime32_start_time` | `uint32` | `optional` | `` |  |
-| 9 | `rtime32_end_time` | `uint32` | `optional` | `` |  |
-| 10 | `comment_count` | `int32` | `optional` | `` |  |
-| 11 | `creator_steamid` | `fixed64` | `optional` | `` |  |
-| 12 | `last_update_steamid` | `fixed64` | `optional` | `` |  |
-| 13 | `event_notes` | `string` | `optional` | `` |  |
-| 14 | `jsondata` | `string` | `optional` | `` |  |
-| 15 | `announcement_body` | `.CCommunity_ClanAnnouncementInfo` | `optional` | `` |  |
-| 16 | `published` | `bool` | `optional` | `` |  |
-| 17 | `hidden` | `bool` | `optional` | `` |  |
-| 18 | `rtime32_visibility_start` | `uint32` | `optional` | `` |  |
-| 19 | `rtime32_visibility_end` | `uint32` | `optional` | `` |  |
-| 20 | `broadcaster_accountid` | `uint32` | `optional` | `` |  |
-| 21 | `follower_count` | `uint32` | `optional` | `` |  |
-| 22 | `ignore_count` | `uint32` | `optional` | `` |  |
-| 23 | `forum_topic_id` | `fixed64` | `optional` | `` |  |
-| 24 | `rtime32_last_modified` | `uint32` | `optional` | `` |  |
-| 25 | `news_post_gid` | `fixed64` | `optional` | `` |  |
-| 26 | `rtime_mod_reviewed` | `uint32` | `optional` | `` |  |
-| 27 | `featured_app_tagid` | `uint32` | `optional` | `` |  |
-| 28 | `referenced_appids` | `uint32` | `repeated` | `` |  |
-| 29 | `build_id` | `uint32` | `optional` | `` |  |
-| 30 | `build_branch` | `string` | `optional` | `` |  |
+| 1 | `gid` | `fixed64` | `optional` |  |  |
+| 2 | `clan_steamid` | `fixed64` | `optional` |  |  |
+| 3 | `event_name` | `string` | `optional` |  |  |
+| 4 | `event_type` | `.EProtoClanEventType` | `optional` |  | default = k_EClanOtherEvent |
+| 5 | `appid` | `uint32` | `optional` |  |  |
+| 6 | `server_address` | `string` | `optional` |  |  |
+| 7 | `server_password` | `string` | `optional` |  |  |
+| 8 | `rtime32_start_time` | `uint32` | `optional` |  |  |
+| 9 | `rtime32_end_time` | `uint32` | `optional` |  |  |
+| 10 | `comment_count` | `int32` | `optional` |  |  |
+| 11 | `creator_steamid` | `fixed64` | `optional` |  |  |
+| 12 | `last_update_steamid` | `fixed64` | `optional` |  |  |
+| 13 | `event_notes` | `string` | `optional` |  |  |
+| 14 | `jsondata` | `string` | `optional` |  |  |
+| 15 | `announcement_body` | `.CCommunity_ClanAnnouncementInfo` | `optional` |  |  |
+| 16 | `published` | `bool` | `optional` |  |  |
+| 17 | `hidden` | `bool` | `optional` |  |  |
+| 18 | `rtime32_visibility_start` | `uint32` | `optional` |  |  |
+| 19 | `rtime32_visibility_end` | `uint32` | `optional` |  |  |
+| 20 | `broadcaster_accountid` | `uint32` | `optional` |  |  |
+| 21 | `follower_count` | `uint32` | `optional` |  |  |
+| 22 | `ignore_count` | `uint32` | `optional` |  |  |
+| 23 | `forum_topic_id` | `fixed64` | `optional` |  |  |
+| 24 | `rtime32_last_modified` | `uint32` | `optional` |  |  |
+| 25 | `news_post_gid` | `fixed64` | `optional` |  |  |
+| 26 | `rtime_mod_reviewed` | `uint32` | `optional` |  |  |
+| 27 | `featured_app_tagid` | `uint32` | `optional` |  |  |
+| 28 | `referenced_appids` | `uint32` | `repeated` |  |  |
+| 29 | `build_id` | `uint32` | `optional` |  |  |
+| 30 | `build_branch` | `string` | `optional` |  |  |
 
 </details>
 
@@ -323,16 +323,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `first_name` | `string` | `optional` | `` |  |
-| 2 | `last_name` | `string` | `optional` | `` |  |
-| 3 | `address1` | `string` | `optional` | `` |  |
-| 4 | `address2` | `string` | `optional` | `` |  |
-| 5 | `city` | `string` | `optional` | `` |  |
-| 6 | `us_state` | `string` | `optional` | `` |  |
-| 7 | `country_code` | `string` | `optional` | `` |  |
-| 8 | `postcode` | `string` | `optional` | `` |  |
-| 9 | `zip_plus4` | `int32` | `optional` | `` |  |
-| 10 | `phone` | `string` | `optional` | `` |  |
+| 1 | `first_name` | `string` | `optional` |  |  |
+| 2 | `last_name` | `string` | `optional` |  |  |
+| 3 | `address1` | `string` | `optional` |  |  |
+| 4 | `address2` | `string` | `optional` |  |  |
+| 5 | `city` | `string` | `optional` |  |  |
+| 6 | `us_state` | `string` | `optional` |  |  |
+| 7 | `country_code` | `string` | `optional` |  |  |
+| 8 | `postcode` | `string` | `optional` |  |  |
+| 9 | `zip_plus4` | `int32` | `optional` |  |  |
+| 10 | `phone` | `string` | `optional` |  |  |
 
 </details>
 
@@ -344,14 +344,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `packageid` | `uint32` | `optional` | `` |  |
-| 2 | `reservation_state` | `int32` | `optional` | `` |  |
-| 3 | `queue_position` | `int32` | `optional` | `` |  |
-| 4 | `total_queue_size` | `int32` | `optional` | `` |  |
-| 5 | `reservation_country_code` | `string` | `optional` | `` |  |
-| 6 | `expired` | `bool` | `optional` | `` |  |
-| 7 | `time_expires` | `uint32` | `optional` | `` |  |
-| 8 | `time_reserved` | `uint32` | `optional` | `` |  |
+| 1 | `packageid` | `uint32` | `optional` |  |  |
+| 2 | `reservation_state` | `int32` | `optional` |  |  |
+| 3 | `queue_position` | `int32` | `optional` |  |  |
+| 4 | `total_queue_size` | `int32` | `optional` |  |  |
+| 5 | `reservation_country_code` | `string` | `optional` |  |  |
+| 6 | `expired` | `bool` | `optional` |  |  |
+| 7 | `time_expires` | `uint32` | `optional` |  |  |
+| 8 | `time_reserved` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -363,8 +363,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `value` | `string` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `value` | `string` | `optional` |  |  |
 
 </details>
 
@@ -376,7 +376,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `pairs` | `.CMsgKeyValuePair` | `repeated` | `` |  |
+| 1 | `pairs` | `.CMsgKeyValuePair` | `repeated` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/steammessages-cloud-steamworkssdk.md
+++ b/docs/cookbook/proto-fields/steammessages-cloud-steamworkssdk.md
@@ -23,7 +23,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` | (description) = "App ID to which a file will be uploaded to." |
+| 1 | `appid` | `uint32` | `optional` |  | (description) = "App ID to which a file will be uploaded to." |
 
 </details>
 
@@ -35,7 +35,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `server_url` | `string` | `optional` | `` |  |
+| 1 | `server_url` | `string` | `optional` |  |  |
 
 </details>
 
@@ -47,8 +47,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ugcid` | `uint64` | `optional` | `` | (description) = "ID of the Cloud file to get details for." |
-| 2 | `appid` | `uint32` | `optional` | `` | (description) = "App ID the file belongs to." |
+| 1 | `ugcid` | `uint64` | `optional` |  | (description) = "ID of the Cloud file to get details for." |
+| 2 | `appid` | `uint32` | `optional` |  | (description) = "App ID the file belongs to." |
 
 </details>
 
@@ -60,13 +60,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` |  |
-| 2 | `ugcid` | `uint64` | `optional` | `` |  |
-| 3 | `filename` | `string` | `optional` | `` |  |
-| 4 | `timestamp` | `uint64` | `optional` | `` |  |
-| 5 | `file_size` | `uint32` | `optional` | `` |  |
-| 6 | `url` | `string` | `optional` | `` |  |
-| 7 | `steamid_creator` | `fixed64` | `optional` | `` |  |
+| 1 | `appid` | `uint32` | `optional` |  |  |
+| 2 | `ugcid` | `uint64` | `optional` |  |  |
+| 3 | `filename` | `string` | `optional` |  |  |
+| 4 | `timestamp` | `uint64` | `optional` |  |  |
+| 5 | `file_size` | `uint32` | `optional` |  |  |
+| 6 | `url` | `string` | `optional` |  |  |
+| 7 | `steamid_creator` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -78,7 +78,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `details` | `.CCloud_UserFile` | `optional` | `` |  |
+| 1 | `details` | `.CCloud_UserFile` | `optional` |  |  |
 
 </details>
 
@@ -90,10 +90,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` | (description) = "App ID to enumerate the files of." |
-| 2 | `extended_details` | `bool` | `optional` | `` | (description) = "(Optional) Get extended details back on the files found. Defaults to only returned the app Id and UGC Id of the files found." |
-| 3 | `count` | `uint32` | `optional` | `` | (description) = "(Optional) Maximum number of results to return on this call. Defaults to a maximum of 500 files returned." |
-| 4 | `start_index` | `uint32` | `optional` | `` | (description) = "(Optional) Starting index to begin enumeration at. Defaults to the beginning of the list." |
+| 1 | `appid` | `uint32` | `optional` |  | (description) = "App ID to enumerate the files of." |
+| 2 | `extended_details` | `bool` | `optional` |  | (description) = "(Optional) Get extended details back on the files found. Defaults to only returned the app Id and UGC Id of the files found." |
+| 3 | `count` | `uint32` | `optional` |  | (description) = "(Optional) Maximum number of results to return on this call. Defaults to a maximum of 500 files returned." |
+| 4 | `start_index` | `uint32` | `optional` |  | (description) = "(Optional) Starting index to begin enumeration at. Defaults to the beginning of the list." |
 
 </details>
 
@@ -105,8 +105,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `files` | `.CCloud_UserFile` | `repeated` | `` |  |
-| 2 | `total_files` | `uint32` | `optional` | `` |  |
+| 1 | `files` | `.CCloud_UserFile` | `repeated` |  |  |
+| 2 | `total_files` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -118,8 +118,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `filename` | `string` | `optional` | `` |  |
-| 2 | `appid` | `uint32` | `optional` | `` | (description) = "App ID the file belongs to." |
+| 1 | `filename` | `string` | `optional` |  |  |
+| 2 | `appid` | `uint32` | `optional` |  | (description) = "App ID the file belongs to." |
 
 </details>
 

--- a/docs/cookbook/proto-fields/steammessages-gamenetworkingui.md
+++ b/docs/cookbook/proto-fields/steammessages-gamenetworkingui.md
@@ -36,33 +36,33 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `connection_key` | `string` | `optional` | `` |  |
-| 2 | `appid` | `uint32` | `optional` | `` |  |
-| 3 | `connection_id_local` | `fixed32` | `optional` | `` |  |
-| 4 | `identity_local` | `string` | `optional` | `` |  |
-| 5 | `identity_remote` | `string` | `optional` | `` |  |
-| 10 | `connection_state` | `uint32` | `optional` | `` |  |
-| 12 | `start_time` | `uint32` | `optional` | `` |  |
-| 13 | `close_time` | `uint32` | `optional` | `` |  |
-| 14 | `close_reason` | `uint32` | `optional` | `` |  |
-| 15 | `close_message` | `string` | `optional` | `` |  |
-| 16 | `status_loc_token` | `string` | `optional` | `` |  |
-| 20 | `transport_kind` | `uint32` | `optional` | `` |  |
-| 21 | `sdrpopid_local` | `string` | `optional` | `` |  |
-| 22 | `sdrpopid_remote` | `string` | `optional` | `` |  |
-| 23 | `address_remote` | `string` | `optional` | `` |  |
-| 24 | `p2p_routing` | `.CMsgSteamDatagramP2PRoutingSummary` | `optional` | `` |  |
-| 25 | `ping_interior` | `uint32` | `optional` | `` |  |
-| 26 | `ping_remote_front` | `uint32` | `optional` | `` |  |
-| 27 | `ping_default_internet_route` | `uint32` | `optional` | `` |  |
-| 30 | `e2e_quality_local` | `.CMsgSteamDatagramConnectionQuality` | `optional` | `` |  |
-| 31 | `e2e_quality_remote` | `.CMsgSteamDatagramConnectionQuality` | `optional` | `` |  |
-| 32 | `e2e_quality_remote_instantaneous_time` | `uint64` | `optional` | `` |  |
-| 33 | `e2e_quality_remote_lifetime_time` | `uint64` | `optional` | `` |  |
-| 40 | `front_quality_local` | `.CMsgSteamDatagramConnectionQuality` | `optional` | `` |  |
-| 41 | `front_quality_remote` | `.CMsgSteamDatagramConnectionQuality` | `optional` | `` |  |
-| 42 | `front_quality_remote_instantaneous_time` | `uint64` | `optional` | `` |  |
-| 43 | `front_quality_remote_lifetime_time` | `uint64` | `optional` | `` |  |
+| 1 | `connection_key` | `string` | `optional` |  |  |
+| 2 | `appid` | `uint32` | `optional` |  |  |
+| 3 | `connection_id_local` | `fixed32` | `optional` |  |  |
+| 4 | `identity_local` | `string` | `optional` |  |  |
+| 5 | `identity_remote` | `string` | `optional` |  |  |
+| 10 | `connection_state` | `uint32` | `optional` |  |  |
+| 12 | `start_time` | `uint32` | `optional` |  |  |
+| 13 | `close_time` | `uint32` | `optional` |  |  |
+| 14 | `close_reason` | `uint32` | `optional` |  |  |
+| 15 | `close_message` | `string` | `optional` |  |  |
+| 16 | `status_loc_token` | `string` | `optional` |  |  |
+| 20 | `transport_kind` | `uint32` | `optional` |  |  |
+| 21 | `sdrpopid_local` | `string` | `optional` |  |  |
+| 22 | `sdrpopid_remote` | `string` | `optional` |  |  |
+| 23 | `address_remote` | `string` | `optional` |  |  |
+| 24 | `p2p_routing` | `.CMsgSteamDatagramP2PRoutingSummary` | `optional` |  |  |
+| 25 | `ping_interior` | `uint32` | `optional` |  |  |
+| 26 | `ping_remote_front` | `uint32` | `optional` |  |  |
+| 27 | `ping_default_internet_route` | `uint32` | `optional` |  |  |
+| 30 | `e2e_quality_local` | `.CMsgSteamDatagramConnectionQuality` | `optional` |  |  |
+| 31 | `e2e_quality_remote` | `.CMsgSteamDatagramConnectionQuality` | `optional` |  |  |
+| 32 | `e2e_quality_remote_instantaneous_time` | `uint64` | `optional` |  |  |
+| 33 | `e2e_quality_remote_lifetime_time` | `uint64` | `optional` |  |  |
+| 40 | `front_quality_local` | `.CMsgSteamDatagramConnectionQuality` | `optional` |  |  |
+| 41 | `front_quality_remote` | `.CMsgSteamDatagramConnectionQuality` | `optional` |  |  |
+| 42 | `front_quality_remote_instantaneous_time` | `uint64` | `optional` |  |  |
+| 43 | `front_quality_remote_lifetime_time` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -74,7 +74,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `connection_state` | `.CGameNetworkingUI_ConnectionState` | `repeated` | `` |  |
+| 1 | `connection_state` | `.CGameNetworkingUI_ConnectionState` | `repeated` |  |  |
 
 </details>
 
@@ -86,14 +86,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `transport_kind` | `uint32` | `optional` | `` |  |
-| 2 | `sdrpop_local` | `string` | `optional` | `` |  |
-| 3 | `sdrpop_remote` | `string` | `optional` | `` |  |
-| 4 | `ping_ms` | `uint32` | `optional` | `` |  |
-| 5 | `packet_loss` | `float` | `optional` | `` |  |
-| 6 | `ping_default_internet_route` | `uint32` | `optional` | `` |  |
-| 7 | `ip_was_shared` | `bool` | `optional` | `` |  |
-| 8 | `connection_state` | `uint32` | `optional` | `` |  |
+| 1 | `transport_kind` | `uint32` | `optional` |  |  |
+| 2 | `sdrpop_local` | `string` | `optional` |  |  |
+| 3 | `sdrpop_remote` | `string` | `optional` |  |  |
+| 4 | `ping_ms` | `uint32` | `optional` |  |  |
+| 5 | `packet_loss` | `float` | `optional` |  |  |
+| 6 | `ping_default_internet_route` | `uint32` | `optional` |  |  |
+| 7 | `ip_was_shared` | `bool` | `optional` |  |  |
+| 8 | `connection_state` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -105,11 +105,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` |  |
-| 10 | `ip_was_shared_with_friend` | `bool` | `optional` | `` |  |
-| 11 | `ip_was_shared_with_nonfriend` | `bool` | `optional` | `` |  |
-| 20 | `active_connections` | `uint32` | `optional` | `` |  |
-| 30 | `main_cxn` | `.CGameNetworkingUI_ConnectionSummary` | `optional` | `` |  |
+| 1 | `appid` | `uint32` | `optional` |  |  |
+| 10 | `ip_was_shared_with_friend` | `bool` | `optional` |  |  |
+| 11 | `ip_was_shared_with_nonfriend` | `bool` | `optional` |  |  |
+| 20 | `active_connections` | `uint32` | `optional` |  |  |
+| 30 | `main_cxn` | `.CGameNetworkingUI_ConnectionSummary` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/steammessages-helprequest-steamworkssdk.md
+++ b/docs/cookbook/proto-fields/steammessages-helprequest-steamworkssdk.md
@@ -23,10 +23,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` |  |
-| 2 | `log_type` | `string` | `optional` | `` |  |
-| 3 | `version_string` | `string` | `optional` | `` |  |
-| 4 | `log_contents` | `string` | `optional` | `` |  |
+| 1 | `appid` | `uint32` | `optional` |  |  |
+| 2 | `log_type` | `string` | `optional` |  |  |
+| 3 | `version_string` | `string` | `optional` |  |  |
+| 4 | `log_contents` | `string` | `optional` |  |  |
 
 </details>
 
@@ -38,7 +38,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `uint64` | `optional` | `` |  |
+| 1 | `id` | `uint64` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/steammessages-int.md
+++ b/docs/cookbook/proto-fields/steammessages-int.md
@@ -23,11 +23,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `status` | `uint32` | `optional` | `` | default = 255 |
-| 2 | `account_id` | `uint32` | `optional` | `` | default = 0 |
-| 3 | `publisher_group_id` | `uint32` | `optional` | `` | default = 0 |
-| 4 | `key_id` | `uint32` | `optional` | `` |  |
-| 5 | `domain` | `string` | `optional` | `` |  |
+| 1 | `status` | `uint32` | `optional` |  | default = 255 |
+| 2 | `account_id` | `uint32` | `optional` |  | default = 0 |
+| 3 | `publisher_group_id` | `uint32` | `optional` |  | default = 0 |
+| 4 | `key_id` | `uint32` | `optional` |  |  |
+| 5 | `domain` | `string` | `optional` |  |  |
 
 </details>
 
@@ -39,15 +39,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `request_method` | `uint32` | `optional` | `` |  |
-| 2 | `hostname` | `string` | `optional` | `` |  |
-| 3 | `url` | `string` | `optional` | `` |  |
-| 4 | `headers` | `.CMsgHttpRequest.RequestHeader` | `repeated` | `` |  |
-| 5 | `get_params` | `.CMsgHttpRequest.QueryParam` | `repeated` | `` |  |
-| 6 | `post_params` | `.CMsgHttpRequest.QueryParam` | `repeated` | `` |  |
-| 7 | `body` | `bytes` | `optional` | `` |  |
-| 8 | `absolute_timeout` | `uint32` | `optional` | `` |  |
-| 9 | `use_https` | `bool` | `optional` | `` |  |
+| 1 | `request_method` | `uint32` | `optional` |  |  |
+| 2 | `hostname` | `string` | `optional` |  |  |
+| 3 | `url` | `string` | `optional` |  |  |
+| 4 | `headers` | `.CMsgHttpRequest.RequestHeader` | `repeated` |  |  |
+| 5 | `get_params` | `.CMsgHttpRequest.QueryParam` | `repeated` |  |  |
+| 6 | `post_params` | `.CMsgHttpRequest.QueryParam` | `repeated` |  |  |
+| 7 | `body` | `bytes` | `optional` |  |  |
+| 8 | `absolute_timeout` | `uint32` | `optional` |  |  |
+| 9 | `use_https` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -59,8 +59,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `value` | `string` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `value` | `string` | `optional` |  |  |
 
 </details>
 
@@ -72,8 +72,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `value` | `bytes` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `value` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -85,12 +85,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `interface_name` | `string` | `optional` | `` |  |
-| 3 | `method_name` | `string` | `optional` | `` |  |
-| 4 | `version` | `uint32` | `optional` | `` |  |
-| 5 | `api_key` | `.CMsgWebAPIKey` | `optional` | `` |  |
-| 6 | `request` | `.CMsgHttpRequest` | `optional` | `` |  |
-| 7 | `routing_app_id` | `uint32` | `optional` | `` |  |
+| 2 | `interface_name` | `string` | `optional` |  |  |
+| 3 | `method_name` | `string` | `optional` |  |  |
+| 4 | `version` | `uint32` | `optional` |  |  |
+| 5 | `api_key` | `.CMsgWebAPIKey` | `optional` |  |  |
+| 6 | `request` | `.CMsgHttpRequest` | `optional` |  |  |
+| 7 | `routing_app_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -102,9 +102,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `status_code` | `uint32` | `optional` | `` |  |
-| 2 | `headers` | `.CMsgHttpResponse.ResponseHeader` | `repeated` | `` |  |
-| 3 | `body` | `bytes` | `optional` | `` |  |
+| 1 | `status_code` | `uint32` | `optional` |  |  |
+| 2 | `headers` | `.CMsgHttpResponse.ResponseHeader` | `repeated` |  |  |
+| 3 | `body` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -116,8 +116,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `value` | `string` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `value` | `string` | `optional` |  |  |
 
 </details>
 
@@ -129,8 +129,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `search_type` | `uint32` | `optional` | `` |  |
-| 2 | `search_string` | `string` | `optional` | `` |  |
+| 1 | `search_type` | `uint32` | `optional` |  |  |
+| 2 | `search_string` | `string` | `optional` |  |  |
 
 </details>
 
@@ -142,7 +142,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steam_id` | `fixed64` | `repeated` | `` |  |
+| 1 | `steam_id` | `fixed64` | `repeated` |  |  |
 
 </details>
 
@@ -154,13 +154,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `source` | `uint32` | `optional` | `` |  |
-| 2 | `alert_type` | `uint32` | `optional` | `` |  |
-| 4 | `critical` | `bool` | `optional` | `` |  |
-| 5 | `time` | `uint32` | `optional` | `` |  |
-| 6 | `appid` | `uint32` | `optional` | `` |  |
-| 7 | `text` | `string` | `optional` | `` |  |
-| 12 | `recipient` | `string` | `optional` | `` |  |
+| 1 | `source` | `uint32` | `optional` |  |  |
+| 2 | `alert_type` | `uint32` | `optional` |  |  |
+| 4 | `critical` | `bool` | `optional` |  |  |
+| 5 | `time` | `uint32` | `optional` |  |  |
+| 6 | `appid` | `uint32` | `optional` |  |  |
+| 7 | `text` | `string` | `optional` |  |  |
+| 12 | `recipient` | `string` | `optional` |  |  |
 
 </details>
 
@@ -172,7 +172,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `optional` | `` |  |
+| 1 | `steamid` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -184,9 +184,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `package_id` | `uint32` | `optional` | `` |  |
-| 2 | `time_created` | `uint32` | `optional` | `` |  |
-| 3 | `owner_id` | `uint32` | `optional` | `` |  |
+| 1 | `package_id` | `uint32` | `optional` |  |  |
+| 2 | `time_created` | `uint32` | `optional` |  |  |
+| 3 | `owner_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -198,8 +198,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `license` | `.CMsgPackageLicense` | `repeated` | `` |  |
-| 2 | `result` | `uint32` | `optional` | `` |  |
+| 1 | `license` | `.CMsgPackageLicense` | `repeated` |  |  |
+| 2 | `result` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -211,8 +211,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `app_id` | `uint32` | `optional` | `` |  |
-| 2 | `command_prefix` | `string` | `optional` | `` |  |
+| 1 | `app_id` | `uint32` | `optional` |  |  |
+| 2 | `command_prefix` | `string` | `optional` |  |  |
 
 </details>
 
@@ -224,7 +224,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `command_name` | `string` | `repeated` | `` |  |
+| 1 | `command_name` | `string` | `repeated` |  |  |
 
 </details>
 
@@ -236,7 +236,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `keys` | `string` | `repeated` | `` |  |
+| 1 | `keys` | `string` | `repeated` |  |  |
 
 </details>
 
@@ -248,7 +248,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `values` | `.CGCMsgMemCachedGetResponse.ValueTag` | `repeated` | `` |  |
+| 1 | `values` | `.CGCMsgMemCachedGetResponse.ValueTag` | `repeated` |  |  |
 
 </details>
 
@@ -260,8 +260,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `found` | `bool` | `optional` | `` |  |
-| 2 | `value` | `bytes` | `optional` | `` |  |
+| 1 | `found` | `bool` | `optional` |  |  |
+| 2 | `value` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -273,7 +273,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `keys` | `.CGCMsgMemCachedSet.KeyPair` | `repeated` | `` |  |
+| 1 | `keys` | `.CGCMsgMemCachedSet.KeyPair` | `repeated` |  |  |
 
 </details>
 
@@ -285,8 +285,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `value` | `bytes` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `value` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -298,7 +298,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `keys` | `string` | `repeated` | `` |  |
+| 1 | `keys` | `string` | `repeated` |  |  |
 
 </details>
 
@@ -322,20 +322,20 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `curr_connections` | `uint64` | `optional` | `` |  |
-| 2 | `cmd_get` | `uint64` | `optional` | `` |  |
-| 3 | `cmd_set` | `uint64` | `optional` | `` |  |
-| 4 | `cmd_flush` | `uint64` | `optional` | `` |  |
-| 5 | `get_hits` | `uint64` | `optional` | `` |  |
-| 6 | `get_misses` | `uint64` | `optional` | `` |  |
-| 7 | `delete_hits` | `uint64` | `optional` | `` |  |
-| 8 | `delete_misses` | `uint64` | `optional` | `` |  |
-| 9 | `bytes_read` | `uint64` | `optional` | `` |  |
-| 10 | `bytes_written` | `uint64` | `optional` | `` |  |
-| 11 | `limit_maxbytes` | `uint64` | `optional` | `` |  |
-| 12 | `curr_items` | `uint64` | `optional` | `` |  |
-| 13 | `evictions` | `uint64` | `optional` | `` |  |
-| 14 | `bytes` | `uint64` | `optional` | `` |  |
+| 1 | `curr_connections` | `uint64` | `optional` |  |  |
+| 2 | `cmd_get` | `uint64` | `optional` |  |  |
+| 3 | `cmd_set` | `uint64` | `optional` |  |  |
+| 4 | `cmd_flush` | `uint64` | `optional` |  |  |
+| 5 | `get_hits` | `uint64` | `optional` |  |  |
+| 6 | `get_misses` | `uint64` | `optional` |  |  |
+| 7 | `delete_hits` | `uint64` | `optional` |  |  |
+| 8 | `delete_misses` | `uint64` | `optional` |  |  |
+| 9 | `bytes_read` | `uint64` | `optional` |  |  |
+| 10 | `bytes_written` | `uint64` | `optional` |  |  |
+| 11 | `limit_maxbytes` | `uint64` | `optional` |  |  |
+| 12 | `curr_items` | `uint64` | `optional` |  |  |
+| 13 | `evictions` | `uint64` | `optional` |  |  |
+| 14 | `bytes` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -347,7 +347,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `schema_catalog` | `uint32` | `optional` | `` |  |
+| 1 | `schema_catalog` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -359,15 +359,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `threads` | `uint32` | `optional` | `` |  |
-| 2 | `threads_connected` | `uint32` | `optional` | `` |  |
-| 3 | `threads_active` | `uint32` | `optional` | `` |  |
-| 4 | `operations_submitted` | `uint32` | `optional` | `` |  |
-| 5 | `prepared_statements_executed` | `uint32` | `optional` | `` |  |
-| 6 | `non_prepared_statements_executed` | `uint32` | `optional` | `` |  |
-| 7 | `deadlock_retries` | `uint32` | `optional` | `` |  |
-| 8 | `operations_timed_out_in_queue` | `uint32` | `optional` | `` |  |
-| 9 | `errors` | `uint32` | `optional` | `` |  |
+| 1 | `threads` | `uint32` | `optional` |  |  |
+| 2 | `threads_connected` | `uint32` | `optional` |  |  |
+| 3 | `threads_active` | `uint32` | `optional` |  |  |
+| 4 | `operations_submitted` | `uint32` | `optional` |  |  |
+| 5 | `prepared_statements_executed` | `uint32` | `optional` |  |  |
+| 6 | `non_prepared_statements_executed` | `uint32` | `optional` |  |  |
+| 7 | `deadlock_retries` | `uint32` | `optional` |  |  |
+| 8 | `operations_timed_out_in_queue` | `uint32` | `optional` |  |  |
+| 9 | `errors` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -379,10 +379,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `optional` | `` |  |
-| 2 | `ip_public` | `uint32` | `optional` | `` |  |
-| 3 | `packageid` | `uint32` | `optional` | `` |  |
-| 4 | `store_country_code` | `string` | `optional` | `` |  |
+| 1 | `steamid` | `fixed64` | `optional` |  |  |
+| 2 | `ip_public` | `uint32` | `optional` |  |  |
+| 3 | `packageid` | `uint32` | `optional` |  |  |
+| 4 | `store_country_code` | `string` | `optional` |  |  |
 
 </details>
 
@@ -394,9 +394,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `eresult` | `int32` | `optional` | `` | default = 2 |
-| 2 | `purchase_result_detail` | `int32` | `optional` | `` |  |
-| 3 | `transid` | `fixed64` | `optional` | `` |  |
+| 1 | `eresult` | `int32` | `optional` |  | default = 2 |
+| 2 | `purchase_result_detail` | `int32` | `optional` |  |  |
+| 3 | `transid` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -408,7 +408,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ips` | `fixed32` | `repeated` | `` |  |
+| 1 | `ips` | `fixed32` | `repeated` |  |  |
 
 </details>
 
@@ -420,7 +420,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ips` | `fixed32` | `repeated` | `` |  |
+| 1 | `ips` | `fixed32` | `repeated` |  |  |
 
 </details>
 
@@ -432,8 +432,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ip` | `fixed32` | `optional` | `` |  |
-| 2 | `asn` | `uint32` | `optional` | `` |  |
+| 1 | `ip` | `fixed32` | `optional` |  |  |
+| 2 | `asn` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -445,7 +445,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `infos` | `.CIPASNInfo` | `repeated` | `` |  |
+| 1 | `infos` | `.CIPASNInfo` | `repeated` |  |  |
 
 </details>
 
@@ -457,12 +457,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `optional` | `` |  |
-| 2 | `email_msg_type` | `uint32` | `optional` | `` |  |
-| 3 | `email_format` | `uint32` | `optional` | `` |  |
-| 5 | `persona_name_tokens` | `.CMsgAMSendEmail.PersonaNameReplacementToken` | `repeated` | `` |  |
-| 6 | `source_gc` | `uint32` | `optional` | `` |  |
-| 7 | `tokens` | `.CMsgAMSendEmail.ReplacementToken` | `repeated` | `` |  |
+| 1 | `steamid` | `fixed64` | `optional` |  |  |
+| 2 | `email_msg_type` | `uint32` | `optional` |  |  |
+| 3 | `email_format` | `uint32` | `optional` |  |  |
+| 5 | `persona_name_tokens` | `.CMsgAMSendEmail.PersonaNameReplacementToken` | `repeated` |  |  |
+| 6 | `source_gc` | `uint32` | `optional` |  |  |
+| 7 | `tokens` | `.CMsgAMSendEmail.ReplacementToken` | `repeated` |  |  |
 
 </details>
 
@@ -474,8 +474,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `token_name` | `string` | `optional` | `` |  |
-| 2 | `token_value` | `string` | `optional` | `` |  |
+| 1 | `token_name` | `string` | `optional` |  |  |
+| 2 | `token_value` | `string` | `optional` |  |  |
 
 </details>
 
@@ -487,8 +487,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `optional` | `` |  |
-| 2 | `token_name` | `string` | `optional` | `` |  |
+| 1 | `steamid` | `fixed64` | `optional` |  |  |
+| 2 | `token_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -500,7 +500,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `eresult` | `uint32` | `optional` | `` | default = 2 |
+| 1 | `eresult` | `uint32` | `optional` |  | default = 2 |
 
 </details>
 
@@ -512,10 +512,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `app_id` | `uint32` | `optional` | `` |  |
-| 2 | `email_msg_type` | `uint32` | `optional` | `` |  |
-| 3 | `email_lang` | `int32` | `optional` | `` |  |
-| 4 | `email_format` | `int32` | `optional` | `` |  |
+| 1 | `app_id` | `uint32` | `optional` |  |  |
+| 2 | `email_msg_type` | `uint32` | `optional` |  |  |
+| 3 | `email_lang` | `int32` | `optional` |  |  |
+| 4 | `email_format` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -527,9 +527,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `eresult` | `uint32` | `optional` | `` | default = 2 |
-| 2 | `template_exists` | `bool` | `optional` | `` |  |
-| 3 | `template` | `string` | `optional` | `` |  |
+| 1 | `eresult` | `uint32` | `optional` |  | default = 2 |
+| 2 | `template_exists` | `bool` | `optional` |  |  |
+| 3 | `template` | `string` | `optional` |  |  |
 
 </details>
 
@@ -541,11 +541,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steam_id` | `fixed64` | `optional` | `` |  |
-| 2 | `package_id` | `uint32` | `optional` | `` |  |
-| 3 | `passes_to_grant` | `int32` | `optional` | `` |  |
-| 4 | `days_to_expiration` | `int32` | `optional` | `` |  |
-| 5 | `action` | `int32` | `optional` | `` |  |
+| 1 | `steam_id` | `fixed64` | `optional` |  |  |
+| 2 | `package_id` | `uint32` | `optional` |  |  |
+| 3 | `passes_to_grant` | `int32` | `optional` |  |  |
+| 4 | `days_to_expiration` | `int32` | `optional` |  |  |
+| 5 | `action` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -557,8 +557,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `eresult` | `int32` | `optional` | `` | default = 2 |
-| 2 | `passes_granted` | `int32` | `optional` | `` | default = 0 |
+| 1 | `eresult` | `int32` | `optional` |  | default = 2 |
+| 2 | `passes_granted` | `int32` | `optional` |  | default = 0 |
 
 </details>
 
@@ -570,7 +570,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamids` | `fixed64` | `repeated` | `` |  |
+| 1 | `steamids` | `fixed64` | `repeated` |  |  |
 
 </details>
 
@@ -582,8 +582,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `succeeded_lookups` | `.CMsgGCGetPersonaNames_Response.PersonaName` | `repeated` | `` |  |
-| 2 | `failed_lookup_steamids` | `fixed64` | `repeated` | `` |  |
+| 1 | `succeeded_lookups` | `.CMsgGCGetPersonaNames_Response.PersonaName` | `repeated` |  |  |
+| 2 | `failed_lookup_steamids` | `fixed64` | `repeated` |  |  |
 
 </details>
 
@@ -595,8 +595,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `optional` | `` |  |
-| 2 | `persona_name` | `string` | `optional` | `` |  |
+| 1 | `steamid` | `fixed64` | `optional` |  |  |
+| 2 | `persona_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -608,8 +608,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid_left` | `fixed64` | `optional` | `` |  |
-| 2 | `steamid_right` | `fixed64` | `optional` | `` |  |
+| 1 | `steamid_left` | `fixed64` | `optional` |  |  |
+| 2 | `steamid_right` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -621,8 +621,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `success` | `bool` | `optional` | `` |  |
-| 2 | `found_friendship` | `bool` | `optional` | `` |  |
+| 1 | `success` | `bool` | `optional` |  |  |
+| 2 | `found_friendship` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -634,9 +634,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `optional` | `` |  |
-| 2 | `include_friendship_timestamps` | `bool` | `optional` | `` |  |
-| 3 | `include_friends_with_no_play_time` | `bool` | `optional` | `` |  |
+| 1 | `steamid` | `fixed64` | `optional` |  |  |
+| 2 | `include_friendship_timestamps` | `bool` | `optional` |  |  |
+| 3 | `include_friends_with_no_play_time` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -648,10 +648,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `success` | `bool` | `optional` | `` |  |
-| 2 | `steamids` | `fixed64` | `repeated` | `` |  |
-| 3 | `friendship_timestamps` | `fixed32` | `repeated` | `` |  |
-| 4 | `last_playtimes` | `fixed32` | `repeated` | `` |  |
+| 1 | `success` | `bool` | `optional` |  |  |
+| 2 | `steamids` | `fixed64` | `repeated` |  |  |
+| 3 | `friendship_timestamps` | `fixed32` | `repeated` |  |  |
+| 4 | `last_playtimes` | `fixed32` | `repeated` |  |  |
 
 </details>
 
@@ -663,8 +663,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `master_dir_index` | `int32` | `optional` | `` | default = -1 |
-| 2 | `dir` | `.CMsgGCMsgMasterSetDirectory.SubGC` | `repeated` | `` |  |
+| 1 | `master_dir_index` | `int32` | `optional` |  | default = -1 |
+| 2 | `dir` | `.CMsgGCMsgMasterSetDirectory.SubGC` | `repeated` |  |  |
 
 </details>
 
@@ -676,11 +676,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `dir_index` | `int32` | `optional` | `` | default = -1 |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `box` | `string` | `optional` | `` |  |
-| 4 | `command_line` | `string` | `optional` | `` |  |
-| 5 | `gc_binary` | `string` | `optional` | `` |  |
+| 1 | `dir_index` | `int32` | `optional` |  | default = -1 |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `box` | `string` | `optional` |  |  |
+| 4 | `command_line` | `string` | `optional` |  |  |
+| 5 | `gc_binary` | `string` | `optional` |  |  |
 
 </details>
 
@@ -692,8 +692,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `eresult` | `int32` | `optional` | `` | default = 2 |
-| 2 | `message` | `string` | `optional` | `` |  |
+| 1 | `eresult` | `int32` | `optional` |  | default = 2 |
+| 2 | `message` | `string` | `optional` |  |  |
 
 </details>
 
@@ -705,7 +705,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `dir_index` | `int32` | `optional` | `` | default = -1 |
+| 1 | `dir_index` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -717,7 +717,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `optional` | `` |  |
+| 1 | `steamid` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -729,10 +729,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `has_prior_purchase_history` | `bool` | `optional` | `` |  |
-| 2 | `has_no_recent_password_resets` | `bool` | `optional` | `` |  |
-| 3 | `is_wallet_cash_trusted` | `bool` | `optional` | `` |  |
-| 4 | `time_all_trusted` | `uint32` | `optional` | `` |  |
+| 1 | `has_prior_purchase_history` | `bool` | `optional` |  |  |
+| 2 | `has_no_recent_password_resets` | `bool` | `optional` |  |  |
+| 3 | `is_wallet_cash_trusted` | `bool` | `optional` |  |  |
+| 4 | `time_all_trusted` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -744,11 +744,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steam_id` | `fixed64` | `optional` | `` |  |
-| 2 | `app_id` | `uint32` | `optional` | `` |  |
-| 3 | `rtime_vacban_starts` | `uint32` | `optional` | `` |  |
-| 4 | `is_banned_now` | `bool` | `optional` | `` |  |
-| 5 | `is_banned_future` | `bool` | `optional` | `` |  |
+| 1 | `steam_id` | `fixed64` | `optional` |  |  |
+| 2 | `app_id` | `uint32` | `optional` |  |  |
+| 3 | `rtime_vacban_starts` | `uint32` | `optional` |  |  |
+| 4 | `is_banned_now` | `bool` | `optional` |  |  |
+| 5 | `is_banned_future` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -760,11 +760,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `dir_index` | `int32` | `repeated` | `` |  |
-| 2 | `method` | `.CMsgGCRoutingInfo.RoutingMethod` | `optional` | `` | default = RANDOM |
-| 3 | `fallback` | `.CMsgGCRoutingInfo.RoutingMethod` | `optional` | `` | default = DISCARD |
-| 4 | `protobuf_field` | `uint32` | `optional` | `` |  |
-| 5 | `webapi_param` | `string` | `optional` | `` |  |
+| 1 | `dir_index` | `int32` | `repeated` |  |  |
+| 2 | `method` | `.CMsgGCRoutingInfo.RoutingMethod` | `optional` |  | default = RANDOM |
+| 3 | `fallback` | `.CMsgGCRoutingInfo.RoutingMethod` | `optional` |  | default = DISCARD |
+| 4 | `protobuf_field` | `uint32` | `optional` |  |  |
+| 5 | `webapi_param` | `string` | `optional` |  |  |
 
 </details>
 
@@ -776,7 +776,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `entries` | `.CMsgGCMsgMasterSetWebAPIRouting.Entry` | `repeated` | `` |  |
+| 1 | `entries` | `.CMsgGCMsgMasterSetWebAPIRouting.Entry` | `repeated` |  |  |
 
 </details>
 
@@ -788,9 +788,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `interface_name` | `string` | `optional` | `` |  |
-| 2 | `method_name` | `string` | `optional` | `` |  |
-| 3 | `routing` | `.CMsgGCRoutingInfo` | `optional` | `` |  |
+| 1 | `interface_name` | `string` | `optional` |  |  |
+| 2 | `method_name` | `string` | `optional` |  |  |
+| 3 | `routing` | `.CMsgGCRoutingInfo` | `optional` |  |  |
 
 </details>
 
@@ -802,7 +802,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `entries` | `.CMsgGCMsgMasterSetClientMsgRouting.Entry` | `repeated` | `` |  |
+| 1 | `entries` | `.CMsgGCMsgMasterSetClientMsgRouting.Entry` | `repeated` |  |  |
 
 </details>
 
@@ -814,8 +814,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `msg_type` | `uint32` | `optional` | `` |  |
-| 2 | `routing` | `.CMsgGCRoutingInfo` | `optional` | `` |  |
+| 1 | `msg_type` | `uint32` | `optional` |  |  |
+| 2 | `routing` | `.CMsgGCRoutingInfo` | `optional` |  |  |
 
 </details>
 
@@ -827,7 +827,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `eresult` | `int32` | `optional` | `` | default = 2 |
+| 1 | `eresult` | `int32` | `optional` |  | default = 2 |
 
 </details>
 
@@ -839,7 +839,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `eresult` | `int32` | `optional` | `` | default = 2 |
+| 1 | `eresult` | `int32` | `optional` |  | default = 2 |
 
 </details>
 
@@ -851,9 +851,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `options` | `.CMsgGCMsgSetOptions.Option` | `repeated` | `` |  |
-| 2 | `client_msg_ranges` | `.CMsgGCMsgSetOptions.MessageRange` | `repeated` | `` |  |
-| 3 | `gcsql_version` | `.CMsgGCMsgSetOptions.GCSQLVersion` | `optional` | `` | default = GCSQL_VERSION_BASELINE |
+| 1 | `options` | `.CMsgGCMsgSetOptions.Option` | `repeated` |  |  |
+| 2 | `client_msg_ranges` | `.CMsgGCMsgSetOptions.MessageRange` | `repeated` |  |  |
+| 3 | `gcsql_version` | `.CMsgGCMsgSetOptions.GCSQLVersion` | `optional` |  | default = GCSQL_VERSION_BASELINE |
 
 </details>
 
@@ -865,8 +865,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `low` | `uint32` | `required` | `` |  |
-| 2 | `high` | `uint32` | `required` | `` |  |
+| 1 | `low` | `uint32` | `required` |  |  |
+| 2 | `high` | `uint32` | `required` |  |  |
 
 </details>
 
@@ -878,15 +878,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steam_id` | `fixed64` | `optional` | `` |  |
-| 2 | `app_id` | `uint32` | `optional` | `` |  |
-| 3 | `online` | `bool` | `optional` | `` |  |
-| 4 | `server_steam_id` | `fixed64` | `optional` | `` |  |
-| 5 | `server_addr` | `uint32` | `optional` | `` |  |
-| 6 | `server_port` | `uint32` | `optional` | `` |  |
-| 7 | `os_type` | `uint32` | `optional` | `` |  |
-| 8 | `client_addr` | `uint32` | `optional` | `` |  |
-| 9 | `extra_fields` | `.CMsgGCHUpdateSession.ExtraField` | `repeated` | `` |  |
+| 1 | `steam_id` | `fixed64` | `optional` |  |  |
+| 2 | `app_id` | `uint32` | `optional` |  |  |
+| 3 | `online` | `bool` | `optional` |  |  |
+| 4 | `server_steam_id` | `fixed64` | `optional` |  |  |
+| 5 | `server_addr` | `uint32` | `optional` |  |  |
+| 6 | `server_port` | `uint32` | `optional` |  |  |
+| 7 | `os_type` | `uint32` | `optional` |  |  |
+| 8 | `client_addr` | `uint32` | `optional` |  |  |
+| 9 | `extra_fields` | `.CMsgGCHUpdateSession.ExtraField` | `repeated` |  |  |
 
 </details>
 
@@ -898,8 +898,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `value` | `string` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `value` | `string` | `optional` |  |  |
 
 </details>
 
@@ -911,9 +911,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `optional` | `` |  |
-| 2 | `appid` | `uint32` | `optional` | `` |  |
-| 3 | `multiple_instances` | `.CMsgNotificationOfSuspiciousActivity.MultipleGameInstances` | `optional` | `` |  |
+| 1 | `steamid` | `fixed64` | `optional` |  |  |
+| 2 | `appid` | `uint32` | `optional` |  |  |
+| 3 | `multiple_instances` | `.CMsgNotificationOfSuspiciousActivity.MultipleGameInstances` | `optional` |  |  |
 
 </details>
 
@@ -925,8 +925,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `app_instance_count` | `uint32` | `optional` | `` |  |
-| 2 | `other_steamids` | `fixed64` | `repeated` | `` |  |
+| 1 | `app_instance_count` | `uint32` | `optional` |  |  |
+| 2 | `other_steamids` | `fixed64` | `repeated` |  |  |
 
 </details>
 
@@ -938,9 +938,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `optional` | `` |  |
-| 2 | `appid` | `uint32` | `optional` | `` |  |
-| 3 | `is_verified` | `bool` | `optional` | `` |  |
+| 1 | `steamid` | `fixed64` | `optional` |  |  |
+| 2 | `appid` | `uint32` | `optional` |  |  |
+| 3 | `is_verified` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -952,11 +952,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `optional` | `` |  |
-| 2 | `appid` | `uint32` | `optional` | `` |  |
-| 3 | `phone_id` | `uint64` | `optional` | `` |  |
-| 4 | `is_verified` | `bool` | `optional` | `` |  |
-| 5 | `is_identifying` | `bool` | `optional` | `` |  |
+| 1 | `steamid` | `fixed64` | `optional` |  |  |
+| 2 | `appid` | `uint32` | `optional` |  |  |
+| 3 | `phone_id` | `uint64` | `optional` |  |  |
+| 4 | `is_verified` | `bool` | `optional` |  |  |
+| 5 | `is_identifying` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -968,9 +968,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `optional` | `` |  |
-| 2 | `appid` | `uint32` | `optional` | `` |  |
-| 3 | `twofactor_enabled` | `bool` | `optional` | `` |  |
+| 1 | `steamid` | `fixed64` | `optional` |  |  |
+| 2 | `appid` | `uint32` | `optional` |  |  |
+| 3 | `twofactor_enabled` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -982,8 +982,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `optional` | `` |  |
-| 2 | `clanid` | `uint32` | `optional` | `` |  |
+| 1 | `steamid` | `fixed64` | `optional` |  |  |
+| 2 | `clanid` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -995,7 +995,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ismember` | `bool` | `optional` | `` |  |
+| 1 | `ismember` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1007,8 +1007,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` |  |
-| 2 | `cheer_targets` | `.CMsgGCHAppCheersReceived.CheerTarget` | `repeated` | `` |  |
+| 1 | `appid` | `uint32` | `optional` |  |  |
+| 2 | `cheer_targets` | `.CMsgGCHAppCheersReceived.CheerTarget` | `repeated` |  |  |
 
 </details>
 
@@ -1020,8 +1020,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cheer_type` | `uint32` | `optional` | `` |  |
-| 2 | `cheer_amount` | `uint32` | `optional` | `` |  |
+| 1 | `cheer_type` | `uint32` | `optional` |  |  |
+| 2 | `cheer_amount` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1033,8 +1033,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cheer_target` | `uint64` | `optional` | `` |  |
-| 2 | `cheer_types` | `.CMsgGCHAppCheersReceived.CheerTypeAmount` | `repeated` | `` |  |
+| 1 | `cheer_target` | `uint64` | `optional` |  |  |
+| 2 | `cheer_types` | `.CMsgGCHAppCheersReceived.CheerTypeAmount` | `repeated` |  |  |
 
 </details>
 
@@ -1046,8 +1046,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` |  |
-| 2 | `cheer_target` | `uint64` | `optional` | `` |  |
+| 1 | `appid` | `uint32` | `optional` |  |  |
+| 2 | `cheer_target` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -1059,9 +1059,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cheer_types_valid_all_users` | `uint32` | `repeated` | `` |  |
-| 2 | `cheer_remaps` | `.CMsgGCHAppCheersGetAllowedTypesResponse.CheerRemaps` | `repeated` | `` |  |
-| 3 | `cache_duration` | `uint32` | `optional` | `` |  |
+| 1 | `cheer_types_valid_all_users` | `uint32` | `repeated` |  |  |
+| 2 | `cheer_remaps` | `.CMsgGCHAppCheersGetAllowedTypesResponse.CheerRemaps` | `repeated` |  |  |
+| 3 | `cache_duration` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1073,9 +1073,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `original_cheer_type` | `uint32` | `optional` | `` |  |
-| 2 | `remapped_cheer_type` | `uint32` | `optional` | `` |  |
-| 3 | `account_ids` | `uint32` | `repeated` | `` |  |
+| 1 | `original_cheer_type` | `uint32` | `optional` |  |  |
+| 2 | `remapped_cheer_type` | `uint32` | `optional` |  |  |
+| 3 | `account_ids` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -1087,11 +1087,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` |  |
-| 2 | `gameitemid` | `uint32` | `optional` | `` |  |
-| 3 | `date` | `string` | `optional` | `` |  |
-| 4 | `payment_us_usd` | `uint64` | `optional` | `` |  |
-| 5 | `payment_row_usd` | `uint64` | `optional` | `` |  |
+| 1 | `appid` | `uint32` | `optional` |  |  |
+| 2 | `gameitemid` | `uint32` | `optional` |  |  |
+| 3 | `date` | `string` | `optional` |  |  |
+| 4 | `payment_us_usd` | `uint64` | `optional` |  |  |
+| 5 | `payment_row_usd` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -1115,9 +1115,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` |  |
-| 2 | `gameitemid` | `uint32` | `optional` | `` |  |
-| 3 | `date` | `string` | `optional` | `` |  |
+| 1 | `appid` | `uint32` | `optional` |  |  |
+| 2 | `gameitemid` | `uint32` | `optional` |  |  |
+| 3 | `date` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1129,7 +1129,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `special_payments` | `.CWorkshop_GetSpecialPayments_Response.SpecialPayment` | `repeated` | `` |  |
+| 1 | `special_payments` | `.CWorkshop_GetSpecialPayments_Response.SpecialPayment` | `repeated` |  |  |
 
 </details>
 
@@ -1141,11 +1141,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` |  |
-| 2 | `gameitemid` | `uint32` | `optional` | `` |  |
-| 3 | `date` | `string` | `optional` | `` |  |
-| 4 | `net_payment_us_usd` | `uint64` | `optional` | `` |  |
-| 5 | `net_payment_row_usd` | `uint64` | `optional` | `` |  |
+| 1 | `appid` | `uint32` | `optional` |  |  |
+| 2 | `gameitemid` | `uint32` | `optional` |  |  |
+| 3 | `date` | `string` | `optional` |  |  |
+| 4 | `net_payment_us_usd` | `uint64` | `optional` |  |  |
+| 5 | `net_payment_row_usd` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -1157,7 +1157,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `metric_data` | `.CMsgGCReportMetrics.MetricEntry` | `repeated` | `` |  |
+| 1 | `metric_data` | `.CMsgGCReportMetrics.MetricEntry` | `repeated` |  |  |
 
 </details>
 
@@ -1169,11 +1169,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `catalog` | `string` | `optional` | `` |  |
-| 2 | `operation` | `string` | `optional` | `` |  |
-| 3 | `timestamp` | `double` | `optional` | `` |  |
-| 10 | `dimensions` | `.CMsgGCReportMetrics.MetricEntry.Dimension` | `repeated` | `` |  |
-| 11 | `measurements` | `.CMsgGCReportMetrics.MetricEntry.Measurement` | `repeated` | `` |  |
+| 1 | `catalog` | `string` | `optional` |  |  |
+| 2 | `operation` | `string` | `optional` |  |  |
+| 3 | `timestamp` | `double` | `optional` |  |  |
+| 10 | `dimensions` | `.CMsgGCReportMetrics.MetricEntry.Dimension` | `repeated` |  |  |
+| 11 | `measurements` | `.CMsgGCReportMetrics.MetricEntry.Measurement` | `repeated` |  |  |
 
 </details>
 
@@ -1185,7 +1185,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
 | 2 | `value_string` | `string` | `oneof` | `value` |  |
 | 3 | `value_integer` | `int64` | `oneof` | `value` |  |
 | 4 | `value_boolean` | `bool` | `oneof` | `value` |  |
@@ -1200,7 +1200,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
 | 2 | `value_integer` | `int64` | `oneof` | `value` |  |
 | 3 | `value_float` | `double` | `oneof` | `value` |  |
 
@@ -1214,8 +1214,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `eresult` | `int32` | `optional` | `` | default = 2 |
-| 2 | `failed_entry_count` | `uint32` | `optional` | `` |  |
+| 1 | `eresult` | `int32` | `optional` |  | default = 2 |
+| 2 | `failed_entry_count` | `uint32` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/steammessages-oauth-steamworkssdk.md
+++ b/docs/cookbook/proto-fields/steammessages-oauth-steamworkssdk.md
@@ -23,7 +23,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `clientid` | `string` | `optional` | `` | (description) = "Client ID for which to count the number of issued tokens" |
+| 1 | `clientid` | `string` | `optional` |  | (description) = "Client ID for which to count the number of issued tokens" |
 
 </details>
 
@@ -35,8 +35,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `access_token` | `string` | `optional` | `` | (description) = "OAuth Token, granted on success" |
-| 2 | `redirect_uri` | `string` | `optional` | `` | (description) = "Redirection URI provided during client registration." |
+| 1 | `access_token` | `string` | `optional` |  | (description) = "OAuth Token, granted on success" |
+| 2 | `redirect_uri` | `string` | `optional` |  | (description) = "Redirection URI provided during client registration." |
 
 </details>
 

--- a/docs/cookbook/proto-fields/steammessages-player-steamworkssdk.md
+++ b/docs/cookbook/proto-fields/steammessages-player-steamworkssdk.md
@@ -35,8 +35,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `optional` | `` |  |
-| 2 | `mutual_friend_account_ids` | `uint32` | `repeated` | `` |  |
+| 1 | `steamid` | `fixed64` | `optional` |  |  |
+| 2 | `mutual_friend_account_ids` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -48,7 +48,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `incoming_invite_mutual_friends_lists` | `.CPlayer_IncomingInviteMutualFriendList` | `repeated` | `` |  |
+| 1 | `incoming_invite_mutual_friends_lists` | `.CPlayer_IncomingInviteMutualFriendList` | `repeated` |  |  |
 
 </details>
 
@@ -60,7 +60,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` |  |
+| 1 | `appid` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -72,12 +72,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `your_info` | `.CPlayer_GetFriendsGameplayInfo_Response.OwnGameplayInfo` | `optional` | `` |  |
-| 2 | `in_game` | `.CPlayer_GetFriendsGameplayInfo_Response.FriendsGameplayInfo` | `repeated` | `` |  |
-| 3 | `played_recently` | `.CPlayer_GetFriendsGameplayInfo_Response.FriendsGameplayInfo` | `repeated` | `` |  |
-| 4 | `played_ever` | `.CPlayer_GetFriendsGameplayInfo_Response.FriendsGameplayInfo` | `repeated` | `` |  |
-| 5 | `owns` | `.CPlayer_GetFriendsGameplayInfo_Response.FriendsGameplayInfo` | `repeated` | `` |  |
-| 6 | `in_wishlist` | `.CPlayer_GetFriendsGameplayInfo_Response.FriendsGameplayInfo` | `repeated` | `` |  |
+| 1 | `your_info` | `.CPlayer_GetFriendsGameplayInfo_Response.OwnGameplayInfo` | `optional` |  |  |
+| 2 | `in_game` | `.CPlayer_GetFriendsGameplayInfo_Response.FriendsGameplayInfo` | `repeated` |  |  |
+| 3 | `played_recently` | `.CPlayer_GetFriendsGameplayInfo_Response.FriendsGameplayInfo` | `repeated` |  |  |
+| 4 | `played_ever` | `.CPlayer_GetFriendsGameplayInfo_Response.FriendsGameplayInfo` | `repeated` |  |  |
+| 5 | `owns` | `.CPlayer_GetFriendsGameplayInfo_Response.FriendsGameplayInfo` | `repeated` |  |  |
+| 6 | `in_wishlist` | `.CPlayer_GetFriendsGameplayInfo_Response.FriendsGameplayInfo` | `repeated` |  |  |
 
 </details>
 
@@ -89,9 +89,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `optional` | `` |  |
-| 2 | `minutes_played` | `uint32` | `optional` | `` |  |
-| 3 | `minutes_played_forever` | `uint32` | `optional` | `` |  |
+| 1 | `steamid` | `fixed64` | `optional` |  |  |
+| 2 | `minutes_played` | `uint32` | `optional` |  |  |
+| 3 | `minutes_played_forever` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -103,11 +103,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `optional` | `` |  |
-| 2 | `minutes_played` | `uint32` | `optional` | `` |  |
-| 3 | `minutes_played_forever` | `uint32` | `optional` | `` |  |
-| 4 | `in_wishlist` | `bool` | `optional` | `` |  |
-| 5 | `owned` | `bool` | `optional` | `` |  |
+| 1 | `steamid` | `fixed64` | `optional` |  |  |
+| 2 | `minutes_played` | `uint32` | `optional` |  |  |
+| 3 | `minutes_played_forever` | `uint32` | `optional` |  |  |
+| 4 | `in_wishlist` | `bool` | `optional` |  |  |
+| 5 | `owned` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -119,7 +119,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` |  |
+| 1 | `appid` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -131,8 +131,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player_level` | `uint32` | `optional` | `` |  |
-| 2 | `badges` | `.CPlayer_GetGameBadgeLevels_Response.Badge` | `repeated` | `` |  |
+| 1 | `player_level` | `uint32` | `optional` |  |  |
+| 2 | `badges` | `.CPlayer_GetGameBadgeLevels_Response.Badge` | `repeated` |  |  |
 
 </details>
 
@@ -144,9 +144,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `level` | `int32` | `optional` | `` |  |
-| 2 | `series` | `int32` | `optional` | `` |  |
-| 3 | `border_color` | `uint32` | `optional` | `` |  |
+| 1 | `level` | `int32` | `optional` |  |  |
+| 2 | `series` | `int32` | `optional` |  |  |
+| 3 | `border_color` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -158,7 +158,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `min_last_played` | `uint32` | `optional` | `` | (description) = "The most recent last-played time the client already knows about" |
+| 1 | `min_last_played` | `uint32` | `optional` |  | (description) = "The most recent last-played time the client already knows about" |
 
 </details>
 
@@ -170,7 +170,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `games` | `.CPlayer_GetLastPlayedTimes_Response.Game` | `repeated` | `` |  |
+| 1 | `games` | `.CPlayer_GetLastPlayedTimes_Response.Game` | `repeated` |  |  |
 
 </details>
 
@@ -182,11 +182,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `int32` | `optional` | `` |  |
-| 2 | `last_playtime` | `uint32` | `optional` | `` |  |
-| 3 | `playtime_2weeks` | `int32` | `optional` | `` |  |
-| 4 | `playtime_forever` | `int32` | `optional` | `` |  |
-| 5 | `first_playtime` | `uint32` | `optional` | `` |  |
+| 1 | `appid` | `int32` | `optional` |  |  |
+| 2 | `last_playtime` | `uint32` | `optional` |  |  |
+| 3 | `playtime_2weeks` | `int32` | `optional` |  |  |
+| 4 | `playtime_forever` | `int32` | `optional` |  |  |
+| 5 | `first_playtime` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -234,7 +234,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `nicknames` | `.CPlayer_GetNicknameList_Response.PlayerNickname` | `repeated` | `` |  |
+| 1 | `nicknames` | `.CPlayer_GetNicknameList_Response.PlayerNickname` | `repeated` |  |  |
 
 </details>
 
@@ -246,8 +246,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `accountid` | `fixed32` | `optional` | `` |  |
-| 2 | `nickname` | `string` | `optional` | `` |  |
+| 1 | `accountid` | `fixed32` | `optional` |  |  |
+| 2 | `nickname` | `string` | `optional` |  |  |
 
 </details>
 
@@ -271,15 +271,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `accountid` | `fixed32` | `optional` | `` |  |
-| 2 | `nickname` | `string` | `optional` | `` |  |
-| 3 | `notifications_showingame` | `.ENotificationSetting` | `optional` | `` | default = k_ENotificationSettingNotifyUseDefault |
-| 4 | `notifications_showonline` | `.ENotificationSetting` | `optional` | `` | default = k_ENotificationSettingNotifyUseDefault |
-| 5 | `notifications_showmessages` | `.ENotificationSetting` | `optional` | `` | default = k_ENotificationSettingNotifyUseDefault |
-| 6 | `sounds_showingame` | `.ENotificationSetting` | `optional` | `` | default = k_ENotificationSettingNotifyUseDefault |
-| 7 | `sounds_showonline` | `.ENotificationSetting` | `optional` | `` | default = k_ENotificationSettingNotifyUseDefault |
-| 8 | `sounds_showmessages` | `.ENotificationSetting` | `optional` | `` | default = k_ENotificationSettingNotifyUseDefault |
-| 9 | `notifications_sendmobile` | `.ENotificationSetting` | `optional` | `` | default = k_ENotificationSettingNotifyUseDefault |
+| 1 | `accountid` | `fixed32` | `optional` |  |  |
+| 2 | `nickname` | `string` | `optional` |  |  |
+| 3 | `notifications_showingame` | `.ENotificationSetting` | `optional` |  | default = k_ENotificationSettingNotifyUseDefault |
+| 4 | `notifications_showonline` | `.ENotificationSetting` | `optional` |  | default = k_ENotificationSettingNotifyUseDefault |
+| 5 | `notifications_showmessages` | `.ENotificationSetting` | `optional` |  | default = k_ENotificationSettingNotifyUseDefault |
+| 6 | `sounds_showingame` | `.ENotificationSetting` | `optional` |  | default = k_ENotificationSettingNotifyUseDefault |
+| 7 | `sounds_showonline` | `.ENotificationSetting` | `optional` |  | default = k_ENotificationSettingNotifyUseDefault |
+| 8 | `sounds_showmessages` | `.ENotificationSetting` | `optional` |  | default = k_ENotificationSettingNotifyUseDefault |
+| 9 | `notifications_sendmobile` | `.ENotificationSetting` | `optional` |  | default = k_ENotificationSettingNotifyUseDefault |
 
 </details>
 
@@ -291,7 +291,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `preferences` | `.PerFriendPreferences` | `repeated` | `` |  |
+| 1 | `preferences` | `.PerFriendPreferences` | `repeated` |  |  |
 
 </details>
 
@@ -303,7 +303,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `preferences` | `.PerFriendPreferences` | `optional` | `` |  |
+| 1 | `preferences` | `.PerFriendPreferences` | `optional` |  |  |
 
 </details>
 
@@ -327,7 +327,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `optional` | `` | (description) = "Steam ID of user to whom to send a friend invite." |
+| 1 | `steamid` | `fixed64` | `optional` |  | (description) = "Steam ID of user to whom to send a friend invite." |
 
 </details>
 
@@ -339,8 +339,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `invite_sent` | `bool` | `optional` | `` | (description) = "True if the operation was successful, false otherwise." |
-| 2 | `friend_relationship` | `uint32` | `optional` | `` | (description) = "the resulting relationship.  Depending on state, may move directly to friends rather than invite sent" |
+| 1 | `invite_sent` | `bool` | `optional` |  | (description) = "True if the operation was successful, false otherwise." |
+| 2 | `friend_relationship` | `uint32` | `optional` |  | (description) = "the resulting relationship.  Depending on state, may move directly to friends rather than invite sent" |
 
 </details>
 
@@ -352,7 +352,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `optional` | `` | (description) = "Steam ID of friend to remove." |
+| 1 | `steamid` | `fixed64` | `optional` |  | (description) = "Steam ID of friend to remove." |
 
 </details>
 
@@ -364,7 +364,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `friend_relationship` | `uint32` | `optional` | `` | (description) = "the resulting relationship" |
+| 1 | `friend_relationship` | `uint32` | `optional` |  | (description) = "the resulting relationship" |
 
 </details>
 
@@ -376,8 +376,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `optional` | `` |  |
-| 2 | `unignore` | `bool` | `optional` | `` | (description) = "If set, remove from ignore/block list instead of adding " |
+| 1 | `steamid` | `fixed64` | `optional` |  |  |
+| 2 | `unignore` | `bool` | `optional` |  | (description) = "If set, remove from ignore/block list instead of adding " |
 
 </details>
 
@@ -389,7 +389,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `friend_relationship` | `uint32` | `optional` | `` | (description) = "the resulting relationship" |
+| 1 | `friend_relationship` | `uint32` | `optional` |  | (description) = "the resulting relationship" |
 
 </details>
 
@@ -413,10 +413,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hide_adult_content_violence` | `bool` | `optional` | `` | default = true |
-| 2 | `hide_adult_content_sex` | `bool` | `optional` | `` | default = true |
-| 3 | `timestamp_updated` | `uint32` | `optional` | `` |  |
-| 4 | `parenthesize_nicknames` | `bool` | `optional` | `` | default = false |
+| 1 | `hide_adult_content_violence` | `bool` | `optional` |  | default = true |
+| 2 | `hide_adult_content_sex` | `bool` | `optional` |  | default = true |
+| 3 | `timestamp_updated` | `uint32` | `optional` |  |  |
+| 4 | `parenthesize_nicknames` | `bool` | `optional` |  | default = false |
 
 </details>
 
@@ -428,7 +428,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `preferences` | `.CPlayer_CommunityPreferences` | `optional` | `` |  |
+| 1 | `preferences` | `.CPlayer_CommunityPreferences` | `optional` |  |  |
 
 </details>
 
@@ -440,7 +440,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `preferences` | `.CPlayer_CommunityPreferences` | `optional` | `` |  |
+| 1 | `preferences` | `.CPlayer_CommunityPreferences` | `optional` |  |  |
 
 </details>
 
@@ -464,7 +464,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `language` | `int32` | `optional` | `` |  |
+| 1 | `language` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -476,11 +476,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `state` | `int32` | `optional` | `` |  |
-| 2 | `announcement_headline` | `string` | `optional` | `` |  |
-| 3 | `announcement_url` | `string` | `optional` | `` |  |
-| 4 | `time_posted` | `uint32` | `optional` | `` |  |
-| 5 | `announcement_gid` | `uint64` | `optional` | `` |  |
+| 1 | `state` | `int32` | `optional` |  |  |
+| 2 | `announcement_headline` | `string` | `optional` |  |  |
+| 3 | `announcement_url` | `string` | `optional` |  |  |
+| 4 | `time_posted` | `uint32` | `optional` |  |  |
+| 5 | `announcement_gid` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -492,8 +492,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `announcement_gid` | `uint64` | `optional` | `` |  |
-| 2 | `time_posted` | `uint32` | `optional` | `` |  |
+| 1 | `announcement_gid` | `uint64` | `optional` |  |  |
+| 2 | `time_posted` | `uint32` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/steammessages-publishedfile-steamworkssdk.md
+++ b/docs/cookbook/proto-fields/steammessages-publishedfile-steamworkssdk.md
@@ -23,10 +23,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `publishedfileid` | `uint64` | `optional` | `` |  |
-| 2 | `list_type` | `uint32` | `optional` | `` |  |
-| 3 | `appid` | `int32` | `optional` | `` |  |
-| 4 | `notify_client` | `bool` | `optional` | `` |  |
+| 1 | `publishedfileid` | `uint64` | `optional` |  |  |
+| 2 | `list_type` | `uint32` | `optional` |  |  |
+| 3 | `appid` | `int32` | `optional` |  |  |
+| 4 | `notify_client` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -50,10 +50,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `publishedfileid` | `uint64` | `optional` | `` |  |
-| 2 | `list_type` | `uint32` | `optional` | `` |  |
-| 3 | `appid` | `int32` | `optional` | `` |  |
-| 4 | `notify_client` | `bool` | `optional` | `` |  |
+| 1 | `publishedfileid` | `uint64` | `optional` |  |  |
+| 2 | `list_type` | `uint32` | `optional` |  |  |
+| 3 | `appid` | `int32` | `optional` |  |  |
+| 4 | `notify_client` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -77,22 +77,22 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` | (description) = "App Id this file is being published FROM." |
-| 2 | `consumer_appid` | `uint32` | `optional` | `` | (description) = "App Id this file is being published TO." |
-| 3 | `cloudfilename` | `string` | `optional` | `` | (description) = "Name of the file to publish in the user's cloud." |
-| 4 | `preview_cloudfilename` | `string` | `optional` | `` | (description) = "Name of the file to use as the published file's preview." |
-| 5 | `title` | `string` | `optional` | `` | (description) = "Text title for the published file." |
-| 6 | `file_description` | `string` | `optional` | `` | (description) = "Text description for the published file." |
-| 7 | `file_type` | `uint32` | `optional` | `` | (description) = "(EWorkshopFileType) Type of Workshop file to publish." |
-| 8 | `consumer_shortcut_name` | `string` | `optional` | `` | (description) = "Shortcut name for the published file." |
-| 9 | `youtube_username` | `string` | `optional` | `` | (description) = "(Optional) User's YouTube account username." |
-| 10 | `youtube_videoid` | `string` | `optional` | `` | (description) = "(Optional) Video Id of a YouTube video for this published file." |
-| 11 | `visibility` | `uint32` | `optional` | `` | (description) = "(ERemoteStoragePublishedFileVisibility) Visibility of the published file (private, friends, public, etc.)" |
-| 12 | `redirect_uri` | `string` | `optional` | `` | (description) = "(Optional) If supplied, the resulting published file's Id is appended to the URI." |
-| 13 | `tags` | `string` | `repeated` | `` | (description) = "Array of text tags to apply to the published file." |
-| 14 | `collection_type` | `string` | `optional` | `` | (description) = "(Optional) Type of collection the published file represents." |
-| 15 | `game_type` | `string` | `optional` | `` | (description) = "(Optional) Type of game the published file represents." |
-| 16 | `url` | `string` | `optional` | `` | (description) = "(Optional) If this represents a game, this is the URL to that game's page." |
+| 1 | `appid` | `uint32` | `optional` |  | (description) = "App Id this file is being published FROM." |
+| 2 | `consumer_appid` | `uint32` | `optional` |  | (description) = "App Id this file is being published TO." |
+| 3 | `cloudfilename` | `string` | `optional` |  | (description) = "Name of the file to publish in the user's cloud." |
+| 4 | `preview_cloudfilename` | `string` | `optional` |  | (description) = "Name of the file to use as the published file's preview." |
+| 5 | `title` | `string` | `optional` |  | (description) = "Text title for the published file." |
+| 6 | `file_description` | `string` | `optional` |  | (description) = "Text description for the published file." |
+| 7 | `file_type` | `uint32` | `optional` |  | (description) = "(EWorkshopFileType) Type of Workshop file to publish." |
+| 8 | `consumer_shortcut_name` | `string` | `optional` |  | (description) = "Shortcut name for the published file." |
+| 9 | `youtube_username` | `string` | `optional` |  | (description) = "(Optional) User's YouTube account username." |
+| 10 | `youtube_videoid` | `string` | `optional` |  | (description) = "(Optional) Video Id of a YouTube video for this published file." |
+| 11 | `visibility` | `uint32` | `optional` |  | (description) = "(ERemoteStoragePublishedFileVisibility) Visibility of the published file (private, friends, public, etc.)" |
+| 12 | `redirect_uri` | `string` | `optional` |  | (description) = "(Optional) If supplied, the resulting published file's Id is appended to the URI." |
+| 13 | `tags` | `string` | `repeated` |  | (description) = "Array of text tags to apply to the published file." |
+| 14 | `collection_type` | `string` | `optional` |  | (description) = "(Optional) Type of collection the published file represents." |
+| 15 | `game_type` | `string` | `optional` |  | (description) = "(Optional) Type of game the published file represents." |
+| 16 | `url` | `string` | `optional` |  | (description) = "(Optional) If this represents a game, this is the URL to that game's page." |
 
 </details>
 
@@ -104,8 +104,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `publishedfileid` | `uint64` | `optional` | `` |  |
-| 2 | `redirect_uri` | `string` | `optional` | `` |  |
+| 1 | `publishedfileid` | `uint64` | `optional` |  |  |
+| 2 | `redirect_uri` | `string` | `optional` |  |  |
 
 </details>
 
@@ -117,13 +117,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `publishedfileids` | `fixed64` | `repeated` | `` | (description) = "Set of published file Ids to retrieve details for." |
-| 2 | `includetags` | `bool` | `optional` | `` | (description) = "If true, return tag information in the returned details." |
-| 3 | `includeadditionalpreviews` | `bool` | `optional` | `` | (description) = "If true, return preview information in the returned details." |
-| 4 | `includechildren` | `bool` | `optional` | `` | (description) = "If true, return children in the returned details." |
-| 5 | `includekvtags` | `bool` | `optional` | `` | (description) = "If true, return key value tags in the returned details." |
-| 6 | `includevotes` | `bool` | `optional` | `` | (description) = "If true, return vote data in the returned details." |
-| 8 | `short_description` | `bool` | `optional` | `` | (description) = "If true, return a short description instead of the full description." |
+| 1 | `publishedfileids` | `fixed64` | `repeated` |  | (description) = "Set of published file Ids to retrieve details for." |
+| 2 | `includetags` | `bool` | `optional` |  | (description) = "If true, return tag information in the returned details." |
+| 3 | `includeadditionalpreviews` | `bool` | `optional` |  | (description) = "If true, return preview information in the returned details." |
+| 4 | `includechildren` | `bool` | `optional` |  | (description) = "If true, return children in the returned details." |
+| 5 | `includekvtags` | `bool` | `optional` |  | (description) = "If true, return key value tags in the returned details." |
+| 6 | `includevotes` | `bool` | `optional` |  | (description) = "If true, return vote data in the returned details." |
+| 8 | `short_description` | `bool` | `optional` |  | (description) = "If true, return a short description instead of the full description." |
 
 </details>
 
@@ -135,62 +135,62 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `uint32` | `optional` | `` |  |
-| 2 | `publishedfileid` | `uint64` | `optional` | `` |  |
-| 3 | `creator` | `fixed64` | `optional` | `` |  |
-| 4 | `creator_appid` | `uint32` | `optional` | `` |  |
-| 5 | `consumer_appid` | `uint32` | `optional` | `` |  |
-| 6 | `consumer_shortcutid` | `uint32` | `optional` | `` |  |
-| 7 | `filename` | `string` | `optional` | `` |  |
-| 8 | `file_size` | `uint64` | `optional` | `` |  |
-| 9 | `preview_file_size` | `uint64` | `optional` | `` |  |
-| 10 | `file_url` | `string` | `optional` | `` |  |
-| 11 | `preview_url` | `string` | `optional` | `` |  |
-| 12 | `youtubevideoid` | `string` | `optional` | `` |  |
-| 13 | `url` | `string` | `optional` | `` |  |
-| 14 | `hcontent_file` | `fixed64` | `optional` | `` |  |
-| 15 | `hcontent_preview` | `fixed64` | `optional` | `` |  |
-| 16 | `title` | `string` | `optional` | `` |  |
-| 17 | `file_description` | `string` | `optional` | `` |  |
-| 18 | `short_description` | `string` | `optional` | `` |  |
-| 19 | `time_created` | `uint32` | `optional` | `` |  |
-| 20 | `time_updated` | `uint32` | `optional` | `` |  |
-| 21 | `visibility` | `uint32` | `optional` | `` |  |
-| 22 | `flags` | `uint32` | `optional` | `` |  |
-| 23 | `workshop_file` | `bool` | `optional` | `` |  |
-| 24 | `workshop_accepted` | `bool` | `optional` | `` |  |
-| 25 | `show_subscribe_all` | `bool` | `optional` | `` |  |
-| 26 | `num_comments_developer` | `int32` | `optional` | `` |  |
-| 27 | `num_comments_public` | `int32` | `optional` | `` |  |
-| 28 | `banned` | `bool` | `optional` | `` |  |
-| 29 | `ban_reason` | `string` | `optional` | `` |  |
-| 30 | `banner` | `fixed64` | `optional` | `` |  |
-| 31 | `can_be_deleted` | `bool` | `optional` | `` |  |
-| 32 | `incompatible` | `bool` | `optional` | `` |  |
-| 33 | `app_name` | `string` | `optional` | `` |  |
-| 34 | `file_type` | `uint32` | `optional` | `` |  |
-| 35 | `can_subscribe` | `bool` | `optional` | `` |  |
-| 36 | `subscriptions` | `uint32` | `optional` | `` |  |
-| 37 | `favorited` | `uint32` | `optional` | `` |  |
-| 38 | `followers` | `uint32` | `optional` | `` |  |
-| 39 | `lifetime_subscriptions` | `uint32` | `optional` | `` |  |
-| 40 | `lifetime_favorited` | `uint32` | `optional` | `` |  |
-| 41 | `lifetime_followers` | `uint32` | `optional` | `` |  |
-| 42 | `views` | `uint32` | `optional` | `` |  |
-| 43 | `image_width` | `uint32` | `optional` | `` |  |
-| 44 | `image_height` | `uint32` | `optional` | `` |  |
-| 45 | `image_url` | `string` | `optional` | `` |  |
-| 46 | `spoiler_tag` | `bool` | `optional` | `` |  |
-| 47 | `shortcutid` | `uint32` | `optional` | `` |  |
-| 48 | `shortcutname` | `string` | `optional` | `` |  |
-| 49 | `num_children` | `uint32` | `optional` | `` |  |
-| 50 | `num_reports` | `uint32` | `optional` | `` |  |
-| 51 | `previews` | `.PublishedFileDetails.Preview` | `repeated` | `` |  |
-| 52 | `tags` | `.PublishedFileDetails.Tag` | `repeated` | `` |  |
-| 53 | `children` | `.PublishedFileDetails.Child` | `repeated` | `` |  |
-| 54 | `kvtags` | `.PublishedFileDetails.KVTag` | `repeated` | `` |  |
-| 55 | `vote_data` | `.PublishedFileDetails.VoteData` | `optional` | `` |  |
-| 56 | `time_subscribed` | `uint32` | `optional` | `` | (description) = "Only valid in PublishedFile.GetUserFiles and not normal PublishedFile.GetDetail calls" |
+| 1 | `result` | `uint32` | `optional` |  |  |
+| 2 | `publishedfileid` | `uint64` | `optional` |  |  |
+| 3 | `creator` | `fixed64` | `optional` |  |  |
+| 4 | `creator_appid` | `uint32` | `optional` |  |  |
+| 5 | `consumer_appid` | `uint32` | `optional` |  |  |
+| 6 | `consumer_shortcutid` | `uint32` | `optional` |  |  |
+| 7 | `filename` | `string` | `optional` |  |  |
+| 8 | `file_size` | `uint64` | `optional` |  |  |
+| 9 | `preview_file_size` | `uint64` | `optional` |  |  |
+| 10 | `file_url` | `string` | `optional` |  |  |
+| 11 | `preview_url` | `string` | `optional` |  |  |
+| 12 | `youtubevideoid` | `string` | `optional` |  |  |
+| 13 | `url` | `string` | `optional` |  |  |
+| 14 | `hcontent_file` | `fixed64` | `optional` |  |  |
+| 15 | `hcontent_preview` | `fixed64` | `optional` |  |  |
+| 16 | `title` | `string` | `optional` |  |  |
+| 17 | `file_description` | `string` | `optional` |  |  |
+| 18 | `short_description` | `string` | `optional` |  |  |
+| 19 | `time_created` | `uint32` | `optional` |  |  |
+| 20 | `time_updated` | `uint32` | `optional` |  |  |
+| 21 | `visibility` | `uint32` | `optional` |  |  |
+| 22 | `flags` | `uint32` | `optional` |  |  |
+| 23 | `workshop_file` | `bool` | `optional` |  |  |
+| 24 | `workshop_accepted` | `bool` | `optional` |  |  |
+| 25 | `show_subscribe_all` | `bool` | `optional` |  |  |
+| 26 | `num_comments_developer` | `int32` | `optional` |  |  |
+| 27 | `num_comments_public` | `int32` | `optional` |  |  |
+| 28 | `banned` | `bool` | `optional` |  |  |
+| 29 | `ban_reason` | `string` | `optional` |  |  |
+| 30 | `banner` | `fixed64` | `optional` |  |  |
+| 31 | `can_be_deleted` | `bool` | `optional` |  |  |
+| 32 | `incompatible` | `bool` | `optional` |  |  |
+| 33 | `app_name` | `string` | `optional` |  |  |
+| 34 | `file_type` | `uint32` | `optional` |  |  |
+| 35 | `can_subscribe` | `bool` | `optional` |  |  |
+| 36 | `subscriptions` | `uint32` | `optional` |  |  |
+| 37 | `favorited` | `uint32` | `optional` |  |  |
+| 38 | `followers` | `uint32` | `optional` |  |  |
+| 39 | `lifetime_subscriptions` | `uint32` | `optional` |  |  |
+| 40 | `lifetime_favorited` | `uint32` | `optional` |  |  |
+| 41 | `lifetime_followers` | `uint32` | `optional` |  |  |
+| 42 | `views` | `uint32` | `optional` |  |  |
+| 43 | `image_width` | `uint32` | `optional` |  |  |
+| 44 | `image_height` | `uint32` | `optional` |  |  |
+| 45 | `image_url` | `string` | `optional` |  |  |
+| 46 | `spoiler_tag` | `bool` | `optional` |  |  |
+| 47 | `shortcutid` | `uint32` | `optional` |  |  |
+| 48 | `shortcutname` | `string` | `optional` |  |  |
+| 49 | `num_children` | `uint32` | `optional` |  |  |
+| 50 | `num_reports` | `uint32` | `optional` |  |  |
+| 51 | `previews` | `.PublishedFileDetails.Preview` | `repeated` |  |  |
+| 52 | `tags` | `.PublishedFileDetails.Tag` | `repeated` |  |  |
+| 53 | `children` | `.PublishedFileDetails.Child` | `repeated` |  |  |
+| 54 | `kvtags` | `.PublishedFileDetails.KVTag` | `repeated` |  |  |
+| 55 | `vote_data` | `.PublishedFileDetails.VoteData` | `optional` |  |  |
+| 56 | `time_subscribed` | `uint32` | `optional` |  | (description) = "Only valid in PublishedFile.GetUserFiles and not normal PublishedFile.GetDetail calls" |
 
 </details>
 
@@ -202,8 +202,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tag` | `string` | `optional` | `` |  |
-| 2 | `adminonly` | `bool` | `optional` | `` |  |
+| 1 | `tag` | `string` | `optional` |  |  |
+| 2 | `adminonly` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -215,12 +215,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `previewid` | `uint64` | `optional` | `` |  |
-| 2 | `sortorder` | `uint32` | `optional` | `` |  |
-| 3 | `url` | `string` | `optional` | `` |  |
-| 4 | `size` | `uint32` | `optional` | `` |  |
-| 5 | `filename` | `string` | `optional` | `` |  |
-| 6 | `youtubevideoid` | `string` | `optional` | `` |  |
+| 1 | `previewid` | `uint64` | `optional` |  |  |
+| 2 | `sortorder` | `uint32` | `optional` |  |  |
+| 3 | `url` | `string` | `optional` |  |  |
+| 4 | `size` | `uint32` | `optional` |  |  |
+| 5 | `filename` | `string` | `optional` |  |  |
+| 6 | `youtubevideoid` | `string` | `optional` |  |  |
 
 </details>
 
@@ -232,9 +232,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `publishedfileid` | `uint64` | `optional` | `` |  |
-| 2 | `sortorder` | `uint32` | `optional` | `` |  |
-| 3 | `file_type` | `uint32` | `optional` | `` |  |
+| 1 | `publishedfileid` | `uint64` | `optional` |  |  |
+| 2 | `sortorder` | `uint32` | `optional` |  |  |
+| 3 | `file_type` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -246,8 +246,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key` | `string` | `optional` | `` |  |
-| 2 | `value` | `string` | `optional` | `` |  |
+| 1 | `key` | `string` | `optional` |  |  |
+| 2 | `value` | `string` | `optional` |  |  |
 
 </details>
 
@@ -259,9 +259,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `score` | `float` | `optional` | `` |  |
-| 2 | `votes_up` | `uint32` | `optional` | `` |  |
-| 3 | `votes_down` | `uint32` | `optional` | `` |  |
+| 1 | `score` | `float` | `optional` |  |  |
+| 2 | `votes_up` | `uint32` | `optional` |  |  |
+| 3 | `votes_down` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -273,7 +273,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `publishedfiledetails` | `.PublishedFileDetails` | `repeated` | `` |  |
+| 1 | `publishedfiledetails` | `.PublishedFileDetails` | `repeated` |  |  |
 
 </details>
 
@@ -285,15 +285,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` | (description) = "App Id to retrieve published files from." |
-| 3 | `page` | `uint32` | `optional` | `` | default = 1, (description) = "(Optional) Starting page for results." |
-| 4 | `numperpage` | `uint32` | `optional` | `` | default = 1, (description) = "(Optional) The number of results, per page to return." |
-| 6 | `sortmethod` | `string` | `optional` | `` | default = "lastupdated", (description) = "(Optional) Sorting method to use on returned values." |
-| 7 | `totalonly` | `bool` | `optional` | `` | (description) = "(Optional) If true, only return the total number of files that satisfy this query." |
-| 9 | `privacy` | `uint32` | `optional` | `` | (description) = "(optional) Filter by privacy settings." |
-| 10 | `ids_only` | `bool` | `optional` | `` | (description) = "(Optional) If true, only return the published file ids of files that satisfy this query." |
-| 11 | `requiredtags` | `string` | `repeated` | `` | (description) = "(Optional) Tags that must be present on a published file to satisfy the query." |
-| 12 | `excludedtags` | `string` | `repeated` | `` | (description) = "(Optional) Tags that must NOT be present on a published file to satisfy the query." |
+| 1 | `appid` | `uint32` | `optional` |  | (description) = "App Id to retrieve published files from." |
+| 3 | `page` | `uint32` | `optional` |  | default = 1, (description) = "(Optional) Starting page for results." |
+| 4 | `numperpage` | `uint32` | `optional` |  | default = 1, (description) = "(Optional) The number of results, per page to return." |
+| 6 | `sortmethod` | `string` | `optional` |  | default = "lastupdated", (description) = "(Optional) Sorting method to use on returned values." |
+| 7 | `totalonly` | `bool` | `optional` |  | (description) = "(Optional) If true, only return the total number of files that satisfy this query." |
+| 9 | `privacy` | `uint32` | `optional` |  | (description) = "(optional) Filter by privacy settings." |
+| 10 | `ids_only` | `bool` | `optional` |  | (description) = "(Optional) If true, only return the published file ids of files that satisfy this query." |
+| 11 | `requiredtags` | `string` | `repeated` |  | (description) = "(Optional) Tags that must be present on a published file to satisfy the query." |
+| 12 | `excludedtags` | `string` | `repeated` |  | (description) = "(Optional) Tags that must NOT be present on a published file to satisfy the query." |
 
 </details>
 
@@ -305,10 +305,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `total` | `uint32` | `optional` | `` |  |
-| 2 | `startindex` | `uint32` | `optional` | `` |  |
-| 3 | `publishedfiledetails` | `.PublishedFileDetails` | `repeated` | `` |  |
-| 4 | `apps` | `.CPublishedFile_GetUserFiles_Response.App` | `repeated` | `` |  |
+| 1 | `total` | `uint32` | `optional` |  |  |
+| 2 | `startindex` | `uint32` | `optional` |  |  |
+| 3 | `publishedfiledetails` | `.PublishedFileDetails` | `repeated` |  |  |
+| 4 | `apps` | `.CPublishedFile_GetUserFiles_Response.App` | `repeated` |  |  |
 
 </details>
 
@@ -320,10 +320,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `shortcutid` | `uint32` | `optional` | `` |  |
-| 4 | `private` | `bool` | `optional` | `` |  |
+| 1 | `appid` | `uint32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `shortcutid` | `uint32` | `optional` |  |  |
+| 4 | `private` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -335,14 +335,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` | (description) = "App Id this published file belongs to." |
-| 2 | `publishedfileid` | `fixed64` | `optional` | `` | (description) = "Published file id of the file we'd like update." |
-| 3 | `title` | `string` | `optional` | `` | (description) = "(Optional) Title of the published file." |
-| 4 | `file_description` | `string` | `optional` | `` | (description) = "(Optional) Description of the published file." |
-| 5 | `visibility` | `uint32` | `optional` | `` | (description) = "(Optional) Visibility of the published file." |
-| 6 | `tags` | `string` | `repeated` | `` | (description) = "(Optional) Set of tags for the published file." |
-| 7 | `filename` | `string` | `optional` | `` | (description) = "(Optional) Filename for the published file." |
-| 8 | `preview_filename` | `string` | `optional` | `` | (description) = "(Optional) Preview filename for the published file." |
+| 1 | `appid` | `uint32` | `optional` |  | (description) = "App Id this published file belongs to." |
+| 2 | `publishedfileid` | `fixed64` | `optional` |  | (description) = "Published file id of the file we'd like update." |
+| 3 | `title` | `string` | `optional` |  | (description) = "(Optional) Title of the published file." |
+| 4 | `file_description` | `string` | `optional` |  | (description) = "(Optional) Description of the published file." |
+| 5 | `visibility` | `uint32` | `optional` |  | (description) = "(Optional) Visibility of the published file." |
+| 6 | `tags` | `string` | `repeated` |  | (description) = "(Optional) Set of tags for the published file." |
+| 7 | `filename` | `string` | `optional` |  | (description) = "(Optional) Filename for the published file." |
+| 8 | `preview_filename` | `string` | `optional` |  | (description) = "(Optional) Preview filename for the published file." |
 
 </details>
 
@@ -366,12 +366,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` |  |
-| 2 | `matching_file_type` | `uint32` | `optional` | `` | (description) = "EPublishedFileInfoMatchingFileType" |
-| 3 | `tags` | `string` | `repeated` | `` | (description) = "Include files that have all the tags or any of the tags if match_all_tags is set to false." |
-| 4 | `match_all_tags` | `bool` | `optional` | `` | default = true, (description) = "If true, then files must have all the tags specified.  If false, then must have at least one of the tags specified." |
-| 5 | `excluded_tags` | `string` | `repeated` | `` | (description) = "Exclude any files that have any of these tags." |
-| 6 | `desired_queue_size` | `uint32` | `optional` | `` | (description) = "Desired number of items in the voting queue.  May be clamped by the server" |
+| 1 | `appid` | `uint32` | `optional` |  |  |
+| 2 | `matching_file_type` | `uint32` | `optional` |  | (description) = "EPublishedFileInfoMatchingFileType" |
+| 3 | `tags` | `string` | `repeated` |  | (description) = "Include files that have all the tags or any of the tags if match_all_tags is set to false." |
+| 4 | `match_all_tags` | `bool` | `optional` |  | default = true, (description) = "If true, then files must have all the tags specified.  If false, then must have at least one of the tags specified." |
+| 5 | `excluded_tags` | `string` | `repeated` |  | (description) = "Exclude any files that have any of these tags." |
+| 6 | `desired_queue_size` | `uint32` | `optional` |  | (description) = "Desired number of items in the voting queue.  May be clamped by the server" |
 
 </details>
 

--- a/docs/cookbook/proto-fields/steammessages-steamlearn-steamworkssdk.md
+++ b/docs/cookbook/proto-fields/steammessages-steamlearn-steamworkssdk.md
@@ -23,7 +23,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `elements` | `.CMsgSteamLearnDataSourceDescElement` | `repeated` | `` |  |
+| 1 | `elements` | `.CMsgSteamLearnDataSourceDescElement` | `repeated` |  |  |
 
 </details>
 
@@ -35,10 +35,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `data_type` | `.ESteamLearnDataType` | `optional` | `` | default = STEAMLEARN_DATATYPE_INVALID |
-| 3 | `object` | `.CMsgSteamLearnDataSourceDescObject` | `optional` | `` |  |
-| 4 | `count` | `uint32` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `data_type` | `.ESteamLearnDataType` | `optional` |  | default = STEAMLEARN_DATATYPE_INVALID |
+| 3 | `object` | `.CMsgSteamLearnDataSourceDescObject` | `optional` |  |  |
+| 4 | `count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -50,13 +50,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `uint32` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `version` | `uint32` | `optional` | `` |  |
-| 4 | `source_description` | `string` | `optional` | `` |  |
-| 5 | `structure` | `.CMsgSteamLearnDataSourceDescObject` | `optional` | `` |  |
-| 6 | `structure_crc` | `uint32` | `optional` | `` |  |
-| 7 | `cache_duration_seconds` | `uint32` | `optional` | `` |  |
+| 1 | `id` | `uint32` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `version` | `uint32` | `optional` |  |  |
+| 4 | `source_description` | `string` | `optional` |  |  |
+| 5 | `structure` | `.CMsgSteamLearnDataSourceDescObject` | `optional` |  |  |
+| 6 | `structure_crc` | `uint32` | `optional` |  |  |
+| 7 | `cache_duration_seconds` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -68,7 +68,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `elements` | `.CMsgSteamLearnDataElement` | `repeated` | `` |  |
+| 1 | `elements` | `.CMsgSteamLearnDataElement` | `repeated` |  |  |
 
 </details>
 
@@ -80,12 +80,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 20 | `data_int32s` | `int32` | `repeated` | `` |  |
-| 21 | `data_floats` | `float` | `repeated` | `` |  |
-| 22 | `data_bools` | `bool` | `repeated` | `` |  |
-| 23 | `data_strings` | `string` | `repeated` | `` |  |
-| 24 | `data_objects` | `.CMsgSteamLearnDataObject` | `repeated` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 20 | `data_int32s` | `int32` | `repeated` |  |  |
+| 21 | `data_floats` | `float` | `repeated` |  |  |
+| 22 | `data_bools` | `bool` | `repeated` |  |  |
+| 23 | `data_strings` | `string` | `repeated` |  |  |
+| 24 | `data_objects` | `.CMsgSteamLearnDataObject` | `repeated` |  |  |
 
 </details>
 
@@ -97,9 +97,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data_source_id` | `uint32` | `optional` | `` |  |
-| 2 | `keys` | `uint64` | `repeated` | `` |  |
-| 3 | `data_object` | `.CMsgSteamLearnDataObject` | `optional` | `` |  |
+| 1 | `data_source_id` | `uint32` | `optional` |  |  |
+| 2 | `keys` | `uint64` | `repeated` |  |  |
+| 3 | `data_object` | `.CMsgSteamLearnDataObject` | `optional` |  |  |
 
 </details>
 
@@ -111,7 +111,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data` | `.CMsgSteamLearnData` | `repeated` | `` |  |
+| 1 | `data` | `.CMsgSteamLearnData` | `repeated` |  |  |
 
 </details>
 
@@ -123,8 +123,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `access_token` | `string` | `optional` | `` |  |
-| 3 | `data_source` | `.CMsgSteamLearnDataSource` | `optional` | `` |  |
+| 1 | `access_token` | `string` | `optional` |  |  |
+| 3 | `data_source` | `.CMsgSteamLearnDataSource` | `optional` |  |  |
 
 </details>
 
@@ -136,8 +136,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.ESteammLearnRegisterDataSourceResult` | `optional` | `` | default = STEAMLEARN_REGISTER_DATA_SOURCE_RESULT_ERROR |
-| 2 | `data_source` | `.CMsgSteamLearnDataSource` | `optional` | `` |  |
+| 1 | `result` | `.ESteammLearnRegisterDataSourceResult` | `optional` |  | default = STEAMLEARN_REGISTER_DATA_SOURCE_RESULT_ERROR |
+| 2 | `data_source` | `.CMsgSteamLearnDataSource` | `optional` |  |  |
 
 </details>
 
@@ -149,8 +149,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `access_token` | `string` | `optional` | `` |  |
-| 3 | `data` | `.CMsgSteamLearnData` | `optional` | `` |  |
+| 1 | `access_token` | `string` | `optional` |  |  |
+| 3 | `data` | `.CMsgSteamLearnData` | `optional` |  |  |
 
 </details>
 
@@ -162,7 +162,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cache_data_result` | `.ESteamLearnCacheDataResult` | `optional` | `` | default = STEAMLEARN_CACHE_DATA_ERROR |
+| 1 | `cache_data_result` | `.ESteamLearnCacheDataResult` | `optional` |  | default = STEAMLEARN_CACHE_DATA_ERROR |
 
 </details>
 
@@ -174,12 +174,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `access_token` | `string` | `optional` | `` |  |
-| 3 | `project_id` | `uint32` | `optional` | `` |  |
-| 4 | `keys` | `uint64` | `repeated` | `` |  |
-| 5 | `data` | `.CMsgSteamLearnData` | `repeated` | `` |  |
-| 6 | `pending_data_limit_seconds` | `uint32` | `optional` | `` |  |
-| 7 | `published_version` | `uint32` | `optional` | `` |  |
+| 1 | `access_token` | `string` | `optional` |  |  |
+| 3 | `project_id` | `uint32` | `optional` |  |  |
+| 4 | `keys` | `uint64` | `repeated` |  |  |
+| 5 | `data` | `.CMsgSteamLearnData` | `repeated` |  |  |
+| 6 | `pending_data_limit_seconds` | `uint32` | `optional` |  |  |
+| 7 | `published_version` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -191,7 +191,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `snapshot_result` | `.ESteamLearnSnapshotProjectResult` | `optional` | `` | default = STEAMLEARN_SNAPSHOT_PROJECT_ERROR |
+| 1 | `snapshot_result` | `.ESteamLearnSnapshotProjectResult` | `optional` |  | default = STEAMLEARN_SNAPSHOT_PROJECT_ERROR |
 
 </details>
 
@@ -203,9 +203,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cache_data_requests` | `.CMsgSteamLearn_CacheData_Request` | `repeated` | `` |  |
-| 2 | `snapshot_requests` | `.CMsgSteamLearn_SnapshotProject_Request` | `repeated` | `` |  |
-| 3 | `inference_requests` | `.CMsgSteamLearn_Inference_Request` | `repeated` | `` |  |
+| 1 | `cache_data_requests` | `.CMsgSteamLearn_CacheData_Request` | `repeated` |  |  |
+| 2 | `snapshot_requests` | `.CMsgSteamLearn_SnapshotProject_Request` | `repeated` |  |  |
+| 3 | `inference_requests` | `.CMsgSteamLearn_Inference_Request` | `repeated` |  |  |
 
 </details>
 
@@ -217,9 +217,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cache_data_responses` | `.CMsgSteamLearn_CacheData_Response` | `repeated` | `` |  |
-| 2 | `snapshot_responses` | `.CMsgSteamLearn_SnapshotProject_Response` | `repeated` | `` |  |
-| 3 | `inference_responses` | `.CMsgSteamLearn_Inference_Response` | `repeated` | `` |  |
+| 1 | `cache_data_responses` | `.CMsgSteamLearn_CacheData_Response` | `repeated` |  |  |
+| 2 | `snapshot_responses` | `.CMsgSteamLearn_SnapshotProject_Response` | `repeated` |  |  |
+| 3 | `inference_responses` | `.CMsgSteamLearn_Inference_Response` | `repeated` |  |  |
 
 </details>
 
@@ -231,10 +231,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `register_data_source_access_token` | `string` | `optional` | `` |  |
-| 2 | `cache_data_access_tokens` | `.CMsgSteamLearnAccessTokens.CacheDataAccessToken` | `repeated` | `` |  |
-| 3 | `snapshot_project_access_tokens` | `.CMsgSteamLearnAccessTokens.SnapshotProjectAccessToken` | `repeated` | `` |  |
-| 4 | `inference_access_tokens` | `.CMsgSteamLearnAccessTokens.InferenceAccessToken` | `repeated` | `` |  |
+| 1 | `register_data_source_access_token` | `string` | `optional` |  |  |
+| 2 | `cache_data_access_tokens` | `.CMsgSteamLearnAccessTokens.CacheDataAccessToken` | `repeated` |  |  |
+| 3 | `snapshot_project_access_tokens` | `.CMsgSteamLearnAccessTokens.SnapshotProjectAccessToken` | `repeated` |  |  |
+| 4 | `inference_access_tokens` | `.CMsgSteamLearnAccessTokens.InferenceAccessToken` | `repeated` |  |  |
 
 </details>
 
@@ -246,8 +246,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data_source_id` | `uint32` | `optional` | `` |  |
-| 2 | `access_token` | `string` | `optional` | `` |  |
+| 1 | `data_source_id` | `uint32` | `optional` |  |  |
+| 2 | `access_token` | `string` | `optional` |  |  |
 
 </details>
 
@@ -259,8 +259,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `project_id` | `uint32` | `optional` | `` |  |
-| 2 | `access_token` | `string` | `optional` | `` |  |
+| 1 | `project_id` | `uint32` | `optional` |  |  |
+| 2 | `access_token` | `string` | `optional` |  |  |
 
 </details>
 
@@ -272,8 +272,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `project_id` | `uint32` | `optional` | `` |  |
-| 2 | `access_token` | `string` | `optional` | `` |  |
+| 1 | `project_id` | `uint32` | `optional` |  |  |
+| 2 | `access_token` | `string` | `optional` |  |  |
 
 </details>
 
@@ -285,7 +285,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `appid` | `uint32` | `optional` | `` |  |
+| 1 | `appid` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -297,8 +297,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `result` | `.ESteamLearnGetAccessTokensResult` | `optional` | `` | default = STEAMLEARN_GET_ACCESS_TOKENS_ERROR |
-| 2 | `access_tokens` | `.CMsgSteamLearnAccessTokens` | `optional` | `` |  |
+| 1 | `result` | `.ESteamLearnGetAccessTokensResult` | `optional` |  | default = STEAMLEARN_GET_ACCESS_TOKENS_ERROR |
+| 2 | `access_tokens` | `.CMsgSteamLearnAccessTokens` | `optional` |  |  |
 
 </details>
 
@@ -310,14 +310,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `beam_length` | `uint32` | `optional` | `` |  |
-| 2 | `beam_width` | `uint32` | `optional` | `` |  |
-| 3 | `item_decay` | `float` | `optional` | `` |  |
-| 4 | `next_item_count` | `uint32` | `optional` | `` |  |
-| 5 | `item_scalars` | `.CMsgInferenceIterateBeamSearch.CustomItemScalar` | `repeated` | `` |  |
-| 7 | `item_sequence_end` | `uint32` | `optional` | `` |  |
-| 8 | `item_sequence_end_threshold` | `float` | `optional` | `` |  |
-| 9 | `repeat_multiplier` | `float` | `optional` | `` |  |
+| 1 | `beam_length` | `uint32` | `optional` |  |  |
+| 2 | `beam_width` | `uint32` | `optional` |  |  |
+| 3 | `item_decay` | `float` | `optional` |  |  |
+| 4 | `next_item_count` | `uint32` | `optional` |  |  |
+| 5 | `item_scalars` | `.CMsgInferenceIterateBeamSearch.CustomItemScalar` | `repeated` |  |  |
+| 7 | `item_sequence_end` | `uint32` | `optional` |  |  |
+| 8 | `item_sequence_end_threshold` | `float` | `optional` |  |  |
+| 9 | `repeat_multiplier` | `float` | `optional` |  |  |
 
 </details>
 
@@ -329,8 +329,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item` | `uint32` | `optional` | `` |  |
-| 2 | `scale` | `float` | `optional` | `` |  |
+| 1 | `item` | `uint32` | `optional` |  |  |
+| 2 | `scale` | `float` | `optional` |  |  |
 
 </details>
 
@@ -342,16 +342,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `access_token` | `string` | `optional` | `` |  |
-| 3 | `project_id` | `uint32` | `optional` | `` |  |
-| 4 | `published_version` | `uint32` | `optional` | `` |  |
-| 5 | `override_train_id` | `uint32` | `optional` | `` |  |
-| 6 | `data` | `.CMsgSteamLearnDataList` | `optional` | `` |  |
-| 7 | `additional_data` | `float` | `repeated` | `` |  |
-| 8 | `keys` | `uint64` | `repeated` | `` |  |
-| 9 | `named_inference` | `string` | `optional` | `` |  |
-| 13 | `iterate_beam_search` | `.CMsgInferenceIterateBeamSearch` | `optional` | `` |  |
-| 14 | `debug_spew` | `uint32` | `optional` | `` |  |
+| 1 | `access_token` | `string` | `optional` |  |  |
+| 3 | `project_id` | `uint32` | `optional` |  |  |
+| 4 | `published_version` | `uint32` | `optional` |  |  |
+| 5 | `override_train_id` | `uint32` | `optional` |  |  |
+| 6 | `data` | `.CMsgSteamLearnDataList` | `optional` |  |  |
+| 7 | `additional_data` | `float` | `repeated` |  |  |
+| 8 | `keys` | `uint64` | `repeated` |  |  |
+| 9 | `named_inference` | `string` | `optional` |  |  |
+| 13 | `iterate_beam_search` | `.CMsgInferenceIterateBeamSearch` | `optional` |  |  |
+| 14 | `debug_spew` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -363,10 +363,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `access_token` | `string` | `optional` | `` |  |
-| 3 | `project_id` | `uint32` | `optional` | `` |  |
-| 4 | `published_version` | `uint32` | `optional` | `` |  |
-| 5 | `override_train_id` | `uint32` | `optional` | `` |  |
+| 1 | `access_token` | `string` | `optional` |  |  |
+| 3 | `project_id` | `uint32` | `optional` |  |  |
+| 4 | `published_version` | `uint32` | `optional` |  |  |
+| 5 | `override_train_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -378,8 +378,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `project_id` | `uint32` | `optional` | `` |  |
-| 2 | `fetch_id` | `uint32` | `optional` | `` |  |
+| 1 | `project_id` | `uint32` | `optional` |  |  |
+| 2 | `fetch_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -391,15 +391,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `inference_metadata_result` | `.ESteamLearnInferenceMetadataResult` | `optional` | `` | default = STEAMLEARN_INFERENCE_METADATA_ERROR |
-| 2 | `row_range` | `.CMsgSteamLearn_InferenceMetadata_Response.RowRange` | `optional` | `` |  |
-| 3 | `ranges` | `.CMsgSteamLearn_InferenceMetadata_Response.Range` | `repeated` | `` |  |
-| 4 | `std_devs` | `.CMsgSteamLearn_InferenceMetadata_Response.StdDev` | `repeated` | `` |  |
-| 5 | `compact_tables` | `.CMsgSteamLearn_InferenceMetadata_Response.CompactTable` | `repeated` | `` |  |
-| 6 | `kmeans` | `.CMsgSteamLearn_InferenceMetadata_Response.KMeans` | `repeated` | `` |  |
-| 7 | `snapshot_histogram` | `.CMsgSteamLearn_InferenceMetadata_Response.SnapshotHistogram` | `optional` | `` |  |
-| 8 | `app_info` | `.CMsgSteamLearn_InferenceMetadata_Response.AppInfoEntry` | `repeated` | `` |  |
-| 9 | `sequence_tables` | `.CMsgSteamLearn_InferenceMetadata_Response.SequenceTable` | `repeated` | `` |  |
+| 1 | `inference_metadata_result` | `.ESteamLearnInferenceMetadataResult` | `optional` |  | default = STEAMLEARN_INFERENCE_METADATA_ERROR |
+| 2 | `row_range` | `.CMsgSteamLearn_InferenceMetadata_Response.RowRange` | `optional` |  |  |
+| 3 | `ranges` | `.CMsgSteamLearn_InferenceMetadata_Response.Range` | `repeated` |  |  |
+| 4 | `std_devs` | `.CMsgSteamLearn_InferenceMetadata_Response.StdDev` | `repeated` |  |  |
+| 5 | `compact_tables` | `.CMsgSteamLearn_InferenceMetadata_Response.CompactTable` | `repeated` |  |  |
+| 6 | `kmeans` | `.CMsgSteamLearn_InferenceMetadata_Response.KMeans` | `repeated` |  |  |
+| 7 | `snapshot_histogram` | `.CMsgSteamLearn_InferenceMetadata_Response.SnapshotHistogram` | `optional` |  |  |
+| 8 | `app_info` | `.CMsgSteamLearn_InferenceMetadata_Response.AppInfoEntry` | `repeated` |  |  |
+| 9 | `sequence_tables` | `.CMsgSteamLearn_InferenceMetadata_Response.SequenceTable` | `repeated` |  |  |
 
 </details>
 
@@ -411,8 +411,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `min_row` | `uint64` | `optional` | `` |  |
-| 2 | `max_row` | `uint64` | `optional` | `` |  |
+| 1 | `min_row` | `uint64` | `optional` |  |  |
+| 2 | `max_row` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -424,9 +424,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data_element_path` | `string` | `optional` | `` |  |
-| 2 | `min_value` | `float` | `optional` | `` |  |
-| 3 | `max_value` | `float` | `optional` | `` |  |
+| 1 | `data_element_path` | `string` | `optional` |  |  |
+| 2 | `min_value` | `float` | `optional` |  |  |
+| 3 | `max_value` | `float` | `optional` |  |  |
 
 </details>
 
@@ -438,9 +438,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data_element_path` | `string` | `optional` | `` |  |
-| 2 | `mean` | `float` | `optional` | `` |  |
-| 3 | `std_dev` | `float` | `optional` | `` |  |
+| 1 | `data_element_path` | `string` | `optional` |  |  |
+| 2 | `mean` | `float` | `optional` |  |  |
+| 3 | `std_dev` | `float` | `optional` |  |  |
 
 </details>
 
@@ -452,9 +452,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `map_values` | `.CMsgSteamLearn_InferenceMetadata_Response.CompactTable.MapValuesEntry` | `repeated` | `` |  |
-| 3 | `map_mappings` | `.CMsgSteamLearn_InferenceMetadata_Response.CompactTable.MapMappingsEntry` | `repeated` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `map_values` | `.CMsgSteamLearn_InferenceMetadata_Response.CompactTable.MapValuesEntry` | `repeated` |  |  |
+| 3 | `map_mappings` | `.CMsgSteamLearn_InferenceMetadata_Response.CompactTable.MapMappingsEntry` | `repeated` |  |  |
 
 </details>
 
@@ -466,9 +466,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `value` | `uint32` | `optional` | `` |  |
-| 2 | `mapping` | `uint32` | `optional` | `` |  |
-| 3 | `count` | `uint64` | `optional` | `` |  |
+| 1 | `value` | `uint32` | `optional` |  |  |
+| 2 | `mapping` | `uint32` | `optional` |  |  |
+| 3 | `count` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -480,8 +480,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `.CMsgSteamLearn_InferenceMetadata_Response.CompactTable.Entry` | `optional` | `` |  |
+| 1 | `key` | `uint32` | `optional` |  |  |
+| 2 | `value` | `.CMsgSteamLearn_InferenceMetadata_Response.CompactTable.Entry` | `optional` |  |  |
 
 </details>
 
@@ -493,8 +493,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `.CMsgSteamLearn_InferenceMetadata_Response.CompactTable.Entry` | `optional` | `` |  |
+| 1 | `key` | `uint32` | `optional` |  |  |
+| 2 | `value` | `.CMsgSteamLearn_InferenceMetadata_Response.CompactTable.Entry` | `optional` |  |  |
 
 </details>
 
@@ -506,10 +506,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `map_values` | `.CMsgSteamLearn_InferenceMetadata_Response.SequenceTable.MapValuesEntry` | `repeated` | `` |  |
-| 3 | `map_mappings` | `.CMsgSteamLearn_InferenceMetadata_Response.SequenceTable.MapMappingsEntry` | `repeated` | `` |  |
-| 4 | `total_count` | `uint64` | `optional` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `map_values` | `.CMsgSteamLearn_InferenceMetadata_Response.SequenceTable.MapValuesEntry` | `repeated` |  |  |
+| 3 | `map_mappings` | `.CMsgSteamLearn_InferenceMetadata_Response.SequenceTable.MapMappingsEntry` | `repeated` |  |  |
+| 4 | `total_count` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -521,9 +521,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `values` | `uint32` | `repeated` | `` |  |
-| 2 | `crc` | `uint32` | `optional` | `` |  |
-| 3 | `count` | `uint32` | `optional` | `` |  |
+| 1 | `values` | `uint32` | `repeated` |  |  |
+| 2 | `crc` | `uint32` | `optional` |  |  |
+| 3 | `count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -535,8 +535,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `.CMsgSteamLearn_InferenceMetadata_Response.SequenceTable.Entry` | `optional` | `` |  |
+| 1 | `key` | `uint32` | `optional` |  |  |
+| 2 | `value` | `.CMsgSteamLearn_InferenceMetadata_Response.SequenceTable.Entry` | `optional` |  |  |
 
 </details>
 
@@ -548,8 +548,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key` | `string` | `optional` | `` |  |
-| 2 | `value` | `.CMsgSteamLearn_InferenceMetadata_Response.SequenceTable.Entry` | `optional` | `` |  |
+| 1 | `key` | `string` | `optional` |  |  |
+| 2 | `value` | `.CMsgSteamLearn_InferenceMetadata_Response.SequenceTable.Entry` | `optional` |  |  |
 
 </details>
 
@@ -561,8 +561,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name` | `string` | `optional` | `` |  |
-| 2 | `clusters` | `.CMsgSteamLearn_InferenceMetadata_Response.KMeans.Cluster` | `repeated` | `` |  |
+| 1 | `name` | `string` | `optional` |  |  |
+| 2 | `clusters` | `.CMsgSteamLearn_InferenceMetadata_Response.KMeans.Cluster` | `repeated` |  |  |
 
 </details>
 
@@ -574,12 +574,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `x` | `float` | `optional` | `` |  |
-| 2 | `y` | `float` | `optional` | `` |  |
-| 3 | `radius` | `float` | `optional` | `` |  |
-| 4 | `radius_75pct` | `float` | `optional` | `` |  |
-| 5 | `radius_50pct` | `float` | `optional` | `` |  |
-| 6 | `radius_25pct` | `float` | `optional` | `` |  |
+| 1 | `x` | `float` | `optional` |  |  |
+| 2 | `y` | `float` | `optional` |  |  |
+| 3 | `radius` | `float` | `optional` |  |  |
+| 4 | `radius_75pct` | `float` | `optional` |  |  |
+| 5 | `radius_50pct` | `float` | `optional` |  |  |
+| 6 | `radius_25pct` | `float` | `optional` |  |  |
 
 </details>
 
@@ -591,10 +591,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `min_value` | `float` | `optional` | `` |  |
-| 2 | `max_value` | `float` | `optional` | `` |  |
-| 3 | `num_buckets` | `uint32` | `optional` | `` |  |
-| 4 | `bucket_counts` | `uint32` | `repeated` | `` |  |
+| 1 | `min_value` | `float` | `optional` |  |  |
+| 2 | `max_value` | `float` | `optional` |  |  |
+| 3 | `num_buckets` | `uint32` | `optional` |  |  |
+| 4 | `bucket_counts` | `uint32` | `repeated` |  |  |
 
 </details>
 
@@ -606,13 +606,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `country_allow` | `string` | `optional` | `` |  |
-| 2 | `country_deny` | `string` | `optional` | `` |  |
-| 3 | `platform_win` | `bool` | `optional` | `` |  |
-| 4 | `platform_mac` | `bool` | `optional` | `` |  |
-| 5 | `platform_linux` | `bool` | `optional` | `` |  |
-| 6 | `adult_violence` | `bool` | `optional` | `` |  |
-| 7 | `adult_sex` | `bool` | `optional` | `` |  |
+| 1 | `country_allow` | `string` | `optional` |  |  |
+| 2 | `country_deny` | `string` | `optional` |  |  |
+| 3 | `platform_win` | `bool` | `optional` |  |  |
+| 4 | `platform_mac` | `bool` | `optional` |  |  |
+| 5 | `platform_linux` | `bool` | `optional` |  |  |
+| 6 | `adult_violence` | `bool` | `optional` |  |  |
+| 7 | `adult_sex` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -624,8 +624,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `.CMsgSteamLearn_InferenceMetadata_Response.AppInfo` | `optional` | `` |  |
+| 1 | `key` | `uint32` | `optional` |  |  |
+| 2 | `value` | `.CMsgSteamLearn_InferenceMetadata_Response.AppInfo` | `optional` |  |  |
 
 </details>
 
@@ -637,7 +637,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `outputs` | `.CMsgSteamLearn_InferenceBackend_Response.Output` | `repeated` | `` |  |
+| 1 | `outputs` | `.CMsgSteamLearn_InferenceBackend_Response.Output` | `repeated` |  |  |
 
 </details>
 
@@ -649,7 +649,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `value` | `float` | `repeated` | `` |  |
+| 1 | `value` | `float` | `repeated` |  |  |
 
 </details>
 
@@ -661,7 +661,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `value` | `float` | `optional` | `` |  |
+| 2 | `value` | `float` | `optional` |  |  |
 
 </details>
 
@@ -673,7 +673,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 3 | `value` | `float` | `repeated` | `` |  |
+| 3 | `value` | `float` | `repeated` |  |  |
 
 </details>
 
@@ -685,7 +685,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `value` | `float` | `optional` | `` |  |
+| 1 | `value` | `float` | `optional` |  |  |
 
 </details>
 
@@ -697,9 +697,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `weight` | `float` | `repeated` | `` |  |
-| 2 | `value` | `float` | `repeated` | `` |  |
-| 3 | `value_sequence` | `.CMsgSteamLearn_InferenceBackend_Response.Sequence` | `repeated` | `` |  |
+| 1 | `weight` | `float` | `repeated` |  |  |
+| 2 | `value` | `float` | `repeated` |  |  |
+| 3 | `value_sequence` | `.CMsgSteamLearn_InferenceBackend_Response.Sequence` | `repeated` |  |  |
 
 </details>
 
@@ -711,9 +711,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `weight` | `float` | `repeated` | `` |  |
-| 2 | `value` | `float` | `repeated` | `` |  |
-| 3 | `value_sequence` | `.CMsgSteamLearn_InferenceBackend_Response.Sequence` | `repeated` | `` |  |
+| 1 | `weight` | `float` | `repeated` |  |  |
+| 2 | `value` | `float` | `repeated` |  |  |
+| 3 | `value_sequence` | `.CMsgSteamLearn_InferenceBackend_Response.Sequence` | `repeated` |  |  |
 
 </details>
 
@@ -741,9 +741,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `inference_result` | `.ESteamLearnInferenceResult` | `optional` | `` | default = STEAMLEARN_INFERENCE_ERROR |
-| 2 | `backend_response` | `.CMsgSteamLearn_InferenceBackend_Response` | `optional` | `` |  |
-| 3 | `keys` | `uint64` | `repeated` | `` |  |
+| 1 | `inference_result` | `.ESteamLearnInferenceResult` | `optional` |  | default = STEAMLEARN_INFERENCE_ERROR |
+| 2 | `backend_response` | `.CMsgSteamLearn_InferenceBackend_Response` | `optional` |  |  |
+| 3 | `keys` | `uint64` | `repeated` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/steammessages.md
+++ b/docs/cookbook/proto-fields/steammessages.md
@@ -23,16 +23,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `client_steam_id` | `fixed64` | `optional` | `` |  |
-| 2 | `client_session_id` | `int32` | `optional` | `` |  |
-| 3 | `source_app_id` | `uint32` | `optional` | `` |  |
-| 10 | `job_id_source` | `fixed64` | `optional` | `` | default = 18446744073709551615 |
-| 11 | `job_id_target` | `fixed64` | `optional` | `` | default = 18446744073709551615 |
-| 12 | `target_job_name` | `string` | `optional` | `` |  |
-| 13 | `eresult` | `int32` | `optional` | `` | default = 2 |
-| 14 | `error_message` | `string` | `optional` | `` |  |
-| 200 | `gc_msg_src` | `.GCProtoBufMsgSrc` | `optional` | `` | default = GCProtoBufMsgSrc_Unspecified |
-| 201 | `gc_dir_index_source` | `int32` | `optional` | `` | default = -1 |
+| 1 | `client_steam_id` | `fixed64` | `optional` |  |  |
+| 2 | `client_session_id` | `int32` | `optional` |  |  |
+| 3 | `source_app_id` | `uint32` | `optional` |  |  |
+| 10 | `job_id_source` | `fixed64` | `optional` |  | default = 18446744073709551615 |
+| 11 | `job_id_target` | `fixed64` | `optional` |  | default = 18446744073709551615 |
+| 12 | `target_job_name` | `string` | `optional` |  |  |
+| 13 | `eresult` | `int32` | `optional` |  | default = 2 |
+| 14 | `error_message` | `string` | `optional` |  |  |
+| 200 | `gc_msg_src` | `.GCProtoBufMsgSrc` | `optional` |  | default = GCProtoBufMsgSrc_Unspecified |
+| 201 | `gc_dir_index_source` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -44,8 +44,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `steamid` | `fixed64` | `optional` | `` |  |
-| 2 | `appid` | `uint32` | `optional` | `` |  |
+| 1 | `steamid` | `fixed64` | `optional` |  |  |
+| 2 | `appid` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -57,43 +57,43 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `eresult_deprecated` | `uint32` | `optional` | `` | default = 2 |
-| 2 | `account_name` | `string` | `optional` | `` |  |
-| 3 | `persona_name` | `string` | `optional` | `` |  |
-| 4 | `is_profile_public` | `bool` | `optional` | `` |  |
-| 5 | `is_inventory_public` | `bool` | `optional` | `` |  |
-| 7 | `is_vac_banned` | `bool` | `optional` | `` |  |
-| 8 | `is_cyber_cafe` | `bool` | `optional` | `` |  |
-| 9 | `is_school_account` | `bool` | `optional` | `` |  |
-| 10 | `is_limited` | `bool` | `optional` | `` |  |
-| 11 | `is_subscribed` | `bool` | `optional` | `` |  |
-| 12 | `package` | `uint32` | `optional` | `` |  |
-| 13 | `is_free_trial_account` | `bool` | `optional` | `` |  |
-| 14 | `free_trial_expiration` | `uint32` | `optional` | `` |  |
-| 15 | `is_low_violence` | `bool` | `optional` | `` |  |
-| 16 | `is_account_locked_down` | `bool` | `optional` | `` |  |
-| 17 | `is_community_banned` | `bool` | `optional` | `` |  |
-| 18 | `is_trade_banned` | `bool` | `optional` | `` |  |
-| 19 | `trade_ban_expiration` | `uint32` | `optional` | `` |  |
-| 20 | `accountid` | `uint32` | `optional` | `` |  |
-| 21 | `suspension_end_time` | `uint32` | `optional` | `` |  |
-| 22 | `currency` | `string` | `optional` | `` |  |
-| 23 | `steam_level` | `uint32` | `optional` | `` |  |
-| 24 | `friend_count` | `uint32` | `optional` | `` |  |
-| 25 | `account_creation_time` | `uint32` | `optional` | `` |  |
-| 26 | `is_profile_created` | `bool` | `optional` | `` |  |
-| 27 | `is_steamguard_enabled` | `bool` | `optional` | `` |  |
-| 28 | `is_phone_verified` | `bool` | `optional` | `` |  |
-| 29 | `is_two_factor_auth_enabled` | `bool` | `optional` | `` |  |
-| 30 | `two_factor_enabled_time` | `uint32` | `optional` | `` |  |
-| 31 | `phone_verification_time` | `uint32` | `optional` | `` |  |
-| 33 | `phone_id` | `uint64` | `optional` | `` |  |
-| 34 | `is_phone_identifying` | `bool` | `optional` | `` |  |
-| 35 | `rt_identity_linked` | `uint32` | `optional` | `` |  |
-| 36 | `rt_birth_date` | `uint32` | `optional` | `` |  |
-| 37 | `txn_country_code` | `string` | `optional` | `` |  |
-| 38 | `has_accepted_china_ssa` | `bool` | `optional` | `` |  |
-| 39 | `is_banned_steam_china` | `bool` | `optional` | `` |  |
+| 1 | `eresult_deprecated` | `uint32` | `optional` |  | default = 2 |
+| 2 | `account_name` | `string` | `optional` |  |  |
+| 3 | `persona_name` | `string` | `optional` |  |  |
+| 4 | `is_profile_public` | `bool` | `optional` |  |  |
+| 5 | `is_inventory_public` | `bool` | `optional` |  |  |
+| 7 | `is_vac_banned` | `bool` | `optional` |  |  |
+| 8 | `is_cyber_cafe` | `bool` | `optional` |  |  |
+| 9 | `is_school_account` | `bool` | `optional` |  |  |
+| 10 | `is_limited` | `bool` | `optional` |  |  |
+| 11 | `is_subscribed` | `bool` | `optional` |  |  |
+| 12 | `package` | `uint32` | `optional` |  |  |
+| 13 | `is_free_trial_account` | `bool` | `optional` |  |  |
+| 14 | `free_trial_expiration` | `uint32` | `optional` |  |  |
+| 15 | `is_low_violence` | `bool` | `optional` |  |  |
+| 16 | `is_account_locked_down` | `bool` | `optional` |  |  |
+| 17 | `is_community_banned` | `bool` | `optional` |  |  |
+| 18 | `is_trade_banned` | `bool` | `optional` |  |  |
+| 19 | `trade_ban_expiration` | `uint32` | `optional` |  |  |
+| 20 | `accountid` | `uint32` | `optional` |  |  |
+| 21 | `suspension_end_time` | `uint32` | `optional` |  |  |
+| 22 | `currency` | `string` | `optional` |  |  |
+| 23 | `steam_level` | `uint32` | `optional` |  |  |
+| 24 | `friend_count` | `uint32` | `optional` |  |  |
+| 25 | `account_creation_time` | `uint32` | `optional` |  |  |
+| 26 | `is_profile_created` | `bool` | `optional` |  |  |
+| 27 | `is_steamguard_enabled` | `bool` | `optional` |  |  |
+| 28 | `is_phone_verified` | `bool` | `optional` |  |  |
+| 29 | `is_two_factor_auth_enabled` | `bool` | `optional` |  |  |
+| 30 | `two_factor_enabled_time` | `uint32` | `optional` |  |  |
+| 31 | `phone_verification_time` | `uint32` | `optional` |  |  |
+| 33 | `phone_id` | `uint64` | `optional` |  |  |
+| 34 | `is_phone_identifying` | `bool` | `optional` |  |  |
+| 35 | `rt_identity_linked` | `uint32` | `optional` |  |  |
+| 36 | `rt_birth_date` | `uint32` | `optional` |  |  |
+| 37 | `txn_country_code` | `string` | `optional` |  |  |
+| 38 | `has_accepted_china_ssa` | `bool` | `optional` |  |  |
+| 39 | `is_banned_steam_china` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -105,12 +105,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ip` | `uint32` | `optional` | `` |  |
-| 2 | `latitude` | `float` | `optional` | `` |  |
-| 3 | `longitude` | `float` | `optional` | `` |  |
-| 4 | `country` | `string` | `optional` | `` |  |
-| 5 | `state` | `string` | `optional` | `` |  |
-| 6 | `city` | `string` | `optional` | `` |  |
+| 1 | `ip` | `uint32` | `optional` |  |  |
+| 2 | `latitude` | `float` | `optional` |  |  |
+| 3 | `longitude` | `float` | `optional` |  |  |
+| 4 | `country` | `string` | `optional` |  |  |
+| 5 | `state` | `string` | `optional` |  |  |
+| 6 | `city` | `string` | `optional` |  |  |
 
 </details>
 
@@ -122,7 +122,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `infos` | `.CIPLocationInfo` | `repeated` | `` |  |
+| 1 | `infos` | `.CIPLocationInfo` | `repeated` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/steamnetworkingsockets-messages-certs.md
+++ b/docs/cookbook/proto-fields/steamnetworkingsockets-messages-certs.md
@@ -19,10 +19,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `generic_bytes` | `bytes` | `optional` | `` |  |
-| 3 | `generic_string` | `string` | `optional` | `` |  |
-| 4 | `ipv6_and_port` | `bytes` | `optional` | `` |  |
-| 16 | `steam_id` | `fixed64` | `optional` | `` |  |
+| 2 | `generic_bytes` | `bytes` | `optional` |  |  |
+| 3 | `generic_string` | `string` | `optional` |  |  |
+| 4 | `ipv6_and_port` | `bytes` | `optional` |  |  |
+| 16 | `steam_id` | `fixed64` | `optional` |  |  |
 
 </details>
 
@@ -34,16 +34,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key_type` | `.CMsgSteamDatagramCertificate.EKeyType` | `optional` | `` | default = INVALID |
-| 2 | `key_data` | `bytes` | `optional` | `` |  |
-| 4 | `legacy_steam_id` | `fixed64` | `optional` | `` |  |
-| 5 | `gameserver_datacenter_ids` | `fixed32` | `repeated` | `` |  |
-| 8 | `time_created` | `fixed32` | `optional` | `` |  |
-| 9 | `time_expiry` | `fixed32` | `optional` | `` |  |
-| 10 | `app_ids` | `uint32` | `repeated` | `` |  |
-| 11 | `legacy_identity_binary` | `.CMsgSteamNetworkingIdentityLegacyBinary` | `optional` | `` |  |
-| 12 | `identity_string` | `string` | `optional` | `` |  |
-| 13 | `ip_addresses` | `string` | `repeated` | `` |  |
+| 1 | `key_type` | `.CMsgSteamDatagramCertificate.EKeyType` | `optional` |  | default = INVALID |
+| 2 | `key_data` | `bytes` | `optional` |  |  |
+| 4 | `legacy_steam_id` | `fixed64` | `optional` |  |  |
+| 5 | `gameserver_datacenter_ids` | `fixed32` | `repeated` |  |  |
+| 8 | `time_created` | `fixed32` | `optional` |  |  |
+| 9 | `time_expiry` | `fixed32` | `optional` |  |  |
+| 10 | `app_ids` | `uint32` | `repeated` |  |  |
+| 11 | `legacy_identity_binary` | `.CMsgSteamNetworkingIdentityLegacyBinary` | `optional` |  |  |
+| 12 | `identity_string` | `string` | `optional` |  |  |
+| 13 | `ip_addresses` | `string` | `repeated` |  |  |
 
 </details>
 
@@ -55,10 +55,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `private_key_data` | `bytes` | `optional` | `` |  |
-| 4 | `cert` | `bytes` | `optional` | `` |  |
-| 5 | `ca_key_id` | `fixed64` | `optional` | `` |  |
-| 6 | `ca_signature` | `bytes` | `optional` | `` |  |
+| 1 | `private_key_data` | `bytes` | `optional` |  |  |
+| 4 | `cert` | `bytes` | `optional` |  |  |
+| 5 | `ca_key_id` | `fixed64` | `optional` |  |  |
+| 6 | `ca_signature` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -70,7 +70,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `cert` | `.CMsgSteamDatagramCertificate` | `optional` | `` |  |
+| 1 | `cert` | `.CMsgSteamDatagramCertificate` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/steamnetworkingsockets-messages-udp.md
+++ b/docs/cookbook/proto-fields/steamnetworkingsockets-messages-udp.md
@@ -24,9 +24,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `connection_id` | `fixed32` | `optional` | `` |  |
-| 3 | `my_timestamp` | `fixed64` | `optional` | `` |  |
-| 4 | `protocol_version` | `uint32` | `optional` | `` |  |
+| 1 | `connection_id` | `fixed32` | `optional` |  |  |
+| 3 | `my_timestamp` | `fixed64` | `optional` |  |  |
+| 4 | `protocol_version` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -38,10 +38,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `connection_id` | `fixed32` | `optional` | `` |  |
-| 2 | `challenge` | `fixed64` | `optional` | `` |  |
-| 3 | `your_timestamp` | `fixed64` | `optional` | `` |  |
-| 4 | `protocol_version` | `uint32` | `optional` | `` |  |
+| 1 | `connection_id` | `fixed32` | `optional` |  |  |
+| 2 | `challenge` | `fixed64` | `optional` |  |  |
+| 3 | `your_timestamp` | `fixed64` | `optional` |  |  |
+| 4 | `protocol_version` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -53,16 +53,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `client_connection_id` | `fixed32` | `optional` | `` |  |
-| 2 | `challenge` | `fixed64` | `optional` | `` |  |
-| 3 | `legacy_client_steam_id` | `fixed64` | `optional` | `` |  |
-| 4 | `cert` | `.CMsgSteamDatagramCertificateSigned` | `optional` | `` |  |
-| 5 | `my_timestamp` | `fixed64` | `optional` | `` |  |
-| 6 | `ping_est_ms` | `uint32` | `optional` | `` |  |
-| 7 | `crypt` | `.CMsgSteamDatagramSessionCryptInfoSigned` | `optional` | `` |  |
-| 8 | `legacy_protocol_version` | `uint32` | `optional` | `` |  |
-| 9 | `legacy_identity_binary` | `.CMsgSteamNetworkingIdentityLegacyBinary` | `optional` | `` |  |
-| 10 | `identity_string` | `string` | `optional` | `` |  |
+| 1 | `client_connection_id` | `fixed32` | `optional` |  |  |
+| 2 | `challenge` | `fixed64` | `optional` |  |  |
+| 3 | `legacy_client_steam_id` | `fixed64` | `optional` |  |  |
+| 4 | `cert` | `.CMsgSteamDatagramCertificateSigned` | `optional` |  |  |
+| 5 | `my_timestamp` | `fixed64` | `optional` |  |  |
+| 6 | `ping_est_ms` | `uint32` | `optional` |  |  |
+| 7 | `crypt` | `.CMsgSteamDatagramSessionCryptInfoSigned` | `optional` |  |  |
+| 8 | `legacy_protocol_version` | `uint32` | `optional` |  |  |
+| 9 | `legacy_identity_binary` | `.CMsgSteamNetworkingIdentityLegacyBinary` | `optional` |  |  |
+| 10 | `identity_string` | `string` | `optional` |  |  |
 
 </details>
 
@@ -74,15 +74,15 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `client_connection_id` | `fixed32` | `optional` | `` |  |
-| 2 | `legacy_server_steam_id` | `fixed64` | `optional` | `` |  |
-| 3 | `your_timestamp` | `fixed64` | `optional` | `` |  |
-| 4 | `delay_time_usec` | `uint32` | `optional` | `` |  |
-| 5 | `server_connection_id` | `fixed32` | `optional` | `` |  |
-| 7 | `crypt` | `.CMsgSteamDatagramSessionCryptInfoSigned` | `optional` | `` |  |
-| 8 | `cert` | `.CMsgSteamDatagramCertificateSigned` | `optional` | `` |  |
-| 10 | `legacy_identity_binary` | `.CMsgSteamNetworkingIdentityLegacyBinary` | `optional` | `` |  |
-| 11 | `identity_string` | `string` | `optional` | `` |  |
+| 1 | `client_connection_id` | `fixed32` | `optional` |  |  |
+| 2 | `legacy_server_steam_id` | `fixed64` | `optional` |  |  |
+| 3 | `your_timestamp` | `fixed64` | `optional` |  |  |
+| 4 | `delay_time_usec` | `uint32` | `optional` |  |  |
+| 5 | `server_connection_id` | `fixed32` | `optional` |  |  |
+| 7 | `crypt` | `.CMsgSteamDatagramSessionCryptInfoSigned` | `optional` |  |  |
+| 8 | `cert` | `.CMsgSteamDatagramCertificateSigned` | `optional` |  |  |
+| 10 | `legacy_identity_binary` | `.CMsgSteamNetworkingIdentityLegacyBinary` | `optional` |  |  |
+| 11 | `identity_string` | `string` | `optional` |  |  |
 
 </details>
 
@@ -94,10 +94,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `debug` | `string` | `optional` | `` |  |
-| 3 | `reason_code` | `uint32` | `optional` | `` |  |
-| 4 | `to_connection_id` | `fixed32` | `optional` | `` |  |
-| 5 | `from_connection_id` | `fixed32` | `optional` | `` |  |
+| 2 | `debug` | `string` | `optional` |  |  |
+| 3 | `reason_code` | `uint32` | `optional` |  |  |
+| 4 | `to_connection_id` | `fixed32` | `optional` |  |  |
+| 5 | `from_connection_id` | `fixed32` | `optional` |  |  |
 
 </details>
 
@@ -109,8 +109,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `from_connection_id` | `fixed32` | `optional` | `` |  |
-| 3 | `to_connection_id` | `fixed32` | `optional` | `` |  |
+| 2 | `from_connection_id` | `fixed32` | `optional` |  |  |
+| 3 | `to_connection_id` | `fixed32` | `optional` |  |  |
 
 </details>
 
@@ -122,8 +122,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `stats` | `.CMsgSteamDatagramConnectionQuality` | `optional` | `` |  |
-| 3 | `flags` | `uint32` | `optional` | `` |  |
+| 1 | `stats` | `.CMsgSteamDatagramConnectionQuality` | `optional` |  |  |
+| 3 | `flags` | `uint32` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/steamnetworkingsockets-messages.md
+++ b/docs/cookbook/proto-fields/steamnetworkingsockets-messages.md
@@ -23,11 +23,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `key_type` | `.CMsgSteamDatagramSessionCryptInfo.EKeyType` | `optional` | `` | default = INVALID |
-| 2 | `key_data` | `bytes` | `optional` | `` |  |
-| 3 | `nonce` | `fixed64` | `optional` | `` |  |
-| 4 | `protocol_version` | `uint32` | `optional` | `` |  |
-| 5 | `ciphers` | `.ESteamNetworkingSocketsCipher` | `repeated` | `` |  |
+| 1 | `key_type` | `.CMsgSteamDatagramSessionCryptInfo.EKeyType` | `optional` |  | default = INVALID |
+| 2 | `key_data` | `bytes` | `optional` |  |  |
+| 3 | `nonce` | `fixed64` | `optional` |  |  |
+| 4 | `protocol_version` | `uint32` | `optional` |  |  |
+| 5 | `ciphers` | `.ESteamNetworkingSocketsCipher` | `repeated` |  |  |
 
 </details>
 
@@ -39,8 +39,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `info` | `bytes` | `optional` | `` |  |
-| 2 | `signature` | `bytes` | `optional` | `` |  |
+| 1 | `info` | `bytes` | `optional` |  |  |
+| 2 | `signature` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -52,8 +52,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `severity` | `uint32` | `optional` | `` |  |
-| 2 | `text` | `string` | `optional` | `` |  |
+| 1 | `severity` | `uint32` | `optional` |  |  |
+| 2 | `text` | `string` | `optional` |  |  |
 
 </details>
 
@@ -65,14 +65,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `out_packets_per_sec_x10` | `uint32` | `optional` | `` |  |
-| 2 | `out_bytes_per_sec` | `uint32` | `optional` | `` |  |
-| 3 | `in_packets_per_sec_x10` | `uint32` | `optional` | `` |  |
-| 4 | `in_bytes_per_sec` | `uint32` | `optional` | `` |  |
-| 5 | `ping_ms` | `uint32` | `optional` | `` |  |
-| 6 | `packets_dropped_pct` | `uint32` | `optional` | `` |  |
-| 7 | `packets_weird_sequence_pct` | `uint32` | `optional` | `` |  |
-| 8 | `peak_jitter_usec` | `uint32` | `optional` | `` |  |
+| 1 | `out_packets_per_sec_x10` | `uint32` | `optional` |  |  |
+| 2 | `out_bytes_per_sec` | `uint32` | `optional` |  |  |
+| 3 | `in_packets_per_sec_x10` | `uint32` | `optional` |  |  |
+| 4 | `in_bytes_per_sec` | `uint32` | `optional` |  |  |
+| 5 | `ping_ms` | `uint32` | `optional` |  |  |
+| 6 | `packets_dropped_pct` | `uint32` | `optional` |  |  |
+| 7 | `packets_weird_sequence_pct` | `uint32` | `optional` |  |  |
+| 8 | `peak_jitter_usec` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -84,53 +84,53 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `connected_seconds` | `uint32` | `optional` | `` |  |
-| 3 | `packets_sent` | `uint64` | `optional` | `` |  |
-| 4 | `kb_sent` | `uint64` | `optional` | `` |  |
-| 5 | `packets_recv` | `uint64` | `optional` | `` |  |
-| 6 | `kb_recv` | `uint64` | `optional` | `` |  |
-| 7 | `packets_recv_sequenced` | `uint64` | `optional` | `` |  |
-| 8 | `packets_recv_dropped` | `uint64` | `optional` | `` |  |
-| 9 | `packets_recv_out_of_order` | `uint64` | `optional` | `` |  |
-| 10 | `packets_recv_duplicate` | `uint64` | `optional` | `` |  |
-| 11 | `packets_recv_lurch` | `uint64` | `optional` | `` |  |
-| 12 | `multipath_packets_recv_sequenced` | `uint64` | `repeated` | `` |  |
-| 13 | `multipath_packets_recv_later` | `uint64` | `repeated` | `` |  |
-| 14 | `multipath_send_enabled` | `uint32` | `optional` | `` |  |
-| 15 | `packets_recv_out_of_order_corrected` | `uint64` | `optional` | `` |  |
-| 21 | `quality_histogram_100` | `uint32` | `optional` | `` |  |
-| 22 | `quality_histogram_99` | `uint32` | `optional` | `` |  |
-| 23 | `quality_histogram_97` | `uint32` | `optional` | `` |  |
-| 24 | `quality_histogram_95` | `uint32` | `optional` | `` |  |
-| 25 | `quality_histogram_90` | `uint32` | `optional` | `` |  |
-| 26 | `quality_histogram_75` | `uint32` | `optional` | `` |  |
-| 27 | `quality_histogram_50` | `uint32` | `optional` | `` |  |
-| 28 | `quality_histogram_1` | `uint32` | `optional` | `` |  |
-| 29 | `quality_histogram_dead` | `uint32` | `optional` | `` |  |
-| 30 | `quality_ntile_2nd` | `uint32` | `optional` | `` |  |
-| 31 | `quality_ntile_5th` | `uint32` | `optional` | `` |  |
-| 32 | `quality_ntile_25th` | `uint32` | `optional` | `` |  |
-| 33 | `quality_ntile_50th` | `uint32` | `optional` | `` |  |
-| 41 | `ping_histogram_25` | `uint32` | `optional` | `` |  |
-| 42 | `ping_histogram_50` | `uint32` | `optional` | `` |  |
-| 43 | `ping_histogram_75` | `uint32` | `optional` | `` |  |
-| 44 | `ping_histogram_100` | `uint32` | `optional` | `` |  |
-| 45 | `ping_histogram_125` | `uint32` | `optional` | `` |  |
-| 46 | `ping_histogram_150` | `uint32` | `optional` | `` |  |
-| 47 | `ping_histogram_200` | `uint32` | `optional` | `` |  |
-| 48 | `ping_histogram_300` | `uint32` | `optional` | `` |  |
-| 49 | `ping_histogram_max` | `uint32` | `optional` | `` |  |
-| 50 | `ping_ntile_5th` | `uint32` | `optional` | `` |  |
-| 51 | `ping_ntile_50th` | `uint32` | `optional` | `` |  |
-| 52 | `ping_ntile_75th` | `uint32` | `optional` | `` |  |
-| 53 | `ping_ntile_95th` | `uint32` | `optional` | `` |  |
-| 54 | `ping_ntile_98th` | `uint32` | `optional` | `` |  |
-| 61 | `jitter_histogram_negligible` | `uint32` | `optional` | `` |  |
-| 62 | `jitter_histogram_1` | `uint32` | `optional` | `` |  |
-| 63 | `jitter_histogram_2` | `uint32` | `optional` | `` |  |
-| 64 | `jitter_histogram_5` | `uint32` | `optional` | `` |  |
-| 65 | `jitter_histogram_10` | `uint32` | `optional` | `` |  |
-| 66 | `jitter_histogram_20` | `uint32` | `optional` | `` |  |
+| 2 | `connected_seconds` | `uint32` | `optional` |  |  |
+| 3 | `packets_sent` | `uint64` | `optional` |  |  |
+| 4 | `kb_sent` | `uint64` | `optional` |  |  |
+| 5 | `packets_recv` | `uint64` | `optional` |  |  |
+| 6 | `kb_recv` | `uint64` | `optional` |  |  |
+| 7 | `packets_recv_sequenced` | `uint64` | `optional` |  |  |
+| 8 | `packets_recv_dropped` | `uint64` | `optional` |  |  |
+| 9 | `packets_recv_out_of_order` | `uint64` | `optional` |  |  |
+| 10 | `packets_recv_duplicate` | `uint64` | `optional` |  |  |
+| 11 | `packets_recv_lurch` | `uint64` | `optional` |  |  |
+| 12 | `multipath_packets_recv_sequenced` | `uint64` | `repeated` |  |  |
+| 13 | `multipath_packets_recv_later` | `uint64` | `repeated` |  |  |
+| 14 | `multipath_send_enabled` | `uint32` | `optional` |  |  |
+| 15 | `packets_recv_out_of_order_corrected` | `uint64` | `optional` |  |  |
+| 21 | `quality_histogram_100` | `uint32` | `optional` |  |  |
+| 22 | `quality_histogram_99` | `uint32` | `optional` |  |  |
+| 23 | `quality_histogram_97` | `uint32` | `optional` |  |  |
+| 24 | `quality_histogram_95` | `uint32` | `optional` |  |  |
+| 25 | `quality_histogram_90` | `uint32` | `optional` |  |  |
+| 26 | `quality_histogram_75` | `uint32` | `optional` |  |  |
+| 27 | `quality_histogram_50` | `uint32` | `optional` |  |  |
+| 28 | `quality_histogram_1` | `uint32` | `optional` |  |  |
+| 29 | `quality_histogram_dead` | `uint32` | `optional` |  |  |
+| 30 | `quality_ntile_2nd` | `uint32` | `optional` |  |  |
+| 31 | `quality_ntile_5th` | `uint32` | `optional` |  |  |
+| 32 | `quality_ntile_25th` | `uint32` | `optional` |  |  |
+| 33 | `quality_ntile_50th` | `uint32` | `optional` |  |  |
+| 41 | `ping_histogram_25` | `uint32` | `optional` |  |  |
+| 42 | `ping_histogram_50` | `uint32` | `optional` |  |  |
+| 43 | `ping_histogram_75` | `uint32` | `optional` |  |  |
+| 44 | `ping_histogram_100` | `uint32` | `optional` |  |  |
+| 45 | `ping_histogram_125` | `uint32` | `optional` |  |  |
+| 46 | `ping_histogram_150` | `uint32` | `optional` |  |  |
+| 47 | `ping_histogram_200` | `uint32` | `optional` |  |  |
+| 48 | `ping_histogram_300` | `uint32` | `optional` |  |  |
+| 49 | `ping_histogram_max` | `uint32` | `optional` |  |  |
+| 50 | `ping_ntile_5th` | `uint32` | `optional` |  |  |
+| 51 | `ping_ntile_50th` | `uint32` | `optional` |  |  |
+| 52 | `ping_ntile_75th` | `uint32` | `optional` |  |  |
+| 53 | `ping_ntile_95th` | `uint32` | `optional` |  |  |
+| 54 | `ping_ntile_98th` | `uint32` | `optional` |  |  |
+| 61 | `jitter_histogram_negligible` | `uint32` | `optional` |  |  |
+| 62 | `jitter_histogram_1` | `uint32` | `optional` |  |  |
+| 63 | `jitter_histogram_2` | `uint32` | `optional` |  |  |
+| 64 | `jitter_histogram_5` | `uint32` | `optional` |  |  |
+| 65 | `jitter_histogram_10` | `uint32` | `optional` |  |  |
+| 66 | `jitter_histogram_20` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -142,8 +142,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `instantaneous` | `.CMsgSteamDatagramLinkInstantaneousStats` | `optional` | `` |  |
-| 2 | `lifetime` | `.CMsgSteamDatagramLinkLifetimeStats` | `optional` | `` |  |
+| 1 | `instantaneous` | `.CMsgSteamDatagramLinkInstantaneousStats` | `optional` |  |  |
+| 2 | `lifetime` | `.CMsgSteamDatagramLinkLifetimeStats` | `optional` |  |  |
 
 </details>
 
@@ -155,7 +155,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 3 | `candidate` | `string` | `optional` | `` |  |
+| 3 | `candidate` | `string` | `optional` |  |  |
 
 </details>
 
@@ -167,8 +167,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `add_candidate` | `.CMsgICECandidate` | `optional` | `` |  |
-| 2 | `auth` | `.CMsgICERendezvous.Auth` | `optional` | `` |  |
+| 1 | `add_candidate` | `.CMsgICECandidate` | `optional` |  |  |
+| 2 | `auth` | `.CMsgICERendezvous.Auth` | `optional` |  |  |
 
 </details>
 
@@ -180,7 +180,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `pwd_frag` | `string` | `optional` | `` |  |
+| 1 | `pwd_frag` | `string` | `optional` |  |  |
 
 </details>
 
@@ -192,21 +192,21 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `to_connection_id` | `fixed32` | `optional` | `` |  |
-| 2 | `sdr_routes` | `bytes` | `optional` | `` |  |
-| 3 | `ack_peer_routes_revision` | `uint32` | `optional` | `` |  |
-| 4 | `connect_request` | `.CMsgSteamNetworkingP2PRendezvous.ConnectRequest` | `optional` | `` |  |
-| 5 | `connect_ok` | `.CMsgSteamNetworkingP2PRendezvous.ConnectOK` | `optional` | `` |  |
-| 6 | `connection_closed` | `.CMsgSteamNetworkingP2PRendezvous.ConnectionClosed` | `optional` | `` |  |
-| 7 | `ice_enabled` | `bool` | `optional` | `` |  |
-| 8 | `from_identity` | `string` | `optional` | `` |  |
-| 9 | `from_connection_id` | `fixed32` | `optional` | `` |  |
-| 10 | `to_identity` | `string` | `optional` | `` |  |
-| 11 | `ack_reliable_msg` | `uint32` | `optional` | `` |  |
-| 12 | `first_reliable_msg` | `uint32` | `optional` | `` |  |
-| 13 | `reliable_messages` | `.CMsgSteamNetworkingP2PRendezvous.ReliableMessage` | `repeated` | `` |  |
-| 14 | `hosted_server_ticket` | `bytes` | `optional` | `` |  |
-| 15 | `application_messages` | `.CMsgSteamNetworkingP2PRendezvous.ApplicationMessage` | `repeated` | `` |  |
+| 1 | `to_connection_id` | `fixed32` | `optional` |  |  |
+| 2 | `sdr_routes` | `bytes` | `optional` |  |  |
+| 3 | `ack_peer_routes_revision` | `uint32` | `optional` |  |  |
+| 4 | `connect_request` | `.CMsgSteamNetworkingP2PRendezvous.ConnectRequest` | `optional` |  |  |
+| 5 | `connect_ok` | `.CMsgSteamNetworkingP2PRendezvous.ConnectOK` | `optional` |  |  |
+| 6 | `connection_closed` | `.CMsgSteamNetworkingP2PRendezvous.ConnectionClosed` | `optional` |  |  |
+| 7 | `ice_enabled` | `bool` | `optional` |  |  |
+| 8 | `from_identity` | `string` | `optional` |  |  |
+| 9 | `from_connection_id` | `fixed32` | `optional` |  |  |
+| 10 | `to_identity` | `string` | `optional` |  |  |
+| 11 | `ack_reliable_msg` | `uint32` | `optional` |  |  |
+| 12 | `first_reliable_msg` | `uint32` | `optional` |  |  |
+| 13 | `reliable_messages` | `.CMsgSteamNetworkingP2PRendezvous.ReliableMessage` | `repeated` |  |  |
+| 14 | `hosted_server_ticket` | `bytes` | `optional` |  |  |
+| 15 | `application_messages` | `.CMsgSteamNetworkingP2PRendezvous.ApplicationMessage` | `repeated` |  |  |
 
 </details>
 
@@ -218,11 +218,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 6 | `crypt` | `.CMsgSteamDatagramSessionCryptInfoSigned` | `optional` | `` |  |
-| 7 | `cert` | `.CMsgSteamDatagramCertificateSigned` | `optional` | `` |  |
-| 9 | `to_virtual_port` | `uint32` | `optional` | `` |  |
-| 10 | `from_virtual_port` | `uint32` | `optional` | `` |  |
-| 11 | `from_fakeip` | `string` | `optional` | `` |  |
+| 6 | `crypt` | `.CMsgSteamDatagramSessionCryptInfoSigned` | `optional` |  |  |
+| 7 | `cert` | `.CMsgSteamDatagramCertificateSigned` | `optional` |  |  |
+| 9 | `to_virtual_port` | `uint32` | `optional` |  |  |
+| 10 | `from_virtual_port` | `uint32` | `optional` |  |  |
+| 11 | `from_fakeip` | `string` | `optional` |  |  |
 
 </details>
 
@@ -234,8 +234,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 5 | `crypt` | `.CMsgSteamDatagramSessionCryptInfoSigned` | `optional` | `` |  |
-| 6 | `cert` | `.CMsgSteamDatagramCertificateSigned` | `optional` | `` |  |
+| 5 | `crypt` | `.CMsgSteamDatagramSessionCryptInfoSigned` | `optional` |  |  |
+| 6 | `cert` | `.CMsgSteamDatagramCertificateSigned` | `optional` |  |  |
 
 </details>
 
@@ -247,8 +247,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 5 | `debug` | `string` | `optional` | `` |  |
-| 6 | `reason_code` | `uint32` | `optional` | `` |  |
+| 5 | `debug` | `string` | `optional` |  |  |
+| 6 | `reason_code` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -260,7 +260,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ice` | `.CMsgICERendezvous` | `optional` | `` |  |
+| 1 | `ice` | `.CMsgICERendezvous` | `optional` |  |  |
 
 </details>
 
@@ -272,10 +272,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `data` | `bytes` | `optional` | `` |  |
-| 2 | `msg_num` | `uint64` | `optional` | `` |  |
-| 3 | `flags` | `uint32` | `optional` | `` |  |
-| 4 | `lane_idx` | `uint32` | `optional` | `` |  |
+| 1 | `data` | `bytes` | `optional` |  |  |
+| 2 | `msg_num` | `uint64` | `optional` |  |  |
+| 3 | `flags` | `uint32` | `optional` |  |  |
+| 4 | `lane_idx` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -287,21 +287,21 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `local_candidate_types` | `uint32` | `optional` | `` |  |
-| 2 | `remote_candidate_types` | `uint32` | `optional` | `` |  |
-| 3 | `initial_route_kind` | `uint32` | `optional` | `` |  |
-| 4 | `initial_ping` | `uint32` | `optional` | `` |  |
-| 5 | `negotiation_ms` | `uint32` | `optional` | `` |  |
-| 6 | `initial_score` | `uint32` | `optional` | `` |  |
-| 7 | `failure_reason_code` | `uint32` | `optional` | `` |  |
-| 12 | `selected_seconds` | `uint32` | `optional` | `` |  |
-| 13 | `user_settings` | `uint32` | `optional` | `` |  |
-| 14 | `ice_enable_var` | `uint32` | `optional` | `` |  |
-| 15 | `local_candidate_types_allowed` | `uint32` | `optional` | `` |  |
-| 16 | `best_route_kind` | `uint32` | `optional` | `` |  |
-| 17 | `best_ping` | `uint32` | `optional` | `` |  |
-| 18 | `best_score` | `uint32` | `optional` | `` |  |
-| 19 | `best_time` | `uint32` | `optional` | `` |  |
+| 1 | `local_candidate_types` | `uint32` | `optional` |  |  |
+| 2 | `remote_candidate_types` | `uint32` | `optional` |  |  |
+| 3 | `initial_route_kind` | `uint32` | `optional` |  |  |
+| 4 | `initial_ping` | `uint32` | `optional` |  |  |
+| 5 | `negotiation_ms` | `uint32` | `optional` |  |  |
+| 6 | `initial_score` | `uint32` | `optional` |  |  |
+| 7 | `failure_reason_code` | `uint32` | `optional` |  |  |
+| 12 | `selected_seconds` | `uint32` | `optional` |  |  |
+| 13 | `user_settings` | `uint32` | `optional` |  |  |
+| 14 | `ice_enable_var` | `uint32` | `optional` |  |  |
+| 15 | `local_candidate_types_allowed` | `uint32` | `optional` |  |  |
+| 16 | `best_route_kind` | `uint32` | `optional` |  |  |
+| 17 | `best_ping` | `uint32` | `optional` |  |  |
+| 18 | `best_score` | `uint32` | `optional` |  |  |
+| 19 | `best_time` | `uint32` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/te.md
+++ b/docs/cookbook/proto-fields/te.md
@@ -23,8 +23,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `pos` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `dir` | `.CMsgVector` | `optional` | `` |  |
+| 1 | `pos` | `.CMsgVector` | `optional` |  |  |
+| 2 | `dir` | `.CMsgVector` | `optional` |  |  |
 
 </details>
 
@@ -36,18 +36,18 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `modelindex` | `fixed64` | `optional` | `` |  |
-| 2 | `haloindex` | `fixed64` | `optional` | `` |  |
-| 3 | `startframe` | `uint32` | `optional` | `` |  |
-| 4 | `framerate` | `uint32` | `optional` | `` |  |
-| 5 | `life` | `float` | `optional` | `` |  |
-| 6 | `width` | `float` | `optional` | `` |  |
-| 7 | `endwidth` | `float` | `optional` | `` |  |
-| 8 | `fadelength` | `uint32` | `optional` | `` |  |
-| 9 | `amplitude` | `float` | `optional` | `` |  |
-| 10 | `color` | `fixed32` | `optional` | `` |  |
-| 11 | `speed` | `uint32` | `optional` | `` |  |
-| 12 | `flags` | `uint32` | `optional` | `` |  |
+| 1 | `modelindex` | `fixed64` | `optional` |  |  |
+| 2 | `haloindex` | `fixed64` | `optional` |  |  |
+| 3 | `startframe` | `uint32` | `optional` |  |  |
+| 4 | `framerate` | `uint32` | `optional` |  |  |
+| 5 | `life` | `float` | `optional` |  |  |
+| 6 | `width` | `float` | `optional` |  |  |
+| 7 | `endwidth` | `float` | `optional` |  |  |
+| 8 | `fadelength` | `uint32` | `optional` |  |  |
+| 9 | `amplitude` | `float` | `optional` |  |  |
+| 10 | `color` | `fixed32` | `optional` |  |  |
+| 11 | `speed` | `uint32` | `optional` |  |  |
+| 12 | `flags` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -59,11 +59,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `base` | `.CMsgTEBaseBeam` | `optional` | `` |  |
-| 2 | `startentity` | `uint32` | `optional` | `` |  |
-| 3 | `endentity` | `uint32` | `optional` | `` |  |
-| 4 | `start` | `.CMsgVector` | `optional` | `` |  |
-| 5 | `end` | `.CMsgVector` | `optional` | `` |  |
+| 1 | `base` | `.CMsgTEBaseBeam` | `optional` |  |  |
+| 2 | `startentity` | `uint32` | `optional` |  |  |
+| 3 | `endentity` | `uint32` | `optional` |  |  |
+| 4 | `start` | `.CMsgVector` | `optional` |  |  |
+| 5 | `end` | `.CMsgVector` | `optional` |  |  |
 
 </details>
 
@@ -75,9 +75,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `base` | `.CMsgTEBaseBeam` | `optional` | `` |  |
-| 2 | `startentity` | `uint32` | `optional` | `` |  |
-| 3 | `endentity` | `uint32` | `optional` | `` |  |
+| 1 | `base` | `.CMsgTEBaseBeam` | `optional` |  |  |
+| 2 | `startentity` | `uint32` | `optional` |  |  |
+| 3 | `endentity` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -89,9 +89,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `base` | `.CMsgTEBaseBeam` | `optional` | `` |  |
-| 2 | `start` | `.CMsgVector` | `optional` | `` |  |
-| 3 | `end` | `.CMsgVector` | `optional` | `` |  |
+| 1 | `base` | `.CMsgTEBaseBeam` | `optional` |  |  |
+| 2 | `start` | `.CMsgVector` | `optional` |  |  |
+| 3 | `end` | `.CMsgVector` | `optional` |  |  |
 
 </details>
 
@@ -103,9 +103,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `base` | `.CMsgTEBaseBeam` | `optional` | `` |  |
-| 2 | `startentity` | `uint32` | `optional` | `` |  |
-| 3 | `endentity` | `uint32` | `optional` | `` |  |
+| 1 | `base` | `.CMsgTEBaseBeam` | `optional` |  |  |
+| 2 | `startentity` | `uint32` | `optional` |  |  |
+| 3 | `endentity` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -117,11 +117,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `mins` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `maxs` | `.CMsgVector` | `optional` | `` |  |
-| 3 | `height` | `float` | `optional` | `` |  |
-| 4 | `count` | `uint32` | `optional` | `` |  |
-| 5 | `speed` | `float` | `optional` | `` |  |
+| 1 | `mins` | `.CMsgVector` | `optional` |  |  |
+| 2 | `maxs` | `.CMsgVector` | `optional` |  |  |
+| 3 | `height` | `float` | `optional` |  |  |
+| 4 | `count` | `uint32` | `optional` |  |  |
+| 5 | `speed` | `float` | `optional` |  |  |
 
 </details>
 
@@ -133,11 +133,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `mins` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `maxs` | `.CMsgVector` | `optional` | `` |  |
-| 3 | `waterz` | `float` | `optional` | `` |  |
-| 4 | `count` | `uint32` | `optional` | `` |  |
-| 5 | `speed` | `float` | `optional` | `` |  |
+| 1 | `mins` | `.CMsgVector` | `optional` |  |  |
+| 2 | `maxs` | `.CMsgVector` | `optional` |  |  |
+| 3 | `waterz` | `float` | `optional` |  |  |
+| 4 | `count` | `uint32` | `optional` |  |  |
+| 5 | `speed` | `float` | `optional` |  |  |
 
 </details>
 
@@ -149,11 +149,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `origin` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `start` | `.CMsgVector` | `optional` | `` |  |
-| 3 | `entity` | `int32` | `optional` | `` | default = -1 |
-| 4 | `hitbox` | `uint32` | `optional` | `` |  |
-| 5 | `index` | `uint32` | `optional` | `` |  |
+| 1 | `origin` | `.CMsgVector` | `optional` |  |  |
+| 2 | `start` | `.CMsgVector` | `optional` |  |  |
+| 3 | `entity` | `int32` | `optional` |  | default = -1 |
+| 4 | `hitbox` | `uint32` | `optional` |  |  |
+| 5 | `index` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -165,25 +165,25 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `origin` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `start` | `.CMsgVector` | `optional` | `` |  |
-| 3 | `normal` | `.CMsgVector` | `optional` | `` |  |
-| 4 | `angles` | `.CMsgQAngle` | `optional` | `` |  |
-| 5 | `entity` | `fixed32` | `optional` | `` | default = 16777215 |
-| 6 | `otherentity` | `fixed32` | `optional` | `` | default = 16777215 |
-| 7 | `scale` | `float` | `optional` | `` |  |
-| 8 | `magnitude` | `float` | `optional` | `` |  |
-| 9 | `radius` | `float` | `optional` | `` |  |
-| 10 | `surfaceprop` | `fixed32` | `optional` | `` |  |
-| 11 | `effectindex` | `fixed64` | `optional` | `` |  |
-| 12 | `damagetype` | `uint32` | `optional` | `` |  |
-| 13 | `material` | `uint32` | `optional` | `` |  |
-| 14 | `hitbox` | `uint32` | `optional` | `` |  |
-| 15 | `color` | `uint32` | `optional` | `` |  |
-| 16 | `flags` | `uint32` | `optional` | `` |  |
-| 17 | `attachmentindex` | `int32` | `optional` | `` |  |
-| 18 | `effectname` | `uint32` | `optional` | `` |  |
-| 19 | `attachmentname` | `uint32` | `optional` | `` | default = 0 |
+| 1 | `origin` | `.CMsgVector` | `optional` |  |  |
+| 2 | `start` | `.CMsgVector` | `optional` |  |  |
+| 3 | `normal` | `.CMsgVector` | `optional` |  |  |
+| 4 | `angles` | `.CMsgQAngle` | `optional` |  |  |
+| 5 | `entity` | `fixed32` | `optional` |  | default = 16777215 |
+| 6 | `otherentity` | `fixed32` | `optional` |  | default = 16777215 |
+| 7 | `scale` | `float` | `optional` |  |  |
+| 8 | `magnitude` | `float` | `optional` |  |  |
+| 9 | `radius` | `float` | `optional` |  |  |
+| 10 | `surfaceprop` | `fixed32` | `optional` |  |  |
+| 11 | `effectindex` | `fixed64` | `optional` |  |  |
+| 12 | `damagetype` | `uint32` | `optional` |  |  |
+| 13 | `material` | `uint32` | `optional` |  |  |
+| 14 | `hitbox` | `uint32` | `optional` |  |  |
+| 15 | `color` | `uint32` | `optional` |  |  |
+| 16 | `flags` | `uint32` | `optional` |  |  |
+| 17 | `attachmentindex` | `int32` | `optional` |  |  |
+| 18 | `effectname` | `uint32` | `optional` |  |  |
+| 19 | `attachmentname` | `uint32` | `optional` |  | default = 0 |
 
 </details>
 
@@ -195,7 +195,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `effectdata` | `.CMsgEffectData` | `optional` | `` |  |
+| 1 | `effectdata` | `.CMsgEffectData` | `optional` |  |  |
 
 </details>
 
@@ -207,9 +207,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `pos` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `dir` | `.CMsgVector` | `optional` | `` |  |
-| 3 | `explosive` | `bool` | `optional` | `` |  |
+| 1 | `pos` | `.CMsgVector` | `optional` |  |  |
+| 2 | `dir` | `.CMsgVector` | `optional` |  |  |
+| 3 | `explosive` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -221,9 +221,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `entity` | `int32` | `optional` | `` | default = -1 |
-| 2 | `density` | `uint32` | `optional` | `` |  |
-| 3 | `current` | `int32` | `optional` | `` |  |
+| 1 | `entity` | `int32` | `optional` |  | default = -1 |
+| 2 | `density` | `uint32` | `optional` |  |  |
+| 3 | `current` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -235,16 +235,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `origin` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `angles` | `.CMsgQAngle` | `optional` | `` |  |
-| 3 | `force` | `.CMsgVector` | `optional` | `` |  |
-| 4 | `forcepos` | `.CMsgVector` | `optional` | `` |  |
-| 5 | `width` | `float` | `optional` | `` |  |
-| 6 | `height` | `float` | `optional` | `` |  |
-| 7 | `shardsize` | `float` | `optional` | `` |  |
-| 8 | `surfacetype` | `uint32` | `optional` | `` |  |
-| 9 | `frontcolor` | `fixed32` | `optional` | `` |  |
-| 10 | `backcolor` | `fixed32` | `optional` | `` |  |
+| 1 | `origin` | `.CMsgVector` | `optional` |  |  |
+| 2 | `angles` | `.CMsgQAngle` | `optional` |  |  |
+| 3 | `force` | `.CMsgVector` | `optional` |  |  |
+| 4 | `forcepos` | `.CMsgVector` | `optional` |  |  |
+| 5 | `width` | `float` | `optional` |  |  |
+| 6 | `height` | `float` | `optional` |  |  |
+| 7 | `shardsize` | `float` | `optional` |  |  |
+| 8 | `surfacetype` | `uint32` | `optional` |  |  |
+| 9 | `frontcolor` | `fixed32` | `optional` |  |  |
+| 10 | `backcolor` | `fixed32` | `optional` |  |  |
 
 </details>
 
@@ -256,10 +256,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `origin` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `scale` | `float` | `optional` | `` |  |
-| 3 | `life` | `float` | `optional` | `` |  |
-| 4 | `brightness` | `uint32` | `optional` | `` |  |
+| 1 | `origin` | `.CMsgVector` | `optional` |  |  |
+| 2 | `scale` | `float` | `optional` |  |  |
+| 3 | `life` | `float` | `optional` |  |  |
+| 4 | `brightness` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -271,9 +271,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `origin` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `normal` | `.CMsgVector` | `optional` | `` |  |
-| 3 | `type` | `uint32` | `optional` | `` |  |
+| 1 | `origin` | `.CMsgVector` | `optional` |  |  |
+| 2 | `normal` | `.CMsgVector` | `optional` |  |  |
+| 3 | `type` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -285,10 +285,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `origin` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `angles` | `.CMsgQAngle` | `optional` | `` |  |
-| 3 | `scale` | `float` | `optional` | `` |  |
-| 4 | `type` | `uint32` | `optional` | `` |  |
+| 1 | `origin` | `.CMsgVector` | `optional` |  |  |
+| 2 | `angles` | `.CMsgQAngle` | `optional` |  |  |
+| 3 | `scale` | `float` | `optional` |  |  |
+| 4 | `type` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -300,10 +300,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `origin` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `direction` | `.CMsgVector` | `optional` | `` |  |
-| 3 | `color` | `fixed32` | `optional` | `` |  |
-| 4 | `amount` | `uint32` | `optional` | `` |  |
+| 1 | `origin` | `.CMsgVector` | `optional` |  |  |
+| 2 | `direction` | `.CMsgVector` | `optional` |  |  |
+| 3 | `color` | `fixed32` | `optional` |  |  |
+| 4 | `amount` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -315,18 +315,18 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `origin` | `.CMsgVector` | `optional` | `` |  |
-| 3 | `flags` | `uint32` | `optional` | `` |  |
-| 4 | `normal` | `.CMsgVector` | `optional` | `` |  |
-| 6 | `radius` | `uint32` | `optional` | `` |  |
-| 7 | `magnitude` | `uint32` | `optional` | `` |  |
-| 9 | `affect_ragdolls` | `bool` | `optional` | `` |  |
-| 10 | `sound_name` | `string` | `optional` | `` |  |
-| 11 | `explosion_type` | `uint32` | `optional` | `` |  |
-| 12 | `create_debris` | `bool` | `optional` | `` |  |
-| 13 | `debris_origin` | `.CMsgVector` | `optional` | `` |  |
-| 14 | `debris_surfaceprop` | `fixed32` | `optional` | `` |  |
-| 15 | `explosion_type_name` | `uint32` | `optional` | `` | default = 0 |
+| 1 | `origin` | `.CMsgVector` | `optional` |  |  |
+| 3 | `flags` | `uint32` | `optional` |  |  |
+| 4 | `normal` | `.CMsgVector` | `optional` |  |  |
+| 6 | `radius` | `uint32` | `optional` |  |  |
+| 7 | `magnitude` | `uint32` | `optional` |  |  |
+| 9 | `affect_ragdolls` | `bool` | `optional` |  |  |
+| 10 | `sound_name` | `string` | `optional` |  |  |
+| 11 | `explosion_type` | `uint32` | `optional` |  |  |
+| 12 | `create_debris` | `bool` | `optional` |  |  |
+| 13 | `debris_origin` | `.CMsgVector` | `optional` |  |  |
+| 14 | `debris_surfaceprop` | `fixed32` | `optional` |  |  |
+| 15 | `explosion_type_name` | `uint32` | `optional` |  | default = 0 |
 
 </details>
 
@@ -338,10 +338,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `origin` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `size` | `float` | `optional` | `` |  |
-| 3 | `speed` | `float` | `optional` | `` |  |
-| 4 | `direction` | `.CMsgVector` | `optional` | `` |  |
+| 1 | `origin` | `.CMsgVector` | `optional` |  |  |
+| 2 | `size` | `float` | `optional` |  |  |
+| 3 | `speed` | `float` | `optional` |  |  |
+| 4 | `direction` | `.CMsgVector` | `optional` |  |  |
 
 </details>
 
@@ -353,8 +353,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `origin` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `reversed` | `uint32` | `optional` | `` |  |
+| 1 | `origin` | `.CMsgVector` | `optional` |  |  |
+| 2 | `reversed` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -366,10 +366,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `origin` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `magnitude` | `uint32` | `optional` | `` |  |
-| 3 | `length` | `uint32` | `optional` | `` |  |
-| 4 | `direction` | `.CMsgVector` | `optional` | `` |  |
+| 1 | `origin` | `.CMsgVector` | `optional` |  |  |
+| 2 | `magnitude` | `uint32` | `optional` |  |  |
+| 3 | `length` | `uint32` | `optional` |  |  |
+| 4 | `direction` | `.CMsgVector` | `optional` |  |  |
 
 </details>
 
@@ -381,19 +381,19 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `origin` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `velocity` | `.CMsgVector` | `optional` | `` |  |
-| 3 | `angles` | `.CMsgQAngle` | `optional` | `` |  |
-| 4 | `skin` | `fixed32` | `optional` | `` | default = 0 |
-| 5 | `flags` | `uint32` | `optional` | `` |  |
-| 6 | `effects` | `uint32` | `optional` | `` |  |
-| 7 | `color` | `fixed32` | `optional` | `` |  |
-| 8 | `modelindex` | `fixed64` | `optional` | `` |  |
-| 9 | `unused_breakmodelsnottomake` | `uint32` | `optional` | `` |  |
-| 10 | `scale` | `float` | `optional` | `` |  |
-| 11 | `dmgpos` | `.CMsgVector` | `optional` | `` |  |
-| 12 | `dmgdir` | `.CMsgVector` | `optional` | `` |  |
-| 13 | `dmgtype` | `int32` | `optional` | `` |  |
+| 1 | `origin` | `.CMsgVector` | `optional` |  |  |
+| 2 | `velocity` | `.CMsgVector` | `optional` |  |  |
+| 3 | `angles` | `.CMsgQAngle` | `optional` |  |  |
+| 4 | `skin` | `fixed32` | `optional` |  | default = 0 |
+| 5 | `flags` | `uint32` | `optional` |  |  |
+| 6 | `effects` | `uint32` | `optional` |  |  |
+| 7 | `color` | `fixed32` | `optional` |  |  |
+| 8 | `modelindex` | `fixed64` | `optional` |  |  |
+| 9 | `unused_breakmodelsnottomake` | `uint32` | `optional` |  |  |
+| 10 | `scale` | `float` | `optional` |  |  |
+| 11 | `dmgpos` | `.CMsgVector` | `optional` |  |  |
+| 12 | `dmgdir` | `.CMsgVector` | `optional` |  |  |
+| 13 | `dmgtype` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -405,8 +405,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `origin` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `scale` | `float` | `optional` | `` |  |
+| 1 | `origin` | `.CMsgVector` | `optional` |  |  |
+| 2 | `scale` | `float` | `optional` |  |  |
 
 </details>
 
@@ -418,9 +418,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `origin` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `normal` | `.CMsgVector` | `optional` | `` |  |
-| 3 | `index` | `uint32` | `optional` | `` |  |
+| 1 | `origin` | `.CMsgVector` | `optional` |  |  |
+| 2 | `normal` | `.CMsgVector` | `optional` |  |  |
+| 3 | `index` | `uint32` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/uifontfile-format.md
+++ b/docs/cookbook/proto-fields/uifontfile-format.md
@@ -19,8 +19,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `font_file_name` | `string` | `optional` | `` |  |
-| 2 | `opentype_font_data` | `bytes` | `optional` | `` |  |
+| 1 | `font_file_name` | `string` | `optional` |  |  |
+| 2 | `opentype_font_data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -32,8 +32,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `package_version` | `uint32` | `optional` | `` |  |
-| 2 | `encrypted_font_files` | `.CUIFontFilePackagePB.CUIEncryptedFontFilePB` | `repeated` | `` |  |
+| 1 | `package_version` | `uint32` | `optional` |  |  |
+| 2 | `encrypted_font_files` | `.CUIFontFilePackagePB.CUIEncryptedFontFilePB` | `repeated` |  |  |
 
 </details>
 
@@ -45,7 +45,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `encrypted_contents` | `bytes` | `optional` | `` |  |
+| 1 | `encrypted_contents` | `bytes` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/usercmd.md
+++ b/docs/cookbook/proto-fields/usercmd.md
@@ -23,9 +23,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `buttonstate1` | `uint64` | `optional` | `` |  |
-| 2 | `buttonstate2` | `uint64` | `optional` | `` |  |
-| 3 | `buttonstate3` | `uint64` | `optional` | `` |  |
+| 1 | `buttonstate1` | `uint64` | `optional` |  |  |
+| 2 | `buttonstate2` | `uint64` | `optional` |  |  |
+| 3 | `buttonstate3` | `uint64` | `optional` |  |  |
 
 </details>
 
@@ -37,13 +37,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `button` | `uint64` | `optional` | `` |  |
-| 2 | `pressed` | `bool` | `optional` | `` |  |
-| 3 | `when` | `float` | `optional` | `` |  |
-| 4 | `analog_forward_delta` | `float` | `optional` | `` |  |
-| 5 | `analog_left_delta` | `float` | `optional` | `` |  |
-| 8 | `pitch_delta` | `float` | `optional` | `` |  |
-| 9 | `yaw_delta` | `float` | `optional` | `` |  |
+| 1 | `button` | `uint64` | `optional` |  |  |
+| 2 | `pressed` | `bool` | `optional` |  |  |
+| 3 | `when` | `float` | `optional` |  |  |
+| 4 | `analog_forward_delta` | `float` | `optional` |  |  |
+| 5 | `analog_left_delta` | `float` | `optional` |  |  |
+| 8 | `pitch_delta` | `float` | `optional` |  |  |
+| 9 | `yaw_delta` | `float` | `optional` |  |  |
 
 </details>
 
@@ -55,7 +55,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ignored_reason` | `string` | `optional` | `` |  |
+| 1 | `ignored_reason` | `string` | `optional` |  |  |
 
 </details>
 
@@ -67,25 +67,25 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `legacy_command_number` | `int32` | `optional` | `` |  |
-| 2 | `client_tick` | `int32` | `optional` | `` |  |
-| 3 | `buttons_pb` | `.CInButtonStatePB` | `optional` | `` |  |
-| 4 | `viewangles` | `.CMsgQAngle` | `optional` | `` |  |
-| 5 | `forwardmove` | `float` | `optional` | `` |  |
-| 6 | `leftmove` | `float` | `optional` | `` |  |
-| 7 | `upmove` | `float` | `optional` | `` |  |
-| 8 | `impulse` | `int32` | `optional` | `` |  |
-| 9 | `weaponselect` | `int32` | `optional` | `` |  |
-| 10 | `random_seed` | `int32` | `optional` | `` |  |
-| 11 | `mousedx` | `int32` | `optional` | `` |  |
-| 12 | `mousedy` | `int32` | `optional` | `` |  |
-| 14 | `pawn_entity_handle` | `uint32` | `optional` | `` | default = 16777215 |
-| 17 | `prediction_offset_ticks_x256` | `uint32` | `optional` | `` |  |
-| 18 | `subtick_moves` | `.CSubtickMoveStep` | `repeated` | `` |  |
-| 19 | `move_crc` | `bytes` | `optional` | `` |  |
-| 20 | `consumed_server_angle_changes` | `uint32` | `optional` | `` |  |
-| 21 | `cmd_flags` | `int32` | `optional` | `` |  |
-| 22 | `execution_notes` | `.CBaseUserCmdExecutionNotes` | `optional` | `` |  |
+| 1 | `legacy_command_number` | `int32` | `optional` |  |  |
+| 2 | `client_tick` | `int32` | `optional` |  |  |
+| 3 | `buttons_pb` | `.CInButtonStatePB` | `optional` |  |  |
+| 4 | `viewangles` | `.CMsgQAngle` | `optional` |  |  |
+| 5 | `forwardmove` | `float` | `optional` |  |  |
+| 6 | `leftmove` | `float` | `optional` |  |  |
+| 7 | `upmove` | `float` | `optional` |  |  |
+| 8 | `impulse` | `int32` | `optional` |  |  |
+| 9 | `weaponselect` | `int32` | `optional` |  |  |
+| 10 | `random_seed` | `int32` | `optional` |  |  |
+| 11 | `mousedx` | `int32` | `optional` |  |  |
+| 12 | `mousedy` | `int32` | `optional` |  |  |
+| 14 | `pawn_entity_handle` | `uint32` | `optional` |  | default = 16777215 |
+| 17 | `prediction_offset_ticks_x256` | `uint32` | `optional` |  |  |
+| 18 | `subtick_moves` | `.CSubtickMoveStep` | `repeated` |  |  |
+| 19 | `move_crc` | `bytes` | `optional` |  |  |
+| 20 | `consumed_server_angle_changes` | `uint32` | `optional` |  |  |
+| 21 | `cmd_flags` | `int32` | `optional` |  |  |
+| 22 | `execution_notes` | `.CBaseUserCmdExecutionNotes` | `optional` |  |  |
 
 </details>
 
@@ -97,7 +97,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `base` | `.CBaseUserCmdPB` | `optional` | `` |  |
+| 1 | `base` | `.CBaseUserCmdPB` | `optional` |  |  |
 
 </details>
 

--- a/docs/cookbook/proto-fields/usermessages.md
+++ b/docs/cookbook/proto-fields/usermessages.md
@@ -23,7 +23,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `achievement` | `uint32` | `optional` | `` |  |
+| 1 | `achievement` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -35,10 +35,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hash` | `fixed32` | `optional` | `` |  |
-| 2 | `duration` | `float` | `optional` | `` |  |
-| 3 | `from_player` | `bool` | `optional` | `` |  |
-| 4 | `ent_index` | `int32` | `optional` | `` | default = -1 |
+| 1 | `hash` | `fixed32` | `optional` |  |  |
+| 2 | `duration` | `float` | `optional` |  |  |
+| 3 | `from_player` | `bool` | `optional` |  |  |
+| 4 | `ent_index` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -50,10 +50,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hash` | `fixed32` | `optional` | `` |  |
-| 2 | `duration` | `float` | `optional` | `` |  |
-| 3 | `from_player` | `bool` | `optional` | `` |  |
-| 4 | `ent_index` | `int32` | `optional` | `` | default = -1 |
+| 1 | `hash` | `fixed32` | `optional` |  |  |
+| 2 | `duration` | `float` | `optional` |  |  |
+| 3 | `from_player` | `bool` | `optional` |  |  |
+| 4 | `ent_index` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -65,10 +65,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `string` | `string` | `optional` | `` |  |
-| 2 | `duration` | `float` | `optional` | `` |  |
-| 3 | `from_player` | `bool` | `optional` | `` |  |
-| 4 | `ent_index` | `int32` | `optional` | `` | default = -1 |
+| 1 | `string` | `string` | `optional` |  |  |
+| 2 | `duration` | `float` | `optional` |  |  |
+| 3 | `from_player` | `bool` | `optional` |  |  |
+| 4 | `ent_index` | `int32` | `optional` |  | default = -1 |
 
 </details>
 
@@ -80,7 +80,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `current` | `float` | `optional` | `` |  |
+| 1 | `current` | `float` | `optional` |  |  |
 
 </details>
 
@@ -92,10 +92,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `desired` | `float` | `optional` | `` |  |
-| 2 | `acceleration` | `float` | `optional` | `` |  |
-| 3 | `minblendrate` | `float` | `optional` | `` |  |
-| 4 | `blenddeltamultiplier` | `float` | `optional` | `` |  |
+| 1 | `desired` | `float` | `optional` |  |  |
+| 2 | `acceleration` | `float` | `optional` |  |  |
+| 3 | `minblendrate` | `float` | `optional` |  |  |
+| 4 | `blenddeltamultiplier` | `float` | `optional` |  |  |
 
 </details>
 
@@ -107,10 +107,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `duration` | `uint32` | `optional` | `` |  |
-| 2 | `hold_time` | `uint32` | `optional` | `` |  |
-| 3 | `flags` | `uint32` | `optional` | `` |  |
-| 4 | `color` | `fixed32` | `optional` | `` |  |
+| 1 | `duration` | `uint32` | `optional` |  |  |
+| 2 | `hold_time` | `uint32` | `optional` |  |  |
+| 3 | `flags` | `uint32` | `optional` |  |  |
+| 4 | `color` | `fixed32` | `optional` |  |  |
 
 </details>
 
@@ -122,10 +122,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `command` | `uint32` | `optional` | `` |  |
-| 2 | `amplitude` | `float` | `optional` | `` |  |
-| 3 | `frequency` | `float` | `optional` | `` |  |
-| 4 | `duration` | `float` | `optional` | `` |  |
+| 1 | `command` | `uint32` | `optional` |  |  |
+| 2 | `amplitude` | `float` | `optional` |  |  |
+| 3 | `frequency` | `float` | `optional` |  |  |
+| 4 | `duration` | `float` | `optional` |  |  |
 
 </details>
 
@@ -137,8 +137,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `shake` | `.CUserMessageShake` | `optional` | `` |  |
-| 2 | `direction` | `.CMsgVector` | `optional` | `` |  |
+| 1 | `shake` | `.CUserMessageShake` | `optional` |  |  |
+| 2 | `direction` | `.CMsgVector` | `optional` |  |  |
 
 </details>
 
@@ -150,10 +150,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `command` | `uint32` | `optional` | `` |  |
-| 2 | `amplitude` | `float` | `optional` | `` |  |
-| 3 | `frequency` | `float` | `optional` | `` |  |
-| 4 | `duration` | `float` | `optional` | `` |  |
+| 1 | `command` | `uint32` | `optional` |  |  |
+| 2 | `amplitude` | `float` | `optional` |  |  |
+| 3 | `frequency` | `float` | `optional` |  |  |
+| 4 | `duration` | `float` | `optional` |  |  |
 
 </details>
 
@@ -165,11 +165,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `command` | `uint32` | `optional` | `` |  |
-| 2 | `ease_in_out` | `bool` | `optional` | `` |  |
-| 3 | `angle` | `.CMsgVector` | `optional` | `` |  |
-| 4 | `duration` | `float` | `optional` | `` |  |
-| 5 | `time` | `float` | `optional` | `` |  |
+| 1 | `command` | `uint32` | `optional` |  |  |
+| 2 | `ease_in_out` | `bool` | `optional` |  |  |
+| 3 | `angle` | `.CMsgVector` | `optional` |  |  |
+| 4 | `duration` | `float` | `optional` |  |  |
+| 5 | `time` | `float` | `optional` |  |  |
 
 </details>
 
@@ -181,9 +181,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `playerindex` | `int32` | `optional` | `` | default = -1 |
-| 2 | `text` | `string` | `optional` | `` |  |
-| 3 | `chat` | `bool` | `optional` | `` |  |
+| 1 | `playerindex` | `int32` | `optional` |  | default = -1 |
+| 2 | `text` | `string` | `optional` |  |  |
+| 3 | `chat` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -195,13 +195,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `entityindex` | `int32` | `optional` | `` | default = -1 |
-| 2 | `chat` | `bool` | `optional` | `` |  |
-| 3 | `messagename` | `string` | `optional` | `` |  |
-| 4 | `param1` | `string` | `optional` | `` |  |
-| 5 | `param2` | `string` | `optional` | `` |  |
-| 6 | `param3` | `string` | `optional` | `` |  |
-| 7 | `param4` | `string` | `optional` | `` |  |
+| 1 | `entityindex` | `int32` | `optional` |  | default = -1 |
+| 2 | `chat` | `bool` | `optional` |  |  |
+| 3 | `messagename` | `string` | `optional` |  |  |
+| 4 | `param1` | `string` | `optional` |  |  |
+| 5 | `param2` | `string` | `optional` |  |  |
+| 6 | `param3` | `string` | `optional` |  |  |
+| 7 | `param4` | `string` | `optional` |  |  |
 
 </details>
 
@@ -213,13 +213,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `channel` | `uint32` | `optional` | `` |  |
-| 2 | `x` | `float` | `optional` | `` |  |
-| 3 | `y` | `float` | `optional` | `` |  |
-| 4 | `color1` | `fixed32` | `optional` | `` |  |
-| 5 | `color2` | `fixed32` | `optional` | `` |  |
-| 6 | `effect` | `uint32` | `optional` | `` |  |
-| 11 | `message` | `string` | `optional` | `` |  |
+| 1 | `channel` | `uint32` | `optional` |  |  |
+| 2 | `x` | `float` | `optional` |  |  |
+| 3 | `y` | `float` | `optional` |  |  |
+| 4 | `color1` | `fixed32` | `optional` |  |  |
+| 5 | `color2` | `fixed32` | `optional` |  |  |
+| 6 | `effect` | `uint32` | `optional` |  |  |
+| 11 | `message` | `string` | `optional` |  |  |
 
 </details>
 
@@ -231,7 +231,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `message` | `string` | `optional` | `` |  |
+| 1 | `message` | `string` | `optional` |  |  |
 
 </details>
 
@@ -243,8 +243,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `dest` | `uint32` | `optional` | `` |  |
-| 2 | `param` | `string` | `repeated` | `` |  |
+| 1 | `dest` | `uint32` | `optional` |  |  |
+| 2 | `param` | `string` | `repeated` |  |  |
 
 </details>
 
@@ -280,8 +280,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `soundname` | `string` | `optional` | `` |  |
-| 2 | `stop` | `bool` | `optional` | `` |  |
+| 1 | `soundname` | `string` | `optional` |  |  |
+| 2 | `stop` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -293,10 +293,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `parameter_type` | `uint32` | `optional` | `` |  |
-| 2 | `name_hash_code` | `uint32` | `optional` | `` |  |
-| 3 | `value` | `float` | `optional` | `` |  |
-| 4 | `int_value` | `uint32` | `optional` | `` |  |
+| 1 | `parameter_type` | `uint32` | `optional` |  |  |
+| 2 | `name_hash_code` | `uint32` | `optional` |  |  |
+| 3 | `value` | `float` | `optional` |  |  |
+| 4 | `int_value` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -308,9 +308,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `gamerules_masks` | `uint32` | `repeated` | `` |  |
-| 2 | `ban_masks` | `uint32` | `repeated` | `` |  |
-| 3 | `mod_enable` | `bool` | `optional` | `` |  |
+| 1 | `gamerules_masks` | `uint32` | `repeated` |  |  |
+| 2 | `ban_masks` | `uint32` | `repeated` |  |  |
+| 3 | `mod_enable` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -334,9 +334,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `index` | `int32` | `optional` | `` |  |
-| 2 | `data` | `int32` | `optional` | `` |  |
-| 3 | `flags` | `int32` | `optional` | `` |  |
+| 1 | `index` | `int32` | `optional` |  |  |
+| 2 | `data` | `int32` | `optional` |  |  |
+| 3 | `flags` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -348,9 +348,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `player` | `int32` | `optional` | `` |  |
-| 2 | `channel` | `int32` | `optional` | `` |  |
-| 3 | `text` | `string` | `optional` | `` |  |
+| 1 | `player` | `int32` | `optional` |  |  |
+| 2 | `channel` | `int32` | `optional` |  |  |
+| 3 | `text` | `string` | `optional` |  |  |
 
 </details>
 
@@ -362,12 +362,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `color` | `uint32` | `optional` | `` |  |
-| 2 | `text` | `string` | `optional` | `` |  |
-| 3 | `reset` | `bool` | `optional` | `` |  |
-| 4 | `context_player_slot` | `int32` | `optional` | `` | default = -1 |
-| 5 | `context_value` | `int32` | `optional` | `` |  |
-| 6 | `context_team_id` | `int32` | `optional` | `` |  |
+| 1 | `color` | `uint32` | `optional` |  |  |
+| 2 | `text` | `string` | `optional` |  |  |
+| 3 | `reset` | `bool` | `optional` |  |  |
+| 4 | `context_player_slot` | `int32` | `optional` |  | default = -1 |
+| 5 | `context_value` | `int32` | `optional` |  |  |
+| 6 | `context_team_id` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -379,7 +379,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `itemname` | `string` | `optional` | `` |  |
+| 1 | `itemname` | `string` | `optional` |  |  |
 
 </details>
 
@@ -391,7 +391,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ammo_id` | `uint32` | `optional` | `` |  |
+| 1 | `ammo_id` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -403,10 +403,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `validslots` | `uint32` | `optional` | `` |  |
-| 2 | `displaytime` | `uint32` | `optional` | `` |  |
-| 3 | `needmore` | `bool` | `optional` | `` |  |
-| 4 | `menustring` | `string` | `optional` | `` |  |
+| 1 | `validslots` | `uint32` | `optional` |  |  |
+| 2 | `displaytime` | `uint32` | `optional` |  |  |
+| 3 | `needmore` | `bool` | `optional` |  |  |
+| 4 | `menustring` | `string` | `optional` |  |  |
 
 </details>
 
@@ -418,8 +418,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `rolltype` | `.eRollType` | `optional` | `` | default = ROLL_NONE |
-| 2 | `logo_length` | `float` | `optional` | `` |  |
+| 1 | `rolltype` | `.eRollType` | `optional` |  | default = ROLL_NONE |
+| 2 | `logo_length` | `float` | `optional` |  |  |
 
 </details>
 
@@ -431,7 +431,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `entity_msg` | `.CEntityMsg` | `optional` | `` |  |
+| 1 | `entity_msg` | `.CEntityMsg` | `optional` |  |  |
 
 </details>
 
@@ -443,8 +443,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `start_effect` | `bool` | `optional` | `` |  |
-| 2 | `entity_msg` | `.CEntityMsg` | `optional` | `` |  |
+| 1 | `start_effect` | `bool` | `optional` |  |  |
+| 2 | `entity_msg` | `.CEntityMsg` | `optional` |  |  |
 
 </details>
 
@@ -456,8 +456,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `remove_decals` | `bool` | `optional` | `` |  |
-| 2 | `entity_msg` | `.CEntityMsg` | `optional` | `` |  |
+| 1 | `remove_decals` | `bool` | `optional` |  |  |
+| 2 | `entity_msg` | `.CEntityMsg` | `optional` |  |  |
 
 </details>
 
@@ -469,8 +469,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `impulse` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `entity_msg` | `.CEntityMsg` | `optional` | `` |  |
+| 1 | `impulse` | `.CMsgVector` | `optional` |  |  |
+| 2 | `entity_msg` | `.CEntityMsg` | `optional` |  |  |
 
 </details>
 
@@ -482,14 +482,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `origin` | `.CMsgVector` | `optional` | `` |  |
-| 2 | `entityindex` | `int32` | `optional` | `` | default = -1 |
-| 3 | `radius` | `float` | `optional` | `` |  |
-| 4 | `color` | `fixed32` | `optional` | `` |  |
-| 5 | `beams` | `uint32` | `optional` | `` |  |
-| 6 | `thick` | `float` | `optional` | `` |  |
-| 7 | `duration` | `float` | `optional` | `` |  |
-| 8 | `entity_msg` | `.CEntityMsg` | `optional` | `` |  |
+| 1 | `origin` | `.CMsgVector` | `optional` |  |  |
+| 2 | `entityindex` | `int32` | `optional` |  | default = -1 |
+| 3 | `radius` | `float` | `optional` |  |  |
+| 4 | `color` | `fixed32` | `optional` |  |  |
+| 5 | `beams` | `uint32` | `optional` |  |  |
+| 6 | `thick` | `float` | `optional` |  |  |
+| 7 | `duration` | `float` | `optional` |  |  |
+| 8 | `entity_msg` | `.CEntityMsg` | `optional` |  |  |
 
 </details>
 
@@ -501,9 +501,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `relative` | `bool` | `optional` | `` |  |
-| 2 | `angle` | `.CMsgQAngle` | `optional` | `` |  |
-| 3 | `entity_msg` | `.CEntityMsg` | `optional` | `` |  |
+| 1 | `relative` | `bool` | `optional` |  |  |
+| 2 | `angle` | `.CMsgQAngle` | `optional` |  |  |
+| 3 | `entity_msg` | `.CEntityMsg` | `optional` |  |  |
 
 </details>
 
@@ -515,9 +515,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `camera_type` | `uint32` | `optional` | `` |  |
-| 2 | `duration` | `float` | `optional` | `` |  |
-| 3 | `params_data_driven` | `.CUserMessageCameraTransition.Transition_DataDriven` | `optional` | `` |  |
+| 1 | `camera_type` | `uint32` | `optional` |  |  |
+| 2 | `duration` | `float` | `optional` |  |  |
+| 3 | `params_data_driven` | `.CUserMessageCameraTransition.Transition_DataDriven` | `optional` |  |  |
 
 </details>
 
@@ -529,9 +529,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `filename` | `string` | `optional` | `` |  |
-| 2 | `attach_ent_index` | `int32` | `optional` | `` | default = -1 |
-| 3 | `duration` | `float` | `optional` | `` |  |
+| 1 | `filename` | `string` | `optional` |  |  |
+| 2 | `attach_ent_index` | `int32` | `optional` |  | default = -1 |
+| 3 | `duration` | `float` | `optional` |  |  |
 
 </details>
 
@@ -543,49 +543,49 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `type` | `.PARTICLE_MESSAGE` | `optional` | `` | default = GAME_PARTICLE_MANAGER_EVENT_CREATE |
-| 2 | `index` | `uint32` | `optional` | `` |  |
-| 3 | `release_particle_index` | `.CUserMsg_ParticleManager.ReleaseParticleIndex` | `optional` | `` |  |
-| 4 | `create_particle` | `.CUserMsg_ParticleManager.CreateParticle` | `optional` | `` |  |
-| 5 | `destroy_particle` | `.CUserMsg_ParticleManager.DestroyParticle` | `optional` | `` |  |
-| 6 | `destroy_particle_involving` | `.CUserMsg_ParticleManager.DestroyParticleInvolving` | `optional` | `` |  |
-| 7 | `update_particle` | `.CUserMsg_ParticleManager.UpdateParticle_OBSOLETE` | `optional` | `` |  |
-| 8 | `update_particle_fwd` | `.CUserMsg_ParticleManager.UpdateParticleFwd_OBSOLETE` | `optional` | `` |  |
-| 9 | `update_particle_orient` | `.CUserMsg_ParticleManager.UpdateParticleOrient_OBSOLETE` | `optional` | `` |  |
-| 10 | `update_particle_fallback` | `.CUserMsg_ParticleManager.UpdateParticleFallback` | `optional` | `` |  |
-| 11 | `update_particle_offset` | `.CUserMsg_ParticleManager.UpdateParticleOffset` | `optional` | `` |  |
-| 12 | `update_particle_ent` | `.CUserMsg_ParticleManager.UpdateParticleEnt` | `optional` | `` |  |
-| 14 | `update_particle_should_draw` | `.CUserMsg_ParticleManager.UpdateParticleShouldDraw` | `optional` | `` |  |
-| 15 | `update_particle_set_frozen` | `.CUserMsg_ParticleManager.UpdateParticleSetFrozen` | `optional` | `` |  |
-| 16 | `change_control_point_attachment` | `.CUserMsg_ParticleManager.ChangeControlPointAttachment` | `optional` | `` |  |
-| 17 | `update_entity_position` | `.CUserMsg_ParticleManager.UpdateEntityPosition` | `optional` | `` |  |
-| 18 | `set_particle_fow_properties` | `.CUserMsg_ParticleManager.SetParticleFoWProperties` | `optional` | `` |  |
-| 19 | `set_particle_text` | `.CUserMsg_ParticleManager.SetParticleText` | `optional` | `` |  |
-| 20 | `set_particle_should_check_fow` | `.CUserMsg_ParticleManager.SetParticleShouldCheckFoW` | `optional` | `` |  |
-| 21 | `set_control_point_model` | `.CUserMsg_ParticleManager.SetControlPointModel` | `optional` | `` |  |
-| 22 | `set_control_point_snapshot` | `.CUserMsg_ParticleManager.SetControlPointSnapshot` | `optional` | `` |  |
-| 23 | `set_texture_attribute` | `.CUserMsg_ParticleManager.SetTextureAttribute` | `optional` | `` |  |
-| 24 | `set_scene_object_generic_flag` | `.CUserMsg_ParticleManager.SetSceneObjectGenericFlag` | `optional` | `` |  |
-| 25 | `set_scene_object_tint_and_desat` | `.CUserMsg_ParticleManager.SetSceneObjectTintAndDesat` | `optional` | `` |  |
-| 26 | `destroy_particle_named` | `.CUserMsg_ParticleManager.DestroyParticleNamed` | `optional` | `` |  |
-| 27 | `particle_skip_to_time` | `.CUserMsg_ParticleManager.ParticleSkipToTime` | `optional` | `` |  |
-| 28 | `particle_can_freeze` | `.CUserMsg_ParticleManager.ParticleCanFreeze` | `optional` | `` |  |
-| 29 | `set_named_value_context` | `.CUserMsg_ParticleManager.SetParticleNamedValueContext` | `optional` | `` |  |
-| 30 | `update_particle_transform` | `.CUserMsg_ParticleManager.UpdateParticleTransform` | `optional` | `` |  |
-| 31 | `particle_freeze_transition_override` | `.CUserMsg_ParticleManager.ParticleFreezeTransitionOverride` | `optional` | `` |  |
-| 32 | `freeze_particle_involving` | `.CUserMsg_ParticleManager.FreezeParticleInvolving` | `optional` | `` |  |
-| 33 | `add_modellist_override_element` | `.CUserMsg_ParticleManager.AddModellistOverrideElement` | `optional` | `` |  |
-| 34 | `clear_modellist_override` | `.CUserMsg_ParticleManager.ClearModellistOverride` | `optional` | `` |  |
-| 35 | `create_physics_sim` | `.CUserMsg_ParticleManager.CreatePhysicsSim` | `optional` | `` |  |
-| 36 | `destroy_physics_sim` | `.CUserMsg_ParticleManager.DestroyPhysicsSim` | `optional` | `` |  |
-| 37 | `set_vdata` | `.CUserMsg_ParticleManager.SetVData` | `optional` | `` |  |
-| 38 | `set_material_override` | `.CUserMsg_ParticleManager.SetMaterialOverride` | `optional` | `` |  |
-| 39 | `add_fan` | `.CUserMsg_ParticleManager.AddFan` | `optional` | `` |  |
-| 40 | `update_fan` | `.CUserMsg_ParticleManager.UpdateFan` | `optional` | `` |  |
-| 41 | `set_particle_cluster_growth` | `.CUserMsg_ParticleManager.SetParticleClusterGrowth` | `optional` | `` |  |
-| 42 | `remove_fan` | `.CUserMsg_ParticleManager.RemoveFan` | `optional` | `` |  |
-| 43 | `create_smoke_grid` | `.CUserMsg_ParticleManager.CreateSmokeGrid` | `optional` | `` |  |
-| 44 | `set_override_texture` | `.CUserMsg_ParticleManager.SetOverrideTexture` | `optional` | `` |  |
+| 1 | `type` | `.PARTICLE_MESSAGE` | `optional` |  | default = GAME_PARTICLE_MANAGER_EVENT_CREATE |
+| 2 | `index` | `uint32` | `optional` |  |  |
+| 3 | `release_particle_index` | `.CUserMsg_ParticleManager.ReleaseParticleIndex` | `optional` |  |  |
+| 4 | `create_particle` | `.CUserMsg_ParticleManager.CreateParticle` | `optional` |  |  |
+| 5 | `destroy_particle` | `.CUserMsg_ParticleManager.DestroyParticle` | `optional` |  |  |
+| 6 | `destroy_particle_involving` | `.CUserMsg_ParticleManager.DestroyParticleInvolving` | `optional` |  |  |
+| 7 | `update_particle` | `.CUserMsg_ParticleManager.UpdateParticle_OBSOLETE` | `optional` |  |  |
+| 8 | `update_particle_fwd` | `.CUserMsg_ParticleManager.UpdateParticleFwd_OBSOLETE` | `optional` |  |  |
+| 9 | `update_particle_orient` | `.CUserMsg_ParticleManager.UpdateParticleOrient_OBSOLETE` | `optional` |  |  |
+| 10 | `update_particle_fallback` | `.CUserMsg_ParticleManager.UpdateParticleFallback` | `optional` |  |  |
+| 11 | `update_particle_offset` | `.CUserMsg_ParticleManager.UpdateParticleOffset` | `optional` |  |  |
+| 12 | `update_particle_ent` | `.CUserMsg_ParticleManager.UpdateParticleEnt` | `optional` |  |  |
+| 14 | `update_particle_should_draw` | `.CUserMsg_ParticleManager.UpdateParticleShouldDraw` | `optional` |  |  |
+| 15 | `update_particle_set_frozen` | `.CUserMsg_ParticleManager.UpdateParticleSetFrozen` | `optional` |  |  |
+| 16 | `change_control_point_attachment` | `.CUserMsg_ParticleManager.ChangeControlPointAttachment` | `optional` |  |  |
+| 17 | `update_entity_position` | `.CUserMsg_ParticleManager.UpdateEntityPosition` | `optional` |  |  |
+| 18 | `set_particle_fow_properties` | `.CUserMsg_ParticleManager.SetParticleFoWProperties` | `optional` |  |  |
+| 19 | `set_particle_text` | `.CUserMsg_ParticleManager.SetParticleText` | `optional` |  |  |
+| 20 | `set_particle_should_check_fow` | `.CUserMsg_ParticleManager.SetParticleShouldCheckFoW` | `optional` |  |  |
+| 21 | `set_control_point_model` | `.CUserMsg_ParticleManager.SetControlPointModel` | `optional` |  |  |
+| 22 | `set_control_point_snapshot` | `.CUserMsg_ParticleManager.SetControlPointSnapshot` | `optional` |  |  |
+| 23 | `set_texture_attribute` | `.CUserMsg_ParticleManager.SetTextureAttribute` | `optional` |  |  |
+| 24 | `set_scene_object_generic_flag` | `.CUserMsg_ParticleManager.SetSceneObjectGenericFlag` | `optional` |  |  |
+| 25 | `set_scene_object_tint_and_desat` | `.CUserMsg_ParticleManager.SetSceneObjectTintAndDesat` | `optional` |  |  |
+| 26 | `destroy_particle_named` | `.CUserMsg_ParticleManager.DestroyParticleNamed` | `optional` |  |  |
+| 27 | `particle_skip_to_time` | `.CUserMsg_ParticleManager.ParticleSkipToTime` | `optional` |  |  |
+| 28 | `particle_can_freeze` | `.CUserMsg_ParticleManager.ParticleCanFreeze` | `optional` |  |  |
+| 29 | `set_named_value_context` | `.CUserMsg_ParticleManager.SetParticleNamedValueContext` | `optional` |  |  |
+| 30 | `update_particle_transform` | `.CUserMsg_ParticleManager.UpdateParticleTransform` | `optional` |  |  |
+| 31 | `particle_freeze_transition_override` | `.CUserMsg_ParticleManager.ParticleFreezeTransitionOverride` | `optional` |  |  |
+| 32 | `freeze_particle_involving` | `.CUserMsg_ParticleManager.FreezeParticleInvolving` | `optional` |  |  |
+| 33 | `add_modellist_override_element` | `.CUserMsg_ParticleManager.AddModellistOverrideElement` | `optional` |  |  |
+| 34 | `clear_modellist_override` | `.CUserMsg_ParticleManager.ClearModellistOverride` | `optional` |  |  |
+| 35 | `create_physics_sim` | `.CUserMsg_ParticleManager.CreatePhysicsSim` | `optional` |  |  |
+| 36 | `destroy_physics_sim` | `.CUserMsg_ParticleManager.DestroyPhysicsSim` | `optional` |  |  |
+| 37 | `set_vdata` | `.CUserMsg_ParticleManager.SetVData` | `optional` |  |  |
+| 38 | `set_material_override` | `.CUserMsg_ParticleManager.SetMaterialOverride` | `optional` |  |  |
+| 39 | `add_fan` | `.CUserMsg_ParticleManager.AddFan` | `optional` |  |  |
+| 40 | `update_fan` | `.CUserMsg_ParticleManager.UpdateFan` | `optional` |  |  |
+| 41 | `set_particle_cluster_growth` | `.CUserMsg_ParticleManager.SetParticleClusterGrowth` | `optional` |  |  |
+| 42 | `remove_fan` | `.CUserMsg_ParticleManager.RemoveFan` | `optional` |  |  |
+| 43 | `create_smoke_grid` | `.CUserMsg_ParticleManager.CreateSmokeGrid` | `optional` |  |  |
+| 44 | `set_override_texture` | `.CUserMsg_ParticleManager.SetOverrideTexture` | `optional` |  |  |
 
 </details>
 
@@ -609,16 +609,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `particle_name_index` | `fixed64` | `optional` | `` |  |
-| 2 | `attach_type` | `int32` | `optional` | `` |  |
-| 3 | `entity_handle` | `uint32` | `optional` | `` | default = 16777215 |
-| 4 | `entity_handle_for_modifiers` | `uint32` | `optional` | `` | default = 16777215 |
-| 5 | `apply_voice_ban_rules` | `bool` | `optional` | `` |  |
-| 6 | `team_behavior` | `int32` | `optional` | `` |  |
-| 7 | `control_point_configuration` | `string` | `optional` | `` |  |
-| 8 | `cluster` | `bool` | `optional` | `` |  |
-| 9 | `endcap_time` | `float` | `optional` | `` |  |
-| 10 | `aggregation_position` | `.CMsgVector` | `optional` | `` |  |
+| 1 | `particle_name_index` | `fixed64` | `optional` |  |  |
+| 2 | `attach_type` | `int32` | `optional` |  |  |
+| 3 | `entity_handle` | `uint32` | `optional` |  | default = 16777215 |
+| 4 | `entity_handle_for_modifiers` | `uint32` | `optional` |  | default = 16777215 |
+| 5 | `apply_voice_ban_rules` | `bool` | `optional` |  |  |
+| 6 | `team_behavior` | `int32` | `optional` |  |  |
+| 7 | `control_point_configuration` | `string` | `optional` |  |  |
+| 8 | `cluster` | `bool` | `optional` |  |  |
+| 9 | `endcap_time` | `float` | `optional` |  |  |
+| 10 | `aggregation_position` | `.CMsgVector` | `optional` |  |  |
 
 </details>
 
@@ -630,7 +630,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `destroy_immediately` | `bool` | `optional` | `` |  |
+| 1 | `destroy_immediately` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -642,8 +642,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `destroy_immediately` | `bool` | `optional` | `` |  |
-| 3 | `entity_handle` | `uint32` | `optional` | `` | default = 16777215 |
+| 1 | `destroy_immediately` | `bool` | `optional` |  |  |
+| 3 | `entity_handle` | `uint32` | `optional` |  | default = 16777215 |
 
 </details>
 
@@ -655,10 +655,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `particle_name_index` | `fixed64` | `optional` | `` |  |
-| 2 | `entity_handle` | `uint32` | `optional` | `` | default = 16777215 |
-| 3 | `destroy_immediately` | `bool` | `optional` | `` |  |
-| 4 | `play_endcap` | `bool` | `optional` | `` |  |
+| 1 | `particle_name_index` | `fixed64` | `optional` |  |  |
+| 2 | `entity_handle` | `uint32` | `optional` |  | default = 16777215 |
+| 3 | `destroy_immediately` | `bool` | `optional` |  |  |
+| 4 | `play_endcap` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -670,8 +670,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `control_point` | `int32` | `optional` | `` |  |
-| 2 | `position` | `.CMsgVector` | `optional` | `` |  |
+| 1 | `control_point` | `int32` | `optional` |  |  |
+| 2 | `position` | `.CMsgVector` | `optional` |  |  |
 
 </details>
 
@@ -683,8 +683,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `control_point` | `int32` | `optional` | `` |  |
-| 2 | `forward` | `.CMsgVector` | `optional` | `` |  |
+| 1 | `control_point` | `int32` | `optional` |  |  |
+| 2 | `forward` | `.CMsgVector` | `optional` |  |  |
 
 </details>
 
@@ -696,11 +696,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `control_point` | `int32` | `optional` | `` |  |
-| 2 | `forward` | `.CMsgVector` | `optional` | `` |  |
-| 3 | `deprecated_right` | `.CMsgVector` | `optional` | `` |  |
-| 4 | `up` | `.CMsgVector` | `optional` | `` |  |
-| 5 | `left` | `.CMsgVector` | `optional` | `` |  |
+| 1 | `control_point` | `int32` | `optional` |  |  |
+| 2 | `forward` | `.CMsgVector` | `optional` |  |  |
+| 3 | `deprecated_right` | `.CMsgVector` | `optional` |  |  |
+| 4 | `up` | `.CMsgVector` | `optional` |  |  |
+| 5 | `left` | `.CMsgVector` | `optional` |  |  |
 
 </details>
 
@@ -712,10 +712,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `control_point` | `int32` | `optional` | `` |  |
-| 2 | `position` | `.CMsgVector` | `optional` | `` |  |
-| 3 | `orientation` | `.CMsgQuaternion` | `optional` | `` |  |
-| 4 | `interpolation_interval` | `float` | `optional` | `` |  |
+| 1 | `control_point` | `int32` | `optional` |  |  |
+| 2 | `position` | `.CMsgVector` | `optional` |  |  |
+| 3 | `orientation` | `.CMsgQuaternion` | `optional` |  |  |
+| 4 | `interpolation_interval` | `float` | `optional` |  |  |
 
 </details>
 
@@ -727,8 +727,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `control_point` | `int32` | `optional` | `` |  |
-| 2 | `position` | `.CMsgVector` | `optional` | `` |  |
+| 1 | `control_point` | `int32` | `optional` |  |  |
+| 2 | `position` | `.CMsgVector` | `optional` |  |  |
 
 </details>
 
@@ -740,9 +740,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `control_point` | `int32` | `optional` | `` |  |
-| 2 | `origin_offset` | `.CMsgVector` | `optional` | `` |  |
-| 3 | `angle_offset` | `.CMsgQAngle` | `optional` | `` |  |
+| 1 | `control_point` | `int32` | `optional` |  |  |
+| 2 | `origin_offset` | `.CMsgVector` | `optional` |  |  |
+| 3 | `angle_offset` | `.CMsgQAngle` | `optional` |  |  |
 
 </details>
 
@@ -754,14 +754,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `control_point` | `int32` | `optional` | `` |  |
-| 2 | `entity_handle` | `uint32` | `optional` | `` | default = 16777215 |
-| 3 | `attach_type` | `int32` | `optional` | `` |  |
-| 4 | `attachment` | `int32` | `optional` | `` |  |
-| 5 | `fallback_position` | `.CMsgVector` | `optional` | `` |  |
-| 6 | `include_wearables` | `bool` | `optional` | `` |  |
-| 7 | `offset_position` | `.CMsgVector` | `optional` | `` |  |
-| 8 | `offset_angles` | `.CMsgQAngle` | `optional` | `` |  |
+| 1 | `control_point` | `int32` | `optional` |  |  |
+| 2 | `entity_handle` | `uint32` | `optional` |  | default = 16777215 |
+| 3 | `attach_type` | `int32` | `optional` |  |  |
+| 4 | `attachment` | `int32` | `optional` |  |  |
+| 5 | `fallback_position` | `.CMsgVector` | `optional` |  |  |
+| 6 | `include_wearables` | `bool` | `optional` |  |  |
+| 7 | `offset_position` | `.CMsgVector` | `optional` |  |  |
+| 8 | `offset_angles` | `.CMsgQAngle` | `optional` |  |  |
 
 </details>
 
@@ -773,8 +773,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `set_frozen` | `bool` | `optional` | `` |  |
-| 2 | `transition_duration` | `float` | `optional` | `` |  |
+| 1 | `set_frozen` | `bool` | `optional` |  |  |
+| 2 | `transition_duration` | `float` | `optional` |  |  |
 
 </details>
 
@@ -786,7 +786,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `should_draw` | `bool` | `optional` | `` |  |
+| 1 | `should_draw` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -798,9 +798,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `attachment_old` | `int32` | `optional` | `` |  |
-| 2 | `attachment_new` | `int32` | `optional` | `` |  |
-| 3 | `entity_handle` | `uint32` | `optional` | `` | default = 16777215 |
+| 1 | `attachment_old` | `int32` | `optional` |  |  |
+| 2 | `attachment_new` | `int32` | `optional` |  |  |
+| 3 | `entity_handle` | `uint32` | `optional` |  | default = 16777215 |
 
 </details>
 
@@ -812,8 +812,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `entity_handle` | `uint32` | `optional` | `` | default = 16777215 |
-| 2 | `position` | `.CMsgVector` | `optional` | `` |  |
+| 1 | `entity_handle` | `uint32` | `optional` |  | default = 16777215 |
+| 2 | `position` | `.CMsgVector` | `optional` |  |  |
 
 </details>
 
@@ -825,9 +825,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `fow_control_point` | `int32` | `optional` | `` |  |
-| 2 | `fow_control_point2` | `int32` | `optional` | `` |  |
-| 3 | `fow_radius` | `float` | `optional` | `` |  |
+| 1 | `fow_control_point` | `int32` | `optional` |  |  |
+| 2 | `fow_control_point2` | `int32` | `optional` |  |  |
+| 3 | `fow_radius` | `float` | `optional` |  |  |
 
 </details>
 
@@ -839,7 +839,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `check_fow` | `bool` | `optional` | `` |  |
+| 1 | `check_fow` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -851,8 +851,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `control_point` | `int32` | `optional` | `` |  |
-| 2 | `model_name` | `string` | `optional` | `` |  |
+| 1 | `control_point` | `int32` | `optional` |  |  |
+| 2 | `model_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -864,8 +864,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `control_point` | `int32` | `optional` | `` |  |
-| 2 | `snapshot_name` | `string` | `optional` | `` |  |
+| 1 | `control_point` | `int32` | `optional` |  |  |
+| 2 | `snapshot_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -877,8 +877,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `text` | `string` | `optional` | `` |  |
-| 2 | `localize` | `bool` | `optional` | `` |  |
+| 1 | `text` | `string` | `optional` |  |  |
+| 2 | `localize` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -890,8 +890,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `attribute_name` | `string` | `optional` | `` |  |
-| 2 | `texture_name` | `string` | `optional` | `` |  |
+| 1 | `attribute_name` | `string` | `optional` |  |  |
+| 2 | `texture_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -903,7 +903,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `texture_name` | `string` | `optional` | `` |  |
+| 1 | `texture_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -915,7 +915,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `flag_value` | `bool` | `optional` | `` |  |
+| 1 | `flag_value` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -927,8 +927,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `tint` | `fixed32` | `optional` | `` |  |
-| 2 | `desat` | `float` | `optional` | `` |  |
+| 1 | `tint` | `fixed32` | `optional` |  |  |
+| 2 | `desat` | `float` | `optional` |  |  |
 
 </details>
 
@@ -940,7 +940,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `skip_to_time` | `float` | `optional` | `` |  |
+| 1 | `skip_to_time` | `float` | `optional` |  |  |
 
 </details>
 
@@ -952,7 +952,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `can_freeze` | `bool` | `optional` | `` |  |
+| 1 | `can_freeze` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -964,7 +964,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `freeze_transition_override` | `float` | `optional` | `` |  |
+| 1 | `freeze_transition_override` | `float` | `optional` |  |  |
 
 </details>
 
@@ -976,9 +976,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `set_frozen` | `bool` | `optional` | `` |  |
-| 2 | `transition_duration` | `float` | `optional` | `` |  |
-| 3 | `entity_handle` | `uint32` | `optional` | `` | default = 16777215 |
+| 1 | `set_frozen` | `bool` | `optional` |  |  |
+| 2 | `transition_duration` | `float` | `optional` |  |  |
+| 3 | `entity_handle` | `uint32` | `optional` |  | default = 16777215 |
 
 </details>
 
@@ -990,9 +990,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `model_name` | `string` | `optional` | `` |  |
-| 2 | `spawn_probability` | `float` | `optional` | `` |  |
-| 3 | `groupid` | `uint32` | `optional` | `` |  |
+| 1 | `model_name` | `string` | `optional` |  |  |
+| 2 | `spawn_probability` | `float` | `optional` |  |  |
+| 3 | `groupid` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1004,7 +1004,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `groupid` | `uint32` | `optional` | `` |  |
+| 1 | `groupid` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1016,10 +1016,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `float_values` | `.CUserMsg_ParticleManager.SetParticleNamedValueContext.FloatContextValue` | `repeated` | `` |  |
-| 2 | `vector_values` | `.CUserMsg_ParticleManager.SetParticleNamedValueContext.VectorContextValue` | `repeated` | `` |  |
-| 3 | `transform_values` | `.CUserMsg_ParticleManager.SetParticleNamedValueContext.TransformContextValue` | `repeated` | `` |  |
-| 4 | `ehandle_values` | `.CUserMsg_ParticleManager.SetParticleNamedValueContext.EHandleContext` | `repeated` | `` |  |
+| 1 | `float_values` | `.CUserMsg_ParticleManager.SetParticleNamedValueContext.FloatContextValue` | `repeated` |  |  |
+| 2 | `vector_values` | `.CUserMsg_ParticleManager.SetParticleNamedValueContext.VectorContextValue` | `repeated` |  |  |
+| 3 | `transform_values` | `.CUserMsg_ParticleManager.SetParticleNamedValueContext.TransformContextValue` | `repeated` |  |  |
+| 4 | `ehandle_values` | `.CUserMsg_ParticleManager.SetParticleNamedValueContext.EHandleContext` | `repeated` |  |  |
 
 </details>
 
@@ -1031,8 +1031,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `value_name_hash` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `float` | `optional` | `` |  |
+| 1 | `value_name_hash` | `uint32` | `optional` |  |  |
+| 2 | `value` | `float` | `optional` |  |  |
 
 </details>
 
@@ -1044,8 +1044,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `value_name_hash` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `.CMsgVector` | `optional` | `` |  |
+| 1 | `value_name_hash` | `uint32` | `optional` |  |  |
+| 2 | `value` | `.CMsgVector` | `optional` |  |  |
 
 </details>
 
@@ -1057,9 +1057,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `value_name_hash` | `uint32` | `optional` | `` |  |
-| 2 | `angles` | `.CMsgQAngle` | `optional` | `` |  |
-| 3 | `translation` | `.CMsgVector` | `optional` | `` |  |
+| 1 | `value_name_hash` | `uint32` | `optional` |  |  |
+| 2 | `angles` | `.CMsgQAngle` | `optional` |  |  |
+| 3 | `translation` | `.CMsgVector` | `optional` |  |  |
 
 </details>
 
@@ -1071,8 +1071,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `value_name_hash` | `uint32` | `optional` | `` |  |
-| 2 | `ent_index` | `uint32` | `optional` | `` | default = 16777215 |
+| 1 | `value_name_hash` | `uint32` | `optional` |  |  |
+| 2 | `ent_index` | `uint32` | `optional` |  | default = 16777215 |
 
 </details>
 
@@ -1084,9 +1084,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `prop_group_name` | `string` | `optional` | `` |  |
-| 2 | `use_high_quality_simulation` | `bool` | `optional` | `` |  |
-| 3 | `max_particle_count` | `uint32` | `optional` | `` |  |
+| 1 | `prop_group_name` | `string` | `optional` |  |  |
+| 2 | `use_high_quality_simulation` | `bool` | `optional` |  |  |
+| 3 | `max_particle_count` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1110,7 +1110,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `vdata_name` | `string` | `optional` | `` |  |
+| 1 | `vdata_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1122,7 +1122,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `vdata_name` | `string` | `optional` | `` |  |
+| 1 | `vdata_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1134,8 +1134,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `material_name` | `string` | `optional` | `` |  |
-| 2 | `include_children` | `bool` | `optional` | `` |  |
+| 1 | `material_name` | `string` | `optional` |  |  |
+| 2 | `include_children` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1147,24 +1147,24 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `active` | `bool` | `optional` | `` |  |
-| 2 | `bounds_mins` | `.CMsgVector` | `optional` | `` |  |
-| 3 | `bounds_maxs` | `.CMsgVector` | `optional` | `` |  |
-| 4 | `fan_origin` | `.CMsgVector` | `optional` | `` |  |
-| 5 | `fan_origin_offset` | `.CMsgVector` | `optional` | `` |  |
-| 6 | `fan_direction` | `.CMsgVector` | `optional` | `` |  |
-| 7 | `force` | `float` | `optional` | `` |  |
-| 8 | `fan_force_curve` | `string` | `optional` | `` |  |
-| 9 | `falloff` | `bool` | `optional` | `` |  |
-| 10 | `pull_towards_point` | `bool` | `optional` | `` |  |
-| 11 | `curve_min_dist` | `float` | `optional` | `` |  |
-| 12 | `curve_max_dist` | `float` | `optional` | `` |  |
-| 13 | `fan_type` | `uint32` | `optional` | `` |  |
-| 14 | `cone_start_radius` | `float` | `optional` | `` |  |
-| 15 | `cone_end_radius` | `float` | `optional` | `` |  |
-| 16 | `cone_length` | `float` | `optional` | `` |  |
-| 17 | `entity_handle` | `uint32` | `optional` | `` | default = 16777215 |
-| 18 | `attachment_name` | `string` | `optional` | `` |  |
+| 1 | `active` | `bool` | `optional` |  |  |
+| 2 | `bounds_mins` | `.CMsgVector` | `optional` |  |  |
+| 3 | `bounds_maxs` | `.CMsgVector` | `optional` |  |  |
+| 4 | `fan_origin` | `.CMsgVector` | `optional` |  |  |
+| 5 | `fan_origin_offset` | `.CMsgVector` | `optional` |  |  |
+| 6 | `fan_direction` | `.CMsgVector` | `optional` |  |  |
+| 7 | `force` | `float` | `optional` |  |  |
+| 8 | `fan_force_curve` | `string` | `optional` |  |  |
+| 9 | `falloff` | `bool` | `optional` |  |  |
+| 10 | `pull_towards_point` | `bool` | `optional` |  |  |
+| 11 | `curve_min_dist` | `float` | `optional` |  |  |
+| 12 | `curve_max_dist` | `float` | `optional` |  |  |
+| 13 | `fan_type` | `uint32` | `optional` |  |  |
+| 14 | `cone_start_radius` | `float` | `optional` |  |  |
+| 15 | `cone_end_radius` | `float` | `optional` |  |  |
+| 16 | `cone_length` | `float` | `optional` |  |  |
+| 17 | `entity_handle` | `uint32` | `optional` |  | default = 16777215 |
+| 18 | `attachment_name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1176,13 +1176,13 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `active` | `bool` | `optional` | `` |  |
-| 2 | `fan_origin` | `.CMsgVector` | `optional` | `` |  |
-| 3 | `fan_origin_offset` | `.CMsgVector` | `optional` | `` |  |
-| 4 | `fan_direction` | `.CMsgVector` | `optional` | `` |  |
-| 5 | `bounds_mins` | `.CMsgVector` | `optional` | `` |  |
-| 6 | `bounds_maxs` | `.CMsgVector` | `optional` | `` |  |
-| 7 | `fan_ramp_ratio` | `float` | `optional` | `` |  |
+| 1 | `active` | `bool` | `optional` |  |  |
+| 2 | `fan_origin` | `.CMsgVector` | `optional` |  |  |
+| 3 | `fan_origin_offset` | `.CMsgVector` | `optional` |  |  |
+| 4 | `fan_direction` | `.CMsgVector` | `optional` |  |  |
+| 5 | `bounds_mins` | `.CMsgVector` | `optional` |  |  |
+| 6 | `bounds_maxs` | `.CMsgVector` | `optional` |  |  |
+| 7 | `fan_ramp_ratio` | `float` | `optional` |  |  |
 
 </details>
 
@@ -1206,8 +1206,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `duration` | `float` | `optional` | `` |  |
-| 2 | `origin` | `.CMsgVector` | `optional` | `` |  |
+| 1 | `duration` | `float` | `optional` |  |  |
+| 2 | `origin` | `.CMsgVector` | `optional` |  |  |
 
 </details>
 
@@ -1219,7 +1219,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `order_id` | `int32` | `optional` | `` |  |
+| 1 | `order_id` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1231,8 +1231,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `event_name` | `string` | `optional` | `` |  |
-| 2 | `data` | `bytes` | `optional` | `` |  |
+| 1 | `event_name` | `string` | `optional` |  |  |
+| 2 | `data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -1244,10 +1244,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hand_id` | `int32` | `optional` | `` |  |
-| 2 | `effect_amplitude` | `float` | `optional` | `` |  |
-| 3 | `effect_frequency` | `float` | `optional` | `` |  |
-| 4 | `effect_duration` | `float` | `optional` | `` |  |
+| 1 | `hand_id` | `int32` | `optional` |  |  |
+| 2 | `effect_amplitude` | `float` | `optional` |  |  |
+| 3 | `effect_frequency` | `float` | `optional` |  |  |
+| 4 | `effect_duration` | `float` | `optional` |  |  |
 
 </details>
 
@@ -1259,9 +1259,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `hand_id` | `int32` | `optional` | `` |  |
-| 2 | `effect_name_hash_code` | `uint32` | `optional` | `` |  |
-| 3 | `effect_scale` | `float` | `optional` | `` |  |
+| 1 | `hand_id` | `int32` | `optional` |  |  |
+| 2 | `effect_name_hash_code` | `uint32` | `optional` |  |  |
+| 3 | `effect_scale` | `float` | `optional` |  |  |
 
 </details>
 
@@ -1273,8 +1273,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `entity_index` | `int32` | `optional` | `` |  |
-| 2 | `data` | `bytes` | `optional` | `` |  |
+| 1 | `entity_index` | `int32` | `optional` |  |  |
+| 2 | `data` | `bytes` | `optional` |  |  |
 
 </details>
 
@@ -1286,9 +1286,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `target_world_panel` | `int32` | `optional` | `` |  |
-| 2 | `css_classes` | `string` | `optional` | `` |  |
-| 3 | `is_add` | `bool` | `optional` | `` |  |
+| 1 | `target_world_panel` | `int32` | `optional` |  |  |
+| 2 | `css_classes` | `string` | `optional` |  |  |
+| 3 | `is_add` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1300,7 +1300,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `frame_time` | `float` | `optional` | `` |  |
+| 1 | `frame_time` | `float` | `optional` |  |  |
 
 </details>
 
@@ -1312,7 +1312,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `distance` | `float` | `optional` | `` |  |
+| 1 | `distance` | `float` | `optional` |  |  |
 
 </details>
 
@@ -1324,8 +1324,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `dll_action` | `string` | `optional` | `` |  |
-| 2 | `full_report` | `bool` | `optional` | `` |  |
+| 1 | `dll_action` | `string` | `optional` |  |  |
+| 2 | `full_report` | `bool` | `optional` |  |  |
 
 </details>
 
@@ -1337,11 +1337,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 2 | `util1` | `int32` | `optional` | `` |  |
-| 3 | `util2` | `int32` | `optional` | `` |  |
-| 4 | `util3` | `int32` | `optional` | `` |  |
-| 5 | `util4` | `int32` | `optional` | `` |  |
-| 6 | `util5` | `int32` | `optional` | `` |  |
+| 2 | `util1` | `int32` | `optional` |  |  |
+| 3 | `util2` | `int32` | `optional` |  |  |
+| 4 | `util3` | `int32` | `optional` |  |  |
+| 5 | `util4` | `int32` | `optional` |  |  |
+| 6 | `util5` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1353,18 +1353,18 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `crc` | `fixed32` | `optional` | `` |  |
-| 2 | `item_count` | `int32` | `optional` | `` |  |
-| 3 | `crc2` | `fixed32` | `optional` | `` |  |
-| 4 | `item_count2` | `int32` | `optional` | `` |  |
-| 5 | `crc_part` | `int32` | `repeated` | `` |  |
-| 6 | `crc_part2` | `int32` | `repeated` | `` |  |
-| 7 | `client_timestamp` | `int32` | `optional` | `` |  |
-| 8 | `platform` | `int32` | `optional` | `` |  |
-| 9 | `itemdetails` | `.CUserMessage_UtilMsg_Response.ItemDetail` | `repeated` | `` |  |
-| 10 | `itemgroup` | `int32` | `optional` | `` |  |
-| 11 | `total_count` | `int32` | `optional` | `` |  |
-| 12 | `total_count2` | `int32` | `optional` | `` |  |
+| 1 | `crc` | `fixed32` | `optional` |  |  |
+| 2 | `item_count` | `int32` | `optional` |  |  |
+| 3 | `crc2` | `fixed32` | `optional` |  |  |
+| 4 | `item_count2` | `int32` | `optional` |  |  |
+| 5 | `crc_part` | `int32` | `repeated` |  |  |
+| 6 | `crc_part2` | `int32` | `repeated` |  |  |
+| 7 | `client_timestamp` | `int32` | `optional` |  |  |
+| 8 | `platform` | `int32` | `optional` |  |  |
+| 9 | `itemdetails` | `.CUserMessage_UtilMsg_Response.ItemDetail` | `repeated` |  |  |
+| 10 | `itemgroup` | `int32` | `optional` |  |  |
+| 11 | `total_count` | `int32` | `optional` |  |  |
+| 12 | `total_count2` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1376,10 +1376,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `index` | `int32` | `optional` | `` |  |
-| 2 | `hash` | `int32` | `optional` | `` |  |
-| 3 | `crc` | `int32` | `optional` | `` |  |
-| 4 | `name` | `string` | `optional` | `` |  |
+| 1 | `index` | `int32` | `optional` |  |  |
+| 2 | `hash` | `int32` | `optional` |  |  |
+| 3 | `crc` | `int32` | `optional` |  |  |
+| 4 | `name` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1391,14 +1391,14 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `file_report` | `string` | `optional` | `` |  |
-| 2 | `command_line` | `string` | `optional` | `` |  |
-| 3 | `total_files` | `uint32` | `optional` | `` |  |
-| 4 | `process_id` | `uint32` | `optional` | `` |  |
-| 5 | `osversion` | `int32` | `optional` | `` |  |
-| 6 | `client_time` | `uint64` | `optional` | `` |  |
-| 7 | `diagnostics` | `.CUserMessage_DllStatus.CVDiagnostic` | `repeated` | `` |  |
-| 8 | `modules` | `.CUserMessage_DllStatus.CModule` | `repeated` | `` |  |
+| 1 | `file_report` | `string` | `optional` |  |  |
+| 2 | `command_line` | `string` | `optional` |  |  |
+| 3 | `total_files` | `uint32` | `optional` |  |  |
+| 4 | `process_id` | `uint32` | `optional` |  |  |
+| 5 | `osversion` | `int32` | `optional` |  |  |
+| 6 | `client_time` | `uint64` | `optional` |  |  |
+| 7 | `diagnostics` | `.CUserMessage_DllStatus.CVDiagnostic` | `repeated` |  |  |
+| 8 | `modules` | `.CUserMessage_DllStatus.CModule` | `repeated` |  |  |
 
 </details>
 
@@ -1410,10 +1410,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `id` | `uint32` | `optional` | `` |  |
-| 2 | `extended` | `uint32` | `optional` | `` |  |
-| 3 | `value` | `uint64` | `optional` | `` |  |
-| 4 | `string_value` | `string` | `optional` | `` |  |
+| 1 | `id` | `uint32` | `optional` |  |  |
+| 2 | `extended` | `uint32` | `optional` |  |  |
+| 3 | `value` | `uint64` | `optional` |  |  |
+| 4 | `string_value` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1425,10 +1425,10 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `base_addr` | `uint64` | `optional` | `` |  |
-| 2 | `name` | `string` | `optional` | `` |  |
-| 3 | `size` | `uint32` | `optional` | `` |  |
-| 4 | `timestamp` | `uint32` | `optional` | `` |  |
+| 1 | `base_addr` | `uint64` | `optional` |  |  |
+| 2 | `name` | `string` | `optional` |  |  |
+| 3 | `size` | `uint32` | `optional` |  |  |
+| 4 | `timestamp` | `uint32` | `optional` |  |  |
 
 </details>
 
@@ -1440,9 +1440,9 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `inventory` | `int32` | `optional` | `` |  |
-| 2 | `offset` | `int32` | `optional` | `` |  |
-| 3 | `options` | `int32` | `optional` | `` |  |
+| 1 | `inventory` | `int32` | `optional` |  |  |
+| 2 | `offset` | `int32` | `optional` |  |  |
+| 3 | `options` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1454,19 +1454,19 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `crc` | `fixed32` | `optional` | `` |  |
-| 2 | `item_count` | `int32` | `optional` | `` |  |
-| 5 | `osversion` | `int32` | `optional` | `` |  |
-| 6 | `perf_time` | `int32` | `optional` | `` |  |
-| 7 | `client_timestamp` | `int32` | `optional` | `` |  |
-| 8 | `platform` | `int32` | `optional` | `` |  |
-| 9 | `inventories` | `.CUserMessage_Inventory_Response.InventoryDetail` | `repeated` | `` |  |
-| 10 | `inventories2` | `.CUserMessage_Inventory_Response.InventoryDetail` | `repeated` | `` |  |
-| 11 | `inv_type` | `int32` | `optional` | `` |  |
-| 12 | `build_version` | `int32` | `optional` | `` |  |
-| 13 | `instance` | `int32` | `optional` | `` |  |
-| 14 | `inventories3` | `.CUserMessage_Inventory_Response.InventoryDetail` | `repeated` | `` |  |
-| 15 | `start_time` | `int64` | `optional` | `` |  |
+| 1 | `crc` | `fixed32` | `optional` |  |  |
+| 2 | `item_count` | `int32` | `optional` |  |  |
+| 5 | `osversion` | `int32` | `optional` |  |  |
+| 6 | `perf_time` | `int32` | `optional` |  |  |
+| 7 | `client_timestamp` | `int32` | `optional` |  |  |
+| 8 | `platform` | `int32` | `optional` |  |  |
+| 9 | `inventories` | `.CUserMessage_Inventory_Response.InventoryDetail` | `repeated` |  |  |
+| 10 | `inventories2` | `.CUserMessage_Inventory_Response.InventoryDetail` | `repeated` |  |  |
+| 11 | `inv_type` | `int32` | `optional` |  |  |
+| 12 | `build_version` | `int32` | `optional` |  |  |
+| 13 | `instance` | `int32` | `optional` |  |  |
+| 14 | `inventories3` | `.CUserMessage_Inventory_Response.InventoryDetail` | `repeated` |  |  |
+| 15 | `start_time` | `int64` | `optional` |  |  |
 
 </details>
 
@@ -1478,16 +1478,16 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `index` | `int32` | `optional` | `` |  |
-| 2 | `primary` | `int64` | `optional` | `` |  |
-| 3 | `offset` | `int64` | `optional` | `` |  |
-| 4 | `first` | `int64` | `optional` | `` |  |
-| 5 | `base` | `int64` | `optional` | `` |  |
-| 6 | `name` | `string` | `optional` | `` |  |
-| 7 | `base_name` | `string` | `optional` | `` |  |
-| 8 | `base_detail` | `int32` | `optional` | `` |  |
-| 9 | `base_time` | `int32` | `optional` | `` |  |
-| 10 | `base_hash` | `int32` | `optional` | `` |  |
+| 1 | `index` | `int32` | `optional` |  |  |
+| 2 | `primary` | `int64` | `optional` |  |  |
+| 3 | `offset` | `int64` | `optional` |  |  |
+| 4 | `first` | `int64` | `optional` |  |  |
+| 5 | `base` | `int64` | `optional` |  |  |
+| 6 | `name` | `string` | `optional` |  |  |
+| 7 | `base_name` | `string` | `optional` |  |  |
+| 8 | `base_detail` | `int32` | `optional` |  |  |
+| 9 | `base_time` | `int32` | `optional` |  |  |
+| 10 | `base_hash` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1499,7 +1499,7 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `diagnostics` | `.CUserMessageRequestDiagnostic.Diagnostic` | `repeated` | `` |  |
+| 1 | `diagnostics` | `.CUserMessageRequestDiagnostic.Diagnostic` | `repeated` |  |  |
 
 </details>
 
@@ -1511,19 +1511,19 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `index` | `int32` | `optional` | `` |  |
-| 2 | `offset` | `int64` | `optional` | `` |  |
-| 3 | `param` | `int32` | `optional` | `` |  |
-| 4 | `length` | `int32` | `optional` | `` |  |
-| 5 | `type` | `int32` | `optional` | `` |  |
-| 6 | `base` | `int64` | `optional` | `` |  |
-| 7 | `range` | `int64` | `optional` | `` |  |
-| 8 | `extent` | `int64` | `optional` | `` |  |
-| 9 | `detail` | `int64` | `optional` | `` |  |
-| 10 | `name` | `string` | `optional` | `` |  |
-| 11 | `alias` | `string` | `optional` | `` |  |
-| 12 | `vardetail` | `bytes` | `optional` | `` |  |
-| 13 | `context` | `int32` | `optional` | `` |  |
+| 1 | `index` | `int32` | `optional` |  |  |
+| 2 | `offset` | `int64` | `optional` |  |  |
+| 3 | `param` | `int32` | `optional` |  |  |
+| 4 | `length` | `int32` | `optional` |  |  |
+| 5 | `type` | `int32` | `optional` |  |  |
+| 6 | `base` | `int64` | `optional` |  |  |
+| 7 | `range` | `int64` | `optional` |  |  |
+| 8 | `extent` | `int64` | `optional` |  |  |
+| 9 | `detail` | `int64` | `optional` |  |  |
+| 10 | `name` | `string` | `optional` |  |  |
+| 11 | `alias` | `string` | `optional` |  |  |
+| 12 | `vardetail` | `bytes` | `optional` |  |  |
+| 13 | `context` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1535,12 +1535,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `diagnostics` | `.CUserMessage_Diagnostic_Response.Diagnostic` | `repeated` | `` |  |
-| 2 | `build_version` | `int32` | `optional` | `` |  |
-| 3 | `instance` | `int32` | `optional` | `` |  |
-| 4 | `start_time` | `int64` | `optional` | `` |  |
-| 5 | `osversion` | `int32` | `optional` | `` |  |
-| 6 | `platform` | `int32` | `optional` | `` |  |
+| 1 | `diagnostics` | `.CUserMessage_Diagnostic_Response.Diagnostic` | `repeated` |  |  |
+| 2 | `build_version` | `int32` | `optional` |  |  |
+| 3 | `instance` | `int32` | `optional` |  |  |
+| 4 | `start_time` | `int64` | `optional` |  |  |
+| 5 | `osversion` | `int32` | `optional` |  |  |
+| 6 | `platform` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1552,21 +1552,21 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `index` | `int32` | `optional` | `` |  |
-| 2 | `offset` | `int64` | `optional` | `` |  |
-| 3 | `param` | `int32` | `optional` | `` |  |
-| 4 | `length` | `int32` | `optional` | `` |  |
-| 5 | `detail` | `bytes` | `optional` | `` |  |
-| 6 | `base` | `int64` | `optional` | `` |  |
-| 7 | `range` | `int64` | `optional` | `` |  |
-| 8 | `type` | `int32` | `optional` | `` |  |
-| 10 | `name` | `string` | `optional` | `` |  |
-| 11 | `alias` | `string` | `optional` | `` |  |
-| 12 | `backup` | `bytes` | `optional` | `` |  |
-| 13 | `context` | `int32` | `optional` | `` |  |
-| 14 | `control` | `int64` | `optional` | `` |  |
-| 15 | `augment` | `int64` | `optional` | `` |  |
-| 16 | `placebo` | `int64` | `optional` | `` |  |
+| 1 | `index` | `int32` | `optional` |  |  |
+| 2 | `offset` | `int64` | `optional` |  |  |
+| 3 | `param` | `int32` | `optional` |  |  |
+| 4 | `length` | `int32` | `optional` |  |  |
+| 5 | `detail` | `bytes` | `optional` |  |  |
+| 6 | `base` | `int64` | `optional` |  |  |
+| 7 | `range` | `int64` | `optional` |  |  |
+| 8 | `type` | `int32` | `optional` |  |  |
+| 10 | `name` | `string` | `optional` |  |  |
+| 11 | `alias` | `string` | `optional` |  |  |
+| 12 | `backup` | `bytes` | `optional` |  |  |
+| 13 | `context` | `int32` | `optional` |  |  |
+| 14 | `control` | `int64` | `optional` |  |  |
+| 15 | `augment` | `int64` | `optional` |  |  |
+| 16 | `placebo` | `int64` | `optional` |  |  |
 
 </details>
 
@@ -1578,11 +1578,11 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `item` | `int32` | `optional` | `` |  |
-| 2 | `value1` | `int64` | `optional` | `` |  |
-| 3 | `value2` | `int64` | `optional` | `` |  |
-| 4 | `detail1` | `bytes` | `repeated` | `` |  |
-| 5 | `detail2` | `bytes` | `repeated` | `` |  |
+| 1 | `item` | `int32` | `optional` |  |  |
+| 2 | `value1` | `int64` | `optional` |  |  |
+| 3 | `value2` | `int64` | `optional` |  |  |
+| 4 | `detail1` | `bytes` | `repeated` |  |  |
+| 5 | `detail2` | `bytes` | `repeated` |  |  |
 
 </details>
 
@@ -1594,18 +1594,18 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ent_index` | `int32` | `optional` | `` | default = -1 |
-| 2 | `rule_name` | `string` | `optional` | `` |  |
-| 3 | `response_value` | `string` | `optional` | `` |  |
-| 4 | `response_concept` | `string` | `optional` | `` |  |
-| 5 | `criteria` | `.CUserMessage_NotifyResponseFound.Criteria` | `repeated` | `` |  |
-| 6 | `int_criteria_names` | `uint32` | `repeated` | `` | packed = true |
-| 7 | `int_criteria_values` | `int32` | `repeated` | `` | packed = true |
-| 8 | `float_criteria_names` | `uint32` | `repeated` | `` | packed = true |
-| 9 | `float_criteria_values` | `float` | `repeated` | `` |  |
-| 10 | `symbol_criteria_names` | `uint32` | `repeated` | `` | packed = true |
-| 11 | `symbol_criteria_values` | `uint32` | `repeated` | `` | packed = true |
-| 12 | `speak_result` | `int32` | `optional` | `` |  |
+| 1 | `ent_index` | `int32` | `optional` |  | default = -1 |
+| 2 | `rule_name` | `string` | `optional` |  |  |
+| 3 | `response_value` | `string` | `optional` |  |  |
+| 4 | `response_concept` | `string` | `optional` |  |  |
+| 5 | `criteria` | `.CUserMessage_NotifyResponseFound.Criteria` | `repeated` |  |  |
+| 6 | `int_criteria_names` | `uint32` | `repeated` |  | packed = true |
+| 7 | `int_criteria_values` | `int32` | `repeated` |  | packed = true |
+| 8 | `float_criteria_names` | `uint32` | `repeated` |  | packed = true |
+| 9 | `float_criteria_values` | `float` | `repeated` |  |  |
+| 10 | `symbol_criteria_names` | `uint32` | `repeated` |  | packed = true |
+| 11 | `symbol_criteria_values` | `uint32` | `repeated` |  | packed = true |
+| 12 | `speak_result` | `int32` | `optional` |  |  |
 
 </details>
 
@@ -1617,8 +1617,8 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `name_symbol` | `uint32` | `optional` | `` |  |
-| 2 | `value` | `string` | `optional` | `` |  |
+| 1 | `name_symbol` | `uint32` | `optional` |  |  |
+| 2 | `value` | `string` | `optional` |  |  |
 
 </details>
 
@@ -1630,12 +1630,12 @@ Expand any message to inspect all fields.
 
 | Tag | Field | Type | Label | Oneof | Notes |
 |---:|---|---|---|---|---|
-| 1 | `ent_index` | `int32` | `optional` | `` | default = -1 |
-| 2 | `player_slots` | `int32` | `repeated` | `` |  |
-| 3 | `response` | `string` | `optional` | `` |  |
-| 4 | `ent_origin` | `.CMsgVector` | `optional` | `` |  |
-| 5 | `pre_delay` | `float` | `optional` | `` |  |
-| 6 | `mix_priority` | `int32` | `optional` | `` |  |
+| 1 | `ent_index` | `int32` | `optional` |  | default = -1 |
+| 2 | `player_slots` | `int32` | `repeated` |  |  |
+| 3 | `response` | `string` | `optional` |  |  |
+| 4 | `ent_origin` | `.CMsgVector` | `optional` |  |  |
+| 5 | `pre_delay` | `float` | `optional` |  |  |
+| 6 | `mix_priority` | `int32` | `optional` |  |  |
 
 </details>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,20 +16,6 @@ title: Gem
   </div>
 </section>
 
-<div class="gem-readout" role="img" aria-label="A replay decoding from raw bytes into a typed ParsedMatch object.">
-  <div class="gem-readout-head">
-    <span class="gem-readout-name">replay.dem</span>
-    <span class="gem-readout-meta">PBDEMS2 · 142 MB</span>
-  </div>
-  <div class="gem-readout-stream">
-    <span class="gem-readout-row"><i>tick</i><b>0x0001f4</b><em>net_Tick</em></span>
-    <span class="gem-readout-row"><i>strtab</i><b>instancebaseline</b><em>baselines ready</em></span>
-    <span class="gem-readout-row"><i>entity</i><b>#612 CREATE</b><em>CDOTA_Unit_Hero</em></span>
-    <span class="gem-readout-row"><i>combat</i><b>DEATH</b><em>hero ← hero</em></span>
-    <span class="gem-readout-row gem-readout-row--out"><i>parsed</i><b>ParsedMatch</b><em>10 players · 42.3 min</em></span>
-  </div>
-</div>
-
 <div class="gem-trust">
   <a class="gem-trust-item" href="https://pypi.org/project/gem-dota/" target="_blank" rel="noreferrer">
     <span class="gem-trust-k">Install</span>
@@ -61,9 +47,19 @@ Requires Python 3.10+. The import name is `gem`; the PyPI package is `gem-dota`.
 
 ```python
 import gem
+from gem.constants import hero_display
 
-match = gem.parse("my_replay.dem")
-print(match.duration_minutes, "min,", len(match.players), "players")
+# Parse a local replay into a typed ParsedMatch object.
+match = gem.parse("replay.dem")
+print(match.duration_minutes, "min ·", len(match.players), "players")
+
+# Every field is a real Python attribute — inspect players directly.
+for p in match.players:
+    print(hero_display(p.hero_name), p.net_worth, p.kills, p.deaths)
+
+# Or pull analysis-ready pandas DataFrames in one call.
+frames = gem.parse_to_dataframe("replay.dem")
+frames["combat_log"].head()
 ```
 
 ## What you can do

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -6,9 +6,7 @@
     "": {
       "name": "gem-dota-docs",
       "devDependencies": {
-        "mermaid": "^11.15.0",
         "vitepress": "^1.6.4",
-        "vitepress-plugin-mermaid": "^2.0.17",
         "vue": "^3.5.13"
       }
     },
@@ -270,20 +268,6 @@
         "node": ">= 14.0.0"
       }
     },
-    "node_modules/@antfu/install-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
-      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "package-manager-detector": "^1.3.0",
-        "tinyexec": "^1.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -333,20 +317,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@braintree/sanitize-url": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
-      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@chevrotain/types": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
-      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/@docsearch/css": {
       "version": "3.8.2",
@@ -807,59 +777,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@iconify/utils": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
-      "integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@antfu/install-pkg": "^1.1.0",
-        "@iconify/types": "^2.0.0",
-        "import-meta-resolve": "^4.2.0"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@mermaid-js/mermaid-mindmap": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/mermaid-mindmap/-/mermaid-mindmap-9.3.0.tgz",
-      "integrity": "sha512-IhtYSVBBRYviH1Ehu8gk69pMDF8DSRqXBRDMWrEfHoaMruHeaP2DXA3PBnuwsMaCdPQhlUUcy/7DBLAEIXvCAw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@braintree/sanitize-url": "^6.0.0",
-        "cytoscape": "^3.23.0",
-        "cytoscape-cose-bilkent": "^4.1.0",
-        "cytoscape-fcose": "^2.1.0",
-        "d3": "^7.0.0",
-        "khroma": "^2.0.0",
-        "non-layered-tidy-tree-layout": "^2.0.2"
-      }
-    },
-    "node_modules/@mermaid-js/mermaid-mindmap/node_modules/@braintree/sanitize-url": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz",
-      "integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@mermaid-js/parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
-      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@chevrotain/types": "~11.1.1"
-      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.0",
@@ -1298,301 +1221,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/d3": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
-      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-array": "*",
-        "@types/d3-axis": "*",
-        "@types/d3-brush": "*",
-        "@types/d3-chord": "*",
-        "@types/d3-color": "*",
-        "@types/d3-contour": "*",
-        "@types/d3-delaunay": "*",
-        "@types/d3-dispatch": "*",
-        "@types/d3-drag": "*",
-        "@types/d3-dsv": "*",
-        "@types/d3-ease": "*",
-        "@types/d3-fetch": "*",
-        "@types/d3-force": "*",
-        "@types/d3-format": "*",
-        "@types/d3-geo": "*",
-        "@types/d3-hierarchy": "*",
-        "@types/d3-interpolate": "*",
-        "@types/d3-path": "*",
-        "@types/d3-polygon": "*",
-        "@types/d3-quadtree": "*",
-        "@types/d3-random": "*",
-        "@types/d3-scale": "*",
-        "@types/d3-scale-chromatic": "*",
-        "@types/d3-selection": "*",
-        "@types/d3-shape": "*",
-        "@types/d3-time": "*",
-        "@types/d3-time-format": "*",
-        "@types/d3-timer": "*",
-        "@types/d3-transition": "*",
-        "@types/d3-zoom": "*"
-      }
-    },
-    "node_modules/@types/d3-array": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-axis": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
-      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-brush": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
-      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-chord": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
-      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-contour": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
-      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-array": "*",
-        "@types/geojson": "*"
-      }
-    },
-    "node_modules/@types/d3-delaunay": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-dispatch": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
-      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-drag": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
-      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-dsv": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
-      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-ease": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-fetch": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
-      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-dsv": "*"
-      }
-    },
-    "node_modules/@types/d3-force": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
-      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-format": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
-      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-geo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
-      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*"
-      }
-    },
-    "node_modules/@types/d3-hierarchy": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
-      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-interpolate": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-color": "*"
-      }
-    },
-    "node_modules/@types/d3-path": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-polygon": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
-      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-quadtree": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
-      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-random": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
-      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-scale-chromatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-selection": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
-      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-shape": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
-      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-path": "*"
-      }
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-time-format": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
-      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-timer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-transition": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
-      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-zoom": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
-      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-interpolate": "*",
-        "@types/d3-selection": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/geojson": {
-      "version": "7946.0.16",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
-      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1641,14 +1273,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -1669,17 +1293,6 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/@upsetjs/venn.js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
-      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "d3-selection": "^3.0.0",
-        "d3-transition": "^3.0.1"
-      }
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.2.4",
@@ -2026,16 +1639,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/copy-anything": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
@@ -2052,580 +1655,12 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
-    "node_modules/cose-base": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
-      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "layout-base": "^1.0.0"
-      }
-    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cytoscape": {
-      "version": "3.34.0",
-      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
-      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/cytoscape-cose-bilkent": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
-      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cose-base": "^1.0.0"
-      },
-      "peerDependencies": {
-        "cytoscape": "^3.2.0"
-      }
-    },
-    "node_modules/cytoscape-fcose": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
-      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cose-base": "^2.2.0"
-      },
-      "peerDependencies": {
-        "cytoscape": "^3.2.0"
-      }
-    },
-    "node_modules/cytoscape-fcose/node_modules/cose-base": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
-      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "layout-base": "^2.0.0"
-      }
-    },
-    "node_modules/cytoscape-fcose/node_modules/layout-base": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
-      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/d3": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
-      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "3",
-        "d3-axis": "3",
-        "d3-brush": "3",
-        "d3-chord": "3",
-        "d3-color": "3",
-        "d3-contour": "4",
-        "d3-delaunay": "6",
-        "d3-dispatch": "3",
-        "d3-drag": "3",
-        "d3-dsv": "3",
-        "d3-ease": "3",
-        "d3-fetch": "3",
-        "d3-force": "3",
-        "d3-format": "3",
-        "d3-geo": "3",
-        "d3-hierarchy": "3",
-        "d3-interpolate": "3",
-        "d3-path": "3",
-        "d3-polygon": "3",
-        "d3-quadtree": "3",
-        "d3-random": "3",
-        "d3-scale": "4",
-        "d3-scale-chromatic": "3",
-        "d3-selection": "3",
-        "d3-shape": "3",
-        "d3-time": "3",
-        "d3-time-format": "4",
-        "d3-timer": "3",
-        "d3-transition": "3",
-        "d3-zoom": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-axis": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
-      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-brush": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
-      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-drag": "2 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-selection": "3",
-        "d3-transition": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-chord": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
-      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-contour": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
-      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-delaunay": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "delaunator": "5"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-dispatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
-      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-drag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
-      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-selection": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-dsv": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
-      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "commander": "7",
-        "iconv-lite": "0.6",
-        "rw": "1"
-      },
-      "bin": {
-        "csv2json": "bin/dsv2json.js",
-        "csv2tsv": "bin/dsv2dsv.js",
-        "dsv2dsv": "bin/dsv2dsv.js",
-        "dsv2json": "bin/dsv2json.js",
-        "json2csv": "bin/json2dsv.js",
-        "json2dsv": "bin/json2dsv.js",
-        "json2tsv": "bin/json2dsv.js",
-        "tsv2csv": "bin/dsv2dsv.js",
-        "tsv2json": "bin/dsv2json.js"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-fetch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
-      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-dsv": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-force": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
-      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-quadtree": "1 - 3",
-        "d3-timer": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-format": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
-      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-geo": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
-      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.5.0 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-hierarchy": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
-      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-polygon": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
-      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-quadtree": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
-      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-random": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
-      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-sankey": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
-      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-array": "1 - 2",
-        "d3-shape": "^1.2.0"
-      }
-    },
-    "node_modules/d3-sankey/node_modules/d3-array": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
-      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "internmap": "^1.0.0"
-      }
-    },
-    "node_modules/d3-sankey/node_modules/d3-path": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
-      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-sankey/node_modules/d3-shape": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
-      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-path": "1"
-      }
-    },
-    "node_modules/d3-sankey/node_modules/internmap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale-chromatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3",
-        "d3-interpolate": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-selection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-time": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-transition": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
-      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3",
-        "d3-dispatch": "1 - 3",
-        "d3-ease": "1 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-timer": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "d3-selection": "2 - 3"
-      }
-    },
-    "node_modules/d3-zoom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
-      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-drag": "2 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-selection": "2 - 3",
-        "d3-transition": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/dagre-d3-es": {
-      "version": "7.0.14",
-      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
-      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "d3": "^7.9.0",
-        "lodash-es": "^4.17.21"
-      }
-    },
-    "node_modules/dayjs": {
-      "version": "1.11.21",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
-      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/delaunator": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
-      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "robust-predicates": "^3.0.2"
-      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -2651,16 +1686,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
-      "dev": true,
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
-    },
     "node_modules/emoji-regex-xs": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
@@ -2680,17 +1705,6 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
-    },
-    "node_modules/es-toolkit": {
-      "version": "1.47.1",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.1.tgz",
-      "integrity": "sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q==",
-      "dev": true,
-      "license": "MIT",
-      "workspaces": [
-        "docs",
-        "benchmarks"
-      ]
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -2763,13 +1777,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/hachure-fill": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
-      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
@@ -2826,40 +1833,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/import-meta-resolve": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/is-what": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
@@ -2872,53 +1845,6 @@
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
       }
-    },
-    "node_modules/katex": {
-      "version": "0.16.47",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
-      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
-      "dev": true,
-      "funding": [
-        "https://opencollective.com/katex",
-        "https://github.com/sponsors/katex"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^8.3.0"
-      },
-      "bin": {
-        "katex": "cli.js"
-      }
-    },
-    "node_modules/katex/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/khroma": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
-      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==",
-      "dev": true
-    },
-    "node_modules/layout-base": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
-      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash-es": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
-      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -2936,19 +1862,6 @@
       "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/marked": {
-      "version": "16.4.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
-      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
     },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.1",
@@ -2970,36 +1883,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mermaid": {
-      "version": "11.15.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
-      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@braintree/sanitize-url": "^7.1.1",
-        "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.1.1",
-        "@types/d3": "^7.4.3",
-        "@upsetjs/venn.js": "^2.0.0",
-        "cytoscape": "^3.33.1",
-        "cytoscape-cose-bilkent": "^4.1.0",
-        "cytoscape-fcose": "^2.2.0",
-        "d3": "^7.9.0",
-        "d3-sankey": "^0.12.3",
-        "dagre-d3-es": "7.0.14",
-        "dayjs": "^1.11.19",
-        "dompurify": "^3.3.1",
-        "es-toolkit": "^1.45.1",
-        "katex": "^0.16.25",
-        "khroma": "^2.1.0",
-        "marked": "^16.3.0",
-        "roughjs": "^4.6.6",
-        "stylis": "^4.3.6",
-        "ts-dedent": "^2.2.0",
-        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
       }
     },
     "node_modules/micromark-util-character": {
@@ -3129,14 +2012,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/non-layered-tidy-tree-layout": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/non-layered-tidy-tree-layout/-/non-layered-tidy-tree-layout-2.0.2.tgz",
-      "integrity": "sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/oniguruma-to-es": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
@@ -3148,20 +2023,6 @@
         "regex": "^6.0.1",
         "regex-recursion": "^6.0.2"
       }
-    },
-    "node_modules/package-manager-detector": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
-      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/path-data-parser": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
-      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
@@ -3176,24 +2037,6 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/points-on-curve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
-      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/points-on-path": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
-      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-data-parser": "0.1.0",
-        "points-on-curve": "0.2.0"
-      }
     },
     "node_modules/postcss": {
       "version": "8.5.8",
@@ -3280,13 +2123,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/robust-predicates": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
-      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
-      "dev": true,
-      "license": "Unlicense"
-    },
     "node_modules/rollup": {
       "version": "4.60.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
@@ -3331,33 +2167,6 @@
         "@rollup/rollup-win32-x64-msvc": "4.60.0",
         "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/roughjs": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
-      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hachure-fill": "^0.5.2",
-        "path-data-parser": "^0.1.0",
-        "points-on-curve": "^0.2.0",
-        "points-on-path": "^0.2.1"
-      }
-    },
-    "node_modules/rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/search-insights": {
       "version": "2.17.3",
@@ -3430,13 +2239,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/stylis": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
-      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/superjson": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
@@ -3457,16 +2259,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/tinyexec": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -3476,16 +2268,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/ts-dedent": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
-      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.10"
       }
     },
     "node_modules/unist-util-is": {
@@ -3559,20 +2341,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vfile": {
@@ -3705,20 +2473,6 @@
         "postcss": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitepress-plugin-mermaid": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/vitepress-plugin-mermaid/-/vitepress-plugin-mermaid-2.0.17.tgz",
-      "integrity": "sha512-IUzYpwf61GC6k0XzfmAmNrLvMi9TRrVRMsUyCA8KNXhg/mQ1VqWnO0/tBVPiX5UoKF1mDUwqn5QV4qAJl6JnUg==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "@mermaid-js/mermaid-mindmap": "^9.3.0"
-      },
-      "peerDependencies": {
-        "mermaid": "10 || 11",
-        "vitepress": "^1.0.0 || ^1.0.0-alpha"
       }
     },
     "node_modules/vue": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,9 +12,7 @@
     "docs:preview": "vitepress preview"
   },
   "devDependencies": {
-    "mermaid": "^11.15.0",
     "vitepress": "^1.6.4",
-    "vitepress-plugin-mermaid": "^2.0.17",
     "vue": "^3.5.13"
   }
 }

--- a/docs/reference/analysis.md
+++ b/docs/reference/analysis.md
@@ -706,10 +706,10 @@ Source: [src/gem/analysis/map_context.py:40](https://github.com/whanyu1212/gem-d
 | `tower_alive_dire` | `int` | `-` |
 | `t1_mid_alive_radiant` | `bool` | `-` |
 | `t1_mid_alive_dire` | `bool` | `-` |
-| `roshan_last_kill_tick` | `int | None` | `-` |
-| `aegis_holder_team` | `int | None` | `-` |
+| `roshan_last_kill_tick` | `int \| None` | `-` |
+| `aegis_holder_team` | `int \| None` | `-` |
 | `aegis_active` | `bool` | `-` |
-| `tormentor_last_kill_tick` | `int | None` | `-` |
+| `tormentor_last_kill_tick` | `int \| None` | `-` |
 | `ward_count_radiant` | `int` | `-` |
 | `ward_count_dire` | `int` | `-` |
 | `net_worth_advantage` | `int` | `-` |
@@ -791,17 +791,17 @@ Source: [src/gem/analysis/roshan.py:55](https://github.com/whanyu1212/gem-dota/b
 | `rosh_number` | `int` | `-` |
 | `rosh_tick` | `int` | `-` |
 | `killer_name` | `str` | `-` |
-| `holder_team` | `int | None` | `-` |
-| `holder_player_id` | `int | None` | `-` |
+| `holder_team` | `int \| None` | `-` |
+| `holder_player_id` | `int \| None` | `-` |
 | `holder_name` | `str` | `-` |
-| `aegis_pickup_tick` | `int | None` | `-` |
+| `aegis_pickup_tick` | `int \| None` | `-` |
 | `immediate_end_tick` | `int` | `-` |
 | `aegis_end_tick` | `int` | `-` |
 | `aegis_eval_end_tick` | `int` | `-` |
 | `extended_end_tick` | `int` | `-` |
 | `aegis_fate` | `Literal['consumed', 'expired', 'denied', 'game_end', 'unknown']` | `-` |
-| `first_fight_tick` | `int | None` | `-` |
-| `first_objective_tick` | `int | None` | `-` |
+| `first_fight_tick` | `int \| None` | `-` |
+| `first_objective_tick` | `int \| None` | `-` |
 | `fight_count` | `int` | `-` |
 | `fights_won` | `int` | `-` |
 | `fights_lost` | `int` | `-` |

--- a/docs/reference/batch.md
+++ b/docs/reference/batch.md
@@ -85,8 +85,8 @@ Source: [src/gem/replays/batch.py:39](https://github.com/whanyu1212/gem-dota/blo
 | Name | Type | Default |
 |---|---|---|
 | `path` | `Path` | `-` |
-| `match` | `ParsedMatch | None` | `-` |
-| `error` | `Exception | None` | `-` |
+| `match` | `ParsedMatch \| None` | `-` |
+| `error` | `Exception \| None` | `-` |
 
 #### Properties
 

--- a/docs/reference/combatlog.md
+++ b/docs/reference/combatlog.md
@@ -97,8 +97,8 @@ Source: [src/gem/combat/log.py:134](https://github.com/whanyu1212/gem-dota/blob/
 | `stun_duration` | `float` | `0.0` |
 | `neutral_camp_type` | `int` | `0` |
 | `neutral_camp_team` | `int` | `0` |
-| `location_x` | `float | None` | `None` |
-| `location_y` | `float | None` | `None` |
-| `timestamp_s` | `float | None` | `None` |
-| `game_time_s` | `int | None` | `None` |
+| `location_x` | `float \| None` | `None` |
+| `location_y` | `float \| None` | `None` |
+| `timestamp_s` | `float \| None` | `None` |
+| `game_time_s` | `int \| None` | `None` |
 | `will_reincarnate` | `bool` | `False` |

--- a/docs/reference/extractors/courier.md
+++ b/docs/reference/extractors/courier.md
@@ -32,8 +32,8 @@ Source: [src/gem/extractors/courier.py:22](https://github.com/whanyu1212/gem-dot
 | `team` | `int` | `-` |
 | `state` | `int` | `-` |
 | `flying` | `bool` | `-` |
-| `x` | `float | None` | `-` |
-| `y` | `float | None` | `-` |
+| `x` | `float \| None` | `-` |
+| `y` | `float \| None` | `-` |
 
 ### `CourierExtractor`
 

--- a/docs/reference/extractors/teamfights.md
+++ b/docs/reference/extractors/teamfights.md
@@ -83,8 +83,8 @@ Source: [src/gem/extractors/teamfights.py:80](https://github.com/whanyu1212/gem-
 | `radiant_kills` | `int` | `0` |
 | `dire_kills` | `int` | `0` |
 | `winner` | `str` | `'unknown'` |
-| `centroid_x` | `float | None` | `None` |
-| `centroid_y` | `float | None` | `None` |
+| `centroid_x` | `float \| None` | `None` |
+| `centroid_y` | `float \| None` | `None` |
 | `centroid_n` | `int` | `0` |
 | `players` | `list[TeamfightPlayer]` | `field(...)` |
 
@@ -113,8 +113,8 @@ Source: [src/gem/extractors/teamfights.py:120](https://github.com/whanyu1212/gem
 | `healing` | `int` | `0` |
 | `gold_delta` | `int` | `0` |
 | `xp_delta` | `int` | `0` |
-| `xp_start` | `int | None` | `None` |
-| `xp_end` | `int | None` | `None` |
+| `xp_start` | `int \| None` | `None` |
+| `xp_end` | `int \| None` | `None` |
 
 ### `OpenDotaTeamfight`
 

--- a/docs/reference/extractors/wards.md
+++ b/docs/reference/extractors/wards.md
@@ -33,10 +33,10 @@ Source: [src/gem/extractors/wards.py:81](https://github.com/whanyu1212/gem-dota/
 | `placer` | `str` | `-` |
 | `ward_type` | `Literal['observer', 'sentry']` | `-` |
 | `team` | `int` | `-` |
-| `x` | `float | None` | `-` |
-| `y` | `float | None` | `-` |
-| `expires_tick` | `int | None` | `-` |
-| `killed_tick` | `int | None` | `-` |
+| `x` | `float \| None` | `-` |
+| `y` | `float \| None` | `-` |
+| `expires_tick` | `int \| None` | `-` |
+| `killed_tick` | `int \| None` | `-` |
 | `killer` | `str` | `-` |
 
 ### `WardsExtractor`

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -54,7 +54,7 @@ Source: [src/gem/results/models.py:32](https://github.com/whanyu1212/gem-dota/bl
 | Name | Type | Default |
 |---|---|---|
 | `tick` | `int` | `-` |
-| `end_tick` | `int | None` | `-` |
+| `end_tick` | `int \| None` | `-` |
 | `modifier_name` | `str` | `-` |
 | `target_name` | `str` | `-` |
 | `caster_name` | `str` | `-` |
@@ -78,8 +78,8 @@ Source: [src/gem/results/models.py:58](https://github.com/whanyu1212/gem-dota/bl
 | `activator` | `str` | `-` |
 | `team` | `int` | `-` |
 | `smoked` | `list[str]` | `field(...)` |
-| `x` | `float | None` | `None` |
-| `y` | `float | None` | `None` |
+| `x` | `float \| None` | `None` |
+| `y` | `float \| None` | `None` |
 
 ### `ChatEntry`
 
@@ -179,7 +179,7 @@ Source: [src/gem/results/models.py:132](https://github.com/whanyu1212/gem-dota/b
 | `damage_targets` | `dict[str, dict[str, int]]` | `field(...)` |
 | `ability_targets` | `dict[str, dict[str, int]]` | `field(...)` |
 | `hero_hits` | `dict[str, int]` | `field(...)` |
-| `max_hero_hit` | `dict[str, Any] | None` | `None` |
+| `max_hero_hit` | `dict[str, Any] \| None` | `None` |
 | `healing` | `dict[str, int]` | `field(...)` |
 | `ability_uses` | `dict[str, int]` | `field(...)` |
 | `ability_upgrades_arr` | `list[int]` | `field(...)` |
@@ -203,8 +203,8 @@ Source: [src/gem/results/models.py:132](https://github.com/whanyu1212/gem-dota/b
 | `lane_total_gold` | `int` | `0` |
 | `lane_total_xp` | `int` | `0` |
 | `lane_efficiency_pct` | `int` | `0` |
-| `lane_gold_adv` | `int | None` | `None` |
-| `lane_xp_adv` | `int | None` | `None` |
+| `lane_gold_adv` | `int \| None` | `None` |
+| `lane_xp_adv` | `int \| None` | `None` |
 | `net_worth` | `int` | `0` |
 | `last_hits` | `int` | `0` |
 | `denies` | `int` | `0` |
@@ -267,14 +267,14 @@ Source: [src/gem/results/models.py:504](https://github.com/whanyu1212/gem-dota/b
 | `match_id` | `int` | `0` |
 | `game_mode` | `int` | `0` |
 | `leagueid` | `int` | `0` |
-| `radiant_win` | `bool | None` | `None` |
+| `radiant_win` | `bool \| None` | `None` |
 | `radiant_team_id` | `int` | `0` |
 | `radiant_team_name` | `str` | `''` |
 | `radiant_team_tag` | `str` | `''` |
 | `dire_team_id` | `int` | `0` |
 | `dire_team_name` | `str` | `''` |
 | `dire_team_tag` | `str` | `''` |
-| `game_start_tick` | `int | None` | `None` |
+| `game_start_tick` | `int \| None` | `None` |
 | `game_end_tick` | `int` | `0` |
 | `duration` | `int` | `0` |
 | `radiant_score` | `int` | `0` |

--- a/docs/reference/reports.md
+++ b/docs/reference/reports.md
@@ -27,9 +27,9 @@ Source: [src/gem/reports/assets.py:12](https://github.com/whanyu1212/gem-dota/bl
 
 | Name | Type | Default |
 |---|---|---|
-| `map_image` | `str | Path | None` | `None` |
-| `hero_icon_dir` | `str | Path | None` | `None` |
-| `item_icon_dir` | `str | Path | None` | `None` |
+| `map_image` | `str \| Path \| None` | `None` |
+| `hero_icon_dir` | `str \| Path \| None` | `None` |
+| `item_icon_dir` | `str \| Path \| None` | `None` |
 
 #### Methods
 

--- a/docs/reference/sendtable.md
+++ b/docs/reference/sendtable.md
@@ -69,17 +69,17 @@ Source: [src/gem/schema/sendtable/models.py:105](https://github.com/whanyu1212/g
 | `serializer_name` | `str` | `-` |
 | `serializer_version` | `int` | `-` |
 | `encoder` | `str` | `-` |
-| `encode_flags` | `int | None` | `-` |
-| `bit_count` | `int | None` | `-` |
-| `low_value` | `float | None` | `-` |
-| `high_value` | `float | None` | `-` |
+| `encode_flags` | `int \| None` | `-` |
+| `bit_count` | `int \| None` | `-` |
+| `low_value` | `float \| None` | `-` |
+| `high_value` | `float \| None` | `-` |
 | `parent_name` | `str` | `''` |
 | `field_type` | `FieldType` | `field(...)` |
-| `serializer` | `Serializer | None` | `None` |
+| `serializer` | `Serializer \| None` | `None` |
 | `model` | `int` | `FIELD_MODEL_SIMPLE` |
-| `decoder` | `FieldDecoder | None` | `None` |
-| `base_decoder` | `FieldDecoder | None` | `None` |
-| `child_decoder` | `FieldDecoder | None` | `None` |
+| `decoder` | `FieldDecoder \| None` | `None` |
+| `base_decoder` | `FieldDecoder \| None` | `None` |
+| `child_decoder` | `FieldDecoder \| None` | `None` |
 
 #### Methods
 
@@ -116,6 +116,6 @@ Source: [src/gem/schema/sendtable/models.py:53](https://github.com/whanyu1212/ge
 | Name | Type | Default |
 |---|---|---|
 | `base_type` | `str` | `-` |
-| `generic_type` | `FieldType | None` | `None` |
+| `generic_type` | `FieldType \| None` | `None` |
 | `pointer` | `bool` | `False` |
 | `count` | `int` | `0` |

--- a/scripts/generate_proto_field_docs.py
+++ b/scripts/generate_proto_field_docs.py
@@ -84,6 +84,17 @@ def _markdown_escape(text: str) -> str:
     return text.replace("|", "\\|")
 
 
+def _code_cell(text: str) -> str:
+    """Format a value as an inline-code table cell.
+
+    Returns an empty string for empty values so absent fields render as a
+    blank cell rather than a stray empty code span (the literal ``````).
+    """
+    if not text:
+        return ""
+    return f"`{_markdown_escape(text)}`"
+
+
 def _strip_line_comment(line: str) -> str:
     # Good enough for current proto style (no inline URL literals).
     idx = line.find("//")
@@ -354,7 +365,8 @@ def render_proto_page(doc: ProtoDoc, out_path: Path) -> tuple[int, int]:
             else:
                 for f in sorted(msg.fields, key=lambda x: x.tag):
                     lines.append(
-                        f"| {f.tag} | `{_markdown_escape(f.name)}` | `{_markdown_escape(f.type_name)}` | `{_markdown_escape(f.label)}` | `{_markdown_escape(f.oneof)}` | {_markdown_escape(f.notes)} |"
+                        f"| {f.tag} | {_code_cell(f.name)} | {_code_cell(f.type_name)} "
+                        f"| {_code_cell(f.label)} | {_code_cell(f.oneof)} | {_markdown_escape(f.notes)} |"
                     )
             lines.append("")
             lines.append("</details>")

--- a/scripts/generate_vitepress_api_reference.py
+++ b/scripts/generate_vitepress_api_reference.py
@@ -419,8 +419,11 @@ def _render_class(cls: ast.ClassDef, context: ModuleContext) -> list[str]:
             out.append("| Name | Type | Default |")
             out.append("|---|---|---|")
             for name, ann, default in fields:
-                ann_text = ann or "-"
-                default_text = default or "-"
+                # Escape pipes so union types (``int | None``) do not split the
+                # markdown table into extra columns. The cells are wrapped in
+                # inline code, where ``\|`` renders as a literal pipe.
+                ann_text = (ann or "-").replace("|", "\\|")
+                default_text = (default or "-").replace("|", "\\|")
                 out.append(f"| `{name}` | `{ann_text}` | `{default_text}` |")
             out.append("")
 


### PR DESCRIPTION
## Summary

Docs-only polish pass plus two fixes to the documentation generators. No library code or version changes.

### Visual polish (`546b936`)
- **Landing page** — replaced the bytes→`ParsedMatch` illustration with a real, copy-pasteable first-parse code snippet (parse → inspect players → export to DataFrame); removed the redundant second snippet. Aligned the hero's `gem.parse` label to brand green.
- **Architecture** — replaced the near-invisible, off-palette Mermaid pipeline graph with a native CSS flow that reuses the existing `.arch-layer` accent tokens. Events + Extractors render as a parallel branch. Removed the now-unused Mermaid plugin + deps (−1300 lockfile lines; faster build).
- **Changelog** — flattened the colored `tip`/`info`/`warning` callouts to one neutral tone via a page-scoped `pageClass`, so the page reads minimally. Semantic colors stay intact on every other docs page (verified guides untouched).
- **Bits & Bytes Primer** — simplified the H1 to match the sidebar label.

### Generator fixes (`1e58cd3`)
Two systematic markdown-table bugs surfaced during a visual sweep:
- **API reference**: union types like `int | None` had an unescaped pipe that split the table into extra columns and leaked literal backticks across the Type/Default cells. Now escapes `|` → `\|` per cell.
- **Proto field atlas**: empty cells (e.g. the Oneof column) rendered as two literal backticks (an empty inline-code span). Added a `_code_cell()` helper that returns an empty string for absent values.

Regenerated all 81 affected reference + proto-field pages.

## Test commands run
- `vitepress build` — passes (and ~30% faster after Mermaid removal).
- Visual verification in Chrome (light + dark, desktop + mobile) across landing, architecture, reference, proto-fields, cookbook, reports, and changelog pages.
- Pre-commit hooks (ruff, ruff format, mypy) pass on the generator scripts.

## Notes
- **No root `CHANGELOG.md` entry**: these are docs-presentation and doc-generator changes — they don't alter how `gem` parses or what it returns, so they fall outside the user-visible-behavior scope that `CHANGELOG.md` tracks.
- Branched from `develop` (not the spent `release/0.4.2` branch, which already shipped to main + PyPI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)