### PR TITLE
Harden replay download writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Empty and heterogeneous `build_dataframes()` tables now preserve declared columns,
   avoiding KeyErrors and inconsistent export schemas when a match has no rows or
   only a subset of event row types.
+- Replay downloads now stream `.bz2` decompression directly to an atomic temporary
+  `.dem` file, preserve normal final-file permissions, and leave any existing
+  final replay untouched if download or decompression fails.
 - Replay download and report asset download helpers now use verified HTTPS/TLS
   contexts instead of disabling certificate and hostname verification; Valve
   replay URLs returned as plain `http://` are upgraded to HTTPS, and other

--- a/src/gem/replays/fetch.py
+++ b/src/gem/replays/fetch.py
@@ -15,9 +15,14 @@ from __future__ import annotations
 
 import bz2
 import json
+import os
+import shutil
 import ssl
+import stat
+import tempfile
 import urllib.parse
 import urllib.request
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -28,6 +33,24 @@ OPENDOTA_API = "https://api.opendota.com/api/matches"
 
 # Use the platform trust store and hostname verification for OpenDota/CDN HTTPS.
 _SSL_CONTEXT = ssl.create_default_context()
+
+# Copy in bounded chunks so large 100-300 MB replay archives are never held fully
+# in memory during download or decompression.
+_DOWNLOAD_CHUNK_SIZE = 1024 * 1024
+
+
+def _default_replay_file_mode() -> int:
+    """Return the normal file mode a new replay should get under the process umask."""
+    current_umask = os.umask(0)
+    os.umask(current_umask)
+    return 0o666 & ~current_umask
+
+
+def _target_replay_file_mode(dem_path: Path) -> int:
+    """Return the final replay mode, preserving existing files when replacing."""
+    with suppress(FileNotFoundError):
+        return stat.S_IMODE(dem_path.stat().st_mode)
+    return _default_replay_file_mode()
 
 
 def _normalize_replay_url(replay_url: str) -> str:
@@ -98,16 +121,34 @@ def download_and_decompress(match_id: int, replay_url: str, out_dir: Path | str 
     out_dir.mkdir(parents=True, exist_ok=True)
 
     dem_path = out_dir / f"{match_id}.dem"
-    bz2_path = out_dir / f"{match_id}.dem.bz2"
+    temp_path: Path | None = None
+    file_mode = _target_replay_file_mode(dem_path)
 
     replay_url = _normalize_replay_url(replay_url)
     req = urllib.request.Request(replay_url, headers={"User-Agent": "Mozilla/5.0"})
-    # Larger timeout than the JSON API calls: a full replay is 100-300 MB.
-    with urllib.request.urlopen(req, context=_SSL_CONTEXT, timeout=120) as resp:
-        bz2_path.write_bytes(resp.read())
+    try:
+        # Larger timeout than the JSON API calls: a full replay is 100-300 MB.
+        with (
+            urllib.request.urlopen(req, context=_SSL_CONTEXT, timeout=120) as resp,
+            tempfile.NamedTemporaryFile(
+                "wb",
+                dir=out_dir,
+                prefix=f".{match_id}.dem.",
+                suffix=".tmp",
+                delete=False,
+            ) as tmp,
+            bz2.BZ2File(resp) as decompressed,
+        ):
+            temp_path = Path(tmp.name)
+            shutil.copyfileobj(decompressed, tmp, length=_DOWNLOAD_CHUNK_SIZE)
 
-    dem_path.write_bytes(bz2.decompress(bz2_path.read_bytes()))
-    bz2_path.unlink()
+        temp_path.chmod(file_mode)
+        temp_path.replace(dem_path)
+    except Exception:
+        if temp_path is not None:
+            with suppress(FileNotFoundError):
+                temp_path.unlink()
+        raise
 
     return dem_path
 

--- a/tests/test_replay_fetch.py
+++ b/tests/test_replay_fetch.py
@@ -7,7 +7,10 @@ import contextlib
 import io
 import json
 import ssl
+import stat
 from pathlib import Path
+
+import pytest
 
 from gem.replays import fetch
 
@@ -45,6 +48,20 @@ def test_fetch_replay_url_returns_https_for_opendota_valve_http_url(monkeypatch)
     assert fetch.fetch_replay_url(123) == "https://replay274.valve.net/570/123_456.dem.bz2"
 
 
+class _ChunkedResponse(io.BytesIO):
+    """BytesIO response that records bounded reads from the decompressor."""
+
+    def __init__(self, data: bytes, *, chunk_size: int = 17) -> None:
+        super().__init__(data)
+        self.chunk_size = chunk_size
+        self.read_sizes: list[int] = []
+
+    def read(self, size: int = -1) -> bytes:
+        self.read_sizes.append(size)
+        size = self.chunk_size if size < 0 else min(size, self.chunk_size)
+        return super().read(size)
+
+
 def test_download_and_decompress_uses_verified_tls_context(
     tmp_path: Path,
     monkeypatch,
@@ -75,3 +92,80 @@ def test_download_and_decompress_uses_verified_tls_context(
     assert len(contexts) == 1
     assert contexts[0].verify_mode == ssl.CERT_REQUIRED
     assert contexts[0].check_hostname is True
+
+
+def test_download_and_decompress_streams_bz2_response(tmp_path: Path, monkeypatch) -> None:
+    payload = bz2.compress(b"demo-bytes" * 4096)
+    response = _ChunkedResponse(payload)
+
+    @contextlib.contextmanager
+    def fake_urlopen(*_args, **_kwargs):
+        yield response
+
+    monkeypatch.setattr(fetch.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(fetch, "_default_replay_file_mode", lambda: 0o664)
+
+    dem_path = fetch.download_and_decompress(
+        456,
+        "https://replay274.valve.net/570/456.dem.bz2",
+        tmp_path,
+    )
+
+    assert dem_path.read_bytes() == b"demo-bytes" * 4096
+    assert response.read_sizes
+    assert all(size != -1 for size in response.read_sizes)
+    assert stat.S_IMODE(dem_path.stat().st_mode) == 0o664
+    assert not (tmp_path / "456.dem.bz2").exists()
+
+
+def test_download_and_decompress_preserves_existing_file_mode_on_replace(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    payload = bz2.compress(b"replacement replay")
+    dem_path = tmp_path / "654.dem"
+    dem_path.write_bytes(b"existing replay")
+    dem_path.chmod(0o640)
+
+    @contextlib.contextmanager
+    def fake_urlopen(*_args, **_kwargs):
+        yield io.BytesIO(payload)
+
+    monkeypatch.setattr(fetch.urllib.request, "urlopen", fake_urlopen)
+
+    result = fetch.download_and_decompress(
+        654,
+        "https://replay274.valve.net/570/654.dem.bz2",
+        tmp_path,
+    )
+
+    assert result == dem_path
+    assert dem_path.read_bytes() == b"replacement replay"
+    assert stat.S_IMODE(dem_path.stat().st_mode) == 0o640
+
+
+def test_download_and_decompress_cleans_temp_and_preserves_existing_file(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    dem_path = tmp_path / "789.dem"
+    dem_path.write_bytes(b"existing replay")
+    dem_path.chmod(0o640)
+
+    @contextlib.contextmanager
+    def fake_urlopen(*_args, **_kwargs):
+        yield io.BytesIO(b"not a bzip2 stream")
+
+    monkeypatch.setattr(fetch.urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises((EOFError, OSError)):
+        fetch.download_and_decompress(
+            789,
+            "https://replay274.valve.net/570/789.dem.bz2",
+            tmp_path,
+        )
+
+    assert dem_path.read_bytes() == b"existing replay"
+    assert stat.S_IMODE(dem_path.stat().st_mode) == 0o640
+    assert not (tmp_path / "789.dem.bz2").exists()
+    assert list(tmp_path.glob(".789.dem.*.tmp")) == []


### PR DESCRIPTION
## Summary
- Stream replay `.bz2` responses through `bz2.BZ2File` instead of buffering the compressed archive and decompressed replay in memory.
- Write decompressed replay bytes to a same-directory temporary `.dem` and atomically replace the final file only after successful decompression.
- Clean up temporary files on download/decompression failure while preserving any existing final replay.
- Update `[Unreleased]` changelog coverage.

## Testing
- `uv run ruff check src/ tests/`
- `uv run mypy src/gem/`
- `uv run pytest`
