### PR TITLE
Restore TLS verification for downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   partial-parse failures in structured output and the `match` DataFrame.
 
 ### Fixed
+- Replay download and report asset download helpers now use verified HTTPS/TLS
+  contexts instead of disabling certificate and hostname verification.
 - `parse_many(timeout=...)` now enforces the timeout per replay inside each
   worker instead of treating it as a global timeout for the whole batch.
 - `parse_many_to_parquet()` now streams completed parse results directly to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Replay download and report asset download helpers now use verified HTTPS/TLS
-  contexts instead of disabling certificate and hostname verification.
+  contexts instead of disabling certificate and hostname verification; Valve
+  replay URLs returned as plain `http://` are upgraded to HTTPS, and other
+  non-HTTPS replay URLs are rejected.
 - `parse_many(timeout=...)` now enforces the timeout per replay inside each
   worker instead of treating it as a global timeout for the whole batch.
 - `parse_many_to_parquet()` now streams completed parse results directly to

--- a/src/gem/replays/fetch.py
+++ b/src/gem/replays/fetch.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import bz2
 import json
 import ssl
+import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -27,6 +28,22 @@ OPENDOTA_API = "https://api.opendota.com/api/matches"
 
 # Use the platform trust store and hostname verification for OpenDota/CDN HTTPS.
 _SSL_CONTEXT = ssl.create_default_context()
+
+
+def _normalize_replay_url(replay_url: str) -> str:
+    """Return an HTTPS replay URL, upgrading known Valve replay hosts."""
+    parsed = urllib.parse.urlsplit(replay_url)
+    scheme = parsed.scheme.lower()
+    if scheme == "https":
+        return replay_url
+
+    host = (parsed.hostname or "").lower()
+    if scheme == "http" and host.startswith("replay") and host.endswith(".valve.net"):
+        return urllib.parse.urlunsplit(
+            ("https", parsed.netloc, parsed.path, parsed.query, parsed.fragment)
+        )
+
+    raise ValueError(f"Replay download URL must use HTTPS: {replay_url}")
 
 
 def fetch_replay_url(match_id: int) -> str:
@@ -60,7 +77,9 @@ def fetch_replay_url(match_id: int) -> str:
             "The match may not have been ingested yet. "
             f"Force a parse with: curl -X POST {OPENDOTA_API.replace('/matches', '')}/request/{match_id}"
         )
-    return replay_url
+    if not isinstance(replay_url, str):
+        raise ValueError(f"OpenDota returned a non-string replay_url for match {match_id}")
+    return _normalize_replay_url(replay_url)
 
 
 def download_and_decompress(match_id: int, replay_url: str, out_dir: Path | str = ".") -> Path:
@@ -81,6 +100,7 @@ def download_and_decompress(match_id: int, replay_url: str, out_dir: Path | str 
     dem_path = out_dir / f"{match_id}.dem"
     bz2_path = out_dir / f"{match_id}.dem.bz2"
 
+    replay_url = _normalize_replay_url(replay_url)
     req = urllib.request.Request(replay_url, headers={"User-Agent": "Mozilla/5.0"})
     # Larger timeout than the JSON API calls: a full replay is 100-300 MB.
     with urllib.request.urlopen(req, context=_SSL_CONTEXT, timeout=120) as resp:

--- a/src/gem/replays/fetch.py
+++ b/src/gem/replays/fetch.py
@@ -25,10 +25,8 @@ if TYPE_CHECKING:
 
 OPENDOTA_API = "https://api.opendota.com/api/matches"
 
-# Relax SSL verification for CDN hosts that occasionally present cert issues.
+# Use the platform trust store and hostname verification for OpenDota/CDN HTTPS.
 _SSL_CONTEXT = ssl.create_default_context()
-_SSL_CONTEXT.check_hostname = False
-_SSL_CONTEXT.verify_mode = ssl.CERT_NONE
 
 
 def fetch_replay_url(match_id: int) -> str:

--- a/src/gem/reports/asset_cache.py
+++ b/src/gem/reports/asset_cache.py
@@ -395,10 +395,8 @@ def _download_dir(out_dir: str | Path | None, subdir: str) -> Path:
 
 
 def _cdn_ssl_context() -> ssl.SSLContext:
-    ctx = ssl.create_default_context()
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE
-    return ctx
+    """Return the verified TLS context used for report asset downloads."""
+    return ssl.create_default_context()
 
 
 def _download_first(urls: list[str], out_path: Path, ctx: ssl.SSLContext) -> bool:

--- a/tests/test_replay_fetch.py
+++ b/tests/test_replay_fetch.py
@@ -1,0 +1,40 @@
+"""Tests for replay download helpers."""
+
+from __future__ import annotations
+
+import bz2
+import contextlib
+import io
+import ssl
+from pathlib import Path
+
+from gem.replays import fetch
+
+
+def test_replay_fetch_tls_context_verifies_certificates() -> None:
+    assert fetch._SSL_CONTEXT.verify_mode == ssl.CERT_REQUIRED
+    assert fetch._SSL_CONTEXT.check_hostname is True
+
+
+def test_download_and_decompress_uses_verified_tls_context(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    payload = bz2.compress(b"demo-bytes")
+    contexts: list[ssl.SSLContext] = []
+
+    @contextlib.contextmanager
+    def fake_urlopen(*_args, **kwargs):
+        contexts.append(kwargs["context"])
+        yield io.BytesIO(payload)
+
+    monkeypatch.setattr(fetch.urllib.request, "urlopen", fake_urlopen)
+
+    dem_path = fetch.download_and_decompress(123, "https://example.invalid/123.dem.bz2", tmp_path)
+
+    assert dem_path == tmp_path / "123.dem"
+    assert dem_path.read_bytes() == b"demo-bytes"
+    assert not (tmp_path / "123.dem.bz2").exists()
+    assert len(contexts) == 1
+    assert contexts[0].verify_mode == ssl.CERT_REQUIRED
+    assert contexts[0].check_hostname is True

--- a/tests/test_replay_fetch.py
+++ b/tests/test_replay_fetch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import bz2
 import contextlib
 import io
+import json
 import ssl
 from pathlib import Path
 
@@ -16,21 +17,57 @@ def test_replay_fetch_tls_context_verifies_certificates() -> None:
     assert fetch._SSL_CONTEXT.check_hostname is True
 
 
+def test_normalize_replay_url_upgrades_valve_http_urls() -> None:
+    assert (
+        fetch._normalize_replay_url("http://replay274.valve.net/570/123.dem.bz2")
+        == "https://replay274.valve.net/570/123.dem.bz2"
+    )
+
+
+def test_normalize_replay_url_rejects_non_https_non_valve_urls() -> None:
+    try:
+        fetch._normalize_replay_url("http://example.invalid/123.dem.bz2")
+    except ValueError as exc:
+        assert "must use HTTPS" in str(exc)
+    else:  # pragma: no cover - defensive assertion for readability
+        raise AssertionError("expected ValueError")
+
+
+def test_fetch_replay_url_returns_https_for_opendota_valve_http_url(monkeypatch) -> None:
+    body = json.dumps({"replay_url": "http://replay274.valve.net/570/123_456.dem.bz2"}).encode()
+
+    @contextlib.contextmanager
+    def fake_urlopen(*_args, **_kwargs):
+        yield io.BytesIO(body)
+
+    monkeypatch.setattr(fetch.urllib.request, "urlopen", fake_urlopen)
+
+    assert fetch.fetch_replay_url(123) == "https://replay274.valve.net/570/123_456.dem.bz2"
+
+
 def test_download_and_decompress_uses_verified_tls_context(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     payload = bz2.compress(b"demo-bytes")
     contexts: list[ssl.SSLContext] = []
+    urls: list[str] = []
 
     @contextlib.contextmanager
-    def fake_urlopen(*_args, **kwargs):
+    def fake_urlopen(request, **kwargs):
+        urls.append(request.full_url)
         contexts.append(kwargs["context"])
         yield io.BytesIO(payload)
 
     monkeypatch.setattr(fetch.urllib.request, "urlopen", fake_urlopen)
 
-    dem_path = fetch.download_and_decompress(123, "https://example.invalid/123.dem.bz2", tmp_path)
+    dem_path = fetch.download_and_decompress(
+        123,
+        "http://replay274.valve.net/570/123.dem.bz2",
+        tmp_path,
+    )
+
+    assert urls == ["https://replay274.valve.net/570/123.dem.bz2"]
 
     assert dem_path == tmp_path / "123.dem"
     assert dem_path.read_bytes() == b"demo-bytes"

--- a/tests/test_report_assets.py
+++ b/tests/test_report_assets.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ssl
 from pathlib import Path
 from typing import Any
 
@@ -7,6 +8,13 @@ import gem.reports.asset_cache as asset_cache
 from gem.reports import ReportAssets, add_map_image, report_asset_status
 
 _PNG_BYTES = b"\x89PNG\r\n\x1a\nfake-png"
+
+
+def test_report_asset_download_tls_context_verifies_certificates() -> None:
+    ctx = asset_cache._cdn_ssl_context()
+
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+    assert ctx.check_hostname is True
 
 
 def test_report_assets_auto_uses_cache_icons_and_fallback_map(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Restore default verified HTTPS/TLS contexts for replay downloads and OpenDota API calls.
- Restore certificate and hostname verification for report asset CDN downloads.
- Add regression tests that assert download contexts keep certificate verification and hostname checking enabled.
- Update the changelog.

## Rationale

- The previous helpers disabled certificate and hostname verification, which made replay/API and asset downloads vulnerable to TLS interception.
- The secure default is to use `ssl.create_default_context()` unchanged and let the platform trust store validate remote hosts.

## Testing

- [x] `uv run ruff check src/ tests/`
- [x] `uv run mypy src/gem/`
- [x] `uv run pytest tests/test_replay_fetch.py tests/test_report_assets.py tests/test_apply_api_rates.py`
- [x] `uv run pytest`
- [ ] Docs build not run; only changelog text changed.

## Notes

- [x] Generated protobuf files under `src/gem/proto/` were not edited manually.
- [x] Large replay artifacts are not committed unless explicitly required for tests.
- [x] Secrets and local credentials are not included.
