### PR TITLE
Harden batch runtime error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parse-result value types including objective events, ward/courier/draft events,
   teamfight records, combat-log records, `SmokeEvent`, and `VisionModifierEvent`
   are now exported consistently from top-level `gem` and `gem.results`.
+- Typed replay error classes (`GemError`, `ReplayParseError`,
+  `ReplayTimeoutError`, `ReplayDownloadError`, `ReplayFetchError`,
+  `ReplayUrlError`, and `ReplayDecompressionError`) are exported from `gem`,
+  with replay-specific classes also available from `gem.replays`.
+- `python -m gem batch` now accepts `--timeout` for per-replay parse limits and
+  `--strict` to exit non-zero when any replay fails.
 
 ### Fixed
 - Empty and heterogeneous `build_dataframes()` tables now preserve declared columns,
@@ -34,11 +40,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   contexts instead of disabling certificate and hostname verification; Valve
   replay URLs returned as plain `http://` are upgraded to HTTPS, and other
   non-HTTPS replay URLs are rejected.
-- `parse_many(timeout=...)` now enforces the timeout per replay inside each
-  worker instead of treating it as a global timeout for the whole batch.
+- `parse_many(timeout=...)` now enforces the timeout per replay with portable
+  worker termination instead of requiring Unix `SIGALRM`/`setitimer` support or
+  treating it as a global timeout for the whole batch.
 - `parse_many_to_parquet()` now streams completed parse results directly to
   parquet output instead of first holding all `ParsedMatch` objects in memory via
   `parse_many()`.
+- Batch CLI exports now report failed replay counts and a typed failure table
+  from the same parse pass used to write outputs, without re-parsing successful
+  replays.
 
 ## [0.5.0] - 2026-06-28
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -42,6 +42,12 @@ Per-player `purchase`, `purchase_time`, and `first_purchase_time` now match the 
 
 :::
 
+::: info Batch/runtime failure handling (unreleased)
+
+Batch parsing now uses portable per-replay timeout termination and surfaces timeouts as `ReplayTimeoutError` (`TimeoutError`-compatible). Replay download/fetch helpers expose typed error classes such as `ReplayFetchError`, `ReplayUrlError`, and `ReplayDecompressionError`, and the batch CLI prints a typed failure table from the same parse pass used to write outputs. The default batch exit code remains `0` for compatibility; pass `--strict` for CI-style failure on any replay error.
+
+:::
+
 ::: tip Report asset cache
 
 HTML reports can inline hero icons, item icons, and map images from a local user cache instead of bundling them in the wheel. Manage the cache from the CLI:

--- a/docs/guides/09_cli.md
+++ b/docs/guides/09_cli.md
@@ -23,6 +23,9 @@ python -m gem parse my_replay.dem --format parquet --output ./out
 # Parse a folder in parallel
 python -m gem batch replays/ --format parquet --output ./out --workers 4
 
+# Fail CI if any replay fails or times out
+python -m gem batch replays/ --format parquet --output ./out --timeout 120 --strict
+
 # Concatenate all replays into one set of DataFrames
 python -m gem batch replays/ --format dataframe --output ./out
 
@@ -112,6 +115,8 @@ python -m gem batch <source> [options]
 | `--output` | directory | - | Required root output directory |
 | `--workers` | integer | `os.cpu_count()` | Number of parallel worker processes |
 | `--recursive` | flag | off | Scan source directories recursively |
+| `--timeout` | seconds | off | Per-replay parse timeout; timed-out replays are reported as failures |
+| `--strict` | flag | off | Exit with code `1` if any replay fails |
 | `--progress` | flag | off | Show a Rich progress bar |
 | `--timings` | flag | off | Print timing breakdown after all replays |
 | `--quiet`, `-q` | flag | off | Suppress all non-essential output |
@@ -149,9 +154,9 @@ python -m gem batch replays/ --format dataframe --output ./out
 ```
 
 ::: warning Exit codes
-The `batch` command exits with code `0` even when some replays fail. It prints a summary
-table of failed replays to stderr, so check the output before treating the batch as
-complete.
+By default, the `batch` command exits with code `0` even when some replays fail, for
+backward compatibility. It prints a batch summary plus a typed table of failed replays;
+pass `--strict` to exit with code `1` whenever any replay fails or times out.
 :::
 
 ## `reports assets` - report asset cache

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -3,6 +3,21 @@
 High-level helpers exposed from `import gem`. The implementation lives in
 `gem.api`; `gem.__init__` re-exports this supported package surface.
 
+## Replay error types
+
+The public API exports typed exceptions for replay workflows:
+
+- `GemError` / `ReplayError` — gem-specific base classes.
+- `ReplayParseError` — parser/batch parse failures surfaced by gem helpers.
+- `ReplayTimeoutError` — per-replay batch timeout; also a `TimeoutError`.
+- `ReplayDownloadError` — replay metadata/download/decompression base class.
+- `ReplayFetchError` and `ReplayUrlError` — OpenDota metadata or URL validation
+  failures; both remain `ValueError` subclasses for compatibility.
+- `ReplayDecompressionError` — invalid `.dem.bz2` download payload; also an
+  `OSError` through `ReplayDownloadError`.
+
+Replay-specific classes are also available from `gem.replays`.
+
 ---
 
 ## Generated API

--- a/docs/reference/batch.md
+++ b/docs/reference/batch.md
@@ -1,7 +1,7 @@
 # Batch Processing
 
-Parallel multi-replay parsing via `ProcessPoolExecutor`.
-Each worker process parses one replay independently, so performance scales with CPU cores.
+Parallel multi-replay parsing with bounded worker processes.
+Each worker parses one replay independently, so performance scales with CPU cores.
 
 ::: info Memory
 `parse_many_to_parquet` streams completed parses directly to parquet and discards
@@ -11,11 +11,11 @@ each match immediately, keeping memory usage flat regardless of batch size.
 :::
 
 ::: info Timeouts
-`timeout=` is enforced per replay inside the worker after that replay starts
-parsing. A timed-out replay is returned as `ParseResult(error=TimeoutError(...))`;
-it does not raise a batch-level timeout or hide other completed results. On
-platforms without `signal.SIGALRM`/`setitimer` support, passing `timeout=` raises
-once before workers start.
+`timeout=` is enforced per replay after that replay starts parsing. A timed-out
+replay is returned as `ParseResult(error=ReplayTimeoutError(...))`, which remains
+a `TimeoutError` subclass for compatibility; it does not raise a batch-level
+timeout or hide other completed results. Timeout enforcement terminates only the
+overdue replay worker and works on platforms without `signal.SIGALRM`.
 :::
 
 ::: tip Parquet dependency
@@ -106,3 +106,15 @@ Signature: `def ParseResult.ok(self) -> bool`
 Return ``True`` when parsing succeeded.
 
 Source: [src/gem/replays/batch.py:57](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/replays/batch.py#L57)
+
+##### `error_type`
+
+Signature: `def ParseResult.error_type(self) -> str`
+
+Return a display type for the parse error, or ``""`` on success.
+
+##### `error_message`
+
+Signature: `def ParseResult.error_message(self) -> str`
+
+Return a display message for the parse error, or ``""`` on success.

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -1,0 +1,19 @@
+# Error Types
+
+Public exception classes exposed from `gem.errors` and top-level `gem`.
+Replay-specific classes are also re-exported from `gem.replays`.
+
+| Class | Compatibility base | When it is used |
+|---|---|---|
+| `GemError` | `Exception` | Base class for gem-specific exceptions |
+| `ReplayError` | `GemError` | Base class for replay-related exceptions |
+| `ReplayParseError` | `ReplayError` | Parser/batch parse failures surfaced by gem helpers |
+| `ReplayTimeoutError` | `TimeoutError` | A replay exceeded `parse_many(timeout=...)` or CLI `batch --timeout` |
+| `ReplayDownloadError` | `OSError` | Base class for replay metadata/download/decompression failures |
+| `ReplayFetchError` | `ValueError` | OpenDota metadata is missing or malformed |
+| `ReplayUrlError` | `ValueError` | Replay URL is not HTTPS and cannot be safely upgraded |
+| `ReplayDecompressionError` | `OSError` | Downloaded `.dem.bz2` payload cannot be decompressed |
+
+The compatibility bases are intentional: existing callers that catch `ValueError`,
+`TimeoutError`, or `OSError` continue to work while callers can now catch typed
+gem-specific errors for finer reporting.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -30,6 +30,7 @@ Use the canonical grouped modules documented below.
 |---|---|
 | [Public API](api.md) | `parse()`, `find_player()`, JSON, DataFrame, and Parquet helpers |
 | [Models](models.md) | `ParsedMatch`, `ParsedPlayer`, output dataclasses |
+| [Error Types](errors.md) | Typed parser, batch timeout, and replay download exceptions |
 | [Catalog](catalog.md) | Grouped hero, item, ability, league, XP, and map-data lookups |
 | [Constants](constants.md) | Compatibility facade for `hero_display()`, `item_display()`, name lookups |
 | [Analysis Helpers](analysis.md) | Spatial, combat, vision, map-context, and Roshan conversion helpers |

--- a/src/gem/api.py
+++ b/src/gem/api.py
@@ -90,6 +90,16 @@ from gem.analysis import (
 )
 from gem.catalog import hero_npc_name
 from gem.combat.log import CombatLogEntry, CombatLogType
+from gem.errors import (
+    GemError,
+    ReplayDecompressionError,
+    ReplayDownloadError,
+    ReplayError,
+    ReplayFetchError,
+    ReplayParseError,
+    ReplayTimeoutError,
+    ReplayUrlError,
+)
 from gem.extractors.courier import CourierSnapshot
 from gem.extractors.draft import DraftEvent, resolve_pick_team
 from gem.extractors.objectives import (
@@ -361,6 +371,14 @@ __all__ = [
     "parse_to_dataframe",
     "to_parquet",
     "parse_to_parquet",
+    "GemError",
+    "ReplayError",
+    "ReplayParseError",
+    "ReplayTimeoutError",
+    "ReplayDownloadError",
+    "ReplayFetchError",
+    "ReplayUrlError",
+    "ReplayDecompressionError",
     "ParseResult",
     "parse_many",
     "parse_many_to_dataframe",

--- a/src/gem/cli.py
+++ b/src/gem/cli.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import argparse
 import sys
 import time
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -35,6 +37,7 @@ from gem import __version__, parse, parse_to_json, parse_to_parquet
 from gem.results.models import ParsedMatch
 
 if TYPE_CHECKING:
+    from gem.replays.batch import ParseResult
     from gem.reports.asset_cache import IconDownloadResult
 
 # ---------------------------------------------------------------------------
@@ -417,8 +420,53 @@ def _print_summary(
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class _BatchResultSummary:
+    """Lightweight parse-result summary that does not retain ParsedMatch data."""
+
+    path: Path
+    error: Exception | None
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None
+
+    @property
+    def error_type(self) -> str:
+        return type(self.error).__name__ if self.error is not None else ""
+
+    @property
+    def error_message(self) -> str:
+        return str(self.error) if self.error is not None else ""
+
+
+def _summarize_batch_result(result: ParseResult) -> _BatchResultSummary:
+    """Copy only lightweight fields needed for batch CLI summaries."""
+    return _BatchResultSummary(path=result.path, error=result.error)
+
+
+def _iter_batch_parse_results(
+    source: list[Path] | Path,
+    *,
+    workers: int | None,
+    recursive: bool,
+    progress: bool,
+    timeout: float | None,
+) -> Iterator[ParseResult]:
+    """Stream parse results for CLI batch commands."""
+    from gem.replays.batch import _collect_paths, _iter_parse_results
+
+    paths = _collect_paths(source, recursive=recursive)
+    yield from _iter_parse_results(
+        paths,
+        workers=workers,
+        progress=progress,
+        timeout=timeout,
+    )
+
+
 def _print_batch_summary(
-    results: list,
+    results: Sequence[_BatchResultSummary],
     console: Console,
     *,
     quiet: bool = False,
@@ -509,7 +557,6 @@ def _run_parse(args: argparse.Namespace, console: Console) -> None:
 
 def _run_batch(args: argparse.Namespace, console: Console) -> None:
     from gem import to_parquet
-    from gem.replays.batch import ParseResult, parse_many
     from gem.results.dataframes import build_dataframes
 
     # source is a list (nargs="+") — unwrap to single path if it's a directory
@@ -523,23 +570,22 @@ def _run_batch(args: argparse.Namespace, console: Console) -> None:
         console=console,
     )
 
-    results: list[ParseResult] = []
+    results: list[_BatchResultSummary] = []
     try:
         if args.format == "parquet":
             tracker.start("batch_parquet")
-            results = parse_many(
+            written = []
+            for result in _iter_batch_parse_results(
                 source,
                 workers=args.workers,
                 recursive=args.recursive,
                 progress=not args.quiet,
                 timeout=args.timeout,
-            )
-            written = []
-            for result in results:
-                if not result.ok or result.match is None:
-                    continue
-                subdir = args.output / result.path.stem
-                written.extend(to_parquet(result.match, subdir))
+            ):
+                if result.ok and result.match is not None:
+                    subdir = args.output / result.path.stem
+                    written.extend(to_parquet(result.match, subdir))
+                results.append(_summarize_batch_result(result))
             tracker.end("batch_parquet")
 
             if not args.quiet:
@@ -550,24 +596,23 @@ def _run_batch(args: argparse.Namespace, console: Console) -> None:
 
         else:  # dataframe
             tracker.start("batch_dataframe")
-            results = parse_many(
+            import pandas as pd
+
+            per_table: dict[str, list[pd.DataFrame]] = {}
+            for result in _iter_batch_parse_results(
                 source,
                 workers=args.workers,
                 recursive=args.recursive,
                 progress=not args.quiet,
                 timeout=args.timeout,
-            )
-            import pandas as pd
-
-            per_table: dict[str, list[pd.DataFrame]] = {}
-            for result in results:
-                if not result.ok or result.match is None:
-                    continue
-                dfs = build_dataframes(result.match)
-                for key, df in dfs.items():
-                    df = df.copy()
-                    df.insert(0, "match_path", str(result.path))
-                    per_table.setdefault(key, []).append(df)
+            ):
+                if result.ok and result.match is not None:
+                    dfs = build_dataframes(result.match)
+                    for key, df in dfs.items():
+                        df = df.copy()
+                        df.insert(0, "match_path", str(result.path))
+                        per_table.setdefault(key, []).append(df)
+                results.append(_summarize_batch_result(result))
             tracker.end("batch_dataframe")
 
             tracker.start("write_dataframe")

--- a/src/gem/cli.py
+++ b/src/gem/cli.py
@@ -119,6 +119,17 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Scan source directory recursively for .dem files.",
     )
+    batch_cmd.add_argument(
+        "--timeout",
+        type=float,
+        default=None,
+        help="Per-replay parse timeout in seconds.",
+    )
+    batch_cmd.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit with status 1 when any replay fails.",
+    )
     _add_common_flags(batch_cmd)
 
     # ── reports subcommand ──────────────────────────────────────────────────
@@ -417,16 +428,18 @@ def _print_batch_summary(
 
     if not quiet:
         console.print(
-            f"\n[green]✓[/green] [bold]{len(ok)}[/bold] succeeded  "
+            f"\n[bold]Batch summary:[/bold] "
+            f"[green]✓[/green] [bold]{len(ok)}[/bold] succeeded  "
             f"[red]✗[/red] [bold]{len(failed)}[/bold] failed"
         )
 
     if failed:
         table = Table(title="Failed replays", show_header=True, header_style="bold red")
-        table.add_column("Path", style="dim")
-        table.add_column("Error")
+        table.add_column("Path", style="dim", overflow="fold")
+        table.add_column("Type", no_wrap=True)
+        table.add_column("Message", overflow="fold")
         for r in failed:
-            table.add_row(str(r.path), str(r.error))
+            table.add_row(str(r.path), r.error_type, r.error_message)
         console.print(table)
 
 
@@ -495,7 +508,9 @@ def _run_parse(args: argparse.Namespace, console: Console) -> None:
 
 
 def _run_batch(args: argparse.Namespace, console: Console) -> None:
-    from gem.replays.batch import parse_many_to_dataframe, parse_many_to_parquet
+    from gem import to_parquet
+    from gem.replays.batch import ParseResult, parse_many
+    from gem.results.dataframes import build_dataframes
 
     # source is a list (nargs="+") — unwrap to single path if it's a directory
     source: list[Path] | Path = (
@@ -508,46 +523,60 @@ def _run_batch(args: argparse.Namespace, console: Console) -> None:
         console=console,
     )
 
+    results: list[ParseResult] = []
     try:
         if args.format == "parquet":
             tracker.start("batch_parquet")
-            # batch already shows its own Rich progress bar; suppress tracker's
-            # bar to avoid two overlapping bars when --progress is set
-            results = parse_many_to_parquet(
+            results = parse_many(
                 source,
-                args.output,
                 workers=args.workers,
                 recursive=args.recursive,
                 progress=not args.quiet,
+                timeout=args.timeout,
             )
+            written = []
+            for result in results:
+                if not result.ok or result.match is None:
+                    continue
+                subdir = args.output / result.path.stem
+                written.extend(to_parquet(result.match, subdir))
             tracker.end("batch_parquet")
 
-            # parse_many_to_parquet returns file paths; recover ParseResults for summary
-            # by re-running parse_many (already done internally) — instead, call parse_many
-            # directly so we can show the failure table.  For the simple case just report counts.
             if not args.quiet:
                 console.print(
-                    f"[green]✓[/green] Wrote [bold]{len(results)}[/bold] "
+                    f"[green]✓[/green] Wrote [bold]{len(written)}[/bold] "
                     f"parquet file(s) to [bold]{args.output}[/bold]"
                 )
 
         else:  # dataframe
             tracker.start("batch_dataframe")
-            dfs = parse_many_to_dataframe(
+            results = parse_many(
                 source,
                 workers=args.workers,
                 recursive=args.recursive,
                 progress=not args.quiet,
+                timeout=args.timeout,
             )
+            import pandas as pd
+
+            per_table: dict[str, list[pd.DataFrame]] = {}
+            for result in results:
+                if not result.ok or result.match is None:
+                    continue
+                dfs = build_dataframes(result.match)
+                for key, df in dfs.items():
+                    df = df.copy()
+                    df.insert(0, "match_path", str(result.path))
+                    per_table.setdefault(key, []).append(df)
             tracker.end("batch_dataframe")
 
             tracker.start("write_dataframe")
             args.output.mkdir(parents=True, exist_ok=True)
             written = []
-            for key, df in dfs.items():
+            for key, frames in per_table.items():
                 p = args.output / f"{key}.parquet"
                 try:
-                    df.to_parquet(p, index=False)
+                    pd.concat(frames, ignore_index=True).to_parquet(p, index=False)
                 except ImportError as exc:
                     raise ImportError(
                         "Parquet export requires 'pyarrow' or 'fastparquet'."
@@ -560,6 +589,10 @@ def _run_batch(args: argparse.Namespace, console: Console) -> None:
                     f"[green]✓[/green] Wrote [bold]{len(written)}[/bold] "
                     f"concatenated parquet file(s) to [bold]{args.output}[/bold]"
                 )
+
+        _print_batch_summary(results, console, quiet=args.quiet)
+        if args.strict and any(not result.ok for result in results):
+            sys.exit(1)
     finally:
         tracker.report()
 

--- a/src/gem/errors.py
+++ b/src/gem/errors.py
@@ -1,0 +1,47 @@
+"""Public exception types for gem replay parsing and download workflows."""
+
+from __future__ import annotations
+
+
+class GemError(Exception):
+    """Base class for gem-specific exceptions."""
+
+
+class ReplayError(GemError):
+    """Base class for replay-related exceptions."""
+
+
+class ReplayParseError(ReplayError):
+    """Base class for replay parsing failures surfaced by gem helpers."""
+
+
+class ReplayTimeoutError(TimeoutError, ReplayParseError):
+    """Raised or returned when replay parsing exceeds a configured timeout."""
+
+
+class ReplayDownloadError(OSError, ReplayError):
+    """Base class for replay download/decompression failures."""
+
+
+class ReplayFetchError(ValueError, ReplayDownloadError):
+    """Raised when OpenDota replay metadata is missing or malformed."""
+
+
+class ReplayUrlError(ValueError, ReplayDownloadError):
+    """Raised when a replay download URL is not allowed or cannot be normalized."""
+
+
+class ReplayDecompressionError(ReplayDownloadError):
+    """Raised when a downloaded replay archive cannot be decompressed."""
+
+
+__all__ = [
+    "GemError",
+    "ReplayError",
+    "ReplayParseError",
+    "ReplayTimeoutError",
+    "ReplayDownloadError",
+    "ReplayFetchError",
+    "ReplayUrlError",
+    "ReplayDecompressionError",
+]

--- a/src/gem/replays/__init__.py
+++ b/src/gem/replays/__init__.py
@@ -1,5 +1,14 @@
 """Replay utility helpers for fetching and batch-processing replay files."""
 
+from gem.errors import (
+    ReplayDecompressionError,
+    ReplayDownloadError,
+    ReplayError,
+    ReplayFetchError,
+    ReplayParseError,
+    ReplayTimeoutError,
+    ReplayUrlError,
+)
 from gem.replays.batch import (
     ParseResult,
     parse_many,
@@ -16,6 +25,13 @@ from gem.replays.fetch import (
 )
 
 __all__ = [
+    "ReplayError",
+    "ReplayParseError",
+    "ReplayTimeoutError",
+    "ReplayDownloadError",
+    "ReplayFetchError",
+    "ReplayUrlError",
+    "ReplayDecompressionError",
     "ParseResult",
     "apply_api_rates",
     "download_and_decompress",

--- a/src/gem/replays/batch.py
+++ b/src/gem/replays/batch.py
@@ -11,22 +11,26 @@ Provides three public functions:
   subdirectory under ``output_dir``, one ``.parquet`` file per table.
   Replays are processed and discarded one at a time to keep memory bounded.
 
-All three functions use ``ProcessPoolExecutor`` for true parallelism (CPU-bound
-work) and display a Rich progress bar by default. Optional timeouts are enforced
-inside each worker process, per replay.
+All three functions use worker processes for true parallelism (CPU-bound work)
+and display a Rich progress bar by default. Optional timeouts are enforced per
+replay with portable worker termination.
 """
 
 from __future__ import annotations
 
+import multiprocessing as mp
 import os
-import signal
+import queue
+import time
+from collections import deque
 from collections.abc import Iterator, Sequence
 from concurrent.futures import Future, ProcessPoolExecutor, as_completed
-from contextlib import contextmanager
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
-from types import FrameType
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+from gem.errors import ReplayParseError, ReplayTimeoutError
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -57,6 +61,16 @@ class ParseResult:
     def ok(self) -> bool:
         """Return ``True`` when parsing succeeded."""
         return self.error is None
+
+    @property
+    def error_type(self) -> str:
+        """Return a stable display type for the parse error, or ``""`` on success."""
+        return type(self.error).__name__ if self.error is not None else ""
+
+    @property
+    def error_message(self) -> str:
+        """Return a display message for the parse error, or ``""`` on success."""
+        return str(self.error) if self.error is not None else ""
 
 
 # ---------------------------------------------------------------------------
@@ -95,48 +109,11 @@ def _collect_paths(
     return [Path(p) for p in source]
 
 
-def _supports_worker_timeout() -> bool:
-    return (
-        hasattr(signal, "SIGALRM")
-        and hasattr(signal, "ITIMER_REAL")
-        and hasattr(signal, "setitimer")
-    )
-
-
 def _validate_timeout(timeout: float | None) -> None:
     if timeout is None:
         return
     if timeout <= 0:
         raise ValueError("timeout must be a positive number of seconds")
-    if not _supports_worker_timeout():
-        raise RuntimeError(
-            "parse_many(timeout=...) requires signal.SIGALRM/setitimer support on this platform"
-        )
-
-
-@contextmanager
-def _replay_timeout(path: Path, timeout: float | None) -> Iterator[None]:
-    """Raise ``TimeoutError`` inside a worker if one replay exceeds *timeout*."""
-    if timeout is None:
-        yield
-        return
-
-    if not _supports_worker_timeout():
-        raise RuntimeError(
-            "parse_many(timeout=...) requires signal.SIGALRM/setitimer support on this platform"
-        )
-
-    def _handle_timeout(signum: int, frame: FrameType | None) -> None:
-        raise TimeoutError(f"Parsing {path} timed out after {timeout:g} seconds")
-
-    previous_handler = signal.getsignal(signal.SIGALRM)
-    signal.signal(signal.SIGALRM, _handle_timeout)
-    signal.setitimer(signal.ITIMER_REAL, timeout)
-    try:
-        yield
-    finally:
-        signal.setitimer(signal.ITIMER_REAL, 0)
-        signal.signal(signal.SIGALRM, previous_handler)
 
 
 def _parse_one(path: Path) -> tuple[Path, ParsedMatch | None, Exception | None]:
@@ -156,16 +133,127 @@ def _parse_one(path: Path) -> tuple[Path, ParsedMatch | None, Exception | None]:
         return path, None, exc
 
 
-def _parse_one_with_timeout(
-    path: Path,
-    timeout: float | None,
-) -> tuple[Path, ParsedMatch | None, Exception | None]:
-    """Parse one replay with an optional worker-local timeout."""
+@dataclass
+class _ActiveParseWorker:
+    """One running replay parse process used for cross-platform timeouts."""
+
+    path: Path
+    process: mp.Process
+    queue: Any
+    started_at: float
+
+
+def _parse_one_process(path: Path, result_queue: Any) -> None:
+    """Run one parse in a child process and send the result through a queue."""
+    result_queue.put(_parse_one(path))
+
+
+def _timeout_error(path: Path, timeout: float) -> ReplayTimeoutError:
+    """Build the public timeout error for one replay."""
+    return ReplayTimeoutError(f"Parsing {path} timed out after {timeout:g} seconds")
+
+
+def _stop_process(process: mp.Process) -> None:
+    """Terminate a timed-out worker process and wait briefly for exit."""
+    if process.is_alive():
+        process.terminate()
+        process.join(timeout=1)
+    if process.is_alive() and hasattr(process, "kill"):
+        process.kill()
+        process.join(timeout=1)
+
+
+def _close_queue(result_queue: Any) -> None:
+    """Close a multiprocessing queue without surfacing cleanup errors."""
+    with suppress(Exception):
+        result_queue.close()
+    with suppress(Exception):
+        result_queue.join_thread()
+
+
+def _result_from_worker(worker: _ActiveParseWorker) -> ParseResult | None:
+    """Return a completed worker result, or ``None`` if it is still running."""
     try:
-        with _replay_timeout(path, timeout):
-            return _parse_one(path)
-    except Exception as exc:  # noqa: BLE001
-        return path, None, exc
+        result_path, match, error = worker.queue.get_nowait()
+    except queue.Empty:
+        if worker.process.is_alive():
+            return None
+        worker.process.join()
+        try:
+            result_path, match, error = worker.queue.get_nowait()
+        except queue.Empty:
+            error = ReplayParseError(
+                f"Worker exited without returning a result (exit code {worker.process.exitcode})"
+            )
+            return ParseResult(path=worker.path, match=None, error=error)
+    else:
+        worker.process.join()
+
+    return ParseResult(path=result_path, match=match, error=error)
+
+
+def _timeout_context() -> Any:
+    """Return a multiprocessing context suitable for timeout-managed workers."""
+    if "fork" in mp.get_all_start_methods():
+        return mp.get_context("fork")
+    return mp.get_context()
+
+
+def _iter_parse_results_with_process_timeout(
+    paths: Sequence[Path],
+    *,
+    workers: int,
+    timeout: float,
+) -> Iterator[ParseResult]:
+    """Yield parse results using one process per replay so timeouts are portable."""
+    ctx = _timeout_context()
+    pending = deque(paths)
+    active: list[_ActiveParseWorker] = []
+
+    def _submit_next() -> None:
+        if not pending:
+            return
+        path = pending.popleft()
+        result_queue = ctx.Queue(maxsize=1)
+        process = ctx.Process(target=_parse_one_process, args=(path, result_queue))
+        process.start()
+        active.append(
+            _ActiveParseWorker(
+                path=path,
+                process=process,
+                queue=result_queue,
+                started_at=time.monotonic(),
+            )
+        )
+
+    for _ in range(workers):
+        _submit_next()
+
+    while active:
+        yielded = False
+        now = time.monotonic()
+        for worker in list(active):
+            result = _result_from_worker(worker)
+            if result is not None:
+                active.remove(worker)
+                _close_queue(worker.queue)
+                _submit_next()
+                yielded = True
+                yield result
+                continue
+
+            if now - worker.started_at >= timeout:
+                _stop_process(worker.process)
+                active.remove(worker)
+                _close_queue(worker.queue)
+                _submit_next()
+                yielded = True
+                yield ParseResult(
+                    path=worker.path, match=None, error=_timeout_error(worker.path, timeout)
+                )
+
+        if not yielded and active:
+            time.sleep(0.05)
 
 
 def _iter_parse_results(
@@ -212,7 +300,7 @@ def _iter_parse_results(
                 path = next(path_iter)
             except StopIteration:
                 return
-            future_to_path[executor.submit(_parse_one_with_timeout, path, timeout)] = path
+            future_to_path[executor.submit(_parse_one, path)] = path
 
         for _ in range(n_workers):
             _submit_next()
@@ -230,6 +318,17 @@ def _iter_parse_results(
             yield ParseResult(path=result_path, match=match, error=error)
 
     def _execute() -> Iterator[ParseResult]:
+        if timeout is not None:
+            for result in _iter_parse_results_with_process_timeout(
+                paths,
+                workers=n_workers,
+                timeout=timeout,
+            ):
+                if rich_progress is not None and task_id is not None:
+                    rich_progress.advance(task_id)
+                yield result
+            return
+
         with ProcessPoolExecutor(max_workers=n_workers) as pool:
             yield from _run(pool)
 

--- a/src/gem/replays/fetch.py
+++ b/src/gem/replays/fetch.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import bz2
 import json
 import os
-import shutil
 import ssl
 import stat
 import tempfile
@@ -25,6 +24,8 @@ import urllib.request
 from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+from gem.errors import ReplayDecompressionError, ReplayFetchError, ReplayUrlError
 
 if TYPE_CHECKING:
     from gem.results.models import ParsedMatch
@@ -66,7 +67,7 @@ def _normalize_replay_url(replay_url: str) -> str:
             ("https", parsed.netloc, parsed.path, parsed.query, parsed.fragment)
         )
 
-    raise ValueError(f"Replay download URL must use HTTPS: {replay_url}")
+    raise ReplayUrlError(f"Replay download URL must use HTTPS: {replay_url}")
 
 
 def fetch_replay_url(match_id: int) -> str:
@@ -79,7 +80,8 @@ def fetch_replay_url(match_id: int) -> str:
         The ``replay_url`` string from the OpenDota API response.
 
     Raises:
-        ValueError: If OpenDota returns no replay URL or a non-JSON response.
+        ReplayFetchError: If OpenDota returns no replay URL or a malformed response.
+        ReplayUrlError: If OpenDota returns a replay URL that cannot be normalized to HTTPS.
         urllib.error.URLError: If the API request fails.
     """
     url = f"{OPENDOTA_API}/{match_id}"
@@ -89,19 +91,19 @@ def fetch_replay_url(match_id: int) -> str:
     try:
         data = json.loads(raw)
     except json.JSONDecodeError as exc:
-        raise ValueError(
+        raise ReplayFetchError(
             f"OpenDota returned a non-JSON response for match {match_id} ({url})"
         ) from exc
 
     replay_url = data.get("replay_url")
     if not replay_url:
-        raise ValueError(
+        raise ReplayFetchError(
             f"OpenDota returned no replay_url for match {match_id}. "
             "The match may not have been ingested yet. "
             f"Force a parse with: curl -X POST {OPENDOTA_API.replace('/matches', '')}/request/{match_id}"
         )
     if not isinstance(replay_url, str):
-        raise ValueError(f"OpenDota returned a non-string replay_url for match {match_id}")
+        raise ReplayFetchError(f"OpenDota returned a non-string replay_url for match {match_id}")
     return _normalize_replay_url(replay_url)
 
 
@@ -116,6 +118,11 @@ def download_and_decompress(match_id: int, replay_url: str, out_dir: Path | str 
 
     Returns:
         Path to the decompressed ``.dem`` file.
+
+    Raises:
+        ReplayUrlError: If *replay_url* is not HTTPS and cannot be upgraded safely.
+        ReplayDecompressionError: If the downloaded payload is not a valid bzip2 stream.
+        urllib.error.URLError: If the download request fails.
     """
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -137,10 +144,19 @@ def download_and_decompress(match_id: int, replay_url: str, out_dir: Path | str 
                 suffix=".tmp",
                 delete=False,
             ) as tmp,
-            bz2.BZ2File(resp) as decompressed,
         ):
             temp_path = Path(tmp.name)
-            shutil.copyfileobj(decompressed, tmp, length=_DOWNLOAD_CHUNK_SIZE)
+            with bz2.BZ2File(resp) as decompressed:
+                while True:
+                    try:
+                        chunk = decompressed.read(_DOWNLOAD_CHUNK_SIZE)
+                    except (EOFError, OSError) as exc:
+                        raise ReplayDecompressionError(
+                            f"Could not decompress replay archive for match {match_id}"
+                        ) from exc
+                    if not chunk:
+                        break
+                    tmp.write(chunk)
 
         temp_path.chmod(file_mode)
         temp_path.replace(dem_path)
@@ -248,7 +264,7 @@ def fetch_opendota_match(match_id: int) -> dict:
     try:
         return json.loads(raw)
     except json.JSONDecodeError as exc:
-        raise ValueError(
+        raise ReplayFetchError(
             f"OpenDota returned a non-JSON response for match {match_id} ({url})"
         ) from exc
 

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
-import signal
+import multiprocessing as mp
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -11,6 +11,7 @@ from unittest.mock import patch
 import pytest
 
 import gem
+from gem.errors import ReplayTimeoutError
 from gem.replays.batch import ParseResult, _collect_paths, parse_many
 from gem.results.models import ParsedMatch
 
@@ -57,11 +58,6 @@ def _fail(path: Path) -> tuple[Path, ParsedMatch | None, Exception | None]:
 
 def _mixed(path: Path) -> tuple[Path, ParsedMatch | None, Exception | None]:
     return _fail(path) if path.name == "bad.dem" else _ok(path)
-
-
-def _slow(path: Path) -> tuple[Path, ParsedMatch | None, Exception | None]:
-    time.sleep(1)
-    return _ok(path)
 
 
 # ---------------------------------------------------------------------------
@@ -205,21 +201,52 @@ class TestParseMany:
         assert batch_sizes[0] == 2
         assert max(batch_sizes) == 2
 
-    @pytest.mark.skipif(not hasattr(signal, "SIGALRM"), reason="requires SIGALRM")
     def test_timeout_is_per_replay_error(self, tmp_path):
         p = tmp_path / "slow.dem"
         p.touch()
 
-        with (
-            patch("gem.replays.batch.ProcessPoolExecutor", _SyncExecutor),
-            patch("gem.replays.batch._parse_one", side_effect=_slow),
+        def _fake_timeout_results(paths, *, workers, timeout):
+            assert list(paths) == [p]
+            assert workers == 1
+            assert timeout == 0.05
+            yield ParseResult(
+                path=p,
+                match=None,
+                error=ReplayTimeoutError("Parsing slow.dem timed out"),
+            )
+
+        with patch(
+            "gem.replays.batch._iter_parse_results_with_process_timeout",
+            side_effect=_fake_timeout_results,
         ):
             results = parse_many([p], progress=False, timeout=0.05)
 
         assert len(results) == 1
         assert not results[0].ok
+        assert isinstance(results[0].error, ReplayTimeoutError)
         assert isinstance(results[0].error, TimeoutError)
-        assert "timed out" in str(results[0].error)
+        assert results[0].error_type == "ReplayTimeoutError"
+        assert "timed out" in results[0].error_message
+
+    @pytest.mark.skipif(
+        "fork" not in mp.get_all_start_methods(), reason="requires fork start method"
+    )
+    def test_timeout_terminates_worker_process(self, tmp_path):
+        p = tmp_path / "slow.dem"
+        p.touch()
+
+        def _sleeping_parse(path: Path) -> tuple[Path, ParsedMatch | None, Exception | None]:
+            time.sleep(30)
+            return _ok(path)
+
+        start = time.monotonic()
+        with patch("gem.replays.batch._parse_one", side_effect=_sleeping_parse):
+            results = parse_many([p], progress=False, timeout=0.05)
+
+        assert time.monotonic() - start < 2
+        assert len(results) == 1
+        assert not results[0].ok
+        assert isinstance(results[0].error, ReplayTimeoutError)
 
     def test_timeout_must_be_positive(self, tmp_path):
         p = tmp_path / "a.dem"
@@ -228,24 +255,29 @@ class TestParseMany:
         with pytest.raises(ValueError, match="timeout must be a positive"):
             parse_many([p], progress=False, timeout=0)
 
-    def test_timeout_unsupported_platform_raises_once_before_workers(self, tmp_path):
+    def test_timeout_does_not_require_sigalrm(self, tmp_path):
         p = tmp_path / "a.dem"
         p.touch()
 
-        class _UnexpectedExecutor:
-            def __init__(self, **kwargs):
-                raise AssertionError("executor should not be created")
+        with patch(
+            "gem.replays.batch._iter_parse_results_with_process_timeout",
+            return_value=iter([ParseResult(path=p, match=ParsedMatch(), error=None)]),
+        ) as worker_timeout:
+            results = parse_many([p], progress=False, timeout=1)
 
-        with (
-            patch("gem.replays.batch._supports_worker_timeout", return_value=False),
-            patch("gem.replays.batch.ProcessPoolExecutor", _UnexpectedExecutor),
-            pytest.raises(RuntimeError, match="requires signal.SIGALRM/setitimer"),
-        ):
-            parse_many([p], progress=False, timeout=1)
+        assert results[0].ok
+        worker_timeout.assert_called_once()
 
     def test_parse_result_ok_property(self):
         assert ParseResult(path=Path("a.dem"), match=ParsedMatch(), error=None).ok is True
         assert ParseResult(path=Path("b.dem"), match=None, error=ValueError()).ok is False
+
+    def test_parse_result_error_display_properties(self):
+        result = ParseResult(path=Path("bad.dem"), match=None, error=ValueError("bad replay"))
+
+        assert result.error_type == "ValueError"
+        assert result.error_message == "bad replay"
+        assert ParseResult(path=Path("ok.dem"), match=ParsedMatch(), error=None).error_type == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -208,7 +208,7 @@ class TestCli:
 
     def test_batch_parquet_reports_failures_from_single_parse(self, monkeypatch, tmp_path, capsys):
         import gem
-        import gem.replays.batch as batch
+        import gem.cli as cli
 
         out_dir = tmp_path / "out"
         good = tmp_path / "good.dem"
@@ -220,18 +220,26 @@ class TestCli:
         ]
         parse_calls = 0
         parquet_dirs: list[Path] = []
+        captured_summary = []
+        original_summary = cli._print_batch_summary
 
-        def _fake_parse_many(source, **kwargs):
+        def _fake_iter_batch_parse_results(source, **kwargs):
             nonlocal parse_calls
             parse_calls += 1
             assert source == [good, bad]
             assert kwargs["timeout"] == 2.5
-            return results
+            yield results[0]
+            assert parquet_dirs == [out_dir / "good"]
+            yield results[1]
 
         def _fake_to_parquet(parsed_match, output_dir):
             assert parsed_match is match
             parquet_dirs.append(Path(output_dir))
             return [Path(output_dir) / "players.parquet"]
+
+        def _capturing_summary(results, console, *, quiet=False):
+            captured_summary.extend(results)
+            original_summary(results, console, quiet=quiet)
 
         monkeypatch.setattr(
             "sys.argv",
@@ -249,7 +257,8 @@ class TestCli:
                 "--no-banner",
             ],
         )
-        monkeypatch.setattr(batch, "parse_many", _fake_parse_many)
+        monkeypatch.setattr(cli, "_iter_batch_parse_results", _fake_iter_batch_parse_results)
+        monkeypatch.setattr(cli, "_print_batch_summary", _capturing_summary)
         monkeypatch.setattr(gem, "to_parquet", _fake_to_parquet)
 
         main()
@@ -257,6 +266,7 @@ class TestCli:
         out = capsys.readouterr().out
         assert parse_calls == 1
         assert parquet_dirs == [out_dir / "good"]
+        assert all(not hasattr(result, "match") for result in captured_summary)
         assert "Wrote 1 parquet file(s)" in out
         assert "Batch summary" in out
         assert "1 succeeded" in out
@@ -265,7 +275,7 @@ class TestCli:
         assert "corrupt replay" in out
 
     def test_batch_strict_exits_nonzero_on_failure(self, monkeypatch, tmp_path):
-        import gem.replays.batch as batch
+        import gem.cli as cli
 
         out_dir = tmp_path / "out"
         bad = tmp_path / "bad.dem"
@@ -285,7 +295,7 @@ class TestCli:
                 "--no-banner",
             ],
         )
-        monkeypatch.setattr(batch, "parse_many", lambda *args, **kwargs: results)
+        monkeypatch.setattr(cli, "_iter_batch_parse_results", lambda *args, **kwargs: iter(results))
 
         with pytest.raises(SystemExit) as exc:
             main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from gem.cli import main
+from gem.replays.batch import ParseResult
 from gem.results.models import ParsedMatch
 
 
@@ -204,3 +205,89 @@ class TestCli:
         assert "Hero icons" in out
         assert "Item icons" in out
         assert "Map images" in out
+
+    def test_batch_parquet_reports_failures_from_single_parse(self, monkeypatch, tmp_path, capsys):
+        import gem
+        import gem.replays.batch as batch
+
+        out_dir = tmp_path / "out"
+        good = tmp_path / "good.dem"
+        bad = tmp_path / "bad.dem"
+        match = _mock_match()
+        results = [
+            ParseResult(path=good, match=match, error=None),
+            ParseResult(path=bad, match=None, error=ValueError("corrupt replay")),
+        ]
+        parse_calls = 0
+        parquet_dirs: list[Path] = []
+
+        def _fake_parse_many(source, **kwargs):
+            nonlocal parse_calls
+            parse_calls += 1
+            assert source == [good, bad]
+            assert kwargs["timeout"] == 2.5
+            return results
+
+        def _fake_to_parquet(parsed_match, output_dir):
+            assert parsed_match is match
+            parquet_dirs.append(Path(output_dir))
+            return [Path(output_dir) / "players.parquet"]
+
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "gem",
+                "batch",
+                str(good),
+                str(bad),
+                "--format",
+                "parquet",
+                "--output",
+                str(out_dir),
+                "--timeout",
+                "2.5",
+                "--no-banner",
+            ],
+        )
+        monkeypatch.setattr(batch, "parse_many", _fake_parse_many)
+        monkeypatch.setattr(gem, "to_parquet", _fake_to_parquet)
+
+        main()
+
+        out = capsys.readouterr().out
+        assert parse_calls == 1
+        assert parquet_dirs == [out_dir / "good"]
+        assert "Wrote 1 parquet file(s)" in out
+        assert "Batch summary" in out
+        assert "1 succeeded" in out
+        assert "1 failed" in out
+        assert "ValueError" in out
+        assert "corrupt replay" in out
+
+    def test_batch_strict_exits_nonzero_on_failure(self, monkeypatch, tmp_path):
+        import gem.replays.batch as batch
+
+        out_dir = tmp_path / "out"
+        bad = tmp_path / "bad.dem"
+        results = [ParseResult(path=bad, match=None, error=ValueError("corrupt replay"))]
+
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "gem",
+                "batch",
+                str(bad),
+                "--format",
+                "parquet",
+                "--output",
+                str(out_dir),
+                "--strict",
+                "--no-banner",
+            ],
+        )
+        monkeypatch.setattr(batch, "parse_many", lambda *args, **kwargs: results)
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+        assert exc.value.code == 1

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -174,3 +174,38 @@ class TestPublicExports:
             assert getattr(gem, name) is obj
             assert name in results.__all__
             assert getattr(results, name) is obj
+
+    def test_error_types_are_publicly_exported(self):
+        import gem
+        import gem.replays as replays
+        from gem.errors import (
+            GemError,
+            ReplayDecompressionError,
+            ReplayDownloadError,
+            ReplayError,
+            ReplayFetchError,
+            ReplayParseError,
+            ReplayTimeoutError,
+            ReplayUrlError,
+        )
+
+        top_level_expected = {
+            "GemError": GemError,
+            "ReplayError": ReplayError,
+            "ReplayParseError": ReplayParseError,
+            "ReplayTimeoutError": ReplayTimeoutError,
+            "ReplayDownloadError": ReplayDownloadError,
+            "ReplayFetchError": ReplayFetchError,
+            "ReplayUrlError": ReplayUrlError,
+            "ReplayDecompressionError": ReplayDecompressionError,
+        }
+        replay_expected = {
+            name: obj for name, obj in top_level_expected.items() if name != "GemError"
+        }
+
+        for name, obj in top_level_expected.items():
+            assert name in gem.__all__
+            assert getattr(gem, name) is obj
+        for name, obj in replay_expected.items():
+            assert name in replays.__all__
+            assert getattr(replays, name) is obj

--- a/tests/test_replay_fetch.py
+++ b/tests/test_replay_fetch.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import pytest
 
+from gem.errors import ReplayDecompressionError, ReplayFetchError, ReplayUrlError
 from gem.replays import fetch
 
 
@@ -28,12 +29,25 @@ def test_normalize_replay_url_upgrades_valve_http_urls() -> None:
 
 
 def test_normalize_replay_url_rejects_non_https_non_valve_urls() -> None:
-    try:
+    with pytest.raises(ReplayUrlError, match="must use HTTPS") as exc:
         fetch._normalize_replay_url("http://example.invalid/123.dem.bz2")
-    except ValueError as exc:
-        assert "must use HTTPS" in str(exc)
-    else:  # pragma: no cover - defensive assertion for readability
-        raise AssertionError("expected ValueError")
+
+    assert isinstance(exc.value, ValueError)
+
+
+def test_fetch_replay_url_rejects_missing_replay_url_with_typed_error(monkeypatch) -> None:
+    body = json.dumps({"match_id": 123}).encode()
+
+    @contextlib.contextmanager
+    def fake_urlopen(*_args, **_kwargs):
+        yield io.BytesIO(body)
+
+    monkeypatch.setattr(fetch.urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(ReplayFetchError, match="returned no replay_url") as exc:
+        fetch.fetch_replay_url(123)
+
+    assert isinstance(exc.value, ValueError)
 
 
 def test_fetch_replay_url_returns_https_for_opendota_valve_http_url(monkeypatch) -> None:
@@ -158,13 +172,14 @@ def test_download_and_decompress_cleans_temp_and_preserves_existing_file(
 
     monkeypatch.setattr(fetch.urllib.request, "urlopen", fake_urlopen)
 
-    with pytest.raises((EOFError, OSError)):
+    with pytest.raises(ReplayDecompressionError, match="Could not decompress") as exc:
         fetch.download_and_decompress(
             789,
             "https://replay274.valve.net/570/789.dem.bz2",
             tmp_path,
         )
 
+    assert isinstance(exc.value, OSError)
     assert dem_path.read_bytes() == b"existing replay"
     assert stat.S_IMODE(dem_path.stat().st_mode) == 0o640
     assert not (tmp_path / "789.dem.bz2").exists()


### PR DESCRIPTION
## Summary

- add public typed replay error classes and export them from `gem` / `gem.replays`
- enforce `parse_many(timeout=...)` with portable per-replay worker termination instead of Unix-only signals
- update batch CLI to parse once, write successful outputs, report typed failures, and support `--timeout` / `--strict`
- document the new batch/runtime error handling and add regression coverage

## Validation

- `uv run ruff check src/ tests/`
- `uv run mypy src/gem/`
- `uv run pytest` (`1738 passed, 3 skipped, 62 deselected`)
