### PR TITLE
release: 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `ParsedPlayer.buybacks` — a list of `BuybackEvent` (`tick`, `player_slot`,
-  `net_worth`, estimated `cost`) alongside the raw `buyback_log`. The per-buyback
-  cost is an estimate from Dota 2's formula `200 + net_worth // 13`, computed from
-  net worth at the buyback tick; the canonical formula lives in
-  `gem.results.derived.buyback_cost`. The HTML report's buyback table now reads
-  this cost instead of recomputing it. The reliable/unreliable gold split is **not**
-  provided — it is empirically unrecoverable offline (the entity gold-pool fields
-  reflect gold after the deduction; OpenDota records no per-buyback cost). (#119)
+  `net_worth`, estimated `cost`) alongside the raw `buyback_log`; also added to the
+  `player_buyback_log` DataFrame (`cost`/`net_worth` columns) and exported as
+  `gem.BuybackEvent`. The HTML report's buyback table reads this `cost` instead of
+  recomputing it; the canonical formula lives in `gem.results.derived.buyback_cost`.
+
+  **The `cost` is an estimate, not a measured value.** It uses Dota 2's published
+  formula `200 + net_worth // 13` over net worth at the buyback tick, because the
+  exact per-buyback cost is **not recoverable from the replay** — confirmed against
+  all three major parsers: gem's entity gold-pool fields reflect gold *after* the
+  deduction (before/after delta is zero) and the BUYBACK combat-log entry carries
+  no gold amount; OpenDota records no per-buyback cost; and STRATZ's API `cost`
+  field is `0` for every buyback (24 events across 3 matches). The
+  reliable/unreliable split is likewise not provided.
+
+  Buyback *detection* (event timing + hero) is **cross-validated against STRATZ** —
+  times and hero IDs match exactly on every event in those matches. Only the cost
+  *value* is an unverifiable formula estimate. (#119)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   centroids, and vision-modifier windows are identical (verified end-to-end on a
   replay fixture); the extractors are internal and not part of the public API.
   (#106 item #2)
+- **Internal:** the ~234-line per-player population loop in
+  `results/assembly.build_parsed_match` is extracted into a dedicated
+  `_populate_player_series(match, ...)` helper, shrinking the orchestrator from
+  527 to ~310 lines. Each player slot is populated independently (no cross-player
+  state), so the loop moved verbatim behind an explicit keyword-only signature.
+  No output change — the OpenDota parity validator and the full suite are
+  unchanged. (#106 item #3)
 
 ## [0.4.2] - 2026-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Refactored the HTML report's ward-map section (`reports/sections/vision.py`,
+  `build_wards`) to inject its data through an inert
+  `<script type="application/json">` tag — matching the cleaner pattern already
+  used by the farming section in the same file — instead of interpolating it into
+  the executable `<script>`. This removes ~240 lines of fragile doubled-brace
+  (`{{ }}`) f-string escaping. No change to the rendered report. (#106 item #6)
+
 ## [0.4.2] - 2026-06-25
 
 Report asset-cache tooling and a documentation overhaul. No change to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-06-26
+
+Adds per-buyback gold cost to the model and bundles a set of code-quality
+refactors (#106). The one user-visible addition is `ParsedPlayer.buybacks` /
+`gem.BuybackEvent`; the rest are behaviour-preserving internal cleanups with no
+change to parse/export output (OpenDota parity validator unchanged).
+
 ### Added
 
 - `ParsedPlayer.buybacks` — a list of `BuybackEvent` (`tick`, `player_slot`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   used by the farming section in the same file — instead of interpolating it into
   the executable `<script>`. This removes ~240 lines of fragile doubled-brace
   (`{{ }}`) f-string escaping. No change to the rendered report. (#106 item #6)
+- **Internal:** the inline Smoke-of-Deceit and vision-modifier collection logic
+  (~100 lines of closures in `gem.api.parse`) is extracted into
+  `gem.extractors.smoke_vision` (`SmokeExtractor`, `VisionModifierExtractor`),
+  following the existing `attach()`/`finalize()` extractor contract. Both take the
+  `PlayerExtractor` (same dependency pattern as `_CombatAggregator`) for live hero
+  positions and the post-parse team back-fill. No output change — smoke groups,
+  centroids, and vision-modifier windows are identical (verified end-to-end on a
+  replay fixture); the extractors are internal and not part of the public API.
+  (#106 item #2)
 
 ## [0.4.2] - 2026-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ParsedPlayer.buybacks` — a list of `BuybackEvent` (`tick`, `player_slot`,
+  `net_worth`, estimated `cost`) alongside the raw `buyback_log`. The per-buyback
+  cost is an estimate from Dota 2's formula `200 + net_worth // 13`, computed from
+  net worth at the buyback tick; the canonical formula lives in
+  `gem.results.derived.buyback_cost`. The HTML report's buyback table now reads
+  this cost instead of recomputing it. The reliable/unreliable gold split is **not**
+  provided — it is empirically unrecoverable offline (the entity gold-pool fields
+  reflect gold after the deduction; OpenDota records no per-buyback cost). (#119)
+
 ### Changed
 
 - Refactored the HTML report's ward-map section (`reports/sections/vision.py`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@ extractors/lane.py          ← lane-position heatmaps
 extractors/courier.py       ← courier state
 extractors/draft.py         ← pick/ban resolution (three-tier hero-ID resolution)
 extractors/teamfights.py    ← teamfight window detection + per-fight stat attribution
+extractors/smoke_vision.py  ← Smoke of Deceit + vision-granting modifier events
 extractors/_snapshots.py    ← shared snapshot dataclasses/sampling helpers
 ```
 
@@ -208,6 +209,12 @@ Reference: `refs/parser/src/main/java/opendota/processors/warding/Wards.java` �
 
 ### Smoke of Deceit — empty group edge case
 
+Smoke and vision-granting modifier collection lives in
+`extractors/smoke_vision.py` (`SmokeExtractor`, `VisionModifierExtractor`),
+attached by `api.parse()` like the other extractors (`attach()`/`finalize()`;
+`finalize()` back-fills teams/centroids from `PlayerExtractor` snapshots). These
+are internal extractors, not part of the public `extractors` `__all__`.
+
 Tracking smoke:
 1. `ITEM` event (`inflictor_name = "item_smoke_of_deceit"`) — item consumed
 2. `MODIFIER_ADD` events (`inflictor_name = "modifier_smoke_of_deceit"`, `target_is_hero = True`) — one per hero that receives the buff
@@ -272,24 +279,38 @@ immediate-outcome window 180 s, event-association window 30 s. It reads only
 
 ## Deferred: buyback cost breakdown (reliable vs unreliable gold)
 
-The HTML report buybacks section shows only time/hero/team. Adding a reliable/unreliable gold
-cost breakdown was investigated but deferred. Key findings:
+Tracked in **issue #119**. A reliable/unreliable gold cost breakdown was
+investigated and deferred. Current state and findings:
 
-- `m_vecDataTeam.{slot}.m_iReliableGold` / `m_iUnreliableGold` on `CDOTADataRadiant/Dire`
-  exist and are readable, but reflect **remaining gold after** the buyback deduction — not the
-  cost paid.
-- `CDOTAUserMsg_SendFinalGold` (type 514) provides per-player reliable/unreliable gold at game
-  end only — not per buyback event.
+- **The HTML report already shows an approximate per-buyback cost.**
+  `reports/sections/economy.py::build_buybacks` renders a "Gold Spent" column
+  using a net-worth formula (`cost = 200 + net_worth // 13`). What is missing is
+  (a) the cost as real `ParsedMatch` data rather than a view-layer computation,
+  and (b) the reliable-vs-unreliable split. `ParsedPlayer.buyback_log` currently
+  holds raw `CombatLogEntry` objects with no cost field.
+- ⚠️ **Formula inconsistency to fix:** this note historically gave the formula as
+  `200 + net_worth / 12`, but the shipped report uses `200 + net_worth // 13`.
+  Centralize it in one helper and make note + code agree.
+- `m_vecDataTeam.{slot}.m_iReliableGold` / `m_iUnreliableGold` on
+  `CDOTADataRadiant/Dire` are readable, but reflect **remaining gold after** the
+  buyback deduction — not the cost paid.
+- `CDOTAUserMsg_SendFinalGold` provides per-player reliable/unreliable gold at game
+  end only — not per buyback event. (Proto is present in `src/gem/proto/` but the
+  parser does not consume it today.)
 - The buyback cost is not stored directly in the entity stream.
 
-**Approaches to explore when revisiting:**
-1. Event-driven sampling: hook the BUYBACK combat log entry and snapshot gold immediately before
-   it fires (requires sampling outside the periodic `_maybe_sample()` loop).
-2. Formula approximation: `cost ≈ 200 + net_worth / 12` (capped ~2100 in Dota 7.x). Net worth
-   at buyback tick is available from the nearest `PlayerStateSnapshot`.
+**Approaches to explore when revisiting (see #119 for the full scoping):**
+1. Formula approximation (cheap, total only): promote the existing report formula
+   into a `results/derived.py` helper + a model field; net worth at the buyback
+   tick comes from the nearest `PlayerStateSnapshot`. Cannot produce the split.
+2. Event-driven sampling (exact, needed for the split): hook the BUYBACK combat-log
+   entry and snapshot `m_iReliableGold`/`m_iUnreliableGold` immediately before vs
+   after it fires (requires sampling outside the periodic `_maybe_sample()` loop);
+   the before-minus-after delta per pool is the exact amount paid.
 
-**Files to change:** `extractors/_snapshots.py`, `extractors/players.py`,
-`results/models.py`, `results/assembly.py`, `reports/_sections.py`.
+**Files to change:** `results/models.py`, `results/assembly.py`,
+`results/derived.py` (formula helper), `reports/sections/economy.py`; plus
+`extractors/_snapshots.py` / `extractors/players.py` for Approach 2 only.
 
 ## Code Style
 
@@ -362,18 +383,22 @@ Key message classes used throughout the parser:
 
 ## Status
 
-Current version: **0.3.0** (see `pyproject.toml` and `CHANGELOG.md`).
+Current version: **0.4.2** (see `pyproject.toml` and `CHANGELOG.md`).
 
 The full parsing pipeline and all extractors are complete and stable: binary
 reader, entity system, combat log (S1+S2), string tables, every extractor, the
 `ParsedMatch` output model, DataFrame/JSON/Parquet export, bulk parsing, and
-replay fetch. Recent work is feature/data refreshes (neutral items, camp-zone
-annotations, Roshan conversion, OpenDota validation fixtures) rather than new
-core subsystems.
+replay fetch. Recent work (0.4.x) has been **OpenDota match-API parity** — final
+inventories, kill breakdowns, per-inflictor/per-target combat dicts, purchase
+timeline, building bitmasks, interval/advantage curves — plus code-quality
+refactors, rather than new core subsystems. `gem-dota` is published to PyPI.
 
 In flight / deferred:
-- **Distribution** — PyPI packaging + CI/CD (`gem-dota` on PyPI). 🚧
 - **Rust extension** (PyO3 + maturin) for a 3–5× speedup. Deferred.
+- **Buyback cost breakdown** (reliable/unreliable gold) — see the deferred
+  section above and issue #119.
+- Documented OpenDota-parity boundaries (replay vs Game-Coordinator data) tracked
+  in issues #67 / #68 / #93 — these are GC-only and exact only via API enrichment.
 
 `CHANGELOG.md` is the per-release record; consult it before assuming a feature's
 state rather than trusting a static table here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,16 +289,31 @@ net worth at the buyback tick; `reports/sections/economy.py::build_buybacks` rea
 `BuybackEvent.cost` instead of recomputing, and `results/dataframes.py` adds
 `cost`/`net_worth` columns to the `player_buyback_log` table.
 
-**The reliable/unreliable split is NOT provided — it is not recoverable offline.**
-Empirically verified (fixture `8855188139`): `m_iReliableGold` / `m_iUnreliableGold`
-on `CDOTA_Data*` (read via `team_data_field(slot, ...)`) are readable but reflect
-gold **after** the deduction, so the before/after delta at the BUYBACK tick is
-**zero** — no usable cost signal. `CDOTAUserMsg_SendFinalGold` is end-of-game only;
-`CMsgDotaScenario_Hero.GoldSpentOnBuybacks` is a cumulative per-hero scenario field
-(not per event, not parsed). OpenDota itself records no per-buyback cost
-(`handleBuyback` stores only time/slot), so there is no parity reference — the cost
-is a deliberate gem-original estimate. An exact split would require an external
-data source that does not exist per-event.
+**The exact per-buyback cost is not recoverable from the replay — confirmed
+against all three major parsers.** The `cost` is a deliberate gem-original
+*estimate* from the published formula, not a measured deduction:
+
+- **gem's entity stream:** `m_iReliableGold` / `m_iUnreliableGold` on `CDOTA_Data*`
+  (read via `team_data_field(slot, ...)`) are readable but reflect gold **after**
+  the deduction — the before/after delta at the BUYBACK tick is **zero** (verified
+  on fixture `8855188139`). The BUYBACK combat-log entry carries only the player
+  slot (`entry.value`), `gold_reason=0`, no gold amount.
+- **OpenDota:** records no per-buyback cost (`handleBuyback` stores only time/slot).
+- **STRATZ:** its GraphQL `BuyBackDetailType` *has* a `cost` field, but it is
+  **0 for every buyback** sampled (24 events across 3 matches: `8855188139`,
+  `8855242704`, `8822593932`) — i.e. even STRATZ (Clarity parser) does not surface
+  a real cost. `CDOTAUserMsg_SendFinalGold` is end-of-game only;
+  `CMsgDotaScenario_Hero.GoldSpentOnBuybacks` is a cumulative per-hero scenario
+  field (not per event, not parsed).
+
+Consequently the **reliable/unreliable split is also not provided** — it would
+require a per-event source that does not exist.
+
+**What IS validated:** buyback *detection* (event timing + hero attribution) is
+cross-validated against STRATZ — the buyback **times** and **hero IDs** match gem
+exactly on every event across those 3 matches (e.g. fixture `8855188139`: Ember
+@2385s, Keeper of the Light @2391s). Only the cost *value* is an unverifiable
+formula estimate; the events themselves are independently confirmed correct.
 
 ## Code Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,26 +270,27 @@ immediate-outcome window 180 s, event-association window 30 s. It reads only
 - Kills by summoned units (Warlock Golem, Undying zombie, Pugna Nether Ward, etc.) should be credited to the owning hero's kill count.
 - Deaths count all causes (hero, tower, creep, neutral, summon) — not just hero-dealt deaths.
 
-## Deferred: buyback cost breakdown (reliable vs unreliable gold)
+## Buyback cost (issue #119, implemented)
 
-The HTML report buybacks section shows only time/hero/team. Adding a reliable/unreliable gold
-cost breakdown was investigated but deferred. Key findings:
+Each player exposes `ParsedPlayer.buybacks: list[BuybackEvent]` (alongside the raw
+`buyback_log`). `BuybackEvent` carries `tick`, `player_slot`, `net_worth` (at the
+buyback tick), and an estimated `cost`. The cost formula lives in one place,
+`results/derived.py::buyback_cost(net_worth)` = **`200 + net_worth // 13`**
+(Dota 2's formula; reduced from `/12` in an earlier patch — ref
+https://liquipedia.net/dota2/Gold). `results/assembly.py` builds the events from
+net worth at the buyback tick; `reports/sections/economy.py::build_buybacks` reads
+`BuybackEvent.cost` instead of recomputing.
 
-- `m_vecDataTeam.{slot}.m_iReliableGold` / `m_iUnreliableGold` on `CDOTADataRadiant/Dire`
-  exist and are readable, but reflect **remaining gold after** the buyback deduction — not the
-  cost paid.
-- `CDOTAUserMsg_SendFinalGold` (type 514) provides per-player reliable/unreliable gold at game
-  end only — not per buyback event.
-- The buyback cost is not stored directly in the entity stream.
-
-**Approaches to explore when revisiting:**
-1. Event-driven sampling: hook the BUYBACK combat log entry and snapshot gold immediately before
-   it fires (requires sampling outside the periodic `_maybe_sample()` loop).
-2. Formula approximation: `cost ≈ 200 + net_worth / 12` (capped ~2100 in Dota 7.x). Net worth
-   at buyback tick is available from the nearest `PlayerStateSnapshot`.
-
-**Files to change:** `extractors/_snapshots.py`, `extractors/players.py`,
-`results/models.py`, `results/assembly.py`, `reports/_sections.py`.
+**The reliable/unreliable split is NOT provided — it is not recoverable offline.**
+Empirically verified (fixture `8855188139`): `m_iReliableGold` / `m_iUnreliableGold`
+on `CDOTA_Data*` (read via `team_data_field(slot, ...)`) are readable but reflect
+gold **after** the deduction, so the before/after delta at the BUYBACK tick is
+**zero** — no usable cost signal. `CDOTAUserMsg_SendFinalGold` is end-of-game only;
+`CMsgDotaScenario_Hero.GoldSpentOnBuybacks` is a cumulative per-hero scenario field
+(not per event, not parsed). OpenDota itself records no per-buyback cost
+(`handleBuyback` stores only time/slot), so there is no parity reference — the cost
+is a deliberate gem-original estimate. An exact split would require an external
+data source that does not exist per-event.
 
 ## Code Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,15 +386,16 @@ Key message classes used throughout the parser:
 
 ## Status
 
-Current version: **0.4.2** (see `pyproject.toml` and `CHANGELOG.md`).
+Current version: **0.4.3** (see `pyproject.toml` and `CHANGELOG.md`).
 
 The full parsing pipeline and all extractors are complete and stable: binary
 reader, entity system, combat log (S1+S2), string tables, every extractor, the
 `ParsedMatch` output model, DataFrame/JSON/Parquet export, bulk parsing, and
 replay fetch. Recent work (0.4.x) has been **OpenDota match-API parity** — final
 inventories, kill breakdowns, per-inflictor/per-target combat dicts, purchase
-timeline, building bitmasks, interval/advantage curves — plus code-quality
-refactors, rather than new core subsystems. `gem-dota` is published to PyPI.
+timeline, building bitmasks, interval/advantage curves — plus small additive
+refinements (e.g. `ParsedPlayer.buybacks` in 0.4.3) and code-quality refactors,
+rather than new core subsystems. `gem-dota` is published to PyPI.
 
 In flight / deferred:
 - **Rust extension** (PyO3 + maturin) for a 3–5× speedup. Deferred.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gem-dota"
-version = "0.4.2"
+version = "0.4.3"
 description = "Dota 2 Source 2 replay parser for data science and ML workflows"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/gem/api.py
+++ b/src/gem/api.py
@@ -109,6 +109,7 @@ from gem.replays.fetch import (
     fetch_replay_url,
 )
 from gem.results.models import (
+    BuybackEvent,
     ChatEntry,
     NeutralItemFoundEvent,
     ParsedMatch,
@@ -335,6 +336,7 @@ __all__ = [
     "OpenDotaTeamfightPlayer",
     "ChatEntry",
     "NeutralItemFoundEvent",
+    "BuybackEvent",
     "find_player",
     "hero_npc_name",
     "position_at_tick",

--- a/src/gem/api.py
+++ b/src/gem/api.py
@@ -145,6 +145,7 @@ def parse(path: str | Path) -> ParsedMatch:
     from gem.extractors.intervals import IntervalExtractor
     from gem.extractors.objectives import ObjectivesExtractor
     from gem.extractors.players import PlayerExtractor
+    from gem.extractors.smoke_vision import SmokeExtractor, VisionModifierExtractor
     from gem.extractors.wards import WardsExtractor
     from gem.parser import ReplayParser
     from gem.results.assembly import build_parsed_match
@@ -176,122 +177,20 @@ def parse(path: str | Path) -> ParsedMatch:
     neutral_item_finds: list[NeutralItemFoundEvent] = []
     p.on_neutral_item_found(neutral_item_finds.append)
 
-    # Smoke of Deceit collection — three combat log event types.
-    # Position is captured live at MODIFIER_ADD time (when each hero actually
-    # receives the buff) and averaged to give the group centroid.
-    # Logic for SmokeEvent collection (item consumption + modifier arrival)
-    from gem.results.models import (
-        SmokeEvent as _SmokeEvent,
-        VisionModifierEvent as _VisionModifierEvent,
-    )
-
-    # Vision modifier tracking — modifiers that reveal/grant vision of enemy heroes.
-    # MODIFIER_ADD opens an event (end_tick=None); MODIFIER_REMOVE closes it.
-    # The same hero can have the same modifier applied multiple times (e.g. refreshed
-    # Dust), so we key by (modifier_name, target_name) and handle stacking by
-    # maintaining a list (LIFO: remove closes the most recently opened open event).
-    _VISION_MODIFIER_NAMES: frozenset[str] = frozenset(
-        {
-            # Slardar — Corrosive Haze (ultimate): true sight of target
-            "modifier_slardar_amplify_damage",
-            # Bounty Hunter — Track: true sight + gold bounty
-            "modifier_bounty_hunter_track",
-            # Dust of Appearance — item AoE reveal
-            "modifier_item_dustofappearance",
-            # Gem of True Sight — carrier aura (hero-level modifier on target)
-            "modifier_item_gem_of_true_sight",
-            "modifier_gem_active_truesight",
-            # Oracle — False Promise: not a reveal but often comboed; skip
-            # Zeus — Thundergods Wrath: global, not a per-hero modifier; skip
-        }
-    )
-    vision_modifier_events: list[_VisionModifierEvent] = []
-    # Track open (not-yet-closed) events: (modifier_name, target_name) → stack of events
-    _open_vision_mods: dict[tuple[str, str], list[_VisionModifierEvent]] = {}
-
-    def _on_vision_modifier_entry(entry: CombatLogEntry) -> None:
-        if entry.log_type == "MODIFIER_ADD":
-            mod = entry.inflictor_name
-            if mod not in _VISION_MODIFIER_NAMES:
-                return
-            ev = _VisionModifierEvent(
-                tick=entry.tick,
-                end_tick=None,
-                modifier_name=mod,
-                target_name=entry.target_name,
-                caster_name=entry.attacker_name,
-                caster_team=0,  # back-filled after parse
-            )
-            vision_modifier_events.append(ev)
-            key = (mod, entry.target_name)
-            if key not in _open_vision_mods:
-                _open_vision_mods[key] = []
-            _open_vision_mods[key].append(ev)
-        elif entry.log_type == "MODIFIER_REMOVE":
-            mod = entry.inflictor_name
-            if mod not in _VISION_MODIFIER_NAMES:
-                return
-            key = (mod, entry.target_name)
-            stack = _open_vision_mods.get(key)
-            if stack:
-                stack.pop().end_tick = entry.tick
-                if not stack:
-                    del _open_vision_mods[key]
-
-    p.on_combat_log_entry(_on_vision_modifier_entry)
-
-    _pending_smokes: dict[str, _SmokeEvent] = {}  # activator npc → active event
-    # Per-event accumulated positions: activator npc → list of (x, y) live coords
-    _smoke_positions: dict[str, list[tuple[float, float]]] = {}
-    smoke_events: list[_SmokeEvent] = []
-
-    def _on_smoke_entry(entry: CombatLogEntry) -> None:
-        if entry.log_type == "ITEM" and entry.inflictor_name == "item_smoke_of_deceit":
-            new_ev = _SmokeEvent(tick=entry.tick, activator=entry.attacker_name, team=0)
-            _pending_smokes[entry.attacker_name] = new_ev
-            _smoke_positions[entry.attacker_name] = []
-            smoke_events.append(new_ev)
-        elif (
-            entry.log_type == "MODIFIER_ADD"
-            and entry.inflictor_name == "modifier_smoke_of_deceit"
-            and entry.target_is_hero
-        ):
-            pending_ev = _pending_smokes.get(entry.attacker_name)
-            if pending_ev is not None:
-                pending_ev.smoked.append(entry.target_name)
-                # Capture this hero's live position right now
-                pos = player_ext.hero_pos(entry.target_name)
-                if pos is not None:
-                    _smoke_positions[entry.attacker_name].append(pos)
-        elif (
-            entry.log_type == "MODIFIER_REMOVE"
-            and entry.inflictor_name == "modifier_smoke_of_deceit"
-            and entry.target_is_hero
-        ):
-            pending_ev = _pending_smokes.get(entry.attacker_name)
-            if pending_ev is not None and len(pending_ev.smoked) >= 1:
-                _pending_smokes.pop(entry.attacker_name, None)
-
-    p.on_combat_log_entry(_on_smoke_entry)
+    # Smoke of Deceit and vision-granting modifiers are collected by dedicated
+    # extractors (positions captured live at MODIFIER_ADD time; teams/centroids
+    # back-filled from player snapshots in finalize() after parse). Both depend
+    # on player_ext for hero positions and the NPC → team map.
+    smoke_ext = SmokeExtractor(player_ext)
+    vision_mod_ext = VisionModifierExtractor(player_ext)
+    smoke_ext.attach(p)
+    vision_mod_ext.attach(p)
 
     p.parse()
     draft_ext.finalize()
     ward_ext.finalize()
-
-    # Back-fill team; centroid x/y already collected live during MODIFIER_ADD
-    _team_by_npc: dict[str, int] = {
-        snap.npc_name: snap.team for snap in player_ext.snapshots if snap.team
-    }
-
-    for ev in smoke_events:
-        ev.team = _team_by_npc.get(ev.activator, 0)
-        positions = _smoke_positions.get(ev.activator, [])
-        if positions:
-            ev.x = sum(p[0] for p in positions) / len(positions)
-            ev.y = sum(p[1] for p in positions) / len(positions)
-
-    for vev in vision_modifier_events:
-        vev.caster_team = _team_by_npc.get(vev.caster_name, 0)
+    smoke_events = smoke_ext.finalize()
+    vision_modifier_events = vision_mod_ext.finalize()
 
     return build_parsed_match(
         parser=p,

--- a/src/gem/extractors/smoke_vision.py
+++ b/src/gem/extractors/smoke_vision.py
@@ -1,0 +1,232 @@
+"""Smoke of Deceit and vision-modifier extractors for Dota 2 replays.
+
+These two extractors were previously inline closures in ``gem.api.parse``.
+They follow the same ``attach()`` / ``finalize()`` contract as the other
+extractors (``objectives.py``, ``wards.py``): ``attach`` registers combat-log
+callbacks on the parser, and ``finalize`` (called after ``parser.parse()``)
+back-fills team numbers from the :class:`PlayerExtractor` snapshots and returns
+the collected events.
+
+``SmokeExtractor`` takes a :class:`PlayerExtractor` because it needs live hero
+positions (``hero_pos``) at modifier-arrival time and the NPC-name → team map
+for the post-parse back-fill — the same dependency pattern as
+``gem.combat.aggregator._CombatAggregator``.
+
+Smoke edge case (documented in CLAUDE.md, not a bug): the ``ITEM`` event fires
+when the item is consumed; one ``MODIFIER_ADD`` fires per hero that receives the
+buff. If the smoke breaks instantly (the activator stands inside a sentry's
+truesight at activation), no ``MODIFIER_ADD`` follows and the group is empty —
+this is correct game behaviour (the item was wasted), so the event is kept with
+an empty ``smoked`` list. ``MODIFIER_ADD`` is filtered by ``target_is_hero`` to
+exclude summoned units (e.g. Beastmaster boars) from the group.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from gem.combat.log import CombatLogEntry
+from gem.results.models import SmokeEvent, VisionModifierEvent
+
+if TYPE_CHECKING:
+    from gem.extractors.players import PlayerExtractor
+    from gem.parser import ReplayParser
+
+# Modifiers that reveal / grant vision of enemy heroes. Kept here (rather than
+# in the catalog) because the set is small and specific to this extractor.
+VISION_MODIFIER_NAMES: frozenset[str] = frozenset(
+    {
+        # Slardar — Corrosive Haze (ultimate): true sight of target
+        "modifier_slardar_amplify_damage",
+        # Bounty Hunter — Track: true sight + gold bounty
+        "modifier_bounty_hunter_track",
+        # Dust of Appearance — item AoE reveal
+        "modifier_item_dustofappearance",
+        # Gem of True Sight — carrier aura (hero-level modifier on target)
+        "modifier_item_gem_of_true_sight",
+        "modifier_gem_active_truesight",
+        # Oracle — False Promise: not a reveal but often comboed; skip
+        # Zeus — Thundergods Wrath: global, not a per-hero modifier; skip
+    }
+)
+
+_SMOKE_ITEM = "item_smoke_of_deceit"
+_SMOKE_MODIFIER = "modifier_smoke_of_deceit"
+
+
+class VisionModifierExtractor:
+    """Collects vision-granting modifier windows (Slardar ulti, Track, Dust, Gem).
+
+    ``MODIFIER_ADD`` opens an event (``end_tick=None``); ``MODIFIER_REMOVE``
+    closes the most recently opened matching event. The same hero can have the
+    same modifier applied multiple times (e.g. refreshed Dust), so open events
+    are keyed by ``(modifier_name, target_name)`` and stacked LIFO.
+
+    Attach to a ``ReplayParser`` before calling ``parse()``, then call
+    ``finalize()`` to back-fill caster teams and get the events:
+
+    Example:
+        >>> ext = VisionModifierExtractor(player_ext)
+        >>> ext.attach(parser)
+        >>> parser.parse()
+        >>> events = ext.finalize()
+
+    Attributes:
+        events: All vision-modifier events in chronological open order.
+    """
+
+    events: list[VisionModifierEvent]
+
+    def __init__(self, player_ext: PlayerExtractor) -> None:
+        """Initialize the extractor.
+
+        Args:
+            player_ext: Attached ``PlayerExtractor``, used to map caster NPC
+                names to team numbers during ``finalize``.
+        """
+        self._player_ext = player_ext
+        self.events = []
+        # (modifier_name, target_name) → stack of not-yet-closed events.
+        self._open: dict[tuple[str, str], list[VisionModifierEvent]] = {}
+
+    def attach(self, parser: ReplayParser) -> None:
+        """Register the combat-log callback with the parser.
+
+        Args:
+            parser: The ``ReplayParser`` instance to attach to.
+        """
+        parser.on_combat_log_entry(self._on_entry)
+
+    def _on_entry(self, entry: CombatLogEntry) -> None:
+        mod = entry.inflictor_name
+        if mod not in VISION_MODIFIER_NAMES:
+            return
+        if entry.log_type == "MODIFIER_ADD":
+            ev = VisionModifierEvent(
+                tick=entry.tick,
+                end_tick=None,
+                modifier_name=mod,
+                target_name=entry.target_name,
+                caster_name=entry.attacker_name,
+                caster_team=0,  # back-filled in finalize()
+            )
+            self.events.append(ev)
+            self._open.setdefault((mod, entry.target_name), []).append(ev)
+        elif entry.log_type == "MODIFIER_REMOVE":
+            key = (mod, entry.target_name)
+            stack = self._open.get(key)
+            if stack:
+                stack.pop().end_tick = entry.tick
+                if not stack:
+                    del self._open[key]
+
+    def finalize(self) -> list[VisionModifierEvent]:
+        """Back-fill caster teams from player snapshots and return the events.
+
+        Call after ``parser.parse()``.
+
+        Returns:
+            The collected vision-modifier events.
+        """
+        team_by_npc = _team_by_npc(self._player_ext)
+        for ev in self.events:
+            ev.caster_team = team_by_npc.get(ev.caster_name, 0)
+        return self.events
+
+
+class SmokeExtractor:
+    """Collects Smoke of Deceit activations with their smoked-hero groups.
+
+    The ``ITEM`` event (item consumed) opens a pending event keyed by the
+    activator's NPC name. Each subsequent ``MODIFIER_ADD`` on a hero target adds
+    that hero to the group and captures its live position; the activation
+    centroid is the mean of those positions. ``MODIFIER_REMOVE`` closes the
+    pending event once at least one hero was smoked.
+
+    Attach to a ``ReplayParser`` before calling ``parse()``, then call
+    ``finalize()`` to back-fill teams / centroids and get the events:
+
+    Example:
+        >>> ext = SmokeExtractor(player_ext)
+        >>> ext.attach(parser)
+        >>> parser.parse()
+        >>> events = ext.finalize()
+
+    Attributes:
+        events: All smoke activations in chronological order.
+    """
+
+    events: list[SmokeEvent]
+
+    def __init__(self, player_ext: PlayerExtractor) -> None:
+        """Initialize the extractor.
+
+        Args:
+            player_ext: Attached ``PlayerExtractor``, used for live hero
+                positions and the NPC-name → team map during ``finalize``.
+        """
+        self._player_ext = player_ext
+        self.events = []
+        # activator NPC → pending (not-yet-closed) event.
+        self._pending: dict[str, SmokeEvent] = {}
+        # activator NPC → live (x, y) positions captured at MODIFIER_ADD time.
+        self._positions: dict[str, list[tuple[float, float]]] = {}
+
+    def attach(self, parser: ReplayParser) -> None:
+        """Register the combat-log callback with the parser.
+
+        Args:
+            parser: The ``ReplayParser`` instance to attach to.
+        """
+        parser.on_combat_log_entry(self._on_entry)
+
+    def _on_entry(self, entry: CombatLogEntry) -> None:
+        if entry.log_type == "ITEM" and entry.inflictor_name == _SMOKE_ITEM:
+            ev = SmokeEvent(tick=entry.tick, activator=entry.attacker_name, team=0)
+            self._pending[entry.attacker_name] = ev
+            self._positions[entry.attacker_name] = []
+            self.events.append(ev)
+        elif (
+            entry.log_type == "MODIFIER_ADD"
+            and entry.inflictor_name == _SMOKE_MODIFIER
+            and entry.target_is_hero
+        ):
+            pending = self._pending.get(entry.attacker_name)
+            if pending is not None:
+                pending.smoked.append(entry.target_name)
+                # Capture this hero's live position at buff-arrival time.
+                pos = self._player_ext.hero_pos(entry.target_name)
+                if pos is not None:
+                    self._positions[entry.attacker_name].append(pos)
+        elif (
+            entry.log_type == "MODIFIER_REMOVE"
+            and entry.inflictor_name == _SMOKE_MODIFIER
+            and entry.target_is_hero
+        ):
+            pending = self._pending.get(entry.attacker_name)
+            if pending is not None and len(pending.smoked) >= 1:
+                self._pending.pop(entry.attacker_name, None)
+
+    def finalize(self) -> list[SmokeEvent]:
+        """Back-fill team + centroid from player snapshots and return the events.
+
+        Call after ``parser.parse()``. The centroid (x, y) is the mean of the
+        live positions captured at each hero's ``MODIFIER_ADD``; an empty group
+        leaves the position ``None``.
+
+        Returns:
+            The collected smoke events.
+        """
+        team_by_npc = _team_by_npc(self._player_ext)
+        for ev in self.events:
+            ev.team = team_by_npc.get(ev.activator, 0)
+            positions = self._positions.get(ev.activator, [])
+            if positions:
+                ev.x = sum(p[0] for p in positions) / len(positions)
+                ev.y = sum(p[1] for p in positions) / len(positions)
+        return self.events
+
+
+def _team_by_npc(player_ext: PlayerExtractor) -> dict[str, int]:
+    """Build an NPC-name → team map from player snapshots (non-zero teams only)."""
+    return {snap.npc_name: snap.team for snap in player_ext.snapshots if snap.team}

--- a/src/gem/reports/sections/economy.py
+++ b/src/gem/reports/sections/economy.py
@@ -625,7 +625,7 @@ def _net_worth_at(pp: ParsedPlayer, tick: int) -> int:
 
 def build_buybacks(match: ParsedMatch) -> str:
     """Build the buybacks section."""
-    total = sum(len(p.buyback_log) for p in match.players)
+    total = sum(len(p.buybacks) for p in match.players)
 
     parts = [
         '<div class="card">',
@@ -642,12 +642,12 @@ def build_buybacks(match: ParsedMatch) -> str:
             "<thead><tr><th>Time</th><th>Hero</th><th>Team</th><th>Gold Spent</th></tr></thead>"
         )
         parts.append("<tbody>")
+        # Cost comes from the model's BuybackEvent (gem.results.derived.buyback_cost),
+        # not recomputed here, so the table matches ParsedPlayer.buybacks exactly.
         entries: list[tuple[int, str, int, int]] = []
         for pp in match.players:
-            for entry in pp.buyback_log:
-                nw = _net_worth_at(pp, entry.tick)
-                cost = 200 + nw // 13
-                entries.append((entry.tick, pp.hero_name, pp.team, cost))
+            for bb in pp.buybacks:
+                entries.append((bb.tick, pp.hero_name, pp.team, bb.cost))
         entries.sort(key=lambda x: x[0])
         for tick, hero_name, team, cost in entries:
             team_color = TEAM_COLOR_CSS.get(team, "#888")

--- a/src/gem/reports/sections/economy.py
+++ b/src/gem/reports/sections/economy.py
@@ -33,6 +33,7 @@ from gem.reports.sections._shared import (
     _DIRE_COLORS,
     _RADIANT_COLORS,
 )
+from gem.results.derived import buyback_cost
 from gem.results.models import (
     ParsedMatch,
     ParsedPlayer,
@@ -625,7 +626,11 @@ def _net_worth_at(pp: ParsedPlayer, tick: int) -> int:
 
 def build_buybacks(match: ParsedMatch) -> str:
     """Build the buybacks section."""
-    total = sum(len(p.buybacks) for p in match.players)
+    # buyback_log is the canonical "a buyback happened" record; buybacks carries
+    # the cost. Count from buyback_log so a recorded buyback is never hidden when
+    # buybacks is unset (manually-assembled / older-serialized matches), matching
+    # build_dataframes' handling.
+    total = sum(len(p.buyback_log) for p in match.players)
 
     parts = [
         '<div class="card">',
@@ -642,12 +647,17 @@ def build_buybacks(match: ParsedMatch) -> str:
             "<thead><tr><th>Time</th><th>Hero</th><th>Team</th><th>Gold Spent</th></tr></thead>"
         )
         parts.append("<tbody>")
-        # Cost comes from the model's BuybackEvent (gem.results.derived.buyback_cost),
-        # not recomputed here, so the table matches ParsedPlayer.buybacks exactly.
+        # Iterate buyback_log (source of truth) and take cost from the aligned
+        # BuybackEvent when present; otherwise fall back to the formula so the row
+        # is still shown with a sensible cost.
         entries: list[tuple[int, str, int, int]] = []
         for pp in match.players:
-            for bb in pp.buybacks:
-                entries.append((bb.tick, pp.hero_name, pp.team, bb.cost))
+            for i, entry in enumerate(pp.buyback_log):
+                if i < len(pp.buybacks):
+                    cost = pp.buybacks[i].cost
+                else:
+                    cost = buyback_cost(_net_worth_at(pp, entry.tick))
+                entries.append((entry.tick, pp.hero_name, pp.team, cost))
         entries.sort(key=lambda x: x[0])
         for tick, hero_name, team, cost in entries:
             team_color = TEAM_COLOR_CSS.get(team, "#888")

--- a/src/gem/reports/sections/vision.py
+++ b/src/gem/reports/sections/vision.py
@@ -103,8 +103,6 @@ def build_wards(match: ParsedMatch, map_b64: str | None) -> str:
             }
         )
 
-    wards_js = json.dumps(ward_data)
-
     _SMOKE_SHOW_TICKS = 300
     smoke_data = []
     for s in match.smoke_events:
@@ -127,9 +125,26 @@ def build_wards(match: ParsedMatch, map_b64: str | None) -> str:
                 "seen": seen_by_enemy,
             }
         )
-    smokes_js = json.dumps(smoke_data)
-
-    img_src_js = "window._GEM_MAP_SRC||''" if map_b64 else "''"
+    # Bundle every value that crosses the Python -> JS boundary into a single
+    # inert ``<script type="application/json">`` config tag (mirrors the cleaner
+    # ``build_farming`` pattern in this file). The executable ``<script>`` below
+    # reads this tag via ``JSON.parse`` instead of having data interpolated into
+    # it, so its body stays a plain string with natural single braces.
+    ward_config = {
+        "wards": ward_data,
+        "smokes": smoke_data,
+        "gameStartTick": match.game_start_tick or 0,
+        "sliderMin": slider_min,
+        "sliderMax": slider_max,
+        "worldWidth": _XMAX - _XMIN,
+        "hasMap": bool(map_b64),
+        "iconObs": ITEM_ICON_B64.get("ward_observer", ""),
+        "iconSen": ITEM_ICON_B64.get("ward_sentry", ""),
+        "iconSmoke": ITEM_ICON_B64.get("smoke_of_deceit", ""),
+    }
+    # ``</`` is escaped so a stray ``</script>`` substring in the data cannot
+    # close the data tag early (defensive; base64/JSON values won't contain it).
+    ward_config_js = json.dumps(ward_config).replace("</", "<\\/")
 
     canvas_html = f"""
 <div style="display:flex;gap:16px;align-items:flex-start;flex-wrap:wrap;margin-bottom:16px">
@@ -175,18 +190,23 @@ def build_wards(match: ParsedMatch, map_b64: str | None) -> str:
     </p>
   </div>
 </div>
+<script type="application/json" id="ward-data">{ward_config_js}</script>
+"""
+
+    ward_script = """
 <script>
-(function() {{
-  var wards = {wards_js};
-  var smokes = {smokes_js};
-var imgSrc = {img_src_js};
-  var iconObsSrc = {json.dumps(ITEM_ICON_B64.get("ward_observer", ""))};
-  var iconSenSrc = {json.dumps(ITEM_ICON_B64.get("ward_sentry", ""))};
-  var iconSmokeSrc = {json.dumps(ITEM_ICON_B64.get("smoke_of_deceit", ""))};
-  var gameStartTick = {match.game_start_tick or 0};
-  var sliderMin = {slider_min};
-  var sliderMax = {slider_max};
-  var WORLD_WIDTH = {_XMAX - _XMIN};
+(function() {
+  var cfg = JSON.parse(document.getElementById('ward-data').textContent || '{}');
+  var wards = cfg.wards || [];
+  var smokes = cfg.smokes || [];
+  var imgSrc = cfg.hasMap ? (window._GEM_MAP_SRC || '') : '';
+  var iconObsSrc = cfg.iconObs || '';
+  var iconSenSrc = cfg.iconSen || '';
+  var iconSmokeSrc = cfg.iconSmoke || '';
+  var gameStartTick = cfg.gameStartTick || 0;
+  var sliderMin = cfg.sliderMin || 0;
+  var sliderMax = cfg.sliderMax || 0;
+  var WORLD_WIDTH = cfg.worldWidth;
   var OBS_VISION_RADIUS = 1600;
   var SEN_TRUESIGHT_RADIUS = 1050;
   var canvas = document.getElementById('wardCanvas');
@@ -202,43 +222,43 @@ var speedSel = document.getElementById('wardSpeed');
   var lastTs = null;
 
   var mapImg = new Image();
-  mapImg.onload = function() {{ draw(currentTick); }};
-  if (imgSrc) {{ mapImg.src = imgSrc; }}
+  mapImg.onload = function() { draw(currentTick); };
+  if (imgSrc) { mapImg.src = imgSrc; }
 
-  function _makeIcon(src) {{
+  function _makeIcon(src) {
     var img = new Image();
     if (src) img.src = src;
     return img;
-  }}
+  }
   var iconObs = _makeIcon(iconObsSrc);
   var iconSen = _makeIcon(iconSenSrc);
   var iconSmoke = _makeIcon(iconSmokeSrc);
 
-  function fmtTick(tick) {{
+  function fmtTick(tick) {
     var rel = tick - gameStartTick;
     var neg = rel < 0;
     var secs = Math.floor(Math.abs(rel) / 30);
     var m = Math.floor(secs / 60), s = secs % 60;
     var t = (m < 10 ? '0' : '') + m + ':' + (s < 10 ? '0' : '') + s;
     return neg ? '-' + t : t;
-  }}
+  }
 
-  function draw(tick) {{
+  function draw(tick) {
     ctx.clearRect(0, 0, W, H);
 
-    if (mapImg.complete && mapImg.naturalWidth > 0) {{
+    if (mapImg.complete && mapImg.naturalWidth > 0) {
       ctx.drawImage(mapImg, 0, 0, W, H);
-    }} else {{
+    } else {
       ctx.fillStyle = '#1a2a1a';
       ctx.fillRect(0, 0, W, H);
-    }}
+    }
 
 
-    function drawIcon(img, cx, cy, size, borderColor, alpha) {{
+    function drawIcon(img, cx, cy, size, borderColor, alpha) {
       var half = size / 2;
       ctx.save();
       ctx.globalAlpha = alpha !== undefined ? alpha : 1.0;
-      if (img && img.complete && img.naturalWidth > 0) {{
+      if (img && img.complete && img.naturalWidth > 0) {
         ctx.beginPath();
         ctx.roundRect(cx - half, cy - half, size, size, 3);
         ctx.clip();
@@ -251,16 +271,16 @@ var speedSel = document.getElementById('wardSpeed');
         ctx.lineWidth = 2;
         ctx.strokeStyle = borderColor;
         ctx.stroke();
-      }} else {{
+      } else {
         ctx.beginPath();
         ctx.arc(cx, cy, half, 0, 2 * Math.PI);
         ctx.fillStyle = borderColor;
         ctx.fill();
-      }}
+      }
       ctx.restore();
-    }}
+    }
 
-    for (var i = 0; i < wards.length; i++) {{
+    for (var i = 0; i < wards.length; i++) {
       var w = wards[i];
       if (tick < w.placed) continue;
       if (w.removed !== null && tick > w.removed) continue;
@@ -284,9 +304,9 @@ var speedSel = document.getElementById('wardSpeed');
       ctx.restore();
 
       drawIcon(icon, cx, cy, isObs ? 18 : 16, borderColor);
-    }}
+    }
 
-    for (var i = 0; i < smokes.length; i++) {{
+    for (var i = 0; i < smokes.length; i++) {
       var s = smokes[i];
       if (tick < s.tick || tick > s.end_tick) continue;
 
@@ -309,51 +329,51 @@ var speedSel = document.getElementById('wardSpeed');
       ctx.textBaseline = 'middle';
       ctx.fillText(s.count, cx + 8, cy - 8);
       ctx.restore();
-    }}
-  }}
+    }
+  }
 
-  function setTick(tick) {{
+  function setTick(tick) {
     currentTick = Math.max(sliderMin, Math.min(sliderMax, tick));
     slider.value = currentTick;
     timeLabel.textContent = fmtTick(currentTick);
     draw(currentTick);
-  }}
+  }
 
-  function animFrame(ts) {{
+  function animFrame(ts) {
     if (!playing) return;
-    if (lastTs !== null) {{
+    if (lastTs !== null) {
       var speed = parseInt(speedSel.value) || 5;
       var delta = (ts - lastTs) * speed * 30 / 1000;
       currentTick = Math.min(sliderMax, currentTick + delta);
       slider.value = currentTick;
       timeLabel.textContent = fmtTick(Math.floor(currentTick));
       draw(Math.floor(currentTick));
-      if (currentTick >= sliderMax) {{
+      if (currentTick >= sliderMax) {
         playing = false;
         playBtn.textContent = '\u25b6';
         lastTs = null;
         return;
-      }}
-    }}
+      }
+    }
     lastTs = ts;
     requestAnimationFrame(animFrame);
-  }}
+  }
 
-  playBtn.addEventListener('click', function() {{
-    if (playing) {{
+  playBtn.addEventListener('click', function() {
+    if (playing) {
       playing = false;
       lastTs = null;
       playBtn.textContent = '\u25b6';
-    }} else {{
+    } else {
       if (currentTick >= sliderMax) setTick(sliderMin);
       playing = true;
       playBtn.textContent = '\u23f8';
       lastTs = null;
       requestAnimationFrame(animFrame);
-    }}
-  }});
+    }
+  });
 
-  slider.addEventListener('input', function() {{
+  slider.addEventListener('input', function() {
     playing = false;
     lastTs = null;
     playBtn.textContent = '\u25b6';
@@ -361,31 +381,31 @@ var speedSel = document.getElementById('wardSpeed');
     timeLabel.textContent = fmtTick(currentTick);
     draw(currentTick);
     tooltip.innerHTML = '';
-  }});
+  });
 
-  canvas.addEventListener('mousemove', function(e) {{
+  canvas.addEventListener('mousemove', function(e) {
     var rect = canvas.getBoundingClientRect();
     var mx = (e.clientX - rect.left) * (W / rect.width);
     var my = (e.clientY - rect.top) * (H / rect.height);
     var hit = null, hitType = null, bestDist = 12;
 
-    for (var i = 0; i < wards.length; i++) {{
+    for (var i = 0; i < wards.length; i++) {
       var w = wards[i];
       if (currentTick < w.placed) continue;
       if (w.removed !== null && currentTick > w.removed) continue;
       var dx = w.fx * W - mx, dy = w.fy * H - my;
       var dist = Math.sqrt(dx * dx + dy * dy);
-      if (dist < bestDist) {{ bestDist = dist; hit = w; hitType = 'ward'; }}
-    }}
-    for (var i = 0; i < smokes.length; i++) {{
+      if (dist < bestDist) { bestDist = dist; hit = w; hitType = 'ward'; }
+    }
+    for (var i = 0; i < smokes.length; i++) {
       var s = smokes[i];
       if (currentTick < s.tick || currentTick > s.end_tick) continue;
       var dx = s.fx * W - mx, dy = s.fy * H - my;
       var dist = Math.sqrt(dx * dx + dy * dy);
-      if (dist < bestDist) {{ bestDist = dist; hit = s; hitType = 'smoke'; }}
-    }}
+      if (dist < bestDist) { bestDist = dist; hit = s; hitType = 'smoke'; }
+    }
 
-    if (hit && hitType === 'ward') {{
+    if (hit && hitType === 'ward') {
       var teamName = hit.team === 2 ? 'Radiant' : 'Dire';
       var teamColor = hit.team === 2 ? '#4caf50' : '#f44336';
       var fateStr = hit.fate === 'killed' ? '&#128308; Killed ' + hit.fate_time
@@ -397,7 +417,7 @@ var speedSel = document.getElementById('wardSpeed');
         'Placed: ' + hit.placed_fmt + ' by ' + hit.placer + '<br>' +
         fateStr;
       canvas.style.cursor = 'pointer';
-    }} else if (hit && hitType === 'smoke') {{
+    } else if (hit && hitType === 'smoke') {
       var teamName = hit.team === 2 ? 'Radiant' : 'Dire';
       var teamColor = hit.team === 2 ? '#4caf50' : '#f44336';
       var seenStr = hit.seen
@@ -410,15 +430,16 @@ var speedSel = document.getElementById('wardSpeed');
         hit.count + ' hero' + (hit.count !== 1 ? 'es' : '') + ' smoked<br>' +
         seenStr;
       canvas.style.cursor = 'pointer';
-    }} else {{
+    } else {
       tooltip.innerHTML = '';
       canvas.style.cursor = 'crosshair';
-    }}
-  }});
-}})();
+    }
+  });
+})();
 </script>"""
 
     parts.append(canvas_html)
+    parts.append(ward_script)
 
     parts.append(
         '<details style="margin-top:8px"><summary style="color:#8b949e;font-size:12px;cursor:pointer">Show full ward table</summary>'

--- a/src/gem/results/assembly.py
+++ b/src/gem/results/assembly.py
@@ -9,11 +9,12 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
+from gem.analysis import net_worth_at
 from gem.catalog import hero_id
 from gem.combat.log import opendota_translate
 from gem.extractors.lane import classify_lane
-from gem.results.derived import building_status, categorize_kills, killed_counts
-from gem.results.models import ParsedMatch
+from gem.results.derived import building_status, buyback_cost, categorize_kills, killed_counts
+from gem.results.models import BuybackEvent, ParsedMatch
 
 if TYPE_CHECKING:
     from gem.combat.aggregator import _CombatAggregator
@@ -658,6 +659,22 @@ def _populate_player_series(
             pp.sentry_uses = agg.item_uses.get("item_ward_sentry", 0)
             pp.runes_log = agg.runes_log
             pp.buyback_log = agg.buyback_log
+            # Structured buybacks with an estimated cost. The per-buyback cost is
+            # not in the replay stream, so it is derived from net worth at the
+            # buyback tick (200 + net_worth // 13); net_worth_t is already
+            # populated above, so net_worth_at() resolves the nearest sample.
+            buybacks: list[BuybackEvent] = []
+            for entry in agg.buyback_log:
+                nw = net_worth_at(pp, entry.tick)
+                buybacks.append(
+                    BuybackEvent(
+                        tick=entry.tick,
+                        player_slot=player_id,
+                        net_worth=nw,
+                        cost=buyback_cost(nw),
+                    )
+                )
+            pp.buybacks = buybacks
             pp.stuns_dealt = agg.stuns_dealt
             # OpenDota-style combat scalars (combat-log reconstruction; exact via
             # apply_api_rates). Best-effort offline estimates.

--- a/src/gem/results/assembly.py
+++ b/src/gem/results/assembly.py
@@ -530,123 +530,36 @@ def _interval_series_by_player(
     return series
 
 
-def build_parsed_match(
-    parser: ReplayParser,
+def _populate_player_series(
+    match: ParsedMatch,
+    *,
     player_ext: PlayerExtractor,
-    obj_ext: ObjectivesExtractor,
-    ward_ext: WardsExtractor,
-    courier_ext: CourierExtractor,
-    draft_ext: DraftExtractor,
     combat_agg: _CombatAggregator,
-    all_entries: list[CombatLogEntry],
-    chat_entries: list[ChatEntry],
-    smoke_events: list[SmokeEvent] | None = None,
-    vision_modifier_events: list[VisionModifierEvent] | None = None,
-    neutral_item_finds: list[NeutralItemFoundEvent] | None = None,
-    interval_ext: IntervalExtractor | None = None,
-) -> ParsedMatch:
-    """Assemble a :class:`ParsedMatch` from extractor state after a completed parse.
+    interval_ext: IntervalExtractor | None,
+    interval_min_series: dict[int, IntervalTimeSeries],
+    game_start_tick: int | None,
+    radiant_win: bool | None,
+) -> None:
+    """Populate per-player time series and combat-log aggregates in place.
 
-    Handles radiant_win resolution (three-tier), per-player time series wiring,
-    player name extraction, ward-to-player assignment, gold/XP advantage curves,
-    and teamfight detection.
+    Iterates the ten player slots and overlays each ``match.players[player_id]``
+    with its dense/minute time series, combat-log attribution, kill aggregates,
+    lane stats, terminal scalars, final inventory, and OpenDota-style computed
+    fields. Each iteration is independent (no cross-player state), so the loop is
+    a straight single-pass population of one ``ParsedPlayer`` per slot.
+
+    Extracted verbatim from ``build_parsed_match`` (issue #106 item #3) to keep
+    the orchestrator readable; behaviour is unchanged.
 
     Args:
-        parser: Completed :class:`ReplayParser` instance.
-        player_ext: Attached :class:`PlayerExtractor`.
-        obj_ext: Attached :class:`ObjectivesExtractor`.
-        ward_ext: Attached :class:`WardsExtractor`.
-        courier_ext: Attached :class:`CourierExtractor`.
-        draft_ext: Attached :class:`DraftExtractor` (already finalized).
-        combat_agg: Populated :class:`_CombatAggregator`.
-        all_entries: All :class:`CombatLogEntry` objects from the replay.
-        chat_entries: All :class:`ChatEntry` objects from the replay.
-        smoke_events: All :class:`SmokeEvent` objects collected during parse.
-        vision_modifier_events: All :class:`VisionModifierEvent` objects collected during parse.
-        neutral_item_finds: Neutral item found events collected during parse.
-        interval_ext: Optional internal interval extractor used for OpenDota-style
-            match-level gold/XP advantage curves.
-
-    Returns:
-        Fully populated :class:`ParsedMatch`.
+        match: The match being assembled; ``match.players`` is mutated in place.
+        player_ext: Source of per-player snapshots / time series / scoreboard.
+        combat_agg: Per-player combat-log aggregates.
+        interval_ext: OpenDota-style interval extractor (team counters, scalars).
+        interval_min_series: Complete interval minute arrays by player id.
+        game_start_tick: Horn tick used for the lane-window time filter.
+        radiant_win: Resolved match winner, or ``None`` if unknown.
     """
-    from gem.extractors.teamfights import detect_opendota_teamfights, detect_teamfights
-
-    # radiant_win resolution — three tiers in priority order:
-    #   1. CDemoFileInfo.game_winner (set during parse, empty for HLTV replays)
-    #   2. m_pGameRules.m_nGameWinner entity field (set post-parse in parser.py)
-    #   3. Ancient DEATH in combat log — no API needed
-    radiant_win = parser.radiant_win
-    if radiant_win is None:
-        radiant_win = _radiant_win_from_ancient(all_entries)
-
-    match = ParsedMatch(
-        match_id=parser.match_id,
-        game_mode=parser.game_mode,
-        leagueid=parser.leagueid,
-        radiant_win=radiant_win,
-        towers=obj_ext.tower_kills,
-        barracks=obj_ext.barracks_kills,
-        roshans=obj_ext.roshan_kills,
-        aegis_events=obj_ext.aegis_events,
-        tormentors=obj_ext.tormentor_kills,
-        shrines=obj_ext.shrine_kills,
-        wards=ward_ext.ward_events,
-        combat_log=all_entries,
-        chat=chat_entries,
-        courier_snapshots=courier_ext.snapshots,
-        neutral_item_finds=neutral_item_finds or [],
-        smoke_events=smoke_events or [],
-        vision_modifiers=vision_modifier_events or [],
-        draft=draft_ext.draft_events,
-        game_start_tick=parser.game_start_tick,
-        game_end_tick=parser.tick,
-        duration=getattr(parser, "duration_s", None) or 0,
-    )
-
-    # Post-process buybacks (7b).
-    # For BUYBACK entries, entry.value = player slot (0-9).
-    # Reference: refs/parser/src/main/java/opendota/CreateParsedDataBlob.java handleBuyback()
-    for entry in all_entries:
-        if entry.log_type != "BUYBACK":
-            continue
-        pid = entry.value
-        if 0 <= pid < 10:
-            combat_agg._agg(pid).buyback_log.append(entry)
-
-    # Capture game_start_tick once — used for lane_pos time filter below
-    game_start_tick = parser.game_start_tick
-    interval_min_series = _interval_series_by_player(interval_ext)
-
-    # first_blood_time: game-clock time of the earliest real hero DEATH. Illusion
-    # deaths and reincarnation triggers are excluded (target_is_hero stays true for
-    # an illusion, so the explicit not-illusion filter is required). The per-player
-    # firstblood_claimed flag is read separately from the authoritative
-    # CDOTA_PlayerResource field below, not reconstructed from this entry.
-    first_blood_entry = next(
-        (
-            e
-            for e in all_entries
-            if e.log_type == "DEATH"
-            and e.target_is_hero
-            and not e.target_is_illusion
-            and not e.will_reincarnate
-        ),
-        None,
-    )
-    if first_blood_entry is not None:
-        if first_blood_entry.game_time_s is not None:
-            match.first_blood_time = int(first_blood_entry.game_time_s)
-        elif game_start_tick is not None:
-            match.first_blood_time = max(0, (first_blood_entry.tick - game_start_tick) // 30)
-
-    # NOTE: pre_game_duration (horn → creep-spawn span, ~90s) is intentionally
-    # left at its default 0 here. It requires the GAME_IN_PROGRESS state-transition
-    # timestamp, which the parser does not yet expose separately from the clock
-    # anchor (m_flGameStartTime is the engine clock zero, not the pre-game span).
-    # Tracked as a follow-up rather than shipping a wrong value.
-
-    # Build per-player time series and overlay combat log aggregates
     for player_id in range(10):
         ts = player_ext.time_series(player_id)
         mts = player_ext.minute_time_series(player_id)
@@ -880,6 +793,134 @@ def build_parsed_match(
         _LANE_GOLD_BASELINE = 4948
         if pp.lane_total_gold > 0:
             pp.lane_efficiency_pct = int(pp.lane_total_gold / _LANE_GOLD_BASELINE * 100)
+
+
+def build_parsed_match(
+    parser: ReplayParser,
+    player_ext: PlayerExtractor,
+    obj_ext: ObjectivesExtractor,
+    ward_ext: WardsExtractor,
+    courier_ext: CourierExtractor,
+    draft_ext: DraftExtractor,
+    combat_agg: _CombatAggregator,
+    all_entries: list[CombatLogEntry],
+    chat_entries: list[ChatEntry],
+    smoke_events: list[SmokeEvent] | None = None,
+    vision_modifier_events: list[VisionModifierEvent] | None = None,
+    neutral_item_finds: list[NeutralItemFoundEvent] | None = None,
+    interval_ext: IntervalExtractor | None = None,
+) -> ParsedMatch:
+    """Assemble a :class:`ParsedMatch` from extractor state after a completed parse.
+
+    Handles radiant_win resolution (three-tier), per-player time series wiring,
+    player name extraction, ward-to-player assignment, gold/XP advantage curves,
+    and teamfight detection.
+
+    Args:
+        parser: Completed :class:`ReplayParser` instance.
+        player_ext: Attached :class:`PlayerExtractor`.
+        obj_ext: Attached :class:`ObjectivesExtractor`.
+        ward_ext: Attached :class:`WardsExtractor`.
+        courier_ext: Attached :class:`CourierExtractor`.
+        draft_ext: Attached :class:`DraftExtractor` (already finalized).
+        combat_agg: Populated :class:`_CombatAggregator`.
+        all_entries: All :class:`CombatLogEntry` objects from the replay.
+        chat_entries: All :class:`ChatEntry` objects from the replay.
+        smoke_events: All :class:`SmokeEvent` objects collected during parse.
+        vision_modifier_events: All :class:`VisionModifierEvent` objects collected during parse.
+        neutral_item_finds: Neutral item found events collected during parse.
+        interval_ext: Optional internal interval extractor used for OpenDota-style
+            match-level gold/XP advantage curves.
+
+    Returns:
+        Fully populated :class:`ParsedMatch`.
+    """
+    from gem.extractors.teamfights import detect_opendota_teamfights, detect_teamfights
+
+    # radiant_win resolution — three tiers in priority order:
+    #   1. CDemoFileInfo.game_winner (set during parse, empty for HLTV replays)
+    #   2. m_pGameRules.m_nGameWinner entity field (set post-parse in parser.py)
+    #   3. Ancient DEATH in combat log — no API needed
+    radiant_win = parser.radiant_win
+    if radiant_win is None:
+        radiant_win = _radiant_win_from_ancient(all_entries)
+
+    match = ParsedMatch(
+        match_id=parser.match_id,
+        game_mode=parser.game_mode,
+        leagueid=parser.leagueid,
+        radiant_win=radiant_win,
+        towers=obj_ext.tower_kills,
+        barracks=obj_ext.barracks_kills,
+        roshans=obj_ext.roshan_kills,
+        aegis_events=obj_ext.aegis_events,
+        tormentors=obj_ext.tormentor_kills,
+        shrines=obj_ext.shrine_kills,
+        wards=ward_ext.ward_events,
+        combat_log=all_entries,
+        chat=chat_entries,
+        courier_snapshots=courier_ext.snapshots,
+        neutral_item_finds=neutral_item_finds or [],
+        smoke_events=smoke_events or [],
+        vision_modifiers=vision_modifier_events or [],
+        draft=draft_ext.draft_events,
+        game_start_tick=parser.game_start_tick,
+        game_end_tick=parser.tick,
+        duration=getattr(parser, "duration_s", None) or 0,
+    )
+
+    # Post-process buybacks (7b).
+    # For BUYBACK entries, entry.value = player slot (0-9).
+    # Reference: refs/parser/src/main/java/opendota/CreateParsedDataBlob.java handleBuyback()
+    for entry in all_entries:
+        if entry.log_type != "BUYBACK":
+            continue
+        pid = entry.value
+        if 0 <= pid < 10:
+            combat_agg._agg(pid).buyback_log.append(entry)
+
+    # Capture game_start_tick once — used for lane_pos time filter below
+    game_start_tick = parser.game_start_tick
+    interval_min_series = _interval_series_by_player(interval_ext)
+
+    # first_blood_time: game-clock time of the earliest real hero DEATH. Illusion
+    # deaths and reincarnation triggers are excluded (target_is_hero stays true for
+    # an illusion, so the explicit not-illusion filter is required). The per-player
+    # firstblood_claimed flag is read separately from the authoritative
+    # CDOTA_PlayerResource field below, not reconstructed from this entry.
+    first_blood_entry = next(
+        (
+            e
+            for e in all_entries
+            if e.log_type == "DEATH"
+            and e.target_is_hero
+            and not e.target_is_illusion
+            and not e.will_reincarnate
+        ),
+        None,
+    )
+    if first_blood_entry is not None:
+        if first_blood_entry.game_time_s is not None:
+            match.first_blood_time = int(first_blood_entry.game_time_s)
+        elif game_start_tick is not None:
+            match.first_blood_time = max(0, (first_blood_entry.tick - game_start_tick) // 30)
+
+    # NOTE: pre_game_duration (horn → creep-spawn span, ~90s) is intentionally
+    # left at its default 0 here. It requires the GAME_IN_PROGRESS state-transition
+    # timestamp, which the parser does not yet expose separately from the clock
+    # anchor (m_flGameStartTime is the engine clock zero, not the pre-game span).
+    # Tracked as a follow-up rather than shipping a wrong value.
+
+    # Build per-player time series and overlay combat log aggregates.
+    _populate_player_series(
+        match,
+        player_ext=player_ext,
+        combat_agg=combat_agg,
+        interval_ext=interval_ext,
+        interval_min_series=interval_min_series,
+        game_start_tick=game_start_tick,
+        radiant_win=radiant_win,
+    )
 
     match_metadata = getattr(parser, "match_metadata", None)
     metadata = getattr(match_metadata, "metadata", None)

--- a/src/gem/results/dataframes.py
+++ b/src/gem/results/dataframes.py
@@ -180,9 +180,17 @@ def build_dataframes(match: ParsedMatch) -> dict[str, pd.DataFrame]:
             row["player_id"] = pp.player_id
             player_runes_rows.append(row)
 
-        for entry in pp.buyback_log:
+        # Buyback rows carry the estimated cost / net worth from the structured
+        # BuybackEvent (built 1:1 with buyback_log) so the DataFrame surfaces cost
+        # too. Iterate buyback_log (the source of truth that a buyback happened)
+        # and pull cost from the aligned BuybackEvent when present, so a row is
+        # never dropped if buybacks is unset.
+        for i, entry in enumerate(pp.buyback_log):
             row = _plain_row(entry)
             row["player_id"] = pp.player_id
+            bb = pp.buybacks[i] if i < len(pp.buybacks) else None
+            row["cost"] = bb.cost if bb is not None else None
+            row["net_worth"] = bb.net_worth if bb is not None else None
             player_buyback_rows.append(row)
 
     players_df = pd.DataFrame(player_rows)

--- a/src/gem/results/derived.py
+++ b/src/gem/results/derived.py
@@ -215,3 +215,31 @@ def building_status(tower_kills: list, barracks_kills: list) -> dict[str, int]:
         "barracks_status_radiant": _rax_mask(rad_rax),
         "barracks_status_dire": _rax_mask(dire_rax),
     }
+
+
+# Buyback cost formula. The Dota 2 cost is ``200 + net_worth / 13`` (reduced from
+# ``/12`` in an earlier patch). This is the canonical home for the formula so the
+# model and the HTML report compute the same value.
+# Reference: https://liquipedia.net/dota2/Gold (Buyback section).
+_BUYBACK_BASE_COST = 200
+_BUYBACK_NET_WORTH_DIVISOR = 13
+
+
+def buyback_cost(net_worth: int) -> int:
+    """Estimate the gold cost of a buyback from the player's net worth.
+
+    Uses the Dota 2 formula ``200 + net_worth // 13``. This is an approximation:
+    the per-buyback cost is not stored in the replay stream, and the exact
+    reliable/unreliable split is not recoverable from the entity gold-pool fields
+    (they reflect gold *after* the deduction). The cost is computed from net worth
+    at the buyback tick instead.
+
+    Args:
+        net_worth: The player's net worth at the buyback tick. Negative values are
+            clamped to 0.
+
+    Returns:
+        The estimated buyback cost in gold.
+    """
+    nw = max(0, net_worth)
+    return _BUYBACK_BASE_COST + nw // _BUYBACK_NET_WORTH_DIVISOR

--- a/src/gem/results/models.py
+++ b/src/gem/results/models.py
@@ -78,6 +78,34 @@ class SmokeEvent:
 
 
 @dataclass
+class BuybackEvent:
+    """One buyback, with its estimated gold cost.
+
+    The per-buyback cost is not stored in the replay stream, so ``cost`` is an
+    estimate from the Dota 2 formula ``200 + net_worth // 13`` evaluated at the
+    buyback tick (see :func:`gem.results.derived.buyback_cost`). The exact
+    reliable/unreliable gold split is *not* recoverable offline — the entity
+    gold-pool fields (``m_iReliableGold`` / ``m_iUnreliableGold``) reflect gold
+    after the deduction, so they show no usable before/after delta at the buyback
+    tick — and is therefore not provided.
+
+    The raw combat-log entries remain on ``ParsedPlayer.buyback_log``; this is the
+    structured, cost-bearing view alongside it.
+
+    Attributes:
+        tick: Game tick when the buyback fired.
+        player_slot: The player's slot (0-9).
+        cost: Estimated buyback cost in gold (``200 + net_worth // 13``).
+        net_worth: Net worth at the buyback tick used to compute ``cost``.
+    """
+
+    tick: int
+    player_slot: int
+    cost: int
+    net_worth: int
+
+
+@dataclass
 class ChatEntry:
     """A single chat message from the match.
 
@@ -235,6 +263,8 @@ class ParsedPlayer:
             still counted in the ``purchase`` map).
         runes_log: ITEM combat log entries for rune pickups.
         buyback_log: BUYBACK combat log entries for this player.
+        buybacks: Structured :class:`BuybackEvent` records with an estimated gold
+            cost per buyback (``200 + net_worth // 13``), alongside ``buyback_log``.
         lane_pos: Dwell-tick counts keyed by ``"x_y"`` grid cell (64-unit resolution).
         position_log: Time-ordered ``(tick, x, y)`` tuples sampled at the
             extractor's interval. Useful for movement time-series and
@@ -423,6 +453,7 @@ class ParsedPlayer:
     purchase_log: list[CombatLogEntry] = field(default_factory=list)
     runes_log: list[CombatLogEntry] = field(default_factory=list)
     buyback_log: list[CombatLogEntry] = field(default_factory=list)
+    buybacks: list[BuybackEvent] = field(default_factory=list)
     lane_pos: defaultdict[str, int] = field(default_factory=lambda: defaultdict(int))
     position_log: list[tuple[int, float, float]] = field(default_factory=list)
     stuns_dealt: float = 0.0

--- a/tests/test_derived_kills.py
+++ b/tests/test_derived_kills.py
@@ -194,3 +194,30 @@ class TestBuildingStatus:
         r = building_status([_TK(2, "npc_dota_goodguys_tower1_bot")], [])
         assert r["tower_status_dire"] == self._ALL_TOWERS
         assert r["tower_status_radiant"] != self._ALL_TOWERS
+
+
+from gem.results.derived import buyback_cost  # noqa: E402
+
+
+class TestBuybackCost:
+    """Buyback cost formula: 200 + net_worth // 13."""
+
+    def test_zero_net_worth_is_base_cost(self):
+        assert buyback_cost(0) == 200
+
+    def test_typical_net_worth(self):
+        # 200 + 13000 // 13 = 200 + 1000 = 1200
+        assert buyback_cost(13000) == 1200
+
+    def test_floor_division(self):
+        # 1300 // 13 = 100, so 200 + 100 = 300; 1301 // 13 floors to 100 too.
+        assert buyback_cost(1300) == 300
+        assert buyback_cost(1301) == 300
+
+    def test_negative_net_worth_clamped(self):
+        assert buyback_cost(-500) == 200
+
+    def test_uses_divisor_13_not_12(self):
+        # Guard against the historical /12 formula regressing.
+        # nw=12 → //13 gives 0 (200); //12 would give 1 (201).
+        assert buyback_cost(12) == 200

--- a/tests/test_html_sections.py
+++ b/tests/test_html_sections.py
@@ -2,7 +2,8 @@
 
 Covers:
 - _net_worth_at: nearest net_worth sample lookup
-- build_buybacks: gold spent column (floor(200 + net_worth / 13))
+- build_buybacks: renders ParsedPlayer.buybacks cost (formula tested in
+  tests/test_derived_kills.py::TestBuybackCost)
 - build_objectives: healing lotus entries appear with correct hero label
 """
 
@@ -70,58 +71,39 @@ class TestNetWorthAt:
 
 
 # ---------------------------------------------------------------------------
-# Buyback gold cost formula: floor(200 + net_worth / 13)
+# build_buybacks renders the model's BuybackEvent cost (the formula itself is
+# tested in tests/test_derived_kills.py::TestBuybackCost).
 # ---------------------------------------------------------------------------
 
 
-class TestBuybackGoldCost:
-    """Verify the buyback cost formula via build_buybacks output."""
+class TestBuybackReport:
+    """Verify build_buybacks renders ParsedPlayer.buybacks cost, not a recompute."""
 
-    def _make_match(self, net_worth: int, buyback_tick: int = 500):
-        from gem.combat.log import CombatLogEntry
+    def _make_match(self, cost: int, buyback_tick: int = 500):
+        from gem.results.models import BuybackEvent
 
-        buyback_entry = CombatLogEntry(tick=buyback_tick, log_type="BUYBACK", value=0)
-
-        pp = _make_player(
-            times=[buyback_tick],
-            net_worth_t=[net_worth],
-        )
-        pp.buyback_log = [buyback_entry]
+        pp = _make_player()
+        pp.buybacks = [BuybackEvent(tick=buyback_tick, player_slot=0, cost=cost, net_worth=0)]
 
         match = MagicMock()
         match.players = [pp]
         return match
 
-    def _cost_in_html(self, net_worth: int) -> str:
-        match = self._make_match(net_worth)
-        html = _sections.build_buybacks(match)
-        return html
+    def _cost_in_html(self, cost: int) -> str:
+        return _sections.build_buybacks(self._make_match(cost))
 
-    def test_zero_net_worth(self):
-        # floor(200 + 0/13) = 200
-        html = self._cost_in_html(0)
-        assert "200g" in html
+    def test_renders_cost_value(self):
+        assert "200g" in self._cost_in_html(200)
 
-    def test_typical_net_worth(self):
-        # net_worth=13000 → floor(200 + 13000/13) = floor(200 + 1000) = 1200
-        html = self._cost_in_html(13000)
-        assert "1,200g" in html
-
-    def test_fractional_rounds_down(self):
-        # net_worth=1300 → floor(200 + 1300/13) = floor(200 + 100) = 300
-        # net_worth=1301 → floor(200 + 1301/13) = floor(200 + 100.07...) = 300
-        html1 = self._cost_in_html(1300)
-        html2 = self._cost_in_html(1301)
-        assert "300g" in html1
-        assert "300g" in html2
+    def test_renders_thousands_separator(self):
+        assert "1,200g" in self._cost_in_html(1200)
 
     def test_gold_spent_column_header_present(self):
-        html = self._cost_in_html(5000)
-        assert "Gold Spent" in html
+        assert "Gold Spent" in self._cost_in_html(5000)
 
     def test_no_buybacks_shows_no_table(self):
         pp = _make_player()
-        pp.buyback_log = []
+        pp.buybacks = []
         match = MagicMock()
         match.players = [pp]
         html = _sections.build_buybacks(match)

--- a/tests/test_html_sections.py
+++ b/tests/test_html_sections.py
@@ -127,3 +127,112 @@ class TestBuybackGoldCost:
         html = _sections.build_buybacks(match)
         assert "Gold Spent" not in html
         assert "no buybacks" in html
+
+
+# ---------------------------------------------------------------------------
+# build_wards: data crosses the Python -> JS boundary via an inert
+# <script type="application/json"> tag (the build_farming pattern), so the
+# executable <script> stays a plain string with no doubled-brace escaping.
+# ---------------------------------------------------------------------------
+
+
+class TestBuildWardsDataTag:
+    """Lock in the JSON-data-tag contract introduced for issue #106 item #6."""
+
+    def _make_ward(
+        self,
+        *,
+        ward_type: str = "observer",
+        team: int = 2,
+        tick: int = 900,
+        x: float = 1000.0,
+        y: float = -2000.0,
+        killed_tick: int | None = 1800,
+        expires_tick: int | None = None,
+    ) -> MagicMock:
+        w = MagicMock()
+        w.ward_type = ward_type
+        w.team = team
+        w.tick = tick
+        w.x = x
+        w.y = y
+        w.killed_tick = killed_tick
+        w.expires_tick = expires_tick
+        w.placer = "npc_dota_hero_axe"
+        w.killer = "npc_dota_hero_lina"
+        return w
+
+    def _make_smoke(self) -> MagicMock:
+        s = MagicMock()
+        s.x = 0.0
+        s.y = 0.0
+        s.tick = 1200
+        s.team = 2
+        s.activator = "npc_dota_hero_axe"
+        s.smoked = ["a", "b"]
+        return s
+
+    def _make_match(self) -> MagicMock:
+        match = MagicMock()
+        match.wards = [
+            self._make_ward(ward_type="observer", team=2),
+            self._make_ward(ward_type="sentry", team=3, killed_tick=None, expires_tick=2000),
+        ]
+        match.smoke_events = [self._make_smoke()]
+        match.game_start_tick = 900
+        match.game_end_tick = 3000
+        # estimate_vision() iterates match.players; empty == no enemy vision.
+        match.players = []
+        return match
+
+    def _data_tag_payload(self, html: str) -> dict:
+        import json
+        import re
+
+        m = re.search(
+            r'<script type="application/json" id="ward-data">(.*?)</script>',
+            html,
+            re.S,
+        )
+        assert m is not None, "ward-data JSON tag missing"
+        return json.loads(m.group(1))
+
+    def test_data_tag_present_and_parses(self):
+        html = _sections.build_wards(self._make_match(), None)
+        cfg = self._data_tag_payload(html)
+        assert len(cfg["wards"]) == 2
+        assert len(cfg["smokes"]) == 1
+        assert cfg["gameStartTick"] == 900
+        assert cfg["sliderMin"] is not None
+        assert cfg["sliderMax"] is not None
+
+    def test_exactly_one_json_data_tag(self):
+        html = _sections.build_wards(self._make_match(), None)
+        assert html.count('type="application/json"') == 1
+
+    def test_no_doubled_braces_in_output(self):
+        # The whole point of the refactor: no f-string brace escaping survives.
+        html = _sections.build_wards(self._make_match(), None)
+        assert "{{" not in html
+        assert "}}" not in html
+
+    def test_script_reads_the_data_tag(self):
+        html = _sections.build_wards(self._make_match(), None)
+        assert "JSON.parse(document.getElementById('ward-data')" in html
+
+    def test_has_map_flag_reflects_map_b64(self):
+        without = self._data_tag_payload(_sections.build_wards(self._make_match(), None))
+        with_map = self._data_tag_payload(_sections.build_wards(self._make_match(), "ZmFrZWI2NA=="))
+        assert without["hasMap"] is False
+        assert with_map["hasMap"] is True
+
+    def test_empty_wards_returns_placeholder_card(self):
+        match = MagicMock()
+        match.wards = []
+        match.smoke_events = []
+        match.game_start_tick = 0
+        match.game_end_tick = 0
+        match.players = []
+        html = _sections.build_wards(match, None)
+        assert "(no ward placement data)" in html
+        assert 'type="application/json"' not in html

--- a/tests/test_html_sections.py
+++ b/tests/test_html_sections.py
@@ -77,12 +77,14 @@ class TestNetWorthAt:
 
 
 class TestBuybackReport:
-    """Verify build_buybacks renders ParsedPlayer.buybacks cost, not a recompute."""
+    """Verify build_buybacks renders BuybackEvent cost and never hides a buyback."""
 
     def _make_match(self, cost: int, buyback_tick: int = 500):
+        from gem.combat.log import CombatLogEntry
         from gem.results.models import BuybackEvent
 
         pp = _make_player()
+        pp.buyback_log = [CombatLogEntry(tick=buyback_tick, log_type="BUYBACK", value=0)]
         pp.buybacks = [BuybackEvent(tick=buyback_tick, player_slot=0, cost=cost, net_worth=0)]
 
         match = MagicMock()
@@ -103,12 +105,29 @@ class TestBuybackReport:
 
     def test_no_buybacks_shows_no_table(self):
         pp = _make_player()
+        pp.buyback_log = []
         pp.buybacks = []
         match = MagicMock()
         match.players = [pp]
         html = _sections.build_buybacks(match)
         assert "Gold Spent" not in html
-        assert "no buybacks" in html
+
+    def test_buyback_log_without_buybacks_is_still_shown(self):
+        # Codex P2: a match with buyback_log populated but buybacks empty (manually
+        # assembled / older serialized data) must still render the buyback, with the
+        # cost derived from the formula fallback rather than being hidden.
+        from gem.combat.log import CombatLogEntry
+
+        pp = _make_player(times=[500], net_worth_t=[13000])
+        pp.buyback_log = [CombatLogEntry(tick=500, log_type="BUYBACK", value=0)]
+        pp.buybacks = []  # not populated
+        match = MagicMock()
+        match.players = [pp]
+        html = _sections.build_buybacks(match)
+        assert "Gold Spent" in html  # table rendered, not hidden
+        assert "Total buybacks: 1" in html
+        # formula fallback: 200 + 13000 // 13 = 1200
+        assert "1,200g" in html
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_smoke_vision_extractor.py
+++ b/tests/test_smoke_vision_extractor.py
@@ -1,0 +1,248 @@
+"""Unit tests for gem.extractors.smoke_vision.
+
+Covers SmokeExtractor and VisionModifierExtractor — the attach()/finalize()
+contract, team/centroid back-fill, the LIFO vision-modifier stacking, and the
+documented empty-group smoke edge case. All tests use fake combat log entries —
+no real .dem files.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from gem.combat.log import CombatLogEntry
+from gem.extractors.smoke_vision import SmokeExtractor, VisionModifierExtractor
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _entry(**kwargs) -> CombatLogEntry:
+    defaults = {
+        "tick": 100,
+        "log_type": "MODIFIER_ADD",
+        "attacker_name": "npc_dota_hero_axe",
+        "target_name": "npc_dota_hero_lina",
+        "inflictor_name": "",
+        "value": 0,
+        "attacker_is_hero": True,
+        "target_is_hero": True,
+        "attacker_is_illusion": False,
+        "target_is_illusion": False,
+        "ability_level": 0,
+        "gold_reason": 0,
+        "xp_reason": 0,
+    }
+    defaults.update(kwargs)
+    return CombatLogEntry(**defaults)
+
+
+class FakeParser:
+    def __init__(self) -> None:
+        self._handlers: list = []
+
+    def on_combat_log_entry(self, handler) -> None:
+        self._handlers.append(handler)
+
+    def fire(self, entry: CombatLogEntry) -> None:
+        for h in self._handlers:
+            h(entry)
+
+
+def _fake_player_ext(
+    *,
+    teams: dict[str, int] | None = None,
+    positions: dict[str, tuple[float, float]] | None = None,
+) -> MagicMock:
+    """A PlayerExtractor stand-in exposing snapshots + hero_pos."""
+    teams = teams or {}
+    positions = positions or {}
+    snaps = []
+    for npc, team in teams.items():
+        snap = MagicMock()
+        snap.npc_name = npc
+        snap.team = team
+        snaps.append(snap)
+    pe = MagicMock()
+    pe.snapshots = snaps
+    pe.hero_pos.side_effect = lambda npc: positions.get(npc)
+    return pe
+
+
+# ---------------------------------------------------------------------------
+# VisionModifierExtractor
+# ---------------------------------------------------------------------------
+
+
+class TestVisionModifierExtractor:
+    def test_add_then_remove_opens_and_closes_window(self):
+        pe = _fake_player_ext(teams={"npc_dota_hero_slardar": 2})
+        ext = VisionModifierExtractor(pe)
+        parser = FakeParser()
+        ext.attach(parser)
+
+        parser.fire(
+            _entry(
+                tick=100,
+                log_type="MODIFIER_ADD",
+                inflictor_name="modifier_slardar_amplify_damage",
+                attacker_name="npc_dota_hero_slardar",
+                target_name="npc_dota_hero_lina",
+            )
+        )
+        parser.fire(
+            _entry(
+                tick=250,
+                log_type="MODIFIER_REMOVE",
+                inflictor_name="modifier_slardar_amplify_damage",
+                attacker_name="npc_dota_hero_slardar",
+                target_name="npc_dota_hero_lina",
+            )
+        )
+        events = ext.finalize()
+        assert len(events) == 1
+        ev = events[0]
+        assert ev.tick == 100
+        assert ev.end_tick == 250
+        assert ev.caster_team == 2  # back-filled from snapshots
+
+    def test_non_vision_modifier_ignored(self):
+        ext = VisionModifierExtractor(_fake_player_ext())
+        parser = FakeParser()
+        ext.attach(parser)
+        parser.fire(_entry(log_type="MODIFIER_ADD", inflictor_name="modifier_some_random_buff"))
+        assert ext.finalize() == []
+
+    def test_unclosed_modifier_keeps_none_end_tick(self):
+        ext = VisionModifierExtractor(_fake_player_ext())
+        parser = FakeParser()
+        ext.attach(parser)
+        parser.fire(
+            _entry(
+                log_type="MODIFIER_ADD",
+                inflictor_name="modifier_bounty_hunter_track",
+            )
+        )
+        events = ext.finalize()
+        assert len(events) == 1
+        assert events[0].end_tick is None
+
+    def test_stacked_adds_close_lifo(self):
+        # Same (modifier, target) applied twice; two removes close most-recent-first.
+        ext = VisionModifierExtractor(_fake_player_ext())
+        parser = FakeParser()
+        ext.attach(parser)
+        common = {
+            "inflictor_name": "modifier_item_dustofappearance",
+            "target_name": "npc_dota_hero_riki",
+        }
+        parser.fire(_entry(tick=100, log_type="MODIFIER_ADD", **common))
+        parser.fire(_entry(tick=120, log_type="MODIFIER_ADD", **common))
+        parser.fire(_entry(tick=200, log_type="MODIFIER_REMOVE", **common))
+        parser.fire(_entry(tick=300, log_type="MODIFIER_REMOVE", **common))
+        events = ext.finalize()
+        assert len(events) == 2
+        # LIFO: the second add (tick=120) is closed first (end=200); first add
+        # (tick=100) closed at 300.
+        by_tick = {e.tick: e.end_tick for e in events}
+        assert by_tick == {100: 300, 120: 200}
+
+
+# ---------------------------------------------------------------------------
+# SmokeExtractor
+# ---------------------------------------------------------------------------
+
+
+class TestSmokeExtractor:
+    def test_item_then_modifiers_builds_group_and_centroid(self):
+        pe = _fake_player_ext(
+            teams={"npc_dota_hero_axe": 2},
+            positions={
+                "npc_dota_hero_lina": (100.0, 200.0),
+                "npc_dota_hero_axe": (300.0, 400.0),
+            },
+        )
+        ext = SmokeExtractor(pe)
+        parser = FakeParser()
+        ext.attach(parser)
+
+        parser.fire(
+            _entry(
+                tick=500,
+                log_type="ITEM",
+                inflictor_name="item_smoke_of_deceit",
+                attacker_name="npc_dota_hero_axe",
+            )
+        )
+        for target in ("npc_dota_hero_lina", "npc_dota_hero_axe"):
+            parser.fire(
+                _entry(
+                    tick=502,
+                    log_type="MODIFIER_ADD",
+                    inflictor_name="modifier_smoke_of_deceit",
+                    attacker_name="npc_dota_hero_axe",
+                    target_name=target,
+                    target_is_hero=True,
+                )
+            )
+        events = ext.finalize()
+        assert len(events) == 1
+        ev = events[0]
+        assert ev.activator == "npc_dota_hero_axe"
+        assert ev.team == 2
+        assert set(ev.smoked) == {"npc_dota_hero_lina", "npc_dota_hero_axe"}
+        # centroid = mean of (100,200) and (300,400)
+        assert ev.x == 200.0
+        assert ev.y == 300.0
+
+    def test_non_hero_modifier_target_excluded_from_group(self):
+        # Summoned units (target_is_hero=False) must not join the smoke group.
+        pe = _fake_player_ext(teams={"npc_dota_hero_beastmaster": 3})
+        ext = SmokeExtractor(pe)
+        parser = FakeParser()
+        ext.attach(parser)
+        parser.fire(
+            _entry(
+                tick=10,
+                log_type="ITEM",
+                inflictor_name="item_smoke_of_deceit",
+                attacker_name="npc_dota_hero_beastmaster",
+            )
+        )
+        parser.fire(
+            _entry(
+                tick=12,
+                log_type="MODIFIER_ADD",
+                inflictor_name="modifier_smoke_of_deceit",
+                attacker_name="npc_dota_hero_beastmaster",
+                target_name="npc_dota_beastmaster_boar",
+                target_is_hero=False,
+            )
+        )
+        events = ext.finalize()
+        assert len(events) == 1
+        assert events[0].smoked == []  # boar excluded
+
+    def test_empty_group_edge_case_still_emits_event(self):
+        # Documented case: smoke breaks instantly (sentry truesight) so no
+        # MODIFIER_ADD fires. The ITEM event is still recorded with an empty group
+        # and no position.
+        pe = _fake_player_ext(teams={"npc_dota_hero_axe": 2})
+        ext = SmokeExtractor(pe)
+        parser = FakeParser()
+        ext.attach(parser)
+        parser.fire(
+            _entry(
+                tick=10,
+                log_type="ITEM",
+                inflictor_name="item_smoke_of_deceit",
+                attacker_name="npc_dota_hero_axe",
+            )
+        )
+        events = ext.finalize()
+        assert len(events) == 1
+        assert events[0].smoked == []
+        assert events[0].x is None
+        assert events[0].y is None
+        assert events[0].team == 2  # team still back-filled

--- a/uv.lock
+++ b/uv.lock
@@ -448,7 +448,7 @@ wheels = [
 
 [[package]]
 name = "gem-dota"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "ipykernel" },


### PR DESCRIPTION
## Summary

Release **0.4.3** → `main`. Bumps `pyproject.toml` 0.4.2 → 0.4.3 and finalizes the
CHANGELOG (`[Unreleased]` → `[0.4.3] - 2026-06-26`).

### Contents since 0.4.2 (3 merged PRs on develop)

**Added (user-visible):**
- **`ParsedPlayer.buybacks` / `gem.BuybackEvent`** (#119, PR #121) — per-buyback
  gold cost estimate (`200 + net_worth // 13`), plus `cost`/`net_worth` columns on
  the `player_buyback_log` DataFrame. The cost is a formula estimate (the exact
  value is unrecoverable — confirmed against gem's stream, OpenDota, and STRATZ);
  buyback *detection* is cross-validated against STRATZ.

**Changed (internal, behaviour-preserving — no output change):** #106, PR #118
- Ward-report data moved to an inert `<script type="application/json">` tag,
  removing ~240 lines of fragile brace-escaping (#106 item #6).
- Smoke/vision collection extracted from `api.parse` into
  `extractors/smoke_vision.py` (#106 item #2).
- `build_parsed_match`'s 234-line per-player loop extracted into
  `_populate_player_series` (#106 item #3).

(PR #120, a docs-only CLAUDE.md refresh, is also included but has no changelog
entry by design — internal docs only.)

## Rationale

Patch bump (0.4.3): the 0.4.x line is the "OpenDota-parity + refinements" series;
the one new field is a small additive refinement and the rest are internal
cleanups. Backwards-compatible — the supported top-level API
(`gem.parse`, `ParsedMatch`, …) is unchanged.

## Testing (release gate, all green)

- [x] `uv run ruff check src/ tests/` — passed
- [x] `uv run ruff format --check src/ tests/` — clean (150 files)
- [x] `uv run mypy src/gem/` — success, 87 files
- [x] `uv run pytest` — 1694 passed, 3 skipped
- [x] `uv run python scripts/validate_opendota.py` — **2 matches, 216/216 passed,
      0 field failures, 0 errors** (advantage curves exact)

## Post-merge steps (manual)

After merging to `main`:
1. Tag `v0.4.3` on the merge commit and push the tag.
2. Publish to PyPI (`gem-dota` 0.4.3).
3. Create the GitHub Release for `v0.4.3`.
4. Merge `main` back into `develop` (or fast-forward) to keep them in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
