### PR TITLE
Fix batch parsing timeouts and parquet streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ParsedMatch.parse_error` and `ParsedMatch.truncated_at_tick` surface opt-in
   partial-parse failures in structured output and the `match` DataFrame.
 
+### Fixed
+- `parse_many(timeout=...)` now enforces the timeout per replay inside each
+  worker instead of treating it as a global timeout for the whole batch.
+- `parse_many_to_parquet()` now streams completed parse results directly to
+  parquet output instead of first holding all `ParsedMatch` objects in memory via
+  `parse_many()`.
+
 ## [0.5.0] - 2026-06-28
 
 Extends the Roshan conversion analysis beyond the Aegis. Non-Aegis Roshan drops

--- a/docs/reference/batch.md
+++ b/docs/reference/batch.md
@@ -4,9 +4,16 @@ Parallel multi-replay parsing via `ProcessPoolExecutor`.
 Each worker process parses one replay independently, so performance scales with CPU cores.
 
 ::: info Memory
-`parse_many_to_parquet` writes and discards each replay immediately, keeping memory
-usage flat regardless of batch size. `parse_many_to_dataframe` holds all results in
-memory until concatenation — prefer `parse_many_to_parquet` for large batches.
+`parse_many_to_parquet` streams completed parses directly to parquet and discards
+each match immediately, keeping memory usage flat regardless of batch size.
+`parse_many_to_dataframe` holds all results in memory until concatenation — prefer
+`parse_many_to_parquet` for large batches.
+:::
+
+::: info Timeouts
+`timeout=` is enforced per replay inside the worker after that replay starts
+parsing. A timed-out replay is returned as `ParseResult(error=TimeoutError(...))`;
+it does not raise a batch-level timeout or hide other completed results.
 :::
 
 ::: tip Parquet dependency
@@ -46,7 +53,7 @@ def parse_many(source: str | Path | Sequence[str | Path], *, workers: int | None
 
 Parse multiple replays in parallel and return a result per replay.
 
-Source: [src/gem/replays/batch.py:116](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/replays/batch.py#L116)
+Source: [src/gem/replays/batch.py:235](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/replays/batch.py#L235)
 
 ### `parse_many_to_dataframe`
 
@@ -56,7 +63,7 @@ def parse_many_to_dataframe(source: str | Path | Sequence[str | Path], *, worker
 
 Parse multiple replays and concatenate results into per-table DataFrames.
 
-Source: [src/gem/replays/batch.py:189](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/replays/batch.py#L189)
+Source: [src/gem/replays/batch.py:271](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/replays/batch.py#L271)
 
 ### `parse_many_to_parquet`
 
@@ -66,7 +73,7 @@ def parse_many_to_parquet(source: str | Path | Sequence[str | Path], output_dir:
 
 Parse multiple replays and write each to its own parquet subdirectory.
 
-Source: [src/gem/replays/batch.py:235](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/replays/batch.py#L235)
+Source: [src/gem/replays/batch.py:317](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/replays/batch.py#L317)
 
 ### Top-level classes
 
@@ -78,7 +85,7 @@ class ParseResult
 
 Outcome of parsing a single replay.
 
-Source: [src/gem/replays/batch.py:39](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/replays/batch.py#L39)
+Source: [src/gem/replays/batch.py:43](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/replays/batch.py#L43)
 
 #### Dataclass fields
 
@@ -96,4 +103,4 @@ Signature: `def ParseResult.ok(self) -> bool`
 
 Return ``True`` when parsing succeeded.
 
-Source: [src/gem/replays/batch.py:53](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/replays/batch.py#L53)
+Source: [src/gem/replays/batch.py:57](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/replays/batch.py#L57)

--- a/docs/reference/batch.md
+++ b/docs/reference/batch.md
@@ -13,7 +13,9 @@ each match immediately, keeping memory usage flat regardless of batch size.
 ::: info Timeouts
 `timeout=` is enforced per replay inside the worker after that replay starts
 parsing. A timed-out replay is returned as `ParseResult(error=TimeoutError(...))`;
-it does not raise a batch-level timeout or hide other completed results.
+it does not raise a batch-level timeout or hide other completed results. On
+platforms without `signal.SIGALRM`/`setitimer` support, passing `timeout=` raises
+once before workers start.
 :::
 
 ::: tip Parquet dependency

--- a/src/gem/replays/batch.py
+++ b/src/gem/replays/batch.py
@@ -12,16 +12,20 @@ Provides three public functions:
   Replays are processed and discarded one at a time to keep memory bounded.
 
 All three functions use ``ProcessPoolExecutor`` for true parallelism (CPU-bound
-work) and display a Rich progress bar by default.
+work) and display a Rich progress bar by default. Optional timeouts are enforced
+inside each worker process, per replay.
 """
 
 from __future__ import annotations
 
 import os
-from collections.abc import Sequence
+import signal
+from collections.abc import Iterator, Sequence
 from concurrent.futures import Future, ProcessPoolExecutor, as_completed
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
+from types import FrameType
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -91,6 +95,34 @@ def _collect_paths(
     return [Path(p) for p in source]
 
 
+def _validate_timeout(timeout: float | None) -> None:
+    if timeout is not None and timeout <= 0:
+        raise ValueError("timeout must be a positive number of seconds")
+
+
+@contextmanager
+def _replay_timeout(path: Path, timeout: float | None) -> Iterator[None]:
+    """Raise ``TimeoutError`` inside a worker if one replay exceeds *timeout*."""
+    if timeout is None:
+        yield
+        return
+
+    if not hasattr(signal, "SIGALRM") or not hasattr(signal, "setitimer"):
+        raise RuntimeError("Per-replay timeout requires signal.SIGALRM support")
+
+    def _handle_timeout(signum: int, frame: FrameType | None) -> None:
+        raise TimeoutError(f"Parsing {path} timed out after {timeout:g} seconds")
+
+    previous_handler = signal.getsignal(signal.SIGALRM)
+    signal.signal(signal.SIGALRM, _handle_timeout)
+    signal.setitimer(signal.ITIMER_REAL, timeout)
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous_handler)
+
+
 def _parse_one(path: Path) -> tuple[Path, ParsedMatch | None, Exception | None]:
     """Top-level worker function — must be importable at module level for pickling.
 
@@ -106,6 +138,93 @@ def _parse_one(path: Path) -> tuple[Path, ParsedMatch | None, Exception | None]:
         return path, parse(path), None
     except Exception as exc:  # noqa: BLE001
         return path, None, exc
+
+
+def _parse_one_with_timeout(
+    path: Path,
+    timeout: float | None,
+) -> tuple[Path, ParsedMatch | None, Exception | None]:
+    """Parse one replay with an optional worker-local timeout."""
+    try:
+        with _replay_timeout(path, timeout):
+            return _parse_one(path)
+    except Exception as exc:  # noqa: BLE001
+        return path, None, exc
+
+
+def _iter_parse_results(
+    paths: Sequence[Path],
+    *,
+    workers: int | None,
+    progress: bool,
+    timeout: float | None,
+) -> Iterator[ParseResult]:
+    """Yield parse results as worker futures complete, with bounded in-flight work."""
+    _validate_timeout(timeout)
+    if not paths:
+        return
+
+    n_workers = min(workers or os.cpu_count() or 1, len(paths))
+
+    from rich.progress import (
+        BarColumn,
+        MofNCompleteColumn,
+        Progress,
+        TaskID,
+        TextColumn,
+        TimeElapsedColumn,
+    )
+
+    rich_progress: Progress | None = (
+        Progress(
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TimeElapsedColumn(),
+        )
+        if progress
+        else None
+    )
+    task_id: TaskID | None = None
+
+    def _run(executor: ProcessPoolExecutor) -> Iterator[ParseResult]:
+        path_iter = iter(paths)
+        future_to_path: dict[Future[tuple], Path] = {}
+
+        def _submit_next() -> None:
+            try:
+                path = next(path_iter)
+            except StopIteration:
+                return
+            future_to_path[executor.submit(_parse_one_with_timeout, path, timeout)] = path
+
+        for _ in range(n_workers):
+            _submit_next()
+
+        while future_to_path:
+            future = next(as_completed(future_to_path))
+            path = future_to_path.pop(future)
+            try:
+                result_path, match, error = future.result()
+            except Exception as exc:  # noqa: BLE001
+                result_path, match, error = path, None, exc
+            _submit_next()
+            if rich_progress is not None and task_id is not None:
+                rich_progress.advance(task_id)
+            yield ParseResult(path=result_path, match=match, error=error)
+
+    def _execute() -> Iterator[ParseResult]:
+        with ProcessPoolExecutor(max_workers=n_workers) as pool:
+            yield from _run(pool)
+
+    if rich_progress is not None:
+        with rich_progress:
+            task_id = rich_progress.add_task(
+                f"[cyan]Parsing {len(paths)} replay(s)…[/cyan]", total=len(paths)
+            )
+            yield from _execute()
+    else:
+        yield from _execute()
 
 
 # ---------------------------------------------------------------------------
@@ -130,60 +249,23 @@ def parse_many(
             capped at the number of replays.
         recursive: When *source* is a directory, scan subdirectories too.
         progress: Show a Rich progress bar while parsing.
-        timeout: Per-replay timeout in seconds.  ``None`` means no limit.
+        timeout: Per-replay parsing timeout in seconds, enforced after a worker
+            starts a replay. Timed-out replays return ``ParseResult(error=TimeoutError(...))``.
+            ``None`` means no limit.
 
     Returns:
         List of :class:`ParseResult` in completion order.  Failed replays have
         ``result.ok == False`` and carry the exception in ``result.error``.
     """
     paths = _collect_paths(source, recursive=recursive)
-    n_workers = min(workers or os.cpu_count() or 1, len(paths))
-
-    results: list[ParseResult] = []
-
-    from rich.progress import (
-        BarColumn,
-        MofNCompleteColumn,
-        Progress,
-        TextColumn,
-        TimeElapsedColumn,
-    )
-
-    rich_progress: Progress | None = (
-        Progress(
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(),
-            MofNCompleteColumn(),
-            TimeElapsedColumn(),
+    return list(
+        _iter_parse_results(
+            paths,
+            workers=workers,
+            progress=progress,
+            timeout=timeout,
         )
-        if progress
-        else None
     )
-
-    def _run(executor: ProcessPoolExecutor) -> None:
-        future_to_path: dict[Future[tuple], Path] = {
-            executor.submit(_parse_one, p): p for p in paths
-        }
-        for future in as_completed(future_to_path, timeout=timeout):
-            path, match, error = future.result()
-            results.append(ParseResult(path=path, match=match, error=error))
-            if rich_progress is not None:
-                rich_progress.advance(task_id)
-
-    def _execute() -> None:
-        with ProcessPoolExecutor(max_workers=n_workers) as pool:
-            _run(pool)
-
-    if rich_progress is not None:
-        with rich_progress:
-            task_id = rich_progress.add_task(
-                f"[cyan]Parsing {len(paths)} replay(s)…[/cyan]", total=len(paths)
-            )
-            _execute()
-    else:
-        _execute()
-
-    return results
 
 
 def parse_many_to_dataframe(
@@ -204,7 +286,7 @@ def parse_many_to_dataframe(
         workers: Number of worker processes (default: ``os.cpu_count()``).
         recursive: Scan subdirectories when *source* is a directory.
         progress: Show a Rich progress bar while parsing.
-        timeout: Per-replay timeout in seconds.
+        timeout: Per-replay parsing timeout in seconds.
 
     Returns:
         ``dict[str, DataFrame]`` with the same keys as
@@ -259,7 +341,7 @@ def parse_many_to_parquet(
         workers: Number of worker processes (default: ``os.cpu_count()``).
         recursive: Scan subdirectories when *source* is a directory.
         progress: Show a Rich progress bar while parsing.
-        timeout: Per-replay timeout in seconds.
+        timeout: Per-replay parsing timeout in seconds.
         index: Whether to include the DataFrame index in parquet output.
 
     Returns:
@@ -267,14 +349,16 @@ def parse_many_to_parquet(
     """
     from gem import to_parquet
 
-    results = parse_many(
-        source, workers=workers, recursive=recursive, progress=progress, timeout=timeout
-    )
-
+    paths = _collect_paths(source, recursive=recursive)
     out_root = Path(output_dir)
     written: list[Path] = []
 
-    for result in results:
+    for result in _iter_parse_results(
+        paths,
+        workers=workers,
+        progress=progress,
+        timeout=timeout,
+    ):
         if not result.ok or result.match is None:
             continue
         subdir = out_root / result.path.stem

--- a/src/gem/replays/batch.py
+++ b/src/gem/replays/batch.py
@@ -95,9 +95,23 @@ def _collect_paths(
     return [Path(p) for p in source]
 
 
+def _supports_worker_timeout() -> bool:
+    return (
+        hasattr(signal, "SIGALRM")
+        and hasattr(signal, "ITIMER_REAL")
+        and hasattr(signal, "setitimer")
+    )
+
+
 def _validate_timeout(timeout: float | None) -> None:
-    if timeout is not None and timeout <= 0:
+    if timeout is None:
+        return
+    if timeout <= 0:
         raise ValueError("timeout must be a positive number of seconds")
+    if not _supports_worker_timeout():
+        raise RuntimeError(
+            "parse_many(timeout=...) requires signal.SIGALRM/setitimer support on this platform"
+        )
 
 
 @contextmanager
@@ -107,8 +121,10 @@ def _replay_timeout(path: Path, timeout: float | None) -> Iterator[None]:
         yield
         return
 
-    if not hasattr(signal, "SIGALRM") or not hasattr(signal, "setitimer"):
-        raise RuntimeError("Per-replay timeout requires signal.SIGALRM support")
+    if not _supports_worker_timeout():
+        raise RuntimeError(
+            "parse_many(timeout=...) requires signal.SIGALRM/setitimer support on this platform"
+        )
 
     def _handle_timeout(signum: int, frame: FrameType | None) -> None:
         raise TimeoutError(f"Parsing {path} timed out after {timeout:g} seconds")
@@ -250,8 +266,10 @@ def parse_many(
         recursive: When *source* is a directory, scan subdirectories too.
         progress: Show a Rich progress bar while parsing.
         timeout: Per-replay parsing timeout in seconds, enforced after a worker
-            starts a replay. Timed-out replays return ``ParseResult(error=TimeoutError(...))``.
-            ``None`` means no limit.
+            starts a replay on platforms with ``signal.SIGALRM``/``setitimer``.
+            Timed-out replays return ``ParseResult(error=TimeoutError(...))``.
+            Unsupported platforms raise once before workers start. ``None`` means
+            no limit.
 
     Returns:
         List of :class:`ParseResult` in completion order.  Failed replays have

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -228,6 +228,21 @@ class TestParseMany:
         with pytest.raises(ValueError, match="timeout must be a positive"):
             parse_many([p], progress=False, timeout=0)
 
+    def test_timeout_unsupported_platform_raises_once_before_workers(self, tmp_path):
+        p = tmp_path / "a.dem"
+        p.touch()
+
+        class _UnexpectedExecutor:
+            def __init__(self, **kwargs):
+                raise AssertionError("executor should not be created")
+
+        with (
+            patch("gem.replays.batch._supports_worker_timeout", return_value=False),
+            patch("gem.replays.batch.ProcessPoolExecutor", _UnexpectedExecutor),
+            pytest.raises(RuntimeError, match="requires signal.SIGALRM/setitimer"),
+        ):
+            parse_many([p], progress=False, timeout=1)
+
     def test_parse_result_ok_property(self):
         assert ParseResult(path=Path("a.dem"), match=ParsedMatch(), error=None).ok is True
         assert ParseResult(path=Path("b.dem"), match=None, error=ValueError()).ok is False

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import concurrent.futures
+import signal
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -55,6 +57,11 @@ def _fail(path: Path) -> tuple[Path, ParsedMatch | None, Exception | None]:
 
 def _mixed(path: Path) -> tuple[Path, ParsedMatch | None, Exception | None]:
     return _fail(path) if path.name == "bad.dem" else _ok(path)
+
+
+def _slow(path: Path) -> tuple[Path, ParsedMatch | None, Exception | None]:
+    time.sleep(1)
+    return _ok(path)
 
 
 # ---------------------------------------------------------------------------
@@ -177,6 +184,50 @@ class TestParseMany:
 
         assert len(results) == 3
 
+    def test_in_flight_work_is_bounded_by_worker_count(self, tmp_path):
+        paths = [tmp_path / f"{i}.dem" for i in range(5)]
+        for p in paths:
+            p.touch()
+        batch_sizes: list[int] = []
+
+        def fake_as_completed(futures):
+            batch_sizes.append(len(futures))
+            return iter([next(iter(futures))])
+
+        with (
+            patch("gem.replays.batch.ProcessPoolExecutor", _SyncExecutor),
+            patch("gem.replays.batch._parse_one", side_effect=_ok),
+            patch("gem.replays.batch.as_completed", side_effect=fake_as_completed),
+        ):
+            results = parse_many(paths, workers=2, progress=False)
+
+        assert len(results) == 5
+        assert batch_sizes[0] == 2
+        assert max(batch_sizes) == 2
+
+    @pytest.mark.skipif(not hasattr(signal, "SIGALRM"), reason="requires SIGALRM")
+    def test_timeout_is_per_replay_error(self, tmp_path):
+        p = tmp_path / "slow.dem"
+        p.touch()
+
+        with (
+            patch("gem.replays.batch.ProcessPoolExecutor", _SyncExecutor),
+            patch("gem.replays.batch._parse_one", side_effect=_slow),
+        ):
+            results = parse_many([p], progress=False, timeout=0.05)
+
+        assert len(results) == 1
+        assert not results[0].ok
+        assert isinstance(results[0].error, TimeoutError)
+        assert "timed out" in str(results[0].error)
+
+    def test_timeout_must_be_positive(self, tmp_path):
+        p = tmp_path / "a.dem"
+        p.touch()
+
+        with pytest.raises(ValueError, match="timeout must be a positive"):
+            parse_many([p], progress=False, timeout=0)
+
     def test_parse_result_ok_property(self):
         assert ParseResult(path=Path("a.dem"), match=ParsedMatch(), error=None).ok is True
         assert ParseResult(path=Path("b.dem"), match=None, error=ValueError()).ok is False
@@ -247,6 +298,35 @@ class TestParseManyToDataframe:
 
 
 class TestParseManyToParquet:
+    def test_streams_each_result_to_parquet_before_requesting_next(self, tmp_path):
+        first = tmp_path / "first.dem"
+        second = tmp_path / "second.dem"
+        first.touch()
+        second.touch()
+        out_dir = tmp_path / "out"
+        calls: list[Path] = []
+
+        def fake_results(*args, **kwargs):
+            yield ParseResult(path=first, match=ParsedMatch(match_id=1), error=None)
+            assert calls == [out_dir / "first"]
+            yield ParseResult(path=second, match=ParsedMatch(match_id=2), error=None)
+
+        def fake_to_parquet(match, subdir, *, index=False):
+            calls.append(subdir)
+            return [subdir / "match.parquet"]
+
+        with (
+            patch("gem.replays.batch._iter_parse_results", side_effect=fake_results),
+            patch("gem.to_parquet", side_effect=fake_to_parquet),
+        ):
+            written = gem.parse_many_to_parquet([first, second], out_dir, progress=False)
+
+        assert calls == [out_dir / "first", out_dir / "second"]
+        assert written == [
+            out_dir / "first" / "match.parquet",
+            out_dir / "second" / "match.parquet",
+        ]
+
     @pytest.mark.skipif(
         not __import__("importlib").util.find_spec("pyarrow"),
         reason="pyarrow not installed",


### PR DESCRIPTION
## Summary

- Enforce `parse_many(timeout=...)` per replay inside each worker, returning `ParseResult(error=TimeoutError(...))` for timed-out replays instead of treating the value as a global batch timeout.
- Keep batch scheduling bounded by the worker count instead of submitting every replay future up front.
- Stream `parse_many_to_parquet()` results directly to parquet output so completed matches are discarded immediately instead of accumulating all `ParsedMatch` objects first.
- Update batch docs and changelog; add regression coverage for timeouts, bounded in-flight work, and parquet streaming.

## Rationale

- The documented timeout behavior was per replay, but `as_completed(..., timeout=...)` applied a single timeout to the whole batch.
- The parquet helper claimed bounded memory usage but previously called `parse_many()` first, retaining all successful parse results before writing.

## Testing

- [x] `uv run ruff check src/ tests/`
- [x] `uv run mypy src/gem/`
- [x] `uv run pytest tests/test_bulk.py tests/test_parquet_export.py`
- [x] `uv run pytest`
- [ ] Docs build not run; documentation changes are reference/changelog text only.

## Notes

- [x] Generated protobuf files under `src/gem/proto/` were not edited manually.
- [x] Large replay artifacts are not committed unless explicitly required for tests.
- [x] Secrets and local credentials are not included.
