### PR TITLE
Add vision modifier export table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `ParsedMatch.parse_error` and `ParsedMatch.truncated_at_tick` surface opt-in
   partial-parse failures in structured output and the `match` DataFrame.
+- `build_dataframes()` / parquet exports now include a `vision_modifiers` table
+  for `ParsedMatch.vision_modifiers`.
+- `SmokeEvent` is now exported from the top-level `gem` package, matching other
+  public parse-result value types.
 
 ### Fixed
 - Replay download and report asset download helpers now use verified HTTPS/TLS

--- a/docs/guides/01_quickstart.md
+++ b/docs/guides/01_quickstart.md
@@ -90,8 +90,8 @@ print(frames["combat_log"].head())
 
 Use DataFrames for pandas, notebooks, and ML pipelines. Common tables include
 `players`, `players_minute`, `positions`, `combat_log`, `wards`, `objectives`,
-`opendota_objectives`, `teamfights`, `opendota_teamfights`, `neutral_item_finds`, and
-per-player event logs.
+`opendota_objectives`, `teamfights`, `opendota_teamfights`, `smoke_events`,
+`vision_modifiers`, `neutral_item_finds`, and per-player event logs.
 
 ### Parquet
 

--- a/docs/guides/05_timeseries.md
+++ b/docs/guides/05_timeseries.md
@@ -63,6 +63,7 @@ Available DataFrames:
 | `teamfights` | Gem teamfight windows with participant stats |
 | `opendota_teamfights` | OpenDota-compatible 3+ death temporal teamfight windows |
 | `smoke_events` | Smoke of Deceit usages and grouped heroes |
+| `vision_modifiers` | Vision/reveal modifier windows used by vision analysis |
 | `courier_snapshots` | Courier state over time |
 | `neutral_item_finds` | Neutral item find events from `DOTA_UM_FoundNeutralItem` |
 | `player_kills_log` | Per-player kill log rows |

--- a/docs/reference/dataframes.md
+++ b/docs/reference/dataframes.md
@@ -19,10 +19,10 @@ pip install pyarrow
 | `"positions"` | Hero position heatmap grid (64-unit cells) |
 | `"combat_log"` | Every damage, kill, heal, and modifier event |
 | `"wards"` | Ward placements with exact map coordinates |
-| `"objectives"` | Tower kills, barracks, Roshan kills |
+| `"objectives"` | Tower kills, barracks, Roshan kills, Aegis events, and other objective events |
 | `"teamfights"` | Detected fight windows with participant stats |
 | `"smoke_events"` | Smoke activations with grouped heroes and centroid |
-| `"aegis_events"` | Aegis pickups, steals, and denies |
+| `"vision_modifiers"` | Vision/reveal modifier windows used by vision analysis |
 | `"draft"` | Pick and ban events in order |
 | `"match"` | Single-row match metadata (id, duration, winner, partial-parse status, …) |
 | `"radiant_advantage"` | Per-minute gold and XP advantage curves |

--- a/src/gem/api.py
+++ b/src/gem/api.py
@@ -116,6 +116,7 @@ from gem.results.models import (
     NeutralItemFoundEvent,
     ParsedMatch,
     ParsedPlayer,
+    SmokeEvent,
     VisionModifierEvent,
 )
 
@@ -287,8 +288,8 @@ def parse_to_dataframe(path: str | Path, *, allow_partial: bool = False) -> dict
         - ``"players"``, ``"players_minute"``
         - ``"positions"``, ``"combat_log"``, ``"wards"``, ``"objectives"``, ``"chat"``
         - ``"match"``, ``"radiant_advantage"``
-        - ``"draft"``, ``"teamfights"``, ``"smoke_events"``, ``"courier_snapshots"``
-        - per-player event logs (kills/purchases/runes/buybacks)
+        - ``"draft"``, ``"teamfights"``, ``"smoke_events"``, ``"vision_modifiers"``
+        - ``"courier_snapshots"`` and per-player event logs (kills/purchases/runes/buybacks)
     """
     from gem.results.dataframes import build_dataframes
 
@@ -369,6 +370,7 @@ __all__ = [
     "ability_level_at_tick",
     "estimate_vision",
     "VisionSource",
+    "SmokeEvent",
     "VisionModifierEvent",
     "net_worth_at",
     "ward_vision_impact",

--- a/src/gem/results/dataframes.py
+++ b/src/gem/results/dataframes.py
@@ -22,9 +22,9 @@ def build_dataframes(match: ParsedMatch) -> dict[str, pd.DataFrame]:
 
     Returns:
         Dictionary with tabular projections of match-level, player-level,
-        and event-level data. Existing keys are preserved:
-        ``players``, ``positions``, ``combat_log``, ``wards``,
-        ``objectives``, and ``chat``.
+        and event-level data. Existing keys are preserved and extended with
+        event tables such as ``smoke_events``, ``vision_modifiers``, and
+        ``neutral_item_finds``.
     """
     from dataclasses import asdict
     from enum import Enum
@@ -372,6 +372,11 @@ def build_dataframes(match: ParsedMatch) -> dict[str, pd.DataFrame]:
         if match.smoke_events
         else pd.DataFrame()
     )
+    vision_modifiers_df = (
+        pd.DataFrame([asdict(ev) for ev in match.vision_modifiers])
+        if match.vision_modifiers
+        else pd.DataFrame()
+    )
     courier_df = (
         pd.DataFrame([asdict(cs) for cs in match.courier_snapshots])
         if match.courier_snapshots
@@ -398,6 +403,7 @@ def build_dataframes(match: ParsedMatch) -> dict[str, pd.DataFrame]:
         "teamfights": teamfights_df,
         "opendota_teamfights": opendota_teamfights_df,
         "smoke_events": smoke_df,
+        "vision_modifiers": vision_modifiers_df,
         "courier_snapshots": courier_df,
         "neutral_item_finds": neutral_item_finds_df,
         "player_kills_log": pd.DataFrame(player_kills_rows),

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -6,7 +6,7 @@ import gem.results.models as model_module
 from gem.combat.log import CombatLogEntry, CombatLogType
 from gem.extractors.objectives import AegisEvent, ShrineKill, TormentorKill
 from gem.results.dataframes import build_dataframes
-from gem.results.models import ParsedMatch, ParsedPlayer
+from gem.results.models import ParsedMatch, ParsedPlayer, VisionModifierEvent
 
 
 class TestBuildDataframes:
@@ -102,6 +102,7 @@ class TestBuildDataframes:
         assert "teamfights" in dfs
         assert "opendota_teamfights" in dfs
         assert "smoke_events" in dfs
+        assert "vision_modifiers" in dfs
         assert "courier_snapshots" in dfs
         assert "neutral_item_finds" in dfs
         assert "player_kills_log" in dfs
@@ -111,6 +112,32 @@ class TestBuildDataframes:
 
         assert dfs["neutral_item_finds"].empty
         assert dfs["opendota_teamfights"].empty
+        assert dfs["vision_modifiers"].empty
+
+    def test_vision_modifiers_dataframe_includes_event_fields(self):
+        match = ParsedMatch(
+            vision_modifiers=[
+                VisionModifierEvent(
+                    tick=100,
+                    end_tick=200,
+                    modifier_name="modifier_bounty_hunter_track",
+                    target_name="npc_dota_hero_axe",
+                    caster_name="npc_dota_hero_bounty_hunter",
+                    caster_team=3,
+                )
+            ]
+        )
+
+        df = build_dataframes(match)["vision_modifiers"]
+
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row["tick"] == 100
+        assert row["end_tick"] == 200
+        assert row["modifier_name"] == "modifier_bounty_hunter_track"
+        assert row["target_name"] == "npc_dota_hero_axe"
+        assert row["caster_name"] == "npc_dota_hero_bounty_hunter"
+        assert row["caster_team"] == 3
 
     def test_match_dataframe_includes_partial_parse_metadata(self):
         match = ParsedMatch(parse_error="bad tail", truncated_at_tick=1234)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -107,10 +107,7 @@ class TestParsedMatchFieldOrder:
 
 
 class TestPublicExports:
-    """``ParsedMatch.banner_plants`` is a public parse-result field whose value
-    type is documented as ``gem.BannerPlant``, so the package must re-export it
-    (matching the ``gem.BuybackEvent`` precedent for a parse-result value type).
-    """
+    """Parse-result value types should be available from the top-level package."""
 
     def test_banner_plant_is_publicly_exported(self):
         import gem
@@ -118,3 +115,10 @@ class TestPublicExports:
 
         assert "BannerPlant" in gem.__all__
         assert gem.BannerPlant is BannerPlant
+
+    def test_smoke_event_is_publicly_exported(self):
+        import gem
+        from gem.results.models import SmokeEvent
+
+        assert "SmokeEvent" in gem.__all__
+        assert gem.SmokeEvent is SmokeEvent


### PR DESCRIPTION
## Summary

- Add a `vision_modifiers` DataFrame/parquet table for `ParsedMatch.vision_modifiers`.
- Export `SmokeEvent` from the top-level `gem` package to match other public parse-result value types.
- Update DataFrame docs/guides and changelog for the schema surface.
- Correct DataFrame docs to describe Aegis rows as part of `objectives`, not a separate `aegis_events` table.

## Rationale

- `ParsedMatch.vision_modifiers` was populated and documented as a public parse-result field, but was missing from tabular/parquet exports.
- `SmokeEvent` is exported from `gem.results` and stored on `ParsedMatch.smoke_events`; top-level export keeps the public API consistent with related event types.

## Testing

- [x] `uv run ruff check src/ tests/`
- [x] `uv run mypy src/gem/`
- [x] `uv run pytest tests/test_dataframes.py tests/test_models.py tests/test_parquet_export.py`
- [x] `uv run pytest`
- [ ] Docs build not run; documentation changes are reference/guides/changelog text only.

## Notes

- [x] Generated protobuf files under `src/gem/proto/` were not edited manually.
- [x] Large replay artifacts are not committed unless explicitly required for tests.
- [x] Secrets and local credentials are not included.
