### PR TITLE
Code-quality: resolve remaining #106 items (ward JSON tag, smoke/vision extract, assembly helper)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   centroids, and vision-modifier windows are identical (verified end-to-end on a
   replay fixture); the extractors are internal and not part of the public API.
   (#106 item #2)
+- **Internal:** the ~234-line per-player population loop in
+  `results/assembly.build_parsed_match` is extracted into a dedicated
+  `_populate_player_series(match, ...)` helper, shrinking the orchestrator from
+  527 to ~310 lines. Each player slot is populated independently (no cross-player
+  state), so the loop moved verbatim behind an explicit keyword-only signature.
+  No output change — the OpenDota parity validator and the full suite are
+  unchanged. (#106 item #3)
 
 ## [0.4.2] - 2026-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Refactored the HTML report's ward-map section (`reports/sections/vision.py`,
+  `build_wards`) to inject its data through an inert
+  `<script type="application/json">` tag — matching the cleaner pattern already
+  used by the farming section in the same file — instead of interpolating it into
+  the executable `<script>`. This removes ~240 lines of fragile doubled-brace
+  (`{{ }}`) f-string escaping. No change to the rendered report. (#106 item #6)
+
 ## [0.4.2] - 2026-06-25
 
 Report asset-cache tooling and a documentation overhaul. No change to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   used by the farming section in the same file — instead of interpolating it into
   the executable `<script>`. This removes ~240 lines of fragile doubled-brace
   (`{{ }}`) f-string escaping. No change to the rendered report. (#106 item #6)
+- **Internal:** the inline Smoke-of-Deceit and vision-modifier collection logic
+  (~100 lines of closures in `gem.api.parse`) is extracted into
+  `gem.extractors.smoke_vision` (`SmokeExtractor`, `VisionModifierExtractor`),
+  following the existing `attach()`/`finalize()` extractor contract. Both take the
+  `PlayerExtractor` (same dependency pattern as `_CombatAggregator`) for live hero
+  positions and the post-parse team back-fill. No output change — smoke groups,
+  centroids, and vision-modifier windows are identical (verified end-to-end on a
+  replay fixture); the extractors are internal and not part of the public API.
+  (#106 item #2)
 
 ## [0.4.2] - 2026-06-25
 

--- a/src/gem/api.py
+++ b/src/gem/api.py
@@ -145,6 +145,7 @@ def parse(path: str | Path) -> ParsedMatch:
     from gem.extractors.intervals import IntervalExtractor
     from gem.extractors.objectives import ObjectivesExtractor
     from gem.extractors.players import PlayerExtractor
+    from gem.extractors.smoke_vision import SmokeExtractor, VisionModifierExtractor
     from gem.extractors.wards import WardsExtractor
     from gem.parser import ReplayParser
     from gem.results.assembly import build_parsed_match
@@ -176,122 +177,20 @@ def parse(path: str | Path) -> ParsedMatch:
     neutral_item_finds: list[NeutralItemFoundEvent] = []
     p.on_neutral_item_found(neutral_item_finds.append)
 
-    # Smoke of Deceit collection — three combat log event types.
-    # Position is captured live at MODIFIER_ADD time (when each hero actually
-    # receives the buff) and averaged to give the group centroid.
-    # Logic for SmokeEvent collection (item consumption + modifier arrival)
-    from gem.results.models import (
-        SmokeEvent as _SmokeEvent,
-        VisionModifierEvent as _VisionModifierEvent,
-    )
-
-    # Vision modifier tracking — modifiers that reveal/grant vision of enemy heroes.
-    # MODIFIER_ADD opens an event (end_tick=None); MODIFIER_REMOVE closes it.
-    # The same hero can have the same modifier applied multiple times (e.g. refreshed
-    # Dust), so we key by (modifier_name, target_name) and handle stacking by
-    # maintaining a list (LIFO: remove closes the most recently opened open event).
-    _VISION_MODIFIER_NAMES: frozenset[str] = frozenset(
-        {
-            # Slardar — Corrosive Haze (ultimate): true sight of target
-            "modifier_slardar_amplify_damage",
-            # Bounty Hunter — Track: true sight + gold bounty
-            "modifier_bounty_hunter_track",
-            # Dust of Appearance — item AoE reveal
-            "modifier_item_dustofappearance",
-            # Gem of True Sight — carrier aura (hero-level modifier on target)
-            "modifier_item_gem_of_true_sight",
-            "modifier_gem_active_truesight",
-            # Oracle — False Promise: not a reveal but often comboed; skip
-            # Zeus — Thundergods Wrath: global, not a per-hero modifier; skip
-        }
-    )
-    vision_modifier_events: list[_VisionModifierEvent] = []
-    # Track open (not-yet-closed) events: (modifier_name, target_name) → stack of events
-    _open_vision_mods: dict[tuple[str, str], list[_VisionModifierEvent]] = {}
-
-    def _on_vision_modifier_entry(entry: CombatLogEntry) -> None:
-        if entry.log_type == "MODIFIER_ADD":
-            mod = entry.inflictor_name
-            if mod not in _VISION_MODIFIER_NAMES:
-                return
-            ev = _VisionModifierEvent(
-                tick=entry.tick,
-                end_tick=None,
-                modifier_name=mod,
-                target_name=entry.target_name,
-                caster_name=entry.attacker_name,
-                caster_team=0,  # back-filled after parse
-            )
-            vision_modifier_events.append(ev)
-            key = (mod, entry.target_name)
-            if key not in _open_vision_mods:
-                _open_vision_mods[key] = []
-            _open_vision_mods[key].append(ev)
-        elif entry.log_type == "MODIFIER_REMOVE":
-            mod = entry.inflictor_name
-            if mod not in _VISION_MODIFIER_NAMES:
-                return
-            key = (mod, entry.target_name)
-            stack = _open_vision_mods.get(key)
-            if stack:
-                stack.pop().end_tick = entry.tick
-                if not stack:
-                    del _open_vision_mods[key]
-
-    p.on_combat_log_entry(_on_vision_modifier_entry)
-
-    _pending_smokes: dict[str, _SmokeEvent] = {}  # activator npc → active event
-    # Per-event accumulated positions: activator npc → list of (x, y) live coords
-    _smoke_positions: dict[str, list[tuple[float, float]]] = {}
-    smoke_events: list[_SmokeEvent] = []
-
-    def _on_smoke_entry(entry: CombatLogEntry) -> None:
-        if entry.log_type == "ITEM" and entry.inflictor_name == "item_smoke_of_deceit":
-            new_ev = _SmokeEvent(tick=entry.tick, activator=entry.attacker_name, team=0)
-            _pending_smokes[entry.attacker_name] = new_ev
-            _smoke_positions[entry.attacker_name] = []
-            smoke_events.append(new_ev)
-        elif (
-            entry.log_type == "MODIFIER_ADD"
-            and entry.inflictor_name == "modifier_smoke_of_deceit"
-            and entry.target_is_hero
-        ):
-            pending_ev = _pending_smokes.get(entry.attacker_name)
-            if pending_ev is not None:
-                pending_ev.smoked.append(entry.target_name)
-                # Capture this hero's live position right now
-                pos = player_ext.hero_pos(entry.target_name)
-                if pos is not None:
-                    _smoke_positions[entry.attacker_name].append(pos)
-        elif (
-            entry.log_type == "MODIFIER_REMOVE"
-            and entry.inflictor_name == "modifier_smoke_of_deceit"
-            and entry.target_is_hero
-        ):
-            pending_ev = _pending_smokes.get(entry.attacker_name)
-            if pending_ev is not None and len(pending_ev.smoked) >= 1:
-                _pending_smokes.pop(entry.attacker_name, None)
-
-    p.on_combat_log_entry(_on_smoke_entry)
+    # Smoke of Deceit and vision-granting modifiers are collected by dedicated
+    # extractors (positions captured live at MODIFIER_ADD time; teams/centroids
+    # back-filled from player snapshots in finalize() after parse). Both depend
+    # on player_ext for hero positions and the NPC → team map.
+    smoke_ext = SmokeExtractor(player_ext)
+    vision_mod_ext = VisionModifierExtractor(player_ext)
+    smoke_ext.attach(p)
+    vision_mod_ext.attach(p)
 
     p.parse()
     draft_ext.finalize()
     ward_ext.finalize()
-
-    # Back-fill team; centroid x/y already collected live during MODIFIER_ADD
-    _team_by_npc: dict[str, int] = {
-        snap.npc_name: snap.team for snap in player_ext.snapshots if snap.team
-    }
-
-    for ev in smoke_events:
-        ev.team = _team_by_npc.get(ev.activator, 0)
-        positions = _smoke_positions.get(ev.activator, [])
-        if positions:
-            ev.x = sum(p[0] for p in positions) / len(positions)
-            ev.y = sum(p[1] for p in positions) / len(positions)
-
-    for vev in vision_modifier_events:
-        vev.caster_team = _team_by_npc.get(vev.caster_name, 0)
+    smoke_events = smoke_ext.finalize()
+    vision_modifier_events = vision_mod_ext.finalize()
 
     return build_parsed_match(
         parser=p,

--- a/src/gem/extractors/smoke_vision.py
+++ b/src/gem/extractors/smoke_vision.py
@@ -1,0 +1,232 @@
+"""Smoke of Deceit and vision-modifier extractors for Dota 2 replays.
+
+These two extractors were previously inline closures in ``gem.api.parse``.
+They follow the same ``attach()`` / ``finalize()`` contract as the other
+extractors (``objectives.py``, ``wards.py``): ``attach`` registers combat-log
+callbacks on the parser, and ``finalize`` (called after ``parser.parse()``)
+back-fills team numbers from the :class:`PlayerExtractor` snapshots and returns
+the collected events.
+
+``SmokeExtractor`` takes a :class:`PlayerExtractor` because it needs live hero
+positions (``hero_pos``) at modifier-arrival time and the NPC-name → team map
+for the post-parse back-fill — the same dependency pattern as
+``gem.combat.aggregator._CombatAggregator``.
+
+Smoke edge case (documented in CLAUDE.md, not a bug): the ``ITEM`` event fires
+when the item is consumed; one ``MODIFIER_ADD`` fires per hero that receives the
+buff. If the smoke breaks instantly (the activator stands inside a sentry's
+truesight at activation), no ``MODIFIER_ADD`` follows and the group is empty —
+this is correct game behaviour (the item was wasted), so the event is kept with
+an empty ``smoked`` list. ``MODIFIER_ADD`` is filtered by ``target_is_hero`` to
+exclude summoned units (e.g. Beastmaster boars) from the group.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from gem.combat.log import CombatLogEntry
+from gem.results.models import SmokeEvent, VisionModifierEvent
+
+if TYPE_CHECKING:
+    from gem.extractors.players import PlayerExtractor
+    from gem.parser import ReplayParser
+
+# Modifiers that reveal / grant vision of enemy heroes. Kept here (rather than
+# in the catalog) because the set is small and specific to this extractor.
+VISION_MODIFIER_NAMES: frozenset[str] = frozenset(
+    {
+        # Slardar — Corrosive Haze (ultimate): true sight of target
+        "modifier_slardar_amplify_damage",
+        # Bounty Hunter — Track: true sight + gold bounty
+        "modifier_bounty_hunter_track",
+        # Dust of Appearance — item AoE reveal
+        "modifier_item_dustofappearance",
+        # Gem of True Sight — carrier aura (hero-level modifier on target)
+        "modifier_item_gem_of_true_sight",
+        "modifier_gem_active_truesight",
+        # Oracle — False Promise: not a reveal but often comboed; skip
+        # Zeus — Thundergods Wrath: global, not a per-hero modifier; skip
+    }
+)
+
+_SMOKE_ITEM = "item_smoke_of_deceit"
+_SMOKE_MODIFIER = "modifier_smoke_of_deceit"
+
+
+class VisionModifierExtractor:
+    """Collects vision-granting modifier windows (Slardar ulti, Track, Dust, Gem).
+
+    ``MODIFIER_ADD`` opens an event (``end_tick=None``); ``MODIFIER_REMOVE``
+    closes the most recently opened matching event. The same hero can have the
+    same modifier applied multiple times (e.g. refreshed Dust), so open events
+    are keyed by ``(modifier_name, target_name)`` and stacked LIFO.
+
+    Attach to a ``ReplayParser`` before calling ``parse()``, then call
+    ``finalize()`` to back-fill caster teams and get the events:
+
+    Example:
+        >>> ext = VisionModifierExtractor(player_ext)
+        >>> ext.attach(parser)
+        >>> parser.parse()
+        >>> events = ext.finalize()
+
+    Attributes:
+        events: All vision-modifier events in chronological open order.
+    """
+
+    events: list[VisionModifierEvent]
+
+    def __init__(self, player_ext: PlayerExtractor) -> None:
+        """Initialize the extractor.
+
+        Args:
+            player_ext: Attached ``PlayerExtractor``, used to map caster NPC
+                names to team numbers during ``finalize``.
+        """
+        self._player_ext = player_ext
+        self.events = []
+        # (modifier_name, target_name) → stack of not-yet-closed events.
+        self._open: dict[tuple[str, str], list[VisionModifierEvent]] = {}
+
+    def attach(self, parser: ReplayParser) -> None:
+        """Register the combat-log callback with the parser.
+
+        Args:
+            parser: The ``ReplayParser`` instance to attach to.
+        """
+        parser.on_combat_log_entry(self._on_entry)
+
+    def _on_entry(self, entry: CombatLogEntry) -> None:
+        mod = entry.inflictor_name
+        if mod not in VISION_MODIFIER_NAMES:
+            return
+        if entry.log_type == "MODIFIER_ADD":
+            ev = VisionModifierEvent(
+                tick=entry.tick,
+                end_tick=None,
+                modifier_name=mod,
+                target_name=entry.target_name,
+                caster_name=entry.attacker_name,
+                caster_team=0,  # back-filled in finalize()
+            )
+            self.events.append(ev)
+            self._open.setdefault((mod, entry.target_name), []).append(ev)
+        elif entry.log_type == "MODIFIER_REMOVE":
+            key = (mod, entry.target_name)
+            stack = self._open.get(key)
+            if stack:
+                stack.pop().end_tick = entry.tick
+                if not stack:
+                    del self._open[key]
+
+    def finalize(self) -> list[VisionModifierEvent]:
+        """Back-fill caster teams from player snapshots and return the events.
+
+        Call after ``parser.parse()``.
+
+        Returns:
+            The collected vision-modifier events.
+        """
+        team_by_npc = _team_by_npc(self._player_ext)
+        for ev in self.events:
+            ev.caster_team = team_by_npc.get(ev.caster_name, 0)
+        return self.events
+
+
+class SmokeExtractor:
+    """Collects Smoke of Deceit activations with their smoked-hero groups.
+
+    The ``ITEM`` event (item consumed) opens a pending event keyed by the
+    activator's NPC name. Each subsequent ``MODIFIER_ADD`` on a hero target adds
+    that hero to the group and captures its live position; the activation
+    centroid is the mean of those positions. ``MODIFIER_REMOVE`` closes the
+    pending event once at least one hero was smoked.
+
+    Attach to a ``ReplayParser`` before calling ``parse()``, then call
+    ``finalize()`` to back-fill teams / centroids and get the events:
+
+    Example:
+        >>> ext = SmokeExtractor(player_ext)
+        >>> ext.attach(parser)
+        >>> parser.parse()
+        >>> events = ext.finalize()
+
+    Attributes:
+        events: All smoke activations in chronological order.
+    """
+
+    events: list[SmokeEvent]
+
+    def __init__(self, player_ext: PlayerExtractor) -> None:
+        """Initialize the extractor.
+
+        Args:
+            player_ext: Attached ``PlayerExtractor``, used for live hero
+                positions and the NPC-name → team map during ``finalize``.
+        """
+        self._player_ext = player_ext
+        self.events = []
+        # activator NPC → pending (not-yet-closed) event.
+        self._pending: dict[str, SmokeEvent] = {}
+        # activator NPC → live (x, y) positions captured at MODIFIER_ADD time.
+        self._positions: dict[str, list[tuple[float, float]]] = {}
+
+    def attach(self, parser: ReplayParser) -> None:
+        """Register the combat-log callback with the parser.
+
+        Args:
+            parser: The ``ReplayParser`` instance to attach to.
+        """
+        parser.on_combat_log_entry(self._on_entry)
+
+    def _on_entry(self, entry: CombatLogEntry) -> None:
+        if entry.log_type == "ITEM" and entry.inflictor_name == _SMOKE_ITEM:
+            ev = SmokeEvent(tick=entry.tick, activator=entry.attacker_name, team=0)
+            self._pending[entry.attacker_name] = ev
+            self._positions[entry.attacker_name] = []
+            self.events.append(ev)
+        elif (
+            entry.log_type == "MODIFIER_ADD"
+            and entry.inflictor_name == _SMOKE_MODIFIER
+            and entry.target_is_hero
+        ):
+            pending = self._pending.get(entry.attacker_name)
+            if pending is not None:
+                pending.smoked.append(entry.target_name)
+                # Capture this hero's live position at buff-arrival time.
+                pos = self._player_ext.hero_pos(entry.target_name)
+                if pos is not None:
+                    self._positions[entry.attacker_name].append(pos)
+        elif (
+            entry.log_type == "MODIFIER_REMOVE"
+            and entry.inflictor_name == _SMOKE_MODIFIER
+            and entry.target_is_hero
+        ):
+            pending = self._pending.get(entry.attacker_name)
+            if pending is not None and len(pending.smoked) >= 1:
+                self._pending.pop(entry.attacker_name, None)
+
+    def finalize(self) -> list[SmokeEvent]:
+        """Back-fill team + centroid from player snapshots and return the events.
+
+        Call after ``parser.parse()``. The centroid (x, y) is the mean of the
+        live positions captured at each hero's ``MODIFIER_ADD``; an empty group
+        leaves the position ``None``.
+
+        Returns:
+            The collected smoke events.
+        """
+        team_by_npc = _team_by_npc(self._player_ext)
+        for ev in self.events:
+            ev.team = team_by_npc.get(ev.activator, 0)
+            positions = self._positions.get(ev.activator, [])
+            if positions:
+                ev.x = sum(p[0] for p in positions) / len(positions)
+                ev.y = sum(p[1] for p in positions) / len(positions)
+        return self.events
+
+
+def _team_by_npc(player_ext: PlayerExtractor) -> dict[str, int]:
+    """Build an NPC-name → team map from player snapshots (non-zero teams only)."""
+    return {snap.npc_name: snap.team for snap in player_ext.snapshots if snap.team}

--- a/src/gem/reports/sections/vision.py
+++ b/src/gem/reports/sections/vision.py
@@ -103,8 +103,6 @@ def build_wards(match: ParsedMatch, map_b64: str | None) -> str:
             }
         )
 
-    wards_js = json.dumps(ward_data)
-
     _SMOKE_SHOW_TICKS = 300
     smoke_data = []
     for s in match.smoke_events:
@@ -127,9 +125,26 @@ def build_wards(match: ParsedMatch, map_b64: str | None) -> str:
                 "seen": seen_by_enemy,
             }
         )
-    smokes_js = json.dumps(smoke_data)
-
-    img_src_js = "window._GEM_MAP_SRC||''" if map_b64 else "''"
+    # Bundle every value that crosses the Python -> JS boundary into a single
+    # inert ``<script type="application/json">`` config tag (mirrors the cleaner
+    # ``build_farming`` pattern in this file). The executable ``<script>`` below
+    # reads this tag via ``JSON.parse`` instead of having data interpolated into
+    # it, so its body stays a plain string with natural single braces.
+    ward_config = {
+        "wards": ward_data,
+        "smokes": smoke_data,
+        "gameStartTick": match.game_start_tick or 0,
+        "sliderMin": slider_min,
+        "sliderMax": slider_max,
+        "worldWidth": _XMAX - _XMIN,
+        "hasMap": bool(map_b64),
+        "iconObs": ITEM_ICON_B64.get("ward_observer", ""),
+        "iconSen": ITEM_ICON_B64.get("ward_sentry", ""),
+        "iconSmoke": ITEM_ICON_B64.get("smoke_of_deceit", ""),
+    }
+    # ``</`` is escaped so a stray ``</script>`` substring in the data cannot
+    # close the data tag early (defensive; base64/JSON values won't contain it).
+    ward_config_js = json.dumps(ward_config).replace("</", "<\\/")
 
     canvas_html = f"""
 <div style="display:flex;gap:16px;align-items:flex-start;flex-wrap:wrap;margin-bottom:16px">
@@ -175,18 +190,23 @@ def build_wards(match: ParsedMatch, map_b64: str | None) -> str:
     </p>
   </div>
 </div>
+<script type="application/json" id="ward-data">{ward_config_js}</script>
+"""
+
+    ward_script = """
 <script>
-(function() {{
-  var wards = {wards_js};
-  var smokes = {smokes_js};
-var imgSrc = {img_src_js};
-  var iconObsSrc = {json.dumps(ITEM_ICON_B64.get("ward_observer", ""))};
-  var iconSenSrc = {json.dumps(ITEM_ICON_B64.get("ward_sentry", ""))};
-  var iconSmokeSrc = {json.dumps(ITEM_ICON_B64.get("smoke_of_deceit", ""))};
-  var gameStartTick = {match.game_start_tick or 0};
-  var sliderMin = {slider_min};
-  var sliderMax = {slider_max};
-  var WORLD_WIDTH = {_XMAX - _XMIN};
+(function() {
+  var cfg = JSON.parse(document.getElementById('ward-data').textContent || '{}');
+  var wards = cfg.wards || [];
+  var smokes = cfg.smokes || [];
+  var imgSrc = cfg.hasMap ? (window._GEM_MAP_SRC || '') : '';
+  var iconObsSrc = cfg.iconObs || '';
+  var iconSenSrc = cfg.iconSen || '';
+  var iconSmokeSrc = cfg.iconSmoke || '';
+  var gameStartTick = cfg.gameStartTick || 0;
+  var sliderMin = cfg.sliderMin || 0;
+  var sliderMax = cfg.sliderMax || 0;
+  var WORLD_WIDTH = cfg.worldWidth;
   var OBS_VISION_RADIUS = 1600;
   var SEN_TRUESIGHT_RADIUS = 1050;
   var canvas = document.getElementById('wardCanvas');
@@ -202,43 +222,43 @@ var speedSel = document.getElementById('wardSpeed');
   var lastTs = null;
 
   var mapImg = new Image();
-  mapImg.onload = function() {{ draw(currentTick); }};
-  if (imgSrc) {{ mapImg.src = imgSrc; }}
+  mapImg.onload = function() { draw(currentTick); };
+  if (imgSrc) { mapImg.src = imgSrc; }
 
-  function _makeIcon(src) {{
+  function _makeIcon(src) {
     var img = new Image();
     if (src) img.src = src;
     return img;
-  }}
+  }
   var iconObs = _makeIcon(iconObsSrc);
   var iconSen = _makeIcon(iconSenSrc);
   var iconSmoke = _makeIcon(iconSmokeSrc);
 
-  function fmtTick(tick) {{
+  function fmtTick(tick) {
     var rel = tick - gameStartTick;
     var neg = rel < 0;
     var secs = Math.floor(Math.abs(rel) / 30);
     var m = Math.floor(secs / 60), s = secs % 60;
     var t = (m < 10 ? '0' : '') + m + ':' + (s < 10 ? '0' : '') + s;
     return neg ? '-' + t : t;
-  }}
+  }
 
-  function draw(tick) {{
+  function draw(tick) {
     ctx.clearRect(0, 0, W, H);
 
-    if (mapImg.complete && mapImg.naturalWidth > 0) {{
+    if (mapImg.complete && mapImg.naturalWidth > 0) {
       ctx.drawImage(mapImg, 0, 0, W, H);
-    }} else {{
+    } else {
       ctx.fillStyle = '#1a2a1a';
       ctx.fillRect(0, 0, W, H);
-    }}
+    }
 
 
-    function drawIcon(img, cx, cy, size, borderColor, alpha) {{
+    function drawIcon(img, cx, cy, size, borderColor, alpha) {
       var half = size / 2;
       ctx.save();
       ctx.globalAlpha = alpha !== undefined ? alpha : 1.0;
-      if (img && img.complete && img.naturalWidth > 0) {{
+      if (img && img.complete && img.naturalWidth > 0) {
         ctx.beginPath();
         ctx.roundRect(cx - half, cy - half, size, size, 3);
         ctx.clip();
@@ -251,16 +271,16 @@ var speedSel = document.getElementById('wardSpeed');
         ctx.lineWidth = 2;
         ctx.strokeStyle = borderColor;
         ctx.stroke();
-      }} else {{
+      } else {
         ctx.beginPath();
         ctx.arc(cx, cy, half, 0, 2 * Math.PI);
         ctx.fillStyle = borderColor;
         ctx.fill();
-      }}
+      }
       ctx.restore();
-    }}
+    }
 
-    for (var i = 0; i < wards.length; i++) {{
+    for (var i = 0; i < wards.length; i++) {
       var w = wards[i];
       if (tick < w.placed) continue;
       if (w.removed !== null && tick > w.removed) continue;
@@ -284,9 +304,9 @@ var speedSel = document.getElementById('wardSpeed');
       ctx.restore();
 
       drawIcon(icon, cx, cy, isObs ? 18 : 16, borderColor);
-    }}
+    }
 
-    for (var i = 0; i < smokes.length; i++) {{
+    for (var i = 0; i < smokes.length; i++) {
       var s = smokes[i];
       if (tick < s.tick || tick > s.end_tick) continue;
 
@@ -309,51 +329,51 @@ var speedSel = document.getElementById('wardSpeed');
       ctx.textBaseline = 'middle';
       ctx.fillText(s.count, cx + 8, cy - 8);
       ctx.restore();
-    }}
-  }}
+    }
+  }
 
-  function setTick(tick) {{
+  function setTick(tick) {
     currentTick = Math.max(sliderMin, Math.min(sliderMax, tick));
     slider.value = currentTick;
     timeLabel.textContent = fmtTick(currentTick);
     draw(currentTick);
-  }}
+  }
 
-  function animFrame(ts) {{
+  function animFrame(ts) {
     if (!playing) return;
-    if (lastTs !== null) {{
+    if (lastTs !== null) {
       var speed = parseInt(speedSel.value) || 5;
       var delta = (ts - lastTs) * speed * 30 / 1000;
       currentTick = Math.min(sliderMax, currentTick + delta);
       slider.value = currentTick;
       timeLabel.textContent = fmtTick(Math.floor(currentTick));
       draw(Math.floor(currentTick));
-      if (currentTick >= sliderMax) {{
+      if (currentTick >= sliderMax) {
         playing = false;
         playBtn.textContent = '\u25b6';
         lastTs = null;
         return;
-      }}
-    }}
+      }
+    }
     lastTs = ts;
     requestAnimationFrame(animFrame);
-  }}
+  }
 
-  playBtn.addEventListener('click', function() {{
-    if (playing) {{
+  playBtn.addEventListener('click', function() {
+    if (playing) {
       playing = false;
       lastTs = null;
       playBtn.textContent = '\u25b6';
-    }} else {{
+    } else {
       if (currentTick >= sliderMax) setTick(sliderMin);
       playing = true;
       playBtn.textContent = '\u23f8';
       lastTs = null;
       requestAnimationFrame(animFrame);
-    }}
-  }});
+    }
+  });
 
-  slider.addEventListener('input', function() {{
+  slider.addEventListener('input', function() {
     playing = false;
     lastTs = null;
     playBtn.textContent = '\u25b6';
@@ -361,31 +381,31 @@ var speedSel = document.getElementById('wardSpeed');
     timeLabel.textContent = fmtTick(currentTick);
     draw(currentTick);
     tooltip.innerHTML = '';
-  }});
+  });
 
-  canvas.addEventListener('mousemove', function(e) {{
+  canvas.addEventListener('mousemove', function(e) {
     var rect = canvas.getBoundingClientRect();
     var mx = (e.clientX - rect.left) * (W / rect.width);
     var my = (e.clientY - rect.top) * (H / rect.height);
     var hit = null, hitType = null, bestDist = 12;
 
-    for (var i = 0; i < wards.length; i++) {{
+    for (var i = 0; i < wards.length; i++) {
       var w = wards[i];
       if (currentTick < w.placed) continue;
       if (w.removed !== null && currentTick > w.removed) continue;
       var dx = w.fx * W - mx, dy = w.fy * H - my;
       var dist = Math.sqrt(dx * dx + dy * dy);
-      if (dist < bestDist) {{ bestDist = dist; hit = w; hitType = 'ward'; }}
-    }}
-    for (var i = 0; i < smokes.length; i++) {{
+      if (dist < bestDist) { bestDist = dist; hit = w; hitType = 'ward'; }
+    }
+    for (var i = 0; i < smokes.length; i++) {
       var s = smokes[i];
       if (currentTick < s.tick || currentTick > s.end_tick) continue;
       var dx = s.fx * W - mx, dy = s.fy * H - my;
       var dist = Math.sqrt(dx * dx + dy * dy);
-      if (dist < bestDist) {{ bestDist = dist; hit = s; hitType = 'smoke'; }}
-    }}
+      if (dist < bestDist) { bestDist = dist; hit = s; hitType = 'smoke'; }
+    }
 
-    if (hit && hitType === 'ward') {{
+    if (hit && hitType === 'ward') {
       var teamName = hit.team === 2 ? 'Radiant' : 'Dire';
       var teamColor = hit.team === 2 ? '#4caf50' : '#f44336';
       var fateStr = hit.fate === 'killed' ? '&#128308; Killed ' + hit.fate_time
@@ -397,7 +417,7 @@ var speedSel = document.getElementById('wardSpeed');
         'Placed: ' + hit.placed_fmt + ' by ' + hit.placer + '<br>' +
         fateStr;
       canvas.style.cursor = 'pointer';
-    }} else if (hit && hitType === 'smoke') {{
+    } else if (hit && hitType === 'smoke') {
       var teamName = hit.team === 2 ? 'Radiant' : 'Dire';
       var teamColor = hit.team === 2 ? '#4caf50' : '#f44336';
       var seenStr = hit.seen
@@ -410,15 +430,16 @@ var speedSel = document.getElementById('wardSpeed');
         hit.count + ' hero' + (hit.count !== 1 ? 'es' : '') + ' smoked<br>' +
         seenStr;
       canvas.style.cursor = 'pointer';
-    }} else {{
+    } else {
       tooltip.innerHTML = '';
       canvas.style.cursor = 'crosshair';
-    }}
-  }});
-}})();
+    }
+  });
+})();
 </script>"""
 
     parts.append(canvas_html)
+    parts.append(ward_script)
 
     parts.append(
         '<details style="margin-top:8px"><summary style="color:#8b949e;font-size:12px;cursor:pointer">Show full ward table</summary>'

--- a/src/gem/results/assembly.py
+++ b/src/gem/results/assembly.py
@@ -530,123 +530,36 @@ def _interval_series_by_player(
     return series
 
 
-def build_parsed_match(
-    parser: ReplayParser,
+def _populate_player_series(
+    match: ParsedMatch,
+    *,
     player_ext: PlayerExtractor,
-    obj_ext: ObjectivesExtractor,
-    ward_ext: WardsExtractor,
-    courier_ext: CourierExtractor,
-    draft_ext: DraftExtractor,
     combat_agg: _CombatAggregator,
-    all_entries: list[CombatLogEntry],
-    chat_entries: list[ChatEntry],
-    smoke_events: list[SmokeEvent] | None = None,
-    vision_modifier_events: list[VisionModifierEvent] | None = None,
-    neutral_item_finds: list[NeutralItemFoundEvent] | None = None,
-    interval_ext: IntervalExtractor | None = None,
-) -> ParsedMatch:
-    """Assemble a :class:`ParsedMatch` from extractor state after a completed parse.
+    interval_ext: IntervalExtractor | None,
+    interval_min_series: dict[int, IntervalTimeSeries],
+    game_start_tick: int | None,
+    radiant_win: bool | None,
+) -> None:
+    """Populate per-player time series and combat-log aggregates in place.
 
-    Handles radiant_win resolution (three-tier), per-player time series wiring,
-    player name extraction, ward-to-player assignment, gold/XP advantage curves,
-    and teamfight detection.
+    Iterates the ten player slots and overlays each ``match.players[player_id]``
+    with its dense/minute time series, combat-log attribution, kill aggregates,
+    lane stats, terminal scalars, final inventory, and OpenDota-style computed
+    fields. Each iteration is independent (no cross-player state), so the loop is
+    a straight single-pass population of one ``ParsedPlayer`` per slot.
+
+    Extracted verbatim from ``build_parsed_match`` (issue #106 item #3) to keep
+    the orchestrator readable; behaviour is unchanged.
 
     Args:
-        parser: Completed :class:`ReplayParser` instance.
-        player_ext: Attached :class:`PlayerExtractor`.
-        obj_ext: Attached :class:`ObjectivesExtractor`.
-        ward_ext: Attached :class:`WardsExtractor`.
-        courier_ext: Attached :class:`CourierExtractor`.
-        draft_ext: Attached :class:`DraftExtractor` (already finalized).
-        combat_agg: Populated :class:`_CombatAggregator`.
-        all_entries: All :class:`CombatLogEntry` objects from the replay.
-        chat_entries: All :class:`ChatEntry` objects from the replay.
-        smoke_events: All :class:`SmokeEvent` objects collected during parse.
-        vision_modifier_events: All :class:`VisionModifierEvent` objects collected during parse.
-        neutral_item_finds: Neutral item found events collected during parse.
-        interval_ext: Optional internal interval extractor used for OpenDota-style
-            match-level gold/XP advantage curves.
-
-    Returns:
-        Fully populated :class:`ParsedMatch`.
+        match: The match being assembled; ``match.players`` is mutated in place.
+        player_ext: Source of per-player snapshots / time series / scoreboard.
+        combat_agg: Per-player combat-log aggregates.
+        interval_ext: OpenDota-style interval extractor (team counters, scalars).
+        interval_min_series: Complete interval minute arrays by player id.
+        game_start_tick: Horn tick used for the lane-window time filter.
+        radiant_win: Resolved match winner, or ``None`` if unknown.
     """
-    from gem.extractors.teamfights import detect_opendota_teamfights, detect_teamfights
-
-    # radiant_win resolution — three tiers in priority order:
-    #   1. CDemoFileInfo.game_winner (set during parse, empty for HLTV replays)
-    #   2. m_pGameRules.m_nGameWinner entity field (set post-parse in parser.py)
-    #   3. Ancient DEATH in combat log — no API needed
-    radiant_win = parser.radiant_win
-    if radiant_win is None:
-        radiant_win = _radiant_win_from_ancient(all_entries)
-
-    match = ParsedMatch(
-        match_id=parser.match_id,
-        game_mode=parser.game_mode,
-        leagueid=parser.leagueid,
-        radiant_win=radiant_win,
-        towers=obj_ext.tower_kills,
-        barracks=obj_ext.barracks_kills,
-        roshans=obj_ext.roshan_kills,
-        aegis_events=obj_ext.aegis_events,
-        tormentors=obj_ext.tormentor_kills,
-        shrines=obj_ext.shrine_kills,
-        wards=ward_ext.ward_events,
-        combat_log=all_entries,
-        chat=chat_entries,
-        courier_snapshots=courier_ext.snapshots,
-        neutral_item_finds=neutral_item_finds or [],
-        smoke_events=smoke_events or [],
-        vision_modifiers=vision_modifier_events or [],
-        draft=draft_ext.draft_events,
-        game_start_tick=parser.game_start_tick,
-        game_end_tick=parser.tick,
-        duration=getattr(parser, "duration_s", None) or 0,
-    )
-
-    # Post-process buybacks (7b).
-    # For BUYBACK entries, entry.value = player slot (0-9).
-    # Reference: refs/parser/src/main/java/opendota/CreateParsedDataBlob.java handleBuyback()
-    for entry in all_entries:
-        if entry.log_type != "BUYBACK":
-            continue
-        pid = entry.value
-        if 0 <= pid < 10:
-            combat_agg._agg(pid).buyback_log.append(entry)
-
-    # Capture game_start_tick once — used for lane_pos time filter below
-    game_start_tick = parser.game_start_tick
-    interval_min_series = _interval_series_by_player(interval_ext)
-
-    # first_blood_time: game-clock time of the earliest real hero DEATH. Illusion
-    # deaths and reincarnation triggers are excluded (target_is_hero stays true for
-    # an illusion, so the explicit not-illusion filter is required). The per-player
-    # firstblood_claimed flag is read separately from the authoritative
-    # CDOTA_PlayerResource field below, not reconstructed from this entry.
-    first_blood_entry = next(
-        (
-            e
-            for e in all_entries
-            if e.log_type == "DEATH"
-            and e.target_is_hero
-            and not e.target_is_illusion
-            and not e.will_reincarnate
-        ),
-        None,
-    )
-    if first_blood_entry is not None:
-        if first_blood_entry.game_time_s is not None:
-            match.first_blood_time = int(first_blood_entry.game_time_s)
-        elif game_start_tick is not None:
-            match.first_blood_time = max(0, (first_blood_entry.tick - game_start_tick) // 30)
-
-    # NOTE: pre_game_duration (horn → creep-spawn span, ~90s) is intentionally
-    # left at its default 0 here. It requires the GAME_IN_PROGRESS state-transition
-    # timestamp, which the parser does not yet expose separately from the clock
-    # anchor (m_flGameStartTime is the engine clock zero, not the pre-game span).
-    # Tracked as a follow-up rather than shipping a wrong value.
-
-    # Build per-player time series and overlay combat log aggregates
     for player_id in range(10):
         ts = player_ext.time_series(player_id)
         mts = player_ext.minute_time_series(player_id)
@@ -880,6 +793,134 @@ def build_parsed_match(
         _LANE_GOLD_BASELINE = 4948
         if pp.lane_total_gold > 0:
             pp.lane_efficiency_pct = int(pp.lane_total_gold / _LANE_GOLD_BASELINE * 100)
+
+
+def build_parsed_match(
+    parser: ReplayParser,
+    player_ext: PlayerExtractor,
+    obj_ext: ObjectivesExtractor,
+    ward_ext: WardsExtractor,
+    courier_ext: CourierExtractor,
+    draft_ext: DraftExtractor,
+    combat_agg: _CombatAggregator,
+    all_entries: list[CombatLogEntry],
+    chat_entries: list[ChatEntry],
+    smoke_events: list[SmokeEvent] | None = None,
+    vision_modifier_events: list[VisionModifierEvent] | None = None,
+    neutral_item_finds: list[NeutralItemFoundEvent] | None = None,
+    interval_ext: IntervalExtractor | None = None,
+) -> ParsedMatch:
+    """Assemble a :class:`ParsedMatch` from extractor state after a completed parse.
+
+    Handles radiant_win resolution (three-tier), per-player time series wiring,
+    player name extraction, ward-to-player assignment, gold/XP advantage curves,
+    and teamfight detection.
+
+    Args:
+        parser: Completed :class:`ReplayParser` instance.
+        player_ext: Attached :class:`PlayerExtractor`.
+        obj_ext: Attached :class:`ObjectivesExtractor`.
+        ward_ext: Attached :class:`WardsExtractor`.
+        courier_ext: Attached :class:`CourierExtractor`.
+        draft_ext: Attached :class:`DraftExtractor` (already finalized).
+        combat_agg: Populated :class:`_CombatAggregator`.
+        all_entries: All :class:`CombatLogEntry` objects from the replay.
+        chat_entries: All :class:`ChatEntry` objects from the replay.
+        smoke_events: All :class:`SmokeEvent` objects collected during parse.
+        vision_modifier_events: All :class:`VisionModifierEvent` objects collected during parse.
+        neutral_item_finds: Neutral item found events collected during parse.
+        interval_ext: Optional internal interval extractor used for OpenDota-style
+            match-level gold/XP advantage curves.
+
+    Returns:
+        Fully populated :class:`ParsedMatch`.
+    """
+    from gem.extractors.teamfights import detect_opendota_teamfights, detect_teamfights
+
+    # radiant_win resolution — three tiers in priority order:
+    #   1. CDemoFileInfo.game_winner (set during parse, empty for HLTV replays)
+    #   2. m_pGameRules.m_nGameWinner entity field (set post-parse in parser.py)
+    #   3. Ancient DEATH in combat log — no API needed
+    radiant_win = parser.radiant_win
+    if radiant_win is None:
+        radiant_win = _radiant_win_from_ancient(all_entries)
+
+    match = ParsedMatch(
+        match_id=parser.match_id,
+        game_mode=parser.game_mode,
+        leagueid=parser.leagueid,
+        radiant_win=radiant_win,
+        towers=obj_ext.tower_kills,
+        barracks=obj_ext.barracks_kills,
+        roshans=obj_ext.roshan_kills,
+        aegis_events=obj_ext.aegis_events,
+        tormentors=obj_ext.tormentor_kills,
+        shrines=obj_ext.shrine_kills,
+        wards=ward_ext.ward_events,
+        combat_log=all_entries,
+        chat=chat_entries,
+        courier_snapshots=courier_ext.snapshots,
+        neutral_item_finds=neutral_item_finds or [],
+        smoke_events=smoke_events or [],
+        vision_modifiers=vision_modifier_events or [],
+        draft=draft_ext.draft_events,
+        game_start_tick=parser.game_start_tick,
+        game_end_tick=parser.tick,
+        duration=getattr(parser, "duration_s", None) or 0,
+    )
+
+    # Post-process buybacks (7b).
+    # For BUYBACK entries, entry.value = player slot (0-9).
+    # Reference: refs/parser/src/main/java/opendota/CreateParsedDataBlob.java handleBuyback()
+    for entry in all_entries:
+        if entry.log_type != "BUYBACK":
+            continue
+        pid = entry.value
+        if 0 <= pid < 10:
+            combat_agg._agg(pid).buyback_log.append(entry)
+
+    # Capture game_start_tick once — used for lane_pos time filter below
+    game_start_tick = parser.game_start_tick
+    interval_min_series = _interval_series_by_player(interval_ext)
+
+    # first_blood_time: game-clock time of the earliest real hero DEATH. Illusion
+    # deaths and reincarnation triggers are excluded (target_is_hero stays true for
+    # an illusion, so the explicit not-illusion filter is required). The per-player
+    # firstblood_claimed flag is read separately from the authoritative
+    # CDOTA_PlayerResource field below, not reconstructed from this entry.
+    first_blood_entry = next(
+        (
+            e
+            for e in all_entries
+            if e.log_type == "DEATH"
+            and e.target_is_hero
+            and not e.target_is_illusion
+            and not e.will_reincarnate
+        ),
+        None,
+    )
+    if first_blood_entry is not None:
+        if first_blood_entry.game_time_s is not None:
+            match.first_blood_time = int(first_blood_entry.game_time_s)
+        elif game_start_tick is not None:
+            match.first_blood_time = max(0, (first_blood_entry.tick - game_start_tick) // 30)
+
+    # NOTE: pre_game_duration (horn → creep-spawn span, ~90s) is intentionally
+    # left at its default 0 here. It requires the GAME_IN_PROGRESS state-transition
+    # timestamp, which the parser does not yet expose separately from the clock
+    # anchor (m_flGameStartTime is the engine clock zero, not the pre-game span).
+    # Tracked as a follow-up rather than shipping a wrong value.
+
+    # Build per-player time series and overlay combat log aggregates.
+    _populate_player_series(
+        match,
+        player_ext=player_ext,
+        combat_agg=combat_agg,
+        interval_ext=interval_ext,
+        interval_min_series=interval_min_series,
+        game_start_tick=game_start_tick,
+        radiant_win=radiant_win,
+    )
 
     match_metadata = getattr(parser, "match_metadata", None)
     metadata = getattr(match_metadata, "metadata", None)

--- a/tests/test_html_sections.py
+++ b/tests/test_html_sections.py
@@ -127,3 +127,112 @@ class TestBuybackGoldCost:
         html = _sections.build_buybacks(match)
         assert "Gold Spent" not in html
         assert "no buybacks" in html
+
+
+# ---------------------------------------------------------------------------
+# build_wards: data crosses the Python -> JS boundary via an inert
+# <script type="application/json"> tag (the build_farming pattern), so the
+# executable <script> stays a plain string with no doubled-brace escaping.
+# ---------------------------------------------------------------------------
+
+
+class TestBuildWardsDataTag:
+    """Lock in the JSON-data-tag contract introduced for issue #106 item #6."""
+
+    def _make_ward(
+        self,
+        *,
+        ward_type: str = "observer",
+        team: int = 2,
+        tick: int = 900,
+        x: float = 1000.0,
+        y: float = -2000.0,
+        killed_tick: int | None = 1800,
+        expires_tick: int | None = None,
+    ) -> MagicMock:
+        w = MagicMock()
+        w.ward_type = ward_type
+        w.team = team
+        w.tick = tick
+        w.x = x
+        w.y = y
+        w.killed_tick = killed_tick
+        w.expires_tick = expires_tick
+        w.placer = "npc_dota_hero_axe"
+        w.killer = "npc_dota_hero_lina"
+        return w
+
+    def _make_smoke(self) -> MagicMock:
+        s = MagicMock()
+        s.x = 0.0
+        s.y = 0.0
+        s.tick = 1200
+        s.team = 2
+        s.activator = "npc_dota_hero_axe"
+        s.smoked = ["a", "b"]
+        return s
+
+    def _make_match(self) -> MagicMock:
+        match = MagicMock()
+        match.wards = [
+            self._make_ward(ward_type="observer", team=2),
+            self._make_ward(ward_type="sentry", team=3, killed_tick=None, expires_tick=2000),
+        ]
+        match.smoke_events = [self._make_smoke()]
+        match.game_start_tick = 900
+        match.game_end_tick = 3000
+        # estimate_vision() iterates match.players; empty == no enemy vision.
+        match.players = []
+        return match
+
+    def _data_tag_payload(self, html: str) -> dict:
+        import json
+        import re
+
+        m = re.search(
+            r'<script type="application/json" id="ward-data">(.*?)</script>',
+            html,
+            re.S,
+        )
+        assert m is not None, "ward-data JSON tag missing"
+        return json.loads(m.group(1))
+
+    def test_data_tag_present_and_parses(self):
+        html = _sections.build_wards(self._make_match(), None)
+        cfg = self._data_tag_payload(html)
+        assert len(cfg["wards"]) == 2
+        assert len(cfg["smokes"]) == 1
+        assert cfg["gameStartTick"] == 900
+        assert cfg["sliderMin"] is not None
+        assert cfg["sliderMax"] is not None
+
+    def test_exactly_one_json_data_tag(self):
+        html = _sections.build_wards(self._make_match(), None)
+        assert html.count('type="application/json"') == 1
+
+    def test_no_doubled_braces_in_output(self):
+        # The whole point of the refactor: no f-string brace escaping survives.
+        html = _sections.build_wards(self._make_match(), None)
+        assert "{{" not in html
+        assert "}}" not in html
+
+    def test_script_reads_the_data_tag(self):
+        html = _sections.build_wards(self._make_match(), None)
+        assert "JSON.parse(document.getElementById('ward-data')" in html
+
+    def test_has_map_flag_reflects_map_b64(self):
+        without = self._data_tag_payload(_sections.build_wards(self._make_match(), None))
+        with_map = self._data_tag_payload(_sections.build_wards(self._make_match(), "ZmFrZWI2NA=="))
+        assert without["hasMap"] is False
+        assert with_map["hasMap"] is True
+
+    def test_empty_wards_returns_placeholder_card(self):
+        match = MagicMock()
+        match.wards = []
+        match.smoke_events = []
+        match.game_start_tick = 0
+        match.game_end_tick = 0
+        match.players = []
+        html = _sections.build_wards(match, None)
+        assert "(no ward placement data)" in html
+        assert 'type="application/json"' not in html

--- a/tests/test_smoke_vision_extractor.py
+++ b/tests/test_smoke_vision_extractor.py
@@ -1,0 +1,248 @@
+"""Unit tests for gem.extractors.smoke_vision.
+
+Covers SmokeExtractor and VisionModifierExtractor — the attach()/finalize()
+contract, team/centroid back-fill, the LIFO vision-modifier stacking, and the
+documented empty-group smoke edge case. All tests use fake combat log entries —
+no real .dem files.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from gem.combat.log import CombatLogEntry
+from gem.extractors.smoke_vision import SmokeExtractor, VisionModifierExtractor
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _entry(**kwargs) -> CombatLogEntry:
+    defaults = {
+        "tick": 100,
+        "log_type": "MODIFIER_ADD",
+        "attacker_name": "npc_dota_hero_axe",
+        "target_name": "npc_dota_hero_lina",
+        "inflictor_name": "",
+        "value": 0,
+        "attacker_is_hero": True,
+        "target_is_hero": True,
+        "attacker_is_illusion": False,
+        "target_is_illusion": False,
+        "ability_level": 0,
+        "gold_reason": 0,
+        "xp_reason": 0,
+    }
+    defaults.update(kwargs)
+    return CombatLogEntry(**defaults)
+
+
+class FakeParser:
+    def __init__(self) -> None:
+        self._handlers: list = []
+
+    def on_combat_log_entry(self, handler) -> None:
+        self._handlers.append(handler)
+
+    def fire(self, entry: CombatLogEntry) -> None:
+        for h in self._handlers:
+            h(entry)
+
+
+def _fake_player_ext(
+    *,
+    teams: dict[str, int] | None = None,
+    positions: dict[str, tuple[float, float]] | None = None,
+) -> MagicMock:
+    """A PlayerExtractor stand-in exposing snapshots + hero_pos."""
+    teams = teams or {}
+    positions = positions or {}
+    snaps = []
+    for npc, team in teams.items():
+        snap = MagicMock()
+        snap.npc_name = npc
+        snap.team = team
+        snaps.append(snap)
+    pe = MagicMock()
+    pe.snapshots = snaps
+    pe.hero_pos.side_effect = lambda npc: positions.get(npc)
+    return pe
+
+
+# ---------------------------------------------------------------------------
+# VisionModifierExtractor
+# ---------------------------------------------------------------------------
+
+
+class TestVisionModifierExtractor:
+    def test_add_then_remove_opens_and_closes_window(self):
+        pe = _fake_player_ext(teams={"npc_dota_hero_slardar": 2})
+        ext = VisionModifierExtractor(pe)
+        parser = FakeParser()
+        ext.attach(parser)
+
+        parser.fire(
+            _entry(
+                tick=100,
+                log_type="MODIFIER_ADD",
+                inflictor_name="modifier_slardar_amplify_damage",
+                attacker_name="npc_dota_hero_slardar",
+                target_name="npc_dota_hero_lina",
+            )
+        )
+        parser.fire(
+            _entry(
+                tick=250,
+                log_type="MODIFIER_REMOVE",
+                inflictor_name="modifier_slardar_amplify_damage",
+                attacker_name="npc_dota_hero_slardar",
+                target_name="npc_dota_hero_lina",
+            )
+        )
+        events = ext.finalize()
+        assert len(events) == 1
+        ev = events[0]
+        assert ev.tick == 100
+        assert ev.end_tick == 250
+        assert ev.caster_team == 2  # back-filled from snapshots
+
+    def test_non_vision_modifier_ignored(self):
+        ext = VisionModifierExtractor(_fake_player_ext())
+        parser = FakeParser()
+        ext.attach(parser)
+        parser.fire(_entry(log_type="MODIFIER_ADD", inflictor_name="modifier_some_random_buff"))
+        assert ext.finalize() == []
+
+    def test_unclosed_modifier_keeps_none_end_tick(self):
+        ext = VisionModifierExtractor(_fake_player_ext())
+        parser = FakeParser()
+        ext.attach(parser)
+        parser.fire(
+            _entry(
+                log_type="MODIFIER_ADD",
+                inflictor_name="modifier_bounty_hunter_track",
+            )
+        )
+        events = ext.finalize()
+        assert len(events) == 1
+        assert events[0].end_tick is None
+
+    def test_stacked_adds_close_lifo(self):
+        # Same (modifier, target) applied twice; two removes close most-recent-first.
+        ext = VisionModifierExtractor(_fake_player_ext())
+        parser = FakeParser()
+        ext.attach(parser)
+        common = {
+            "inflictor_name": "modifier_item_dustofappearance",
+            "target_name": "npc_dota_hero_riki",
+        }
+        parser.fire(_entry(tick=100, log_type="MODIFIER_ADD", **common))
+        parser.fire(_entry(tick=120, log_type="MODIFIER_ADD", **common))
+        parser.fire(_entry(tick=200, log_type="MODIFIER_REMOVE", **common))
+        parser.fire(_entry(tick=300, log_type="MODIFIER_REMOVE", **common))
+        events = ext.finalize()
+        assert len(events) == 2
+        # LIFO: the second add (tick=120) is closed first (end=200); first add
+        # (tick=100) closed at 300.
+        by_tick = {e.tick: e.end_tick for e in events}
+        assert by_tick == {100: 300, 120: 200}
+
+
+# ---------------------------------------------------------------------------
+# SmokeExtractor
+# ---------------------------------------------------------------------------
+
+
+class TestSmokeExtractor:
+    def test_item_then_modifiers_builds_group_and_centroid(self):
+        pe = _fake_player_ext(
+            teams={"npc_dota_hero_axe": 2},
+            positions={
+                "npc_dota_hero_lina": (100.0, 200.0),
+                "npc_dota_hero_axe": (300.0, 400.0),
+            },
+        )
+        ext = SmokeExtractor(pe)
+        parser = FakeParser()
+        ext.attach(parser)
+
+        parser.fire(
+            _entry(
+                tick=500,
+                log_type="ITEM",
+                inflictor_name="item_smoke_of_deceit",
+                attacker_name="npc_dota_hero_axe",
+            )
+        )
+        for target in ("npc_dota_hero_lina", "npc_dota_hero_axe"):
+            parser.fire(
+                _entry(
+                    tick=502,
+                    log_type="MODIFIER_ADD",
+                    inflictor_name="modifier_smoke_of_deceit",
+                    attacker_name="npc_dota_hero_axe",
+                    target_name=target,
+                    target_is_hero=True,
+                )
+            )
+        events = ext.finalize()
+        assert len(events) == 1
+        ev = events[0]
+        assert ev.activator == "npc_dota_hero_axe"
+        assert ev.team == 2
+        assert set(ev.smoked) == {"npc_dota_hero_lina", "npc_dota_hero_axe"}
+        # centroid = mean of (100,200) and (300,400)
+        assert ev.x == 200.0
+        assert ev.y == 300.0
+
+    def test_non_hero_modifier_target_excluded_from_group(self):
+        # Summoned units (target_is_hero=False) must not join the smoke group.
+        pe = _fake_player_ext(teams={"npc_dota_hero_beastmaster": 3})
+        ext = SmokeExtractor(pe)
+        parser = FakeParser()
+        ext.attach(parser)
+        parser.fire(
+            _entry(
+                tick=10,
+                log_type="ITEM",
+                inflictor_name="item_smoke_of_deceit",
+                attacker_name="npc_dota_hero_beastmaster",
+            )
+        )
+        parser.fire(
+            _entry(
+                tick=12,
+                log_type="MODIFIER_ADD",
+                inflictor_name="modifier_smoke_of_deceit",
+                attacker_name="npc_dota_hero_beastmaster",
+                target_name="npc_dota_beastmaster_boar",
+                target_is_hero=False,
+            )
+        )
+        events = ext.finalize()
+        assert len(events) == 1
+        assert events[0].smoked == []  # boar excluded
+
+    def test_empty_group_edge_case_still_emits_event(self):
+        # Documented case: smoke breaks instantly (sentry truesight) so no
+        # MODIFIER_ADD fires. The ITEM event is still recorded with an empty group
+        # and no position.
+        pe = _fake_player_ext(teams={"npc_dota_hero_axe": 2})
+        ext = SmokeExtractor(pe)
+        parser = FakeParser()
+        ext.attach(parser)
+        parser.fire(
+            _entry(
+                tick=10,
+                log_type="ITEM",
+                inflictor_name="item_smoke_of_deceit",
+                attacker_name="npc_dota_hero_axe",
+            )
+        )
+        events = ext.finalize()
+        assert len(events) == 1
+        assert events[0].smoked == []
+        assert events[0].x is None
+        assert events[0].y is None
+        assert events[0].team == 2  # team still back-filled


### PR DESCRIPTION
## Summary

Clears the remaining actionable items on #106 — three **behaviour-preserving**
structural refactors, no output or API changes:

- **#6 — ward report data via JSON tag.** `reports/sections/vision.py::build_wards`
  injected its data directly into the executable `<script>` f-string, forcing
  ~240 lines of JS to double every brace (`{{ }}`). Ported to the cleaner pattern
  `build_farming` already uses in the same file: all data goes into one inert
  `<script type="application/json" id="ward-data">` tag, and the executable JS is a
  plain (non-f) string that reads it via `JSON.parse`. The JSON escapes `</`
  defensively. No change to the rendered report.
- **#2 — smoke/vision logic out of `api.parse`.** The ~100 lines of inline
  Smoke-of-Deceit and vision-modifier closures are extracted into
  `gem.extractors.smoke_vision` (`SmokeExtractor`, `VisionModifierExtractor`),
  following the existing `attach()`/`finalize()` extractor contract. Both take the
  `PlayerExtractor` (same dependency pattern as `_CombatAggregator`). Internal —
  not added to the public extractors `__all__`.
- **#3 — per-player loop out of `build_parsed_match`.** The ~234-line per-player
  population loop is lifted verbatim into `_populate_player_series(match, ...)`
  with an explicit keyword-only signature. The orchestrator drops from 527 to
  ~310 lines. Each player slot is populated independently, so the move is a pure
  relocation.

After this merges, **every actionable #106 item is resolved** (the cheap items #1
and #4 already shipped in #107/#108). Only the two verified non-issues remain
(#5 correct dependency direction, #7 self-correcting DataFrame pairing) — both
won't-do by decision — so `Closes #106`.

## Rationale

These were tagged "when-touched / not now" in #106 to avoid churning
parity-validated code for cosmetic gain. The caution was about prioritisation, not
correctness: each is a structural move with a mechanical safety net (brace-balance
+ no-`{{` assertion for #6; end-to-end event-count equivalence for #2; mypy proving
no closed-over variable was dropped + the OpenDota parity validator for #3). None
changes a single output value. Doing them now removes a real maintenance landmine
(the brace-doubling) and makes two of the densest functions in the codebase
readable.

## Testing

- [x] `uv run ruff check .` — All checks passed
- [x] `uv run ruff format --check .` — 169 files already formatted
- [x] `uv run mypy src` — Success, no issues in 87 source files
- [x] `uv run pytest tests/ -m "not integration"` — 1689 passed, 3 skipped
- [ ] Docs build, if docs changed — n/a (no docs changed)

Additional behaviour-preservation checks beyond the suite:

- **#6:** new `TestBuildWardsDataTag` (6 tests) — data tag parses, exactly one
  `application/json` tag, **no `{{`/`}}` survive in output**, script reads the tag,
  `hasMap` reflects `map_b64`, empty-wards placeholder unchanged.
- **#2:** new `tests/test_smoke_vision_extractor.py` (7 tests) — attach/finalize,
  LIFO modifier stacking, non-hero target exclusion, the documented empty-group
  smoke edge case. End-to-end on fixture `8822520406`: **6 smoke events** (teams +
  centroids set) and **85 vision-modifier windows** (all `caster_team` back-filled,
  all closed), matching the prior inline behaviour.
- **#3:** `test_match_builder.py` + `test_validate_opendota.py` (125 parity-pinned
  tests) pass unchanged; end-to-end parse populates all 10 players' fields
  correctly through the new helper.

## Notes

- [x] Generated protobuf files under `src/gem/proto/` were not edited manually.
- [x] Large replay artifacts are not committed unless explicitly required for tests.
- [x] Secrets and local credentials are not included.
- All three changes are internal refactors; the public API (`gem.parse`,
  `ParsedMatch`, …) and all output values are unchanged. `CHANGELOG.md`
  `[Unreleased]` updated with one entry per item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
