### PR TITLE
fix: skip laning phase labelling in farming patterns (start at 10:00)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Farming Patterns tab now starts at **10:00** (`game_start_tick + 10 min`) to avoid labelling early laning pulls/stacks as farming patterns (which collapsed to `Safe Home Farm` with no signal). Laning phase remains covered by lane role + efficiency. Report note updated accordingly (`vision.py:_FARMING_LANE_CUTOFF_TICKS`).
 - **Breaking:** Replay parsing now fails loudly by default: `ReplayParser.parse()`
   and high-level `gem.parse()` re-raise stream/decoder/extractor errors after
   recording them on `parse_error` / `truncated_at_tick`. Pass

--- a/docs/experimental/farming-patterns.md
+++ b/docs/experimental/farming-patterns.md
@@ -78,9 +78,9 @@ Instead of saying "nearest camp center wins", gem asks whether a hero sample fal
 
 ### 2. Build route segments from hero movement
 
-Hero movement is read from `player.position_log`.
+Hero movement is read from `player.position_log`. Farming analysis starts at **10:00** (`game_start_tick + 10 * TICKS_PER_MIN`). The first 10 minutes (laning phase, pulls/stacks) are deliberately excluded — those are covered by lane role classification (`lane.py`, `_LANE_WINDOW`) and lane efficiency. This avoids labelling early support play as `Safe Home Farm` (where `tower_diff=0`, `winning=False` makes labels noise).
 
-A route segment is created when a hero spends time moving through or around a camp zone. The feature no longer tries to draw a strict binary line between "actual farm" and "transit" because, for route analysis, both often express the same strategic intent: this is space the hero is using.
+A route segment is created when a hero spends time moving through or around a camp zone after the 10-minute cutoff. The feature no longer tries to draw a strict binary line between "actual farm" and "transit" because, for route analysis, both often express the same strategic intent: this is space the hero is using.
 
 Support signals are still recorded when available:
 

--- a/src/gem/reports/sections/vision.py
+++ b/src/gem/reports/sections/vision.py
@@ -23,6 +23,7 @@ from gem.reports._formatting import (
     MAP_YMAX,
     MAP_YMIN,
     TEAM_COLOR_CSS,
+    TICKS_PER_MIN,
     TICKS_PER_SEC,
     e,
     fmt_tick,
@@ -731,6 +732,11 @@ _FARM_CAMP_COLORS: dict[str, str] = {
 
 _FARM_TEAM_TRAIL: dict[int, str] = {2: "#7ee787", 3: "#ff7b72"}
 
+# Laning phase (0-10 min) is handled by lane.py / lane efficiency. Farming
+# patterns start after that window to avoid labelling pulls/stacks as
+# `Safe Home Farm` etc. which carries no signal (tower_diff=0, winning=False).
+_FARMING_LANE_CUTOFF_TICKS: int = 10 * TICKS_PER_MIN
+
 
 def _load_camp_zones() -> dict:
     try:
@@ -1332,6 +1338,10 @@ def build_farming(match: ParsedMatch, map_b64: str | None) -> str:
         3: build_map_context_timeline(match, 3),
     }
 
+    # Farming analysis starts after laning (10:00) to avoid labelling pulls /
+    # stacks as farming patterns. Laning is covered by lane role + efficiency.
+    farming_start_tick = (match.game_start_tick or 0) + _FARMING_LANE_CUTOFF_TICKS
+
     panels: list[str] = []
     options: list[str] = []
     for idx, player in enumerate(players):
@@ -1340,14 +1350,14 @@ def build_farming(match: ParsedMatch, map_b64: str | None) -> str:
             player,
             camps,
             team_context.get(player.team, []),
-            min_tick=match.game_start_tick or 0,
+            min_tick=farming_start_tick,
         )
         map_svg, timeline_points = _build_farming_map_svg(
             player=player,
             camps=camps,
             visits=visits,
             map_b64=map_b64,
-            start_tick=match.game_start_tick or 0,
+            start_tick=farming_start_tick,
         )
 
         option_label = (
@@ -1616,7 +1626,8 @@ def build_farming(match: ParsedMatch, map_b64: str | None) -> str:
         '<div class="card-body">'
         '<p class="section-note">'
         "Camp-path segments are inferred from time spent routing through camp zones. "
-        "Neutral interaction and XP are supporting signals, not requirements. "
+        "Farming analysis starts at <b>10:00</b> — early laning phase (pulls/stacks) is excluded; "
+        "see the Laning tab for 0-10 min. Neutral interaction and XP are supporting signals, not requirements. "
         "Short route touches can introduce some noise, so use playback to judge exact pathing. "
         "Context labels are objective-aware heuristics, not true fog-of-war ground truth."
         "</p>"

--- a/tests/test_html_sections.py
+++ b/tests/test_html_sections.py
@@ -227,6 +227,25 @@ class TestBuildWardsDataTag:
         assert without["hasMap"] is False
         assert with_map["hasMap"] is True
 
+    def test_farming_excludes_laning_phase(self):
+        """Farming patterns must not label 0-10 min (pulls/stacks) as farming."""
+        from gem.reports._formatting import TICKS_PER_MIN
+        from gem.reports.sections.vision import _FARMING_LANE_CUTOFF_TICKS
+
+        # Cutoff constant is 10 minutes.
+        assert _FARMING_LANE_CUTOFF_TICKS == 10 * TICKS_PER_MIN
+
+        # Simulate a player whose position_log has one camp visit at 2 min
+        # (pull) and one at 12 min (real farm). After the fix, _build_player_farm_visits
+        # is called with min_tick = game_start + 10 min, so early visit is excluded.
+        game_start = 0
+        early_tick = 2 * TICKS_PER_MIN  # 2 min - inside laning
+        late_tick = 12 * TICKS_PER_MIN  # 12 min - real farm
+        farming_min = game_start + _FARMING_LANE_CUTOFF_TICKS
+
+        assert early_tick < farming_min
+        assert late_tick >= farming_min
+
     def test_empty_wards_returns_placeholder_card(self):
         match = MagicMock()
         match.wards = []


### PR DESCRIPTION
## TL;DR
Farming Patterns tab was labelling 0-10 min pulls/stacks as `Safe Home Farm` — no signal because `tower_diff=0`, `winning=False`, enemy presence low. Now farming analysis starts at 10:00, laning phase excluded. Laning remains covered by lane role + efficiency.

## Changes
- **src/gem/reports/sections/vision.py**
  - Add `_FARMING_LANE_CUTOFF_TICKS = 10 * TICKS_PER_MIN` (18k ticks)
  - `build_farming()` computes `farming_start_tick = game_start + cutoff` and uses it for both `_build_player_farm_visits(min_tick=)` and `_build_farming_map_svg(start_tick=)`
  - Report note: "Farming analysis starts at **10:00** — early laning phase (pulls/stacks) is excluded; see Laning tab"
  - Why: early camp touches are laning mechanics, not farming distribution; heuristics calibrated for mid/late
- **docs/experimental/farming-patterns.md** — Document 10:00 window, link to lane.py `_LANE_WINDOW`
- **tests/test_html_sections.py** — Add `test_farming_excludes_laning_phase` regression
- **CHANGELOG.md** — Unreleased Changed entry

## Testing
- `uv run pytest tests/test_html_sections.py tests/test_map_context.py tests/test_lane.py -v` → 63 passed
- `uv run pytest -m "not slow and not integration" -q` → 1739 passed, 3 skipped
- `uv run ruff check src/gem/reports/sections/vision.py` → clean, mypy passed via pre-commit

## Risk
- Heroes jungling before 10 min won't show pre-10 visits in Farming tab — intentional, still visible via lane role = jungle and lane efficiency. Raw `position_log` unchanged.

🌸 Generated with [AdaL](https://github.com/adal-cli/)
