### PR TITLE
Align OpenDota minute-curve boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Explicit game-time axes for minute curves.** `ParsedPlayer.game_times_min`
+  and `ParsedMatch.game_times_min` now carry the game-relative seconds
+  (`0, 60, 120, ...`) parallel to their minute arrays. The `players_minute` and
+  `radiant_advantage` DataFrames expose the same axis as `game_time_s` plus the
+  derived integer `minute`, so callers no longer need to infer time from list
+  position or absolute replay ticks.
+
 ### Fixed
 - **OpenDota minute-curve boundary parity.** Minute-zero interval samples now
-  retain live player counters instead of synthetic zeros, and terminal recovery
-  no longer fabricates a future interval boundary when postGame arrives before
-  the next minute.
+  retain live player counters instead of synthetic zeros, remove only the
+  observed one-unit earned-gold initialization offset, and sample one decoded
+  network tick after the first rounded-minute crossing to match Clarity's
+  effective `@OnTickStart` phase. Terminal recovery no longer fabricates a
+  future interval boundary when postGame arrives before the next minute.
+- **OpenDota validation alignment.** Minute curves are now joined by explicit
+  game-minute keys before comparison, so equal-length shifted curves fail the
+  gate instead of being compared positionally. End-of-game net worth, last hits,
+  and denies are compared terminal-to-terminal; the misleading last-minute vs
+  final-scalar rows were removed. In-tolerance residuals above the review band
+  are reported as warnings without changing the validator's exit code.
+- **Stricter OpenDota minute-curve gates.** Match gold/XP curve limits are now
+  0.25% (from 3.0%/2.5%), player gold/XP limits are both 0.25% (from 3.0%),
+  and the review band begins at 0.05%. Last-hit curves now allow
+  `max(2, 0.25%)` instead of `max(5, 2%)`, deny curves allow one unit, and any
+  count mismatch enters review. The separate terminal net-worth limit is
+  unchanged because it compares replay state with a Steam-sourced scalar.
 
 ### Changed
 - **Dota 2 protobuf definitions refreshed.** Regenerated the bundled Python

--- a/README.md
+++ b/README.md
@@ -262,8 +262,8 @@ In short: think of `ParsedMatch` as one container holding both **per-player summ
 | Hero picks and bans with timestamps | `ParsedMatch.draft` |
 | Per-player K/D/A + core combat summaries | `ParsedPlayer.kills` / `.deaths` / `.assists` / `.damage` |
 | Gold / XP / net-worth time series | `ParsedPlayer.times`, `.gold_t`, `.xp_t`, `.net_worth_t` |
-| Minute-aligned economy/XP series | `ParsedPlayer.times_min`, `.total_earned_gold_t_min`, `.total_earned_xp_t_min` |
-| Radiant gold / XP advantage curves | `ParsedMatch.radiant_gold_adv` / `.radiant_xp_adv` |
+| Minute-aligned economy/XP series | `ParsedPlayer.game_times_min`, `.times_min`, `.total_earned_gold_t_min`, `.total_earned_xp_t_min` |
+| Radiant gold / XP advantage curves | `ParsedMatch.game_times_min`, `.radiant_gold_adv`, `.radiant_xp_adv` |
 | Ward placements with exact coordinates | `ParsedMatch.wards` |
 | Smoke of Deceit activations + grouped heroes | `ParsedMatch.smoke_events` |
 | Roshan kills + aegis events | `ParsedMatch.roshans` / `.aegis_events` |

--- a/docs/deep-dives/index.md
+++ b/docs/deep-dives/index.md
@@ -49,8 +49,9 @@ Important parser state includes:
 - `match_id`, `game_mode`, `leagueid`, `radiant_win`, and `match_metadata`
 - `game_start_tick`, `game_time_s`, `combat_log_time_s`, and `duration_s`
 - `parse_error` and `truncated_at_tick` for partial parses
-- callback hooks such as `on_entity`, `on_combat_log_entry`, `on_chat_message`,
-  `on_chat_event`, `on_neutral_item_found`, `on_game_start`, and `on_game_end`
+- callback hooks such as `on_entity`, `on_tick_start`, `on_combat_log_entry`,
+  `on_chat_message`, `on_chat_event`, `on_neutral_item_found`, `on_game_start`,
+  and `on_game_end`
 
 For custom callback usage, see [Writing Custom Extractors](../guides/07_custom_extractors.md).
 

--- a/docs/guides/04_match_data.md
+++ b/docs/guides/04_match_data.md
@@ -137,6 +137,7 @@ player.denies          # int: deny count at game end
 # Net worth / gold / XP are also available as per-minute time-series. The minute
 # arrays can lag the exact game-end tick by up to ~59s, so prefer the scalars above
 # for terminal values and the arrays for curves.
+player.game_times_min                 # [0, 60, 120, ...]: authoritative game-time axis
 player.net_worth_t_min[-1]          # int: net worth at the last minute sample
 player.total_earned_gold_t_min[-1]  # int: cumulative gold at the last minute sample
 player.lh_t_min[-1]                 # int: last-hit count at the last minute sample

--- a/docs/guides/05_timeseries.md
+++ b/docs/guides/05_timeseries.md
@@ -7,7 +7,8 @@ outputs from the high-level API and, when needed, from the lower-level extractor
 ## Per-minute advantage curves
 
 `match.radiant_gold_adv` and `match.radiant_xp_adv` are lists of integers, one entry per
-game minute. Positive values favor Radiant; negative values favor Dire.
+game minute. `match.game_times_min` is their parallel, authoritative game-relative axis
+in seconds (`0, 60, 120, ...`). Positive values favor Radiant; negative values favor Dire.
 
 ```python
 import gem
@@ -15,7 +16,13 @@ import gem
 match = gem.parse("my_replay.dem")
 
 print("Minute  Gold adv  XP adv")
-for minute, (gold, xp) in enumerate(zip(match.radiant_gold_adv, match.radiant_xp_adv)):
+for game_time_s, gold, xp in zip(
+    match.game_times_min,
+    match.radiant_gold_adv,
+    match.radiant_xp_adv,
+    strict=True,
+):
+    minute = game_time_s // 60
     gold_sign = "+" if gold >= 0 else ""
     xp_sign = "+" if xp >= 0 else ""
     print(f"{minute:>6}  {gold_sign}{gold:>8,}  {xp_sign}{xp:>7,}")
@@ -50,7 +57,7 @@ Available DataFrames:
 | Key | Contents |
 |---|---|
 | `players` | Per-player sampled state with terminal scalar stats repeated on each row |
-| `players_minute` | Per-player series resampled to one row per game minute |
+| `players_minute` | Per-player series resampled to one row per game minute, with `game_time_s` / `minute` join keys |
 | `positions` | Per-player world `(x, y)` positions over time |
 | `combat_log` | Raw normalized combat log entries |
 | `wards` | Ward placement events with coordinates |
@@ -58,7 +65,7 @@ Available DataFrames:
 | `opendota_objectives` | OpenDota-shaped unified objective timeline |
 | `chat` | Chat messages |
 | `match` | Single-row match metadata and final status bitmasks |
-| `radiant_advantage` | Radiant gold/XP advantage per minute |
+| `radiant_advantage` | Radiant gold/XP advantage per minute, with `game_time_s` / `minute` join keys |
 | `draft` | Pick and ban events |
 | `teamfights` | Gem teamfight windows with participant stats |
 | `opendota_teamfights` | OpenDota-compatible 3+ death temporal teamfight windows |
@@ -102,7 +109,7 @@ import gem
 
 match = gem.parse("my_replay.dem")
 
-minutes = list(range(len(match.radiant_gold_adv)))
+minutes = [game_time_s / 60 for game_time_s in match.game_times_min]
 gold_adv = match.radiant_gold_adv
 
 fig, ax = plt.subplots(figsize=(12, 4))
@@ -140,7 +147,9 @@ print(series.y_t[:5])
 `PlayerTimeSeries` fields include `player_id`, `ticks`, `gold_t`,
 `total_earned_gold_t`, `total_earned_xp_t`, `net_worth_t`, `lh_t`, `dn_t`, `xp_t`,
 `hp_t`, `mana_t`, `x_t`, `y_t`, `total_hero_damage_t`, `total_hero_healing_t`,
-`total_deaths_t`, and `total_stuns_t`.
+`total_deaths_t`, and `total_stuns_t`. The object returned by
+`minute_time_series()` also populates `game_times_s` with its exact game-relative
+minute boundaries; the dense `time_series()` output leaves that axis empty.
 
 For most analysis code, prefer `gem.parse()` or `gem.parse_to_dataframe()` and use the
 lower-level extractor only when you need a different sampling interval or custom parser

--- a/docs/reference/assembly.md
+++ b/docs/reference/assembly.md
@@ -22,4 +22,4 @@ def build_parsed_match(parser: ReplayParser, player_ext: PlayerExtractor, obj_ex
 
 Assemble a :class:`ParsedMatch` from extractor state after a completed parse.
 
-Source: [src/gem/results/assembly.py:815](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/assembly.py#L815)
+Source: [src/gem/results/assembly.py:833](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/assembly.py#L833)

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -269,6 +269,7 @@ Source: [src/gem/results/models.py:161](https://github.com/whanyu1212/gem-dota/b
 | `observer_uses` | `int` | `0` |
 | `sentry_uses` | `int` | `0` |
 | `observers_placed` | `int` | `0` |
+| `game_times_min` | `list[int]` | `field(...)` |
 
 ### `ParsedMatch`
 
@@ -278,7 +279,7 @@ class ParsedMatch
 
 Top-level parsed output for a single Dota 2 replay.
 
-Source: [src/gem/results/models.py:536](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/models.py#L536)
+Source: [src/gem/results/models.py:542](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/models.py#L542)
 
 #### Dataclass fields
 
@@ -327,6 +328,7 @@ Source: [src/gem/results/models.py:536](https://github.com/whanyu1212/gem-dota/b
 | `opendota_teamfights` | `list[OpenDotaTeamfight]` | `field(...)` |
 | `vision_modifiers` | `list[VisionModifierEvent]` | `field(...)` |
 | `banner_plants` | `list[BannerPlant]` | `field(...)` |
+| `game_times_min` | `list[int]` | `field(...)` |
 
 #### Properties
 
@@ -336,7 +338,7 @@ Signature: `def ParsedMatch.duration_seconds(self) -> float`
 
 Game duration in seconds, derived from ``game_start_tick`` and ``game_end_tick``.
 
-Source: [src/gem/results/models.py:668](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/models.py#L668)
+Source: [src/gem/results/models.py:678](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/models.py#L678)
 
 ##### `duration_minutes`
 
@@ -344,4 +346,4 @@ Signature: `def ParsedMatch.duration_minutes(self) -> float`
 
 Game duration in minutes, derived from ``game_start_tick`` and ``game_end_tick``.
 
-Source: [src/gem/results/models.py:674](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/models.py#L674)
+Source: [src/gem/results/models.py:684](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/models.py#L684)

--- a/docs/reference/parser.md
+++ b/docs/reference/parser.md
@@ -18,7 +18,7 @@ class ReplayParser
 
 Drives a full Source 2 replay parse, wiring all subsystems together.
 
-Source: [src/gem/parser.py:160](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L160)
+Source: [src/gem/parser.py:162](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L162)
 
 #### Methods
 
@@ -28,7 +28,15 @@ Signature: `def ReplayParser.on_entity(self, callback: EntityCallback) -> None`
 
 Register a handler called for every entity create/update/delete.
 
-Source: [src/gem/parser.py:240](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L240)
+Source: [src/gem/parser.py:241](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L241)
+
+##### `on_tick_start`
+
+Signature: `def ReplayParser.on_tick_start(self, callback: TickStartCallback) -> None`
+
+Register a handler called before the current tick's entity deltas.
+
+Source: [src/gem/parser.py:251](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L251)
 
 ##### `on_game_event`
 
@@ -36,7 +44,7 @@ Signature: `def ReplayParser.on_game_event(self, name: str, handler: GameEventHa
 
 Register a handler for the named game event.
 
-Source: [src/gem/parser.py:291](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L291)
+Source: [src/gem/parser.py:306](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L306)
 
 ##### `on_combat_log_entry`
 
@@ -44,7 +52,7 @@ Signature: `def ReplayParser.on_combat_log_entry(self, handler: CombatLogHandler
 
 Register a handler for all combat log entries (S1 + S2).
 
-Source: [src/gem/parser.py:300](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L300)
+Source: [src/gem/parser.py:315](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L315)
 
 ##### `on_chat_message`
 
@@ -52,7 +60,7 @@ Signature: `def ReplayParser.on_chat_message(self, handler: ChatCallback) -> Non
 
 Register a handler for all-chat and team-chat messages.
 
-Source: [src/gem/parser.py:308](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L308)
+Source: [src/gem/parser.py:323](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L323)
 
 ##### `on_chat_event`
 
@@ -60,7 +68,7 @@ Signature: `def ReplayParser.on_chat_event(self, handler: ChatEventCallback) -> 
 
 Register a handler for all CDOTAUserMsg_ChatEvent messages.
 
-Source: [src/gem/parser.py:316](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L316)
+Source: [src/gem/parser.py:331](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L331)
 
 ##### `on_neutral_item_found`
 
@@ -68,7 +76,7 @@ Signature: `def ReplayParser.on_neutral_item_found(self, handler: NeutralItemFou
 
 Register a handler for neutral item found messages.
 
-Source: [src/gem/parser.py:324](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L324)
+Source: [src/gem/parser.py:339](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L339)
 
 ##### `on_game_start`
 
@@ -76,7 +84,7 @@ Signature: `def ReplayParser.on_game_start(self, callback: Callable[[int], None]
 
 Register a handler called once when game time reaches zero.
 
-Source: [src/gem/parser.py:332](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L332)
+Source: [src/gem/parser.py:347](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L347)
 
 ##### `on_game_end`
 
@@ -84,7 +92,7 @@ Signature: `def ReplayParser.on_game_end(self, callback: Callable[[int], None]) 
 
 Register a handler called once when the ancient is destroyed.
 
-Source: [src/gem/parser.py:344](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L344)
+Source: [src/gem/parser.py:359](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L359)
 
 ##### `stop_after_tick`
 
@@ -92,7 +100,7 @@ Signature: `def ReplayParser.stop_after_tick(self, tick: int) -> None`
 
 Stop parsing after this tick (inclusive).
 
-Source: [src/gem/parser.py:384](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L384)
+Source: [src/gem/parser.py:399](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L399)
 
 ##### `parse`
 
@@ -100,4 +108,4 @@ Signature: `def ReplayParser.parse(self) -> None`
 
 Parse the replay from start to finish (or until stop_after_tick).
 
-Source: [src/gem/parser.py:396](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L396)
+Source: [src/gem/parser.py:411](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L411)

--- a/scripts/validate_opendota.py
+++ b/scripts/validate_opendota.py
@@ -9,13 +9,14 @@ Notes on expected discrepancies
 OpenDota's scalar per-player stats (``kills``, ``deaths``, ``last_hits``,
 ``net_worth``) are sourced from the Steam API ``GetMatchDetails`` endpoint,
 which records the final game-state snapshot taken by the server at game-end.
-gem's ``_t`` arrays are sampled from entity state at 30-tick (≈1 s) intervals
-and the ``_min`` arrays at exact 60-second game-time boundaries.  A small
-residual difference is therefore expected and acceptable. ``net_worth`` is the
-least stable scalar here: the replay-exposed ``m_iNetWorth`` /
-``m_vecDataTeam.*.m_iNetWorth`` values can diverge slightly from Steam's final
-server scalar, so the validator uses a looser tolerance for that field than it
-does for kills / last hits / denies.
+gem forces a terminal entity sample at the game-end tick and samples ``_min``
+arrays at exact non-negative 60-second game-time boundaries. Terminal scalars
+are compared only with terminal scalars; minute curves are joined to OpenDota's
+array indices through gem's explicit game-time axes before their values are
+compared. ``net_worth`` is the least stable scalar here: the replay-exposed
+``m_iNetWorth`` / ``m_vecDataTeam.*.m_iNetWorth`` values can diverge slightly
+from Steam's final server scalar, so the validator uses a looser tolerance for
+that field than it does for kills / last hits / denies.
 
 OpenDota data availability
 --------------------------
@@ -110,6 +111,7 @@ class FieldResult:
     note: str = ""  # optional explanatory note shown in verbose mode
     skip: bool = False  # True = known limitation, exclude from pass/fail count
     ok_override: bool | None = None  # if set, overrides ok computation
+    warn_override: bool = False  # True = within hard tolerance but outside warning band
 
     @property
     def diff(self) -> float | None:
@@ -129,6 +131,16 @@ class FieldResult:
         if d is None:
             return self.gem_value == self.ref_value
         return d <= self.tolerance
+
+    @property
+    def status(self) -> Literal["PASS", "WARN", "FAIL", "SKIP"]:
+        if self.skip:
+            return "SKIP"
+        if not self.ok:
+            return "FAIL"
+        if self.warn_override:
+            return "WARN"
+        return "PASS"
 
 
 @dataclass
@@ -150,11 +162,19 @@ class MatchResult:
 
     @property
     def passed(self) -> int:
-        return sum(1 for f in self.all_fields if f.ok)
+        return sum(1 for f in self.all_fields if f.status == "PASS")
+
+    @property
+    def warned(self) -> int:
+        return sum(1 for f in self.all_fields if f.status == "WARN")
 
     @property
     def failed(self) -> int:
-        return sum(1 for f in self.all_fields if not f.ok)
+        return sum(1 for f in self.all_fields if f.status == "FAIL")
+
+    @property
+    def skipped(self) -> int:
+        return sum(1 for f in self.all_fields if f.status == "SKIP")
 
 
 @dataclass
@@ -404,50 +424,44 @@ def _opendota_teamfights_from_combat_log(combat_log: list[Any]) -> list[dict[str
 # Core validation
 # ---------------------------------------------------------------------------
 
-_SAMPLE_NOTE = (
-    "gem samples entity state at 30-tick (≈1 s) intervals; "
-    "OpenDota uses the server's final game-end snapshot. "
-    "Small residual differences are expected; net worth can drift a bit more "
-    "than kills / last hits because Steam final scalars and replay-exposed "
-    "m_iNetWorth values are not always identical."
+_TERMINAL_NOTE = (
+    "Terminal-to-terminal comparison. gem forces a dense entity sample at the "
+    "game-end tick; OpenDota's scalar comes from Steam's final server snapshot. "
+    "Replay-exposed m_iNetWorth can still differ slightly from the Steam scalar."
 )
 
 _NET_WORTH_TOLERANCE = 0.08
-# Advantage and player minute curves: gem samples interval boundaries on the
-# combat-log timestamp axis OpenDota uses (parser.combat_log_time_s) AND reads
-# the team-data frame observed one entity tick before the boundary crossing
-# (the boundary-nudge fix), matching OpenDota's effective read instant. The
-# curves now coincide with OpenDota almost exactly. Observed max element-wise
-# error across the five validation fixtures (tournament + ranked pub), measured
-# 2026-06-18: gold_t <=0.65%, xp_t <=0.40%, gold_adv <=0.88%, xp_adv <=0.47%,
-# with every advantage final matching to within 1 unit. Tolerances sit a few
-# multiples above that worst case: tight enough that reverting the nudge or the
-# clock/source alignment (which pushes errors back to ~10%) fails the gate,
-# loose enough that an unseen fixture's sub-second end-game wiggle still passes.
-_GOLD_ADV_TOLERANCE = 0.02
-_GOLD_ADV_CURVE_TOLERANCE_PCT = 3.0
-_XP_ADV_TOLERANCE = 0.02
-_XP_ADV_CURVE_TOLERANCE_PCT = 2.5
-_PLAYER_GOLD_T_CURVE_TOLERANCE_PCT = 3.0
-_PLAYER_XP_T_CURVE_TOLERANCE_PCT = 3.0
-_PLAYER_LH_T_ABS_TOLERANCE = 5
-_PLAYER_LH_T_REL_TOLERANCE = 0.02
-_PLAYER_DN_T_ABS_TOLERANCE = 2
+# Advantage and player minute curves: gem decodes CNETMsg_Tick, queues the first
+# rounded-minute crossing, and samples the reconstructed entity table at the
+# following tick start. This reproduces Clarity's effective @OnTickStart phase;
+# the minute-zero m_iTotalEarnedGold offset is removed without zeroing genuine
+# pre-horn earnings. Across four replay fixtures (1,410 player-minute points per
+# metric, including the 2026 TI sample), gold/XP/LH/DN and both advantage curves
+# are point-exact after this alignment. The remaining nonzero gates are narrow
+# portability headroom for unseen patches: a one-creep boundary regression is
+# warned immediately and meaningful frame/clock drift fails.
+_GOLD_ADV_TOLERANCE = 0.0025
+_GOLD_ADV_CURVE_TOLERANCE_PCT = 0.25
+_XP_ADV_TOLERANCE = 0.0025
+_XP_ADV_CURVE_TOLERANCE_PCT = 0.25
+_PLAYER_GOLD_T_CURVE_TOLERANCE_PCT = 0.25
+_PLAYER_XP_T_CURVE_TOLERANCE_PCT = 0.25
+_PLAYER_LH_T_ABS_TOLERANCE = 2
+_PLAYER_LH_T_REL_TOLERANCE = 0.0025
+_PLAYER_DN_T_ABS_TOLERANCE = 1
+_ADV_CURVE_WARNING_PCT = 0.05
+_PLAYER_CURVE_WARNING_PCT = 0.05
+_PLAYER_LH_T_WARNING_ABS = 0
+_PLAYER_DN_T_WARNING_ABS = 0
 _GOLD_ADV_NOTE = (
-    "gem builds gold_adv from m_iTotalEarnedGold sampled on the combat-log "
-    "timestamp axis (the same axis OpenDota uses for its interval boundaries), "
-    "so the curves match OpenDota almost exactly. Any residual is sub-second "
-    "end-game wiggle at the final minute boundary."
+    "gem builds advantage curves from m_iTotalEarnedGold/m_iTotalEarnedXP at "
+    "the decoded network-tick phase corresponding to OpenDota's @OnTickStart "
+    "interval read. Any residual indicates an entity-update boundary mismatch."
 )
 _PLAYER_MINUTE_ARRAY_NOTE = (
-    "OpenDota player minute arrays come from its interval parser pipeline. "
-    "Compare by array index; residual drift is tracked before changing parser behavior."
-)
-_MINUTE_SAMPLE_NOTE = (
-    "This is the last whole-minute snapshot before game end, compared against "
-    "a final server scalar. It is informational only and is excluded from "
-    "pass/fail counts because up to 59 seconds of gameplay can elapse after "
-    "the final minute boundary."
+    "OpenDota player minute arrays come from its @OnTickStart interval pipeline. "
+    "Values are joined by the explicit non-negative game-minute key; list "
+    "position is never used when gem exposes its game-time axis."
 )
 
 
@@ -475,61 +489,123 @@ def _allowed_abs_error(
     return max(absolute_floor, math.ceil(max_abs_ref * relative_tolerance))
 
 
+def _minute_key_summary(keys: list[int]) -> str:
+    """Return a compact, readable representation of a minute-key axis."""
+    if not keys:
+        return "[]"
+    if keys == list(range(keys[0], keys[-1] + 1)):
+        return f"{keys[0]}..{keys[-1]} ({len(keys)} keys)"
+    if len(keys) <= 10:
+        return str(keys)
+    return f"{keys[:4]} ... {keys[-4:]} ({len(keys)} keys)"
+
+
 def _compare_opendota_player_array(
     label: str,
     name: str,
     gem_values: list[int],
     ref_values: list[int],
     *,
+    gem_times_s: list[int] | None = None,
     max_curve_error_pct: float | None = None,
     max_abs_error: int | None = None,
     max_abs_error_pct: float | None = None,
+    final_relative_tolerance: float | None = None,
+    warning_curve_error_pct: float | None = None,
+    warning_abs_error: int | None = None,
+    comparison_note: str | None = None,
 ) -> list[FieldResult]:
-    """Compare one gem player minute array against one OpenDota player array."""
+    """Compare one gem minute array against OpenDota by game-minute key.
+
+    OpenDota arrays are indexed by the non-negative game minute. ``gem_times_s``
+    carries gem's explicit game-relative axis. ``None`` is retained only as a
+    backwards-compatible positional axis for direct helper callers; production
+    validation always passes the parsed axis explicitly.
+    """
+    prefix = f"{label}/{name}" if label else name
     missing_ref = not ref_values
-    missing_note = f"OpenDota did not expose player {name} for this match."
-    note = missing_note if missing_ref else _PLAYER_MINUTE_ARRAY_NOTE
+    missing_note = (
+        f"OpenDota did not expose player {name} for this match."
+        if label
+        else f"OpenDota did not expose {name} for this match."
+    )
+    note = missing_note if missing_ref else (comparison_note or _PLAYER_MINUTE_ARRAY_NOTE)
+
+    if gem_times_s is None:
+        gem_minute_keys = list(range(len(gem_values)))
+        axis_valid = True
+    else:
+        axis_valid = len(gem_times_s) == len(gem_values) and all(
+            isinstance(time_s, int) and time_s >= 0 and time_s % 60 == 0 for time_s in gem_times_s
+        )
+        gem_minute_keys = [time_s // 60 for time_s in gem_times_s]
+        axis_valid = axis_valid and len(set(gem_minute_keys)) == len(gem_minute_keys)
+
+    ref_minute_keys = list(range(len(ref_values)))
+    coverage_matches = axis_valid and gem_minute_keys == ref_minute_keys
     fields = [
         FieldResult(
-            f"{label}/{name}/length",
+            f"{prefix}/length",
             len(gem_values),
             len(ref_values),
             skip=missing_ref,
             note=note if missing_ref else "",
-        )
+        ),
+        FieldResult(
+            f"{prefix}/minute_keys",
+            _minute_key_summary(gem_minute_keys),
+            _minute_key_summary(ref_minute_keys),
+            skip=missing_ref,
+            ok_override=coverage_matches,
+            note=note,
+        ),
     ]
 
-    gem_final = gem_values[-1] if gem_values else None
+    # A value comparison is meaningful only when both curves cover the same
+    # minute keys. The length/key fields above provide the actionable failure.
+    if missing_ref or not coverage_matches:
+        return fields
+
+    gem_by_minute = dict(zip(gem_minute_keys, gem_values, strict=True))
+    aligned_gem_values = [gem_by_minute[minute] for minute in ref_minute_keys]
+
+    gem_final = aligned_gem_values[-1] if aligned_gem_values else None
     ref_final = ref_values[-1] if ref_values else None
     if max_curve_error_pct is not None:
+        final_tolerance = (
+            final_relative_tolerance
+            if final_relative_tolerance is not None
+            else max_curve_error_pct / 100
+        )
+        final_warn = False
+        if (
+            warning_curve_error_pct is not None
+            and isinstance(gem_final, (int, float))
+            and isinstance(ref_final, (int, float))
+            and ref_final != 0
+        ):
+            final_warn = abs(gem_final - ref_final) / abs(ref_final) * 100 > warning_curve_error_pct
         fields.append(
             FieldResult(
-                f"{label}/{name}/final",
+                f"{prefix}/final",
                 gem_final,
                 ref_final,
-                tolerance=max_curve_error_pct / 100,
-                skip=missing_ref,
+                tolerance=final_tolerance,
+                warn_override=final_warn,
                 note=note,
             )
         )
-        if gem_values and ref_values and len(gem_values) == len(ref_values):
-            err_pct = _max_curve_error_pct(gem_values, ref_values)
+        if aligned_gem_values and ref_values:
+            err_pct = _max_curve_error_pct(aligned_gem_values, ref_values)
             fields.append(
                 FieldResult(
-                    f"{label}/{name}/max_curve_err%",
+                    f"{prefix}/max_curve_err%",
                     err_pct,
                     max_curve_error_pct,
                     ok_override=err_pct <= max_curve_error_pct,
-                    note=note,
-                )
-            )
-        elif missing_ref:
-            fields.append(
-                FieldResult(
-                    f"{label}/{name}/max_curve_err%",
-                    None,
-                    max_curve_error_pct,
-                    skip=True,
+                    warn_override=(
+                        warning_curve_error_pct is not None and err_pct > warning_curve_error_pct
+                    ),
                     note=note,
                 )
             )
@@ -546,32 +622,27 @@ def _compare_opendota_player_array(
     )
     fields.append(
         FieldResult(
-            f"{label}/{name}/final_abs_err",
+            f"{prefix}/final_abs_err",
             final_abs_error,
             allowed_abs_error,
-            skip=missing_ref,
             ok_override=final_abs_error is not None and final_abs_error <= allowed_abs_error,
+            warn_override=(
+                warning_abs_error is not None
+                and final_abs_error is not None
+                and final_abs_error > warning_abs_error
+            ),
             note=note,
         )
     )
-    if gem_values and ref_values and len(gem_values) == len(ref_values):
-        err = _max_abs_error(gem_values, ref_values)
+    if aligned_gem_values and ref_values:
+        err = _max_abs_error(aligned_gem_values, ref_values)
         fields.append(
             FieldResult(
-                f"{label}/{name}/max_abs_err",
+                f"{prefix}/max_abs_err",
                 err,
                 allowed_abs_error,
                 ok_override=err <= allowed_abs_error,
-                note=note,
-            )
-        )
-    elif missing_ref:
-        fields.append(
-            FieldResult(
-                f"{label}/{name}/max_abs_err",
-                None,
-                allowed_abs_error,
-                skip=True,
+                warn_override=warning_abs_error is not None and err > warning_abs_error,
                 note=note,
             )
         )
@@ -690,99 +761,40 @@ def validate_match(
             )
 
     if mode in {"parsed", "full"}:
-        # radiant_gold_adv / radiant_xp_adv — per-minute curves
-        # Compare array length and last value (full curve comparison via max element-wise diff)
+        # Radiant advantage curves: OpenDota's array index is the non-negative
+        # game minute. Join it to gem's explicit game-time axis before measuring
+        # final or max error; equal-length shifted curves must not compare.
         od_gold_adv = od.get("radiant_gold_adv") or []
         od_xp_adv = od.get("radiant_xp_adv") or []
         gem_gold_adv = m.radiant_gold_adv or []
         gem_xp_adv = m.radiant_xp_adv or []
-
-        od_adv_missing = not od_gold_adv and not od_xp_adv
-        result.match_fields.append(
-            FieldResult(
-                "radiant_gold_adv/length",
-                len(gem_gold_adv),
-                len(od_gold_adv),
-                skip=od_adv_missing,
-                note="OpenDota did not compute gold/XP advantage curves for this match."
-                if od_adv_missing
-                else "",
+        gem_adv_times = list(m.game_times_min or [])
+        result.match_fields.extend(
+            _compare_opendota_player_array(
+                "",
+                "radiant_gold_adv",
+                list(gem_gold_adv),
+                list(od_gold_adv),
+                gem_times_s=gem_adv_times,
+                max_curve_error_pct=_GOLD_ADV_CURVE_TOLERANCE_PCT,
+                final_relative_tolerance=_GOLD_ADV_TOLERANCE,
+                warning_curve_error_pct=_ADV_CURVE_WARNING_PCT,
+                comparison_note=_GOLD_ADV_NOTE,
             )
         )
-        result.match_fields.append(
-            FieldResult(
-                "radiant_xp_adv/length",
-                len(gem_xp_adv),
-                len(od_xp_adv),
-                skip=od_adv_missing,
-                note="OpenDota did not compute gold/XP advantage curves for this match."
-                if od_adv_missing
-                else "",
+        result.match_fields.extend(
+            _compare_opendota_player_array(
+                "",
+                "radiant_xp_adv",
+                list(gem_xp_adv),
+                list(od_xp_adv),
+                gem_times_s=gem_adv_times,
+                max_curve_error_pct=_XP_ADV_CURVE_TOLERANCE_PCT,
+                final_relative_tolerance=_XP_ADV_TOLERANCE,
+                warning_curve_error_pct=_ADV_CURVE_WARNING_PCT,
+                comparison_note=_GOLD_ADV_NOTE,
             )
         )
-
-        # Final value comparison (last minute — most meaningful single scalar)
-        gem_gold_final = gem_gold_adv[-1] if gem_gold_adv else None
-        od_gold_final = od_gold_adv[-1] if od_gold_adv else None
-        result.match_fields.append(
-            FieldResult(
-                "radiant_gold_adv/final",
-                gem_gold_final,
-                od_gold_final,
-                tolerance=_GOLD_ADV_TOLERANCE,
-                skip=od_adv_missing,
-                note="OpenDota did not compute gold/XP advantage curves for this match."
-                if od_adv_missing
-                else _GOLD_ADV_NOTE,
-            )
-        )
-        gem_xp_final = gem_xp_adv[-1] if gem_xp_adv else None
-        od_xp_final = od_xp_adv[-1] if od_xp_adv else None
-        result.match_fields.append(
-            FieldResult(
-                "radiant_xp_adv/final",
-                gem_xp_final,
-                od_xp_final,
-                tolerance=_XP_ADV_TOLERANCE,
-                skip=od_adv_missing,
-                note="OpenDota did not compute gold/XP advantage curves for this match."
-                if od_adv_missing
-                else "",
-            )
-        )
-
-        # Max element-wise relative error across the curve (gem=actual %, ref=5% threshold).
-        if gem_gold_adv and od_gold_adv and len(gem_gold_adv) == len(od_gold_adv):
-            max_abs = max(abs(v) for v in od_gold_adv) or 1
-            err_pct = round(
-                max(abs(g - o) for g, o in zip(gem_gold_adv, od_gold_adv, strict=True))
-                / max_abs
-                * 100,
-                2,
-            )
-            result.match_fields.append(
-                FieldResult(
-                    "radiant_gold_adv/max_curve_err%",
-                    err_pct,
-                    _GOLD_ADV_CURVE_TOLERANCE_PCT,
-                    ok_override=err_pct <= _GOLD_ADV_CURVE_TOLERANCE_PCT,
-                    note=_GOLD_ADV_NOTE,
-                )
-            )
-        if gem_xp_adv and od_xp_adv and len(gem_xp_adv) == len(od_xp_adv):
-            max_abs = max(abs(v) for v in od_xp_adv) or 1
-            err_pct = round(
-                max(abs(g - o) for g, o in zip(gem_xp_adv, od_xp_adv, strict=True)) / max_abs * 100,
-                2,
-            )
-            result.match_fields.append(
-                FieldResult(
-                    "radiant_xp_adv/max_curve_err%",
-                    err_pct,
-                    _XP_ADV_CURVE_TOLERANCE_PCT,
-                    ok_override=err_pct <= _XP_ADV_CURVE_TOLERANCE_PCT,
-                )
-            )
 
     # -----------------------------------------------------------------------
     # Player-level fields
@@ -808,61 +820,31 @@ def validate_match(
             result.player_fields.append(fields)
             continue
 
-        # --- 30-tick sampler (last sample, ≈1 s resolution) ---
-        gem_nw = gp.net_worth_t[-1] if gp.net_worth_t else None
+        # --- terminal scalars (same game-end semantic on both sides) ---
         fields.append(
             FieldResult(
-                f"{label}/net_worth[30t]",
-                gem_nw,
+                f"{label}/net_worth[terminal]",
+                gp.net_worth,
                 od_player["net_worth"],
                 tolerance=_NET_WORTH_TOLERANCE,
-                note=_SAMPLE_NOTE,
+                note=_TERMINAL_NOTE,
             )
         )
-        gem_lh = gp.lh_t[-1] if gp.lh_t else None
         fields.append(
             FieldResult(
-                f"{label}/last_hits[30t]",
-                gem_lh,
+                f"{label}/last_hits[terminal]",
+                gp.last_hits,
                 od_player["last_hits"],
                 tolerance=0.01,
-                note=_SAMPLE_NOTE,
+                note=_TERMINAL_NOTE,
             )
         )
-        gem_dn = gp.dn_t[-1] if gp.dn_t else None
-        fields.append(FieldResult(f"{label}/denies[30t]", gem_dn, od_player["denies"]))
-
-        # --- per-minute sampler (last whole-minute snapshot, OpenDota-aligned) ---
-        gem_nw_min = gp.net_worth_t_min[-1] if gp.net_worth_t_min else None
         fields.append(
             FieldResult(
-                f"{label}/net_worth[min]",
-                gem_nw_min,
-                od_player["net_worth"],
-                tolerance=_NET_WORTH_TOLERANCE,
-                note=_MINUTE_SAMPLE_NOTE,
-                skip=True,
-            )
-        )
-        gem_lh_min = gp.lh_t_min[-1] if gp.lh_t_min else None
-        fields.append(
-            FieldResult(
-                f"{label}/last_hits[min]",
-                gem_lh_min,
-                od_player["last_hits"],
-                tolerance=0.01,
-                note=_MINUTE_SAMPLE_NOTE,
-                skip=True,
-            )
-        )
-        gem_dn_min = gp.dn_t_min[-1] if gp.dn_t_min else None
-        fields.append(
-            FieldResult(
-                f"{label}/denies[min]",
-                gem_dn_min,
+                f"{label}/denies[terminal]",
+                gp.denies,
                 od_player["denies"],
-                note=_MINUTE_SAMPLE_NOTE,
-                skip=True,
+                note=_TERMINAL_NOTE,
             )
         )
 
@@ -873,7 +855,9 @@ def validate_match(
                     "gold_t",
                     list(gp.gold_t_min),
                     list(od_player.get("gold_t") or []),
+                    gem_times_s=list(gp.game_times_min),
                     max_curve_error_pct=_PLAYER_GOLD_T_CURVE_TOLERANCE_PCT,
+                    warning_curve_error_pct=_PLAYER_CURVE_WARNING_PCT,
                 )
             )
             fields.extend(
@@ -882,7 +866,9 @@ def validate_match(
                     "xp_t",
                     list(gp.xp_t_min),
                     list(od_player.get("xp_t") or []),
+                    gem_times_s=list(gp.game_times_min),
                     max_curve_error_pct=_PLAYER_XP_T_CURVE_TOLERANCE_PCT,
+                    warning_curve_error_pct=_PLAYER_CURVE_WARNING_PCT,
                 )
             )
             fields.extend(
@@ -891,8 +877,10 @@ def validate_match(
                     "lh_t",
                     list(gp.lh_t_min),
                     list(od_player.get("lh_t") or []),
+                    gem_times_s=list(gp.game_times_min),
                     max_abs_error=_PLAYER_LH_T_ABS_TOLERANCE,
                     max_abs_error_pct=_PLAYER_LH_T_REL_TOLERANCE,
+                    warning_abs_error=_PLAYER_LH_T_WARNING_ABS,
                 )
             )
             fields.extend(
@@ -901,7 +889,9 @@ def validate_match(
                     "dn_t",
                     list(gp.dn_t_min),
                     list(od_player.get("dn_t") or []),
+                    gem_times_s=list(gp.game_times_min),
                     max_abs_error=_PLAYER_DN_T_ABS_TOLERANCE,
+                    warning_abs_error=_PLAYER_DN_T_WARNING_ABS,
                 )
             )
 
@@ -928,9 +918,13 @@ def _diff_str(f: FieldResult) -> str:
 
 def _status_style(f: FieldResult) -> tuple[str, str]:
     """Return (status_text, rich_style) for a field result."""
-    if f.skip:
-        return ("SKIP", "yellow")
-    return ("OK", "green") if f.ok else ("FAIL", "bold red")
+    styles = {
+        "PASS": "green",
+        "WARN": "bold yellow",
+        "FAIL": "bold red",
+        "SKIP": "dim",
+    }
+    return f.status, styles[f.status]
 
 
 def print_result(r: MatchResult, verbose: bool = False) -> None:
@@ -978,8 +972,8 @@ def print_result(r: MatchResult, verbose: bool = False) -> None:
     console.print(mtable)
 
     # --- Per-player table ---
-    failures = [f for pf in r.player_fields for f in pf if not f.ok]
-    shown_fields = [f for pf in r.player_fields for f in pf] if verbose else failures
+    findings = [f for pf in r.player_fields for f in pf if f.status in {"WARN", "FAIL"}]
+    shown_fields = [f for pf in r.player_fields for f in pf] if verbose else findings
 
     if shown_fields:
         ptable = Table(box=box.SIMPLE_HEAVY, show_header=True, header_style="bold")
@@ -1001,18 +995,23 @@ def print_result(r: MatchResult, verbose: bool = False) -> None:
 
         console.print(
             "[bold]Per-player[/]"
-            + ("" if verbose else " [dim](failures only — use --verbose for all)[/]")
+            + ("" if verbose else " [dim](warnings/failures only — use --verbose for all)[/]")
         )
         console.print(ptable)
 
-        if failures and verbose:
-            console.print(f"  [dim]{_SAMPLE_NOTE}[/]")
+        if findings and verbose:
+            console.print(f"  [dim]{_TERMINAL_NOTE}[/]")
     else:
         console.print("[bold]Per-player[/]")
         console.print("  [green]All player fields OK[/] [dim](use --verbose to show all)[/]")
 
-    style = "green" if r.failed == 0 else "bold red"
-    console.print(f"  Result: [{style}]{r.passed} passed, {r.failed} failed[/]\n")
+    style = "green" if r.failed == 0 and r.warned == 0 else "yellow"
+    if r.failed:
+        style = "bold red"
+    console.print(
+        f"  Result: [{style}]{r.passed} passed, {r.warned} warned, "
+        f"{r.failed} failed, {r.skipped} skipped[/]\n"
+    )
 
 
 def results_to_jsonable(results: list[MatchResult]) -> list[dict[str, Any]]:
@@ -1026,13 +1025,16 @@ def results_to_jsonable(results: list[MatchResult]) -> list[dict[str, Any]]:
                 "mode": r.mode,
                 "errors": r.errors,
                 "passed": r.passed,
+                "warned": r.warned,
                 "failed": r.failed,
+                "skipped": r.skipped,
                 "fields": [
                     {
                         "name": f.name,
                         "gem": f.gem_value,
                         "ref": f.ref_value,
                         "ok": f.ok,
+                        "status": f.status,
                         "diff_pct": round(f.diff * 100, 2) if f.diff is not None else None,
                         "note": f.note or None,
                     }
@@ -1317,12 +1319,18 @@ def main() -> None:
             print_result(r, verbose=args.verbose)
 
         total_failed = sum(r.failed for r in results)
+        total_warned = sum(r.warned for r in results)
         total_errors = sum(len(r.errors) for r in results)
         console.print(Rule())
-        style = "green" if total_failed == 0 and total_errors == 0 else "bold red"
+        style = "green"
+        if total_warned:
+            style = "yellow"
+        if total_failed or total_errors:
+            style = "bold red"
         console.print(
             f"[{style}]Summary: {len(results)} match(es), "
-            f"{total_failed} field failures, {total_errors} errors[/]"
+            f"{total_warned} field warnings, {total_failed} field failures, "
+            f"{total_errors} errors[/]"
         )
 
     total_failed = sum(r.failed for r in results)

--- a/src/gem/extractors/README.md
+++ b/src/gem/extractors/README.md
@@ -170,21 +170,23 @@ so the authoritative `gold_t`/`xp_t` advantage curves come from
 `CDOTA_DataRadiant`/`Dire` (via `m_vecDataTeam`) sampled exactly on game-clock
 interval boundaries, without overloading `PlayerExtractor`.
 
-Two subtle behaviours distinguish it from the dense player sampler:
+Three subtle behaviours distinguish it from the dense player sampler:
 
-- **Clock axis** (`_clock`): it samples on `parser.combat_log_time_s` (the
-  combat-log timestamp axis anchored at the GAME_STATE==5 horn), falling back to
-  `parser.game_time_s` only before the horn timestamp is known. This avoids an
-  off-by-one final minute.
-- **Frame nudge** (`_team_data_values`): OpenDota reads the interval one entity
-  frame *before* gem's clock crossing, so `_emit` uses the latest team-data
-  frame with `observed_tick < emit_tick` rather than the live boundary-tick
-  value, removing a systematic +1. `_emit_final_boundary` is the one exception —
-  a terminal read at game end keeps the live value.
+- **Network-tick clock**: `ReplayParser` decodes `CNETMsg_Tick` and refreshes
+  `game_time_s` from that server tick (including pause ticks), rather than the
+  unrelated outer demo tick or the latest, possibly stale combat-log event.
+- **Clarity phase** (`_on_tick_start`): the first rounded-minute crossing is
+  queued and sampled at the following network tick start. This includes the
+  crossing tick's entity deltas but precedes the next tick's deltas, matching
+  OpenDota's effective `@OnTickStart` read. Parsers without the new callback
+  retain the two-frame entity-callback fallback.
+- **Minute-zero offset**: the production path subtracts the observed one-unit
+  earned-gold initialization offset while preserving genuine
+  pre-horn earnings. `_emit_final_boundary` remains a live terminal read.
 
 It also carries terminal scalar counters (`team_counters`) read from the same
 `m_vecDataTeam` entry (camps/creeps stacked, wards placed, rune pickups, tower
-kills) and emits OpenDota's synthetic t=0 baseline.
+kills) and emits OpenDota's observed t=0 baseline.
 
 ### teamfights.py — `detect_teamfights` (post-parse function)
 

--- a/src/gem/extractors/_snapshots.py
+++ b/src/gem/extractors/_snapshots.py
@@ -335,6 +335,9 @@ class PlayerTimeSeries:
     Attributes:
         player_id: Player slot (0-9).
         ticks: Tick values for each sample.
+        game_times_s: Game-relative seconds for each minute sample, using exact
+            non-negative 60-second boundaries. Populated by
+            ``PlayerExtractor.minute_time_series``; empty for the dense series.
         gold_t: Current unspent gold at each sample tick.
         total_earned_gold_t: Cumulative total earned gold at each sample tick.
         total_earned_xp_t: Cumulative total earned XP at each sample tick.
@@ -369,3 +372,6 @@ class PlayerTimeSeries:
     total_hero_healing_t: list[int] = field(default_factory=list)
     total_deaths_t: list[int] = field(default_factory=list)
     total_stuns_t: list[float] = field(default_factory=list)
+    # Append-only: this internal dataclass is also constructed in downstream
+    # integrations, so keep new defaulted fields at the end.
+    game_times_s: list[int] = field(default_factory=list)

--- a/src/gem/extractors/intervals.py
+++ b/src/gem/extractors/intervals.py
@@ -100,10 +100,11 @@ class IntervalTimeSeries:
 class IntervalExtractor:
     """Collect 60-second player intervals from authoritative team entities.
 
-    The extractor is internal plumbing for OpenDota-parity output. It samples
-    only when the parser's game clock lands on an exact interval boundary and
-    falls silent otherwise; callers can fall back to existing player minute
-    series when no complete interval data was observed for a replay.
+    The extractor is internal plumbing for OpenDota-parity output. It queues an
+    exact rounded-minute crossing, then samples at the following network tick
+    start before that tick's entity deltas. This mirrors OpenDota's effective
+    Clarity ``@OnTickStart`` phase; callers can fall back to existing player
+    minute series when no complete interval data was observed for a replay.
     """
 
     snapshots: list[IntervalSnapshot]
@@ -126,18 +127,11 @@ class IntervalExtractor:
         self._data_radiant: Entity | None = None
         self._data_dire: Entity | None = None
         # Per-team-slot team-data history, kept to the two most recent observed
-        # frames as ``(observed_tick, (gold, xp, lh, dn, net_worth))``. OpenDota's
-        # interval read lands one entity frame earlier than gem's clock crossing,
-        # so emitting the live (boundary-tick) value double-counts the increment
-        # that arrived on the boundary tick. ``_emit`` instead reads the latest
-        # frame observed *strictly before* the boundary tick, removing the
-        # systematic +1. Two frames suffice for that rule: when a slot updates on
-        # the boundary tick the prior frame is used; when a slot is off-cadence
-        # and did not update on the boundary tick its current frame already
-        # precedes the crossing and is used directly. Entities mutate in place,
-        # so values are copied eagerly rather than held by reference. See
-        # ``_record_team_data`` / ``_team_data_values`` and
-        # ``test_nudge_reads_previous_data_frame``.
+        # frames as ``(observed_tick, (gold, xp, lh, dn, net_worth))``. The
+        # production tick-start path reads ``cur`` after its one-tick deferral.
+        # ``prev`` preserves the entity-callback compatibility path, where the
+        # latest frame strictly before a crossing is required. Entities mutate
+        # in place, so values are copied eagerly rather than held by reference.
         self._prev_data_radiant: dict[int, _TeamDataFrame] = {}
         self._prev_data_dire: dict[int, _TeamDataFrame] = {}
         self._cur_data_radiant: dict[int, _TeamDataFrame] = {}
@@ -152,6 +146,13 @@ class IntervalExtractor:
         self._player_team_slot: dict[int, int] = {}
         self._hero_names: dict[int, str] = {}
         self._next_interval_s: int | None = None
+        self._tick_start_driven = False
+        # Clarity's @OnTickStart interval read is effectively one decoded net
+        # tick after the first CNETMsg_Tick whose rounded clock reaches the
+        # boundary. Queue that first crossing and emit at the next tick start,
+        # after the crossing tick's entity deltas but before the next tick's.
+        self._pending_tick_start_boundary: tuple[int, int] | None = None
+        self._last_queued_time_s: int | None = None
         self._last_clock_tick: int | None = None
         self._last_emitted_time_s: int | None = None
         self._last_emitted_tick: int | None = None
@@ -164,6 +165,10 @@ class IntervalExtractor:
         self._parser = parser
         parser.on_entity(self._on_entity)
         parser.on_game_end(self._on_game_end)
+        on_tick_start = getattr(parser, "on_tick_start", None)
+        if callable(on_tick_start):
+            self._tick_start_driven = True
+            on_tick_start(self._on_tick_start)
 
     @property
     def all_snapshots(self) -> list[IntervalSnapshot]:
@@ -195,21 +200,16 @@ class IntervalExtractor:
         return ts
 
     def _clock(self) -> int | None:
-        """Return the game clock the extractor samples boundaries on.
+        """Return the clock used by the entity-callback fallback and final flush.
 
-        OpenDota times its interval boundaries and its postGame stop on a single
-        axis: the combat-log timestamp axis, anchored at the GAME_STATE==5 horn.
-        gem's entity-derived ``game_time_s`` differs from that axis by a
-        per-replay constant (the gap between the horn timestamp and
-        ``m_flGameStartTime``), large enough on some replays to drop the final
-        minute boundary before ``_on_game_end`` (also combat-log timed) fires.
+        Normal parsing samples ``parser.game_time_s`` directly from
+        :meth:`_on_tick_start`; the parser refreshes it from ``CNETMsg_Tick``
+        before current-tick entity deltas. The combat-log clock remains useful
+        for the terminal recovery path because postGame is itself a combat-log
+        event. It is also retained for parsers without tick-start callbacks.
 
-        Prefer the combat-log axis (``parser.combat_log_time_s``); fall back to
-        the entity clock (``game_time_s``) before the horn timestamp is known,
-        when no intervals should emit yet anyway.
-
-        Reference: refs/parser/src/main/java/opendota/Parse.java — single
-        ``time`` axis shifted by ``gameStartTime`` for intervals and postGame.
+        Reference: refs/parser/src/main/java/opendota/Parse.java —
+        ``@OnTickStart`` for intervals and combat-log GAME_STATE 6 for postGame.
         """
         if self._parser is None:
             return None
@@ -221,6 +221,39 @@ class IntervalExtractor:
     def _on_game_end(self, tick: int) -> None:
         self._emit_final_boundary(tick)
         self._ended = True
+
+    def _on_tick_start(self, net_tick: int) -> None:
+        """Queue a crossing, then sample before the following tick's updates.
+
+        ``ReplayParser`` refreshes ``game_time_s`` from ``net_tick`` before
+        invoking this callback. Clarity's ``@OnTickStart`` interval handler is
+        one network tick later than the first rounded-clock crossing observed
+        here. Deferring to the following callback includes the crossing tick's
+        entity deltas while still reading before the next tick's mutations.
+
+        Args:
+            net_tick: Decoded ``CNETMsg_Tick.tick`` value.
+        """
+        if self._parser is None or self._ended:
+            return
+        game_time_s = getattr(self._parser, "game_time_s", None)
+        if (
+            self._pending_tick_start_boundary is None
+            and game_time_s is not None
+            and game_time_s >= 0
+            and game_time_s % self._interval_s == 0
+            and game_time_s != self._last_queued_time_s
+        ):
+            self._pending_tick_start_boundary = (game_time_s, net_tick)
+            self._last_queued_time_s = game_time_s
+
+        pending = self._pending_tick_start_boundary
+        if pending is None or net_tick <= pending[1]:
+            return
+        boundary_time_s = pending[0]
+        self._try_emit(boundary_time_s, use_live=True)
+        if self._last_emitted_time_s == boundary_time_s:
+            self._pending_tick_start_boundary = None
 
     def _on_entity(self, entity: Entity, op: EntityOp) -> None:
         cls = entity.get_class_name()
@@ -293,10 +326,22 @@ class IntervalExtractor:
         self._player_team_slot = scan.team_slot_by_id
 
     def _maybe_emit(self) -> None:
+        if self._tick_start_driven or self._parser is None:
+            return
+
+        self._try_emit(self._clock(), use_live=False, require_fresh_clock=True)
+
+    def _try_emit(
+        self,
+        game_time_s: int | None,
+        *,
+        use_live: bool,
+        require_fresh_clock: bool = False,
+    ) -> None:
+        """Emit one complete interval batch when ``game_time_s`` is eligible."""
         if self._parser is None or self._ended:
             return
 
-        game_time_s = self._clock()
         if game_time_s is None or game_time_s < 0:
             return
         if game_time_s == 0 and self._last_emitted_time_s is None:
@@ -317,7 +362,11 @@ class IntervalExtractor:
         # The one exception is a pending initial t=0 boundary: the clock callback
         # may precede the player/team entities needed for a complete batch, and
         # the combat-log clock may advance before those entities arrive.
-        if self._last_clock_tick != self._parser.tick and not initial_boundary:
+        if (
+            require_fresh_clock
+            and self._last_clock_tick != self._parser.tick
+            and not initial_boundary
+        ):
             return
         if boundary_time_s % self._interval_s != 0:
             return
@@ -326,7 +375,7 @@ class IntervalExtractor:
         if self._next_interval_s is not None and boundary_time_s < self._next_interval_s:
             return
 
-        emitted = self._emit(boundary_time_s, use_live=initial_boundary)
+        emitted = self._emit(boundary_time_s, use_live=use_live or initial_boundary)
         if emitted:
             if initial_boundary:
                 self._initial_boundary_pending = False
@@ -540,6 +589,13 @@ class IntervalExtractor:
                 tick,
                 use_live=use_live,
             )
+            # The live team-data baseline is consistently one earned-gold unit
+            # above OpenDota at minute zero. Remove only that initialization
+            # offset in the production tick-start path. Genuine nonzero pre-horn
+            # earnings remain intact (e.g. 322 -> 321, not 322 -> 0), and legacy
+            # parser adapters retain their raw values.
+            if self._tick_start_driven and game_time_s == 0 and gold > 0:
+                gold -= 1
             player_slot = team_slot if team == TEAM_RADIANT else 128 + team_slot
             self.snapshots.append(
                 IntervalSnapshot(

--- a/src/gem/extractors/players.py
+++ b/src/gem/extractors/players.py
@@ -307,7 +307,8 @@ class PlayerExtractor:
         Returns a ``PlayerTimeSeries`` sampled at each game-minute boundary
         (every 1800 ticks from game start). ``total_earned_gold_t`` /
         ``total_earned_xp_t`` match OpenDota's cumulative gold/XP semantics;
-        ``gold_t`` remains current unspent gold.
+        ``gold_t`` remains current unspent gold. ``game_times_s`` is the
+        authoritative parallel game-relative axis (``0, 60, 120, ...``).
 
         Only populated when ``minute_snapshots=True`` (the default) and the
         parser fires the game-start event.
@@ -336,6 +337,15 @@ class PlayerExtractor:
         ts = PlayerTimeSeries(player_id=player_id)
         for snap in (seen[k] for k in sorted(seen)):
             ts.ticks.append(snap.tick)
+            # ``seen`` is keyed by the authoritative game-minute index. Preserve
+            # that axis explicitly instead of asking consumers to reconstruct it
+            # from absolute replay ticks (whose origin differs across replays).
+            if snap.game_time_s is not None and snap.game_time_s >= 0:
+                ts.game_times_s.append((snap.game_time_s // 60) * 60)
+            elif self._game_start_tick is not None:
+                ts.game_times_s.append(max(0, (snap.tick - self._game_start_tick) // 1800) * 60)
+            else:
+                ts.game_times_s.append(len(ts.game_times_s) * 60)
             ts.gold_t.append(snap.gold)
             ts.total_earned_gold_t.append(snap.total_earned_gold)
             ts.total_earned_xp_t.append(snap.total_earned_xp)

--- a/src/gem/parser.py
+++ b/src/gem/parser.py
@@ -80,6 +80,7 @@ from gem.proto.netmessages_pb2 import (
     CSVCMsg_UpdateStringTable,
     CSVCMsg_UserMessage,
 )
+from gem.proto.networkbasetypes_pb2 import CNETMsg_Tick
 from gem.results.models import ChatEntry, NeutralItemFoundEvent
 from gem.schema.sendtable import parse_send_tables
 from gem.state.entities import Entity, EntityManager, EntityOp
@@ -131,6 +132,7 @@ def _round_positive_seconds(value: float) -> int:
 
 
 EntityCallback = Callable[[Entity, EntityOp], None]
+TickStartCallback = Callable[[int], None]
 ChatCallback = Callable[["ChatEntry"], None]
 ChatEventCallback = Callable[["CDOTAUserMsg_ChatEvent", int], None]
 NeutralItemFoundCallback = Callable[["NeutralItemFoundEvent"], None]
@@ -171,6 +173,7 @@ class ReplayParser:
     Attributes:
         tick: Current game tick.
         net_tick: Current net tick (from net_Tick inner messages).
+        game_time_s: Rounded game-relative clock refreshed at network tick start.
         game_build: Build number extracted from CSVCMsg_ServerInfo.
         string_tables: All string tables created so far.
         entity_manager: Live entity table.
@@ -182,12 +185,14 @@ class ReplayParser:
         self._source = source
         self.tick: int = 0
         self.net_tick: int = 0
+        self._net_tick_seen: bool = False
         self.game_build: int = 0
         self.string_tables = StringTables()
         self.entity_manager: EntityManager | None = None
         self.game_event_manager = GameEventManager()
         self.combat_log = CombatLogProcessor()
         self._entity_callbacks: list[EntityCallback] = [self._on_entity_game_start]
+        self._tick_start_callbacks: list[TickStartCallback] = []
         self._chat_callbacks: list[ChatCallback] = []
         self._chat_event_callbacks: list[ChatEventCallback] = []
         self._neutral_item_found_callbacks: list[NeutralItemFoundCallback] = []
@@ -201,13 +206,9 @@ class ReplayParser:
         self.radiant_win: bool | None = None
         self.game_start_tick: int | None = None
         self.game_time_s: int | None = None
-        # OpenDota-axis game clock, anchored on the combat-log timestamp (the
-        # GAME_STATE==5 horn). ``game_time_s`` is the entity-derived clock; this
-        # one tracks the combat-log timestamp axis that OpenDota uses for its
-        # interval boundaries AND its postGame stop. The two differ by a
-        # per-replay constant (the gap between the horn timestamp and
-        # ``m_flGameStartTime``), so consumers that must agree with OpenDota's
-        # minute boundaries (the interval extractor) should read this clock.
+        # Horn-anchored timestamp of the latest combat-log entry. This is an
+        # event clock, not a continuously advancing sampling clock; interval
+        # consumers use ``game_time_s`` refreshed at CNETMsg_Tick start instead.
         self.combat_log_time_s: int | None = None
         # OpenDota-style match duration in seconds: the horn-anchored combat-log
         # time at GAME_STATE==6 (ancient destroyed). None until that state is seen.
@@ -247,6 +248,19 @@ class ReplayParser:
         if self.entity_manager is not None:
             self.entity_manager.on_entity(callback)
 
+    def on_tick_start(self, callback: TickStartCallback) -> None:
+        """Register a handler called before the current tick's entity deltas.
+
+        ``CNETMsg_Tick`` is dispatched ahead of ``svc_PacketEntities``. The
+        callback therefore sees the reconstructed entity table at the same
+        pre-update boundary as Clarity's ``@OnTickStart``, which OpenDota uses
+        for interval snapshots.
+
+        Args:
+            callback: ``(net_tick: int) -> None``.
+        """
+        self._tick_start_callbacks.append(callback)
+
     def _on_entity_game_start(self, entity: Entity, op: EntityOp) -> None:
         if entity.get_class_name() != "CDOTAGamerulesProxy":
             return
@@ -283,7 +297,8 @@ class ReplayParser:
             paused = entity.get_bool("m_pGameRules.m_bGamePaused") or False
             pause_start_tick = entity.get_int32("m_pGameRules.m_nPauseStartTick")
             total_paused_ticks = entity.get_int32("m_pGameRules.m_nTotalPausedTicks") or 0
-            time_tick = pause_start_tick if paused and pause_start_tick is not None else self.tick
+            parser_tick = self.net_tick if self._net_tick_seen else self.tick
+            time_tick = pause_start_tick if paused and pause_start_tick is not None else parser_tick
             raw_time_s = _round_positive_seconds((time_tick - total_paused_ticks) / 30.0)
 
         self.game_time_s = raw_time_s - self._game_start_time_s
@@ -524,8 +539,20 @@ class ReplayParser:
 
     def _dispatch_inner(self, type_id: int, payload: bytes) -> None:
         if type_id == _NET_TICK:
-            # net_Tick is tiny — just skip (tick already set from outer)
-            pass
+            tick_msg = CNETMsg_Tick()
+            tick_msg.ParseFromString(payload)
+            self.net_tick = tick_msg.tick
+            self._net_tick_seen = True
+
+            # Match OpenDota/Clarity's @OnTickStart ordering: compute the clock
+            # and notify samplers from the entity table reconstructed through
+            # the previous tick, before this packet's entity deltas are applied.
+            if self.entity_manager is not None:
+                grp = self.entity_manager.find_by_class_name("CDOTAGamerulesProxy")
+                if grp is not None:
+                    self._update_game_clock(grp)
+            for callback in self._tick_start_callbacks:
+                callback(self.net_tick)
 
         elif type_id == _SVC_SERVER_INFO:
             m = CSVCMsg_ServerInfo()

--- a/src/gem/results/assembly.py
+++ b/src/gem/results/assembly.py
@@ -364,15 +364,17 @@ def _radiant_win_from_ancient(combat_log: list[CombatLogEntry]) -> bool | None:
 
 def _radiant_adv_from_intervals(
     interval_ext: IntervalExtractor | None,
-) -> tuple[list[int], list[int]] | None:
+) -> tuple[list[int], list[int], list[int]] | None:
     """Build Radiant gold/XP advantage from OpenDota-style interval snapshots."""
     batches = _complete_interval_batches(interval_ext)
     if batches is None:
         return None
 
+    game_times_s: list[int] = []
     gold_adv: list[int] = []
     xp_adv: list[int] = []
     for by_player in batches:
+        game_times_s.append(next(iter(by_player.values())).time_s)
         gold = 0
         xp = 0
         for snap in by_player.values():
@@ -382,7 +384,7 @@ def _radiant_adv_from_intervals(
         gold_adv.append(gold)
         xp_adv.append(xp)
 
-    return gold_adv, xp_adv
+    return game_times_s, gold_adv, xp_adv
 
 
 _MINUTE_TICKS = 1800  # 60 s * 30 ticks/s
@@ -390,7 +392,7 @@ _MINUTE_TICKS = 1800  # 60 s * 30 ticks/s
 
 def _radiant_adv_from_minute_series(
     players: list[ParsedPlayer],
-) -> tuple[list[int], list[int]] | None:
+) -> tuple[list[int], list[int], list[int]] | None:
     """Build Radiant gold/XP advantage from dense per-player minute series.
 
     Fallback for when no complete interval batches exist. Buckets each player's
@@ -407,17 +409,18 @@ def _radiant_adv_from_minute_series(
             ``total_earned_gold_t_min`` / ``total_earned_xp_t_min`` minute arrays.
 
     Returns:
-        ``(gold_adv, xp_adv)`` lists, or ``None`` if no player has minute data.
+        ``(game_times_s, gold_adv, xp_adv)`` lists, or ``None`` if no player has
+        minute data.
     """
     active = [pp for pp in players if pp.total_earned_gold_t_min and pp.total_earned_xp_t_min]
     if not active:
         return None
 
-    # Map each player's samples to absolute minute indices using times_min. The
+    # ``game_times_min`` is authoritative. ``times_min`` remains as a legacy
+    # fallback for ParsedPlayer objects built by older/custom integrations. Its
     # global origin is the earliest sample tick across players, so a player who
-    # first appears at minute 1 lands at index 1, not 0. Fall back to 0 when no
-    # player has tick data (positional indexing kicks in per-player below).
-    first_ticks = [pp.times_min[0] for pp in active if pp.times_min]
+    # first appears at minute 1 lands at index 1 rather than index 0.
+    first_ticks = [pp.times_min[0] for pp in active if not pp.game_times_min and pp.times_min]
     origin = min(first_ticks) if first_ticks else 0
 
     def _minute_index(tick: int) -> int:
@@ -429,17 +432,23 @@ def _radiant_adv_from_minute_series(
     for pp in active:
         sign = 1 if pp.team == 2 else -1  # 2=Radiant, 3=Dire
         by_minute: dict[int, tuple[int, int]] = {}
-        ticks = pp.times_min
         gold_series = pp.total_earned_gold_t_min
         xp_series = pp.total_earned_xp_t_min
-        n = min(len(ticks), len(gold_series), len(xp_series))
-        for i in range(n):
-            minute = _minute_index(ticks[i])
-            by_minute[minute] = (gold_series[i], xp_series[i])
-            last_minute = max(last_minute, minute)
-        # A player with no times_min falls back to positional indexing so we never
-        # silently drop their contribution.
-        if not ticks:
+        if pp.game_times_min:
+            n = min(len(pp.game_times_min), len(gold_series), len(xp_series))
+            for i in range(n):
+                minute = max(0, pp.game_times_min[i] // 60)
+                by_minute[minute] = (gold_series[i], xp_series[i])
+                last_minute = max(last_minute, minute)
+        elif pp.times_min:
+            n = min(len(pp.times_min), len(gold_series), len(xp_series))
+            for i in range(n):
+                minute = _minute_index(pp.times_min[i])
+                by_minute[minute] = (gold_series[i], xp_series[i])
+                last_minute = max(last_minute, minute)
+        else:
+            # A player with neither axis falls back to positional indexing so we
+            # never silently drop their contribution.
             for i in range(min(len(gold_series), len(xp_series))):
                 by_minute[i] = (gold_series[i], xp_series[i])
                 last_minute = max(last_minute, i)
@@ -458,7 +467,8 @@ def _radiant_adv_from_minute_series(
             # after their last sample it holds the final monotonic value.
             gold_adv[minute] += sign * carry_gold
             xp_adv[minute] += sign * carry_xp
-    return gold_adv, xp_adv
+    game_times_s = [minute * 60 for minute in range(n_minutes)]
+    return game_times_s, gold_adv, xp_adv
 
 
 def _complete_interval_batches(
@@ -579,6 +589,7 @@ def _populate_player_series(
             # gold_t/xp_t. Mirror that on the minute arrays when complete
             # interval batches are available; keep dense series unchanged.
             pp.times_min = interval_ts.ticks
+            pp.game_times_min = interval_ts.times
             pp.gold_t_min = interval_ts.gold_t
             pp.total_earned_gold_t_min = interval_ts.gold_t
             pp.total_earned_xp_t_min = interval_ts.xp_t
@@ -588,6 +599,13 @@ def _populate_player_series(
             pp.xp_t_min = interval_ts.xp_t
         else:
             pp.times_min = mts.ticks
+            minute_game_times = list(getattr(mts, "game_times_s", []) or [])
+            # Real PlayerTimeSeries objects always carry the explicit axis. Keep
+            # a positional compatibility fallback for third-party/custom
+            # extractors that still return the pre-axis shape.
+            if len(minute_game_times) != len(pp.times_min):
+                minute_game_times = [i * 60 for i in range(len(pp.times_min))]
+            pp.game_times_min = minute_game_times
             pp.gold_t_min = mts.gold_t
             pp.total_earned_gold_t_min = mts.total_earned_gold_t
             pp.total_earned_xp_t_min = mts.total_earned_xp_t
@@ -1065,7 +1083,8 @@ def build_parsed_match(
     interval_adv = _radiant_adv_from_intervals(interval_ext)
     if interval_adv is not None:
         # Authoritative path: OpenDota-style interval snapshots are complete.
-        gold_adv, xp_adv = interval_adv
+        game_times_s, gold_adv, xp_adv = interval_adv
+        match.game_times_min = game_times_s
         match.radiant_gold_adv = gold_adv
         match.radiant_xp_adv = xp_adv
     else:
@@ -1073,7 +1092,7 @@ def build_parsed_match(
         # the curves from the dense player minute series' total-earned arrays.
         minute_adv = _radiant_adv_from_minute_series(match.players)
         if minute_adv is not None:
-            match.radiant_gold_adv, match.radiant_xp_adv = minute_adv
+            match.game_times_min, match.radiant_gold_adv, match.radiant_xp_adv = minute_adv
 
     # Detect teamfights (Phase 9)
     hero_to_slot = {pp.hero_name: pp.player_id for pp in match.players if pp.hero_name}

--- a/src/gem/results/dataframes.py
+++ b/src/gem/results/dataframes.py
@@ -144,6 +144,7 @@ def build_dataframes(match: ParsedMatch) -> dict[str, pd.DataFrame]:
 
         m = len(pp.times_min)
         for i in range(m):
+            game_time_s = pp.game_times_min[i] if i < len(pp.game_times_min) else None
             player_min_rows.append(
                 {
                     "player_id": pp.player_id,
@@ -151,6 +152,8 @@ def build_dataframes(match: ParsedMatch) -> dict[str, pd.DataFrame]:
                     "hero_name": pp.hero_name,
                     "team": pp.team,
                     "tick": pp.times_min[i],
+                    "game_time_s": game_time_s,
+                    "minute": game_time_s // 60 if game_time_s is not None else None,
                     "gold": pp.gold_t_min[i] if i < len(pp.gold_t_min) else 0,
                     "total_earned_gold": (
                         pp.total_earned_gold_t_min[i] if i < len(pp.total_earned_gold_t_min) else 0
@@ -345,7 +348,8 @@ def build_dataframes(match: ParsedMatch) -> dict[str, pd.DataFrame]:
     adv_len = max(len(match.radiant_gold_adv), len(match.radiant_xp_adv))
     advantage_rows = [
         {
-            "minute": i,
+            "game_time_s": (match.game_times_min[i] if i < len(match.game_times_min) else i * 60),
+            "minute": (match.game_times_min[i] // 60 if i < len(match.game_times_min) else i),
             "radiant_gold_adv": match.radiant_gold_adv[i] if i < len(match.radiant_gold_adv) else 0,
             "radiant_xp_adv": match.radiant_xp_adv[i] if i < len(match.radiant_xp_adv) else 0,
         }

--- a/src/gem/results/models.py
+++ b/src/gem/results/models.py
@@ -179,6 +179,9 @@ class ParsedPlayer:
         dn_t: Deny count at each sample tick.
         xp_t: Cumulative XP at each sample tick.
         times_min: Tick values at each game-minute boundary (OpenDota-aligned).
+        game_times_min: Game-relative seconds parallel to ``times_min`` and all
+            ``*_t_min`` arrays. Values are exact non-negative minute boundaries
+            (``0, 60, 120, ...``) and are the authoritative join key.
         gold_t_min: OpenDota-compatible cumulative earned gold at each
             game-minute boundary when interval data is available; legacy
             current-unspent-gold fallback on replays without complete intervals.
@@ -517,6 +520,9 @@ class ParsedPlayer:
     sentry_uses: int = 0
     observers_placed: int = 0
     _ability_snapshots: list[tuple[int, dict[str, int]]] = field(default_factory=list)
+    # Append-only: ParsedPlayer is a public dataclass and supports positional
+    # construction, so new fields go last to avoid shifting existing callers.
+    game_times_min: list[int] = field(default_factory=list)
 
     def __repr__(self) -> str:
         hero = self.hero_name.removeprefix("npc_dota_hero_") if self.hero_name else "unknown"
@@ -578,6 +584,9 @@ class ParsedMatch:
         wards: All ward placement events with coordinates.
         radiant_gold_adv: Radiant gold advantage at each minute boundary.
         radiant_xp_adv: Radiant XP advantage at each minute boundary.
+        game_times_min: Game-relative seconds parallel to
+            ``radiant_gold_adv`` / ``radiant_xp_adv``. Values are exact
+            non-negative minute boundaries and are the authoritative join key.
         combat_log: All raw combat log entries (unfiltered).
         chat: All chat messages in chronological order.
         courier_snapshots: Courier state snapshots at each sample interval.
@@ -660,9 +669,10 @@ class ParsedMatch:
     vision_modifiers: list[VisionModifierEvent] = field(default_factory=list)
     # Append-only: ParsedMatch is a public dataclass and supports positional
     # construction, so new fields go LAST to avoid shifting existing positional
-    # arguments. (Logically banner_plants belongs near the other objective lists,
-    # but inserting it there would silently misalign positional callers.)
+    # arguments. (Logically these fields belong beside related timelines, but
+    # inserting them there would silently misalign positional callers.)
     banner_plants: list[BannerPlant] = field(default_factory=list)
+    game_times_min: list[int] = field(default_factory=list)
 
     @property
     def duration_seconds(self) -> float:

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -112,6 +112,33 @@ class TestBuildDataframes:
         assert dfs["neutral_item_finds"].empty
         assert dfs["opendota_teamfights"].empty
 
+    def test_minute_tables_include_authoritative_game_time_axis(self):
+        pp = ParsedPlayer(
+            player_id=0,
+            team=2,
+            times_min=[12_345, 14_145],
+            gold_t_min=[600, 700],
+            game_times_min=[0, 60],
+        )
+        match = ParsedMatch(
+            players=[pp],
+            radiant_gold_adv=[100, 250],
+            radiant_xp_adv=[50, 125],
+            game_times_min=[0, 60],
+        )
+
+        dfs = build_dataframes(match)
+
+        assert list(dfs["players_minute"]["game_time_s"]) == [0, 60]
+        assert list(dfs["players_minute"]["minute"]) == [0, 1]
+        assert list(dfs["radiant_advantage"]["game_time_s"]) == [0, 60]
+        assert list(dfs["radiant_advantage"]["minute"]) == [0, 1]
+
+        legacy = ParsedMatch(radiant_gold_adv=[100, 250], radiant_xp_adv=[50, 125])
+        legacy_adv = build_dataframes(legacy)["radiant_advantage"]
+        assert list(legacy_adv["game_time_s"]) == [0, 60]
+        assert list(legacy_adv["minute"]) == [0, 1]
+
     def test_neutral_item_finds_dataframe_includes_event_fields(self):
         neutral_event_cls = getattr(model_module, "NeutralItemFoundEvent", None)
         assert neutral_event_cls is not None

--- a/tests/test_intervals_axis_integration.py
+++ b/tests/test_intervals_axis_integration.py
@@ -1,15 +1,9 @@
-"""Integration lock-in: the combat-log axis beats the entity axis for intervals.
+"""Integration lock-in for OpenDota's tick-start interval boundary.
 
-OpenDota times its interval boundaries on the combat-log timestamp axis, anchored
-at the GAME_STATE==5 horn. gem's entity-derived ``game_time_s`` differs from that
-axis by a per-replay constant, so sampling boundaries on the entity clock drifts
-the per-minute gold/xp/lh curves away from OpenDota.
-
-This test parses one fixture once and attaches two interval extractors: one on the
-authoritative combat-log axis (the default) and one forced onto the entity axis. It
-asserts the combat-log axis produces a strictly smaller residual against the
-published OpenDota arrays. It is a guard against any future change flipping
-``IntervalExtractor._clock()`` back to the entity clock.
+OpenDota reads interval entities from Clarity's ``@OnTickStart`` callback. Gem
+decodes ``CNETMsg_Tick``, queues the first rounded-minute crossing, and samples
+before the following tick's entity deltas to reproduce Clarity's effective
+phase. This fixture locks in point-level parity against the published arrays.
 
 Marked ``slow`` + ``integration`` — needs a real ``.dem`` plus its ``.opendota.json``.
 """
@@ -35,9 +29,9 @@ def _od_slot_to_logical(slot: int) -> int:
     return slot if slot < 128 else (slot - 128) + 5
 
 
-def _residual(series_fn, od_by_logical: dict[int, dict]) -> int:
-    """Sum element-wise absolute error of a player's minute arrays vs OpenDota."""
-    total = 0
+def _residuals(series_fn, od_by_logical: dict[int, dict]) -> dict[str, int]:
+    """Sum element-wise absolute error by metric vs OpenDota."""
+    totals = dict.fromkeys(_METRICS, 0)
     for pid, ref in od_by_logical.items():
         ts = series_fn(pid)
         gem = {"gold_t": ts.gold_t, "xp_t": ts.xp_t, "lh_t": ts.lh_t, "dn_t": ts.dn_t}
@@ -45,20 +39,16 @@ def _residual(series_fn, od_by_logical: dict[int, dict]) -> int:
             g, r = gem[metric], ref[metric]
             # Compare the overlapping prefix; arrays may differ in trailing length.
             for a, b in zip(g, r, strict=False):
-                total += abs(a - b)
-    return total
+                totals[metric] += abs(a - b)
+    return totals
 
 
 @pytest.mark.slow
 @pytest.mark.integration
 class TestIntervalAxisLockIn:
     @pytest.fixture(scope="class")
-    def axes(self):
-        """Parse the fixture once, sampling both clock axes in a single pass.
-
-        Returns:
-            ``(combat_log_residual, entity_residual)`` against OpenDota arrays.
-        """
+    def residuals(self):
+        """Parse once and return per-metric residuals against OpenDota."""
         dem = FIXTURES_DIR / f"{_MATCH_ID}.dem"
         od_path = FIXTURES_DIR / f"{_MATCH_ID}.opendota.json"
         if not dem.exists() or not od_path.exists():
@@ -66,19 +56,8 @@ class TestIntervalAxisLockIn:
 
         parser = ReplayParser(str(dem))
 
-        combat_log_ext = IntervalExtractor(interval_s=60)
-        entity_ext = IntervalExtractor(interval_s=60)
-
-        # Force the second extractor onto the entity clock so both axes are
-        # measured from the same single parse. The default extractor keeps the
-        # authoritative combat-log axis.
-        def _entity_clock() -> int | None:
-            return getattr(parser, "game_time_s", None)
-
-        entity_ext._clock = _entity_clock  # type: ignore[method-assign]
-
-        combat_log_ext.attach(parser)
-        entity_ext.attach(parser)
+        interval_ext = IntervalExtractor(interval_s=60)
+        interval_ext.attach(parser)
         parser.parse()
 
         with open(od_path) as fh:
@@ -93,18 +72,12 @@ class TestIntervalAxisLockIn:
                 "dn_t": player.get("dn_t") or [],
             }
 
-        combat_log_residual = _residual(combat_log_ext.series, od_by_logical)
-        entity_residual = _residual(entity_ext.series, od_by_logical)
-        return combat_log_residual, entity_residual
+        return _residuals(interval_ext.series, od_by_logical)
 
-    def test_combat_log_axis_residual_is_smaller_than_entity_axis(self, axes):
-        combat_log_residual, entity_residual = axes
-        # The combat-log axis must beat the entity axis by a wide margin; on this
-        # fixture the entity axis drifts the curves by orders of magnitude more.
-        assert combat_log_residual < entity_residual
+    def test_tick_start_xp_lh_and_denies_are_exact(self, residuals):
+        assert residuals["xp_t"] == 0
+        assert residuals["lh_t"] == 0
+        assert residuals["dn_t"] == 0
 
-    def test_combat_log_axis_residual_is_small_absolute(self, axes):
-        combat_log_residual, _ = axes
-        # The nudged combat-log axis lands the per-minute curves within a few
-        # hundred total absolute units across all 10 players (measured ~142).
-        assert combat_log_residual < 400
+    def test_tick_start_gold_is_exact(self, residuals):
+        assert residuals["gold_t"] == 0

--- a/tests/test_intervals_extractor.py
+++ b/tests/test_intervals_extractor.py
@@ -45,6 +45,21 @@ class FakeParser:
         self.game_end_handlers.append(handler)
 
 
+class TickStartFakeParser(FakeParser):
+    """Fake parser exposing the pre-entity-update callback used in production."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.tick_start_handlers = []
+
+    def on_tick_start(self, handler):
+        self.tick_start_handlers.append(handler)
+
+    def fire_tick_start(self, net_tick: int) -> None:
+        for handler in self.tick_start_handlers:
+            handler(net_tick)
+
+
 def _player_resource() -> Entity:
     """Build PlayerResource with non-contiguous resource indices."""
     return _ent(
@@ -394,6 +409,54 @@ def _radiant_data_with(gold: int, xp: int, lh: int, dn: int, net_worth: int) -> 
             "m_vecDataTeam.0001.m_iNetWorth": net_worth,
         },
     )
+
+
+def test_tick_start_defers_crossing_by_one_net_tick():
+    """Production sampling includes crossing-tick but not next-tick deltas."""
+    ext = IntervalExtractor()
+    parser = TickStartFakeParser(tick=1700, game_time_s=58)
+    ext.attach(parser)  # type: ignore[arg-type]
+    ext._on_entity(_player_resource(), EntityOp.UPDATED)
+    ext._on_entity(_radiant_data(), EntityOp.UPDATED)
+    ext._on_entity(_dire_data(), EntityOp.UPDATED)
+
+    # The first CNETMsg_Tick at t=60 queues the boundary. Its entity delta is
+    # incorporated, then the next CNETMsg_Tick emits before any newer delta.
+    parser.tick = 1800
+    parser.game_time_s = 60
+    parser.fire_tick_start(6000)
+    assert ext.snapshots == []
+    ext._on_entity(_radiant_data_with(1500, 1100, 30, 5, 2200), EntityOp.UPDATED)
+    ext._on_entity(_ent("CDOTAGamerulesProxy"), EntityOp.UPDATED)
+    parser.tick = 1801
+    parser.fire_tick_start(6001)
+
+    assert len(ext.snapshots) == 2
+    radiant = next(s for s in ext.snapshots if s.team == 2)
+    assert radiant.time_s == 60
+    assert radiant.gold == 1500
+    assert radiant.xp == 1100
+    assert radiant.lh == 30
+    assert radiant.dn == 5
+
+
+def test_tick_start_removes_only_minute_zero_gold_offset():
+    ext = IntervalExtractor()
+    parser = TickStartFakeParser(tick=1800, game_time_s=0)
+    ext.attach(parser)  # type: ignore[arg-type]
+    ext._on_entity(_player_resource(), EntityOp.UPDATED)
+    ext._on_entity(_radiant_data_with(322, 40, 0, 0, 922), EntityOp.UPDATED)
+    ext._on_entity(_dire_data(), EntityOp.UPDATED)
+
+    parser.fire_tick_start(6000)
+    parser.tick = 1801
+    parser.fire_tick_start(6001)
+
+    radiant = next(s for s in ext.snapshots if s.team == 2)
+    dire = next(s for s in ext.snapshots if s.team == 3)
+    assert radiant.gold == 321
+    assert dire.gold == 599
+    assert radiant.xp == 40
 
 
 def test_nudge_reads_previous_data_frame_not_boundary_frame():

--- a/tests/test_match_builder.py
+++ b/tests/test_match_builder.py
@@ -45,6 +45,7 @@ def _damage_entry(pid_attacker_name: str = "hero_a", tick: int = 100) -> CombatL
 @dataclass
 class _FakeTimeSeries:
     ticks: list[int] = field(default_factory=list)
+    game_times_s: list[int] = field(default_factory=list)
     gold_t: list[int] = field(default_factory=list)
     net_worth_t: list[int] = field(default_factory=list)
     lh_t: list[int] = field(default_factory=list)
@@ -877,6 +878,7 @@ class TestBuildParsedMatchGoldXpAdv:
         def make_ts(gold, xp):
             ts = _FakeTimeSeries()
             ts.ticks = [1800 * (i + 1) for i in range(max(len(gold), len(xp)))]
+            ts.game_times_s = [i * 60 for i in range(max(len(gold), len(xp)))]
             ts.gold_t = [value // 10 for value in gold]
             ts.total_earned_gold_t = gold
             ts.total_earned_xp_t = xp
@@ -930,6 +932,7 @@ class TestBuildParsedMatchGoldXpAdv:
         assert m.radiant_gold_adv[0] == 500
         assert m.radiant_gold_adv[1] == 1000
         assert m.radiant_xp_adv == [300, 600]
+        assert m.game_times_min == [0, 60]
 
     def test_dire_ahead(self):
         ts = {
@@ -1107,6 +1110,7 @@ class TestBuildParsedMatchGoldXpAdv:
 
         p0 = m.players[0]
         assert p0.times_min == [1800]
+        assert p0.game_times_min == [60]
         assert p0.gold_t_min == [1000]
         assert p0.total_earned_gold_t_min == [1000]
         assert p0.xp_t_min == [700]
@@ -1180,6 +1184,7 @@ class TestBuildParsedMatchGoldXpAdv:
 
         p0 = m.players[0]
         assert p0.times_min == [1800]
+        assert p0.game_times_min == [0]
         assert p0.gold_t_min == [100]
         assert p0.total_earned_gold_t_min == [1000]
         assert p0.xp_t_min == [500]
@@ -2306,6 +2311,7 @@ class TestRadiantAdvFromMinuteSeries:
         pp.total_earned_xp_t_min = xp
         # Default to one sample per game minute starting at tick 0 (minute 0).
         pp.times_min = times if times is not None else [i * 1800 for i in range(len(gold))]
+        pp.game_times_min = [tick // 30 for tick in pp.times_min]
         return pp
 
     def test_full_length_equal_teams(self):
@@ -2315,7 +2321,8 @@ class TestRadiantAdvFromMinuteSeries:
             self._player(0, 2, [100, 200, 300], [10, 20, 30]),
             self._player(5, 3, [100, 200, 300], [10, 20, 30]),
         ]
-        gold_adv, xp_adv = _radiant_adv_from_minute_series(players)
+        game_times_s, gold_adv, xp_adv = _radiant_adv_from_minute_series(players)
+        assert game_times_s == [0, 60, 120]
         assert gold_adv == [0, 0, 0]
         assert xp_adv == [0, 0, 0]
 
@@ -2330,9 +2337,10 @@ class TestRadiantAdvFromMinuteSeries:
             self._player(0, 2, [100, 200, 300, 400], [0, 0, 0, 0]),  # Radiant, full
             self._player(5, 3, [100, 200], [0, 0]),  # Dire, leaves after minute 1
         ]
-        gold_adv, _ = _radiant_adv_from_minute_series(players)
+        game_times_s, gold_adv, _ = _radiant_adv_from_minute_series(players)
         # Curve spans 4 minutes (longest), not 2 (shortest).
         assert len(gold_adv) == 4
+        assert game_times_s == [0, 60, 120, 180]
         # Radiant pulls ahead as Dire's carried-forward value (200) stays flat.
         assert gold_adv == [0, 0, 100, 200]
 
@@ -2346,7 +2354,8 @@ class TestRadiantAdvFromMinuteSeries:
         radiant = self._player(0, 2, [100, 200, 300], [0, 0, 0], times=[0, 1800, 3600])
         # Dire missing minute 0: samples land at ticks 1800 (min 1) and 3600 (min 2).
         dire = self._player(5, 3, [500, 700], [0, 0], times=[1800, 3600])
-        gold_adv, _ = _radiant_adv_from_minute_series([radiant, dire])
+        game_times_s, gold_adv, _ = _radiant_adv_from_minute_series([radiant, dire])
+        assert game_times_s == [0, 60, 120]
         # Minute 0: only Radiant present (Dire contributes 0, not its minute-1 value).
         assert gold_adv[0] == 100
         # Minute 1: 200 - 500. Minute 2: 300 - 700.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -75,12 +75,12 @@ class TestParsedMatchFieldOrder:
     argument by one slot.
     """
 
-    def test_banner_plants_is_last_field(self):
+    def test_additive_fields_remain_at_the_tail(self):
         import dataclasses
 
         fields = [f.name for f in dataclasses.fields(ParsedMatch)]
-        assert fields[-1] == "banner_plants", (
-            "banner_plants must remain the last field to preserve positional "
+        assert fields[-2:] == ["banner_plants", "game_times_min"], (
+            "new ParsedMatch fields must be appended to preserve positional "
             f"construction; current order tail: {fields[-3:]}"
         )
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -41,6 +41,7 @@ from gem.parser import (
     ReplayParser,
     _read_inner_messages,
 )
+from gem.proto.networkbasetypes_pb2 import CNETMsg_Tick
 
 # ---------------------------------------------------------------------------
 # Helpers — build synthetic inner message blobs
@@ -316,6 +317,26 @@ class TestReplayParserGameClock:
         assert p._combat_log_game_time_s(start) == 0
         assert p._combat_log_game_time_s(death) == 30
 
+    def test_fallback_clock_uses_decoded_net_tick(self):
+        p = ReplayParser(b"")
+        p.tick = 9999
+        p.net_tick = 6000
+        p._net_tick_seen = True
+        entity = MagicMock()
+        entity.get_float32.side_effect = lambda name: {
+            "m_pGameRules.m_flGameStartTime": 100.0,
+            "m_pGameRules.m_fGameTime": None,
+        }.get(name)
+        entity.get_bool.return_value = False
+        entity.get_int32.side_effect = lambda name: {
+            "m_pGameRules.m_nPauseStartTick": 0,
+            "m_pGameRules.m_nTotalPausedTicks": 0,
+        }.get(name)
+
+        p._update_game_clock(entity)
+
+        assert p.game_time_s == 100
+
 
 # ---------------------------------------------------------------------------
 # Callback registration
@@ -356,6 +377,15 @@ class TestCallbackRegistration:
         p.on_entity(cb2)
         user_callbacks = [cb for cb in p._entity_callbacks if cb in {cb1, cb2}]
         assert user_callbacks == [cb1, cb2]
+
+    def test_on_tick_start_appends_callback(self):
+        p = ReplayParser(b"")
+
+        def cb(tick):
+            return None
+
+        p.on_tick_start(cb)
+        assert cb in p._tick_start_callbacks
 
     def test_on_chat_message_appends_callback(self):
         p = ReplayParser(b"")
@@ -541,11 +571,23 @@ class TestOnServerInfo:
 
 
 class TestDispatchInnerRouting:
-    def test_net_tick_is_a_noop(self):
-        """_NET_TICK must not raise and must not change any state."""
+    def test_net_tick_updates_clock_then_dispatches_tick_start(self):
         p = ReplayParser(b"")
-        # Just prove it doesn't raise
-        p._dispatch_inner(_NET_TICK, b"")
+        grp = MagicMock()
+        p.entity_manager = MagicMock()
+        p.entity_manager.find_by_class_name.return_value = grp
+        order = []
+        p.on_tick_start(lambda tick: order.append(("callback", tick)))
+        message = CNETMsg_Tick(tick=4321)
+
+        with patch.object(
+            p, "_update_game_clock", side_effect=lambda entity: order.append(("clock", entity))
+        ):
+            p._dispatch_inner(_NET_TICK, message.SerializeToString())
+
+        assert p.net_tick == 4321
+        assert p._net_tick_seen is True
+        assert order == [("clock", grp), ("callback", 4321)]
 
     def test_svc_packet_entities_skipped_when_no_entity_manager(self):
         p = ReplayParser(b"")

--- a/tests/test_players_extractor.py
+++ b/tests/test_players_extractor.py
@@ -878,6 +878,7 @@ class TestTimeSeries:
         ts = ext.minute_time_series(0)
 
         assert ts.ticks == [99999, 3600]
+        assert ts.game_times_s == [60, 120]
         assert ts.gold_t == [250, 300]
 
     def test_maybe_sample_uses_parser_game_time_for_minute_boundaries(self):

--- a/tests/test_validate_opendota.py
+++ b/tests/test_validate_opendota.py
@@ -56,6 +56,7 @@ def test_player_curve_comparison_passes_within_percent_tolerance() -> None:
 
     assert [field.name for field in fields] == [
         "npc_dota_hero_axe/gold_t/length",
+        "npc_dota_hero_axe/gold_t/minute_keys",
         "npc_dota_hero_axe/gold_t/final",
         "npc_dota_hero_axe/gold_t/max_curve_err%",
     ]
@@ -73,9 +74,9 @@ def test_player_curve_comparison_fails_above_percent_tolerance() -> None:
     )
 
     assert fields[0].ok
-    assert not fields[1].ok
     assert not fields[2].ok
-    assert fields[2].gem_value == 50.0
+    assert not fields[3].ok
+    assert fields[3].gem_value == 50.0
 
 
 def test_player_curve_length_mismatch_fails_and_skips_max_curve_error() -> None:
@@ -92,7 +93,7 @@ def test_player_curve_length_mismatch_fails_and_skips_max_curve_error() -> None:
     assert fields[0].ref_value == 3
     assert [field.name for field in fields] == [
         "npc_dota_hero_axe/gold_t/length",
-        "npc_dota_hero_axe/gold_t/final",
+        "npc_dota_hero_axe/gold_t/minute_keys",
     ]
 
 
@@ -107,6 +108,39 @@ def test_missing_opendota_player_curve_is_skipped() -> None:
 
     assert all(field.skip for field in fields)
     assert all(field.ok for field in fields)
+
+
+def test_equal_length_shifted_player_curve_fails_minute_key_alignment() -> None:
+    fields = _compare_opendota_player_array(
+        "npc_dota_hero_axe",
+        "gold_t",
+        [0, 100, 200],
+        [0, 100, 200],
+        gem_times_s=[60, 120, 180],
+        max_curve_error_pct=3.0,
+    )
+
+    assert fields[0].ok
+    assert not fields[1].ok
+    assert fields[1].name == "npc_dota_hero_axe/gold_t/minute_keys"
+    assert fields[1].gem_value == "1..3 (3 keys)"
+    assert fields[1].ref_value == "0..2 (3 keys)"
+    assert len(fields) == 2
+
+
+def test_player_curve_inside_hard_tolerance_can_warn() -> None:
+    fields = _compare_opendota_player_array(
+        "npc_dota_hero_axe",
+        "gold_t",
+        [0, 100, 196],
+        [0, 100, 200],
+        max_curve_error_pct=3.0,
+        warning_curve_error_pct=1.0,
+    )
+
+    assert all(field.ok for field in fields)
+    assert fields[-1].gem_value == 2.0
+    assert fields[-1].status == "WARN"
 
 
 def test_player_count_curve_comparison_uses_absolute_error_threshold() -> None:
@@ -126,9 +160,9 @@ def test_player_count_curve_comparison_uses_absolute_error_threshold() -> None:
     )
 
     assert all(field.ok for field in passing)
-    assert not failing[1].ok
     assert not failing[2].ok
-    assert failing[2].gem_value == 5
+    assert not failing[3].ok
+    assert failing[3].gem_value == 5
 
 
 def test_player_count_curve_comparison_can_scale_absolute_error_threshold() -> None:
@@ -142,6 +176,6 @@ def test_player_count_curve_comparison_can_scale_absolute_error_threshold() -> N
     )
 
     assert all(field.ok for field in fields)
-    assert fields[1].ref_value == 15
-    assert fields[2].gem_value == 15
     assert fields[2].ref_value == 15
+    assert fields[3].gem_value == 15
+    assert fields[3].ref_value == 15


### PR DESCRIPTION
## Summary

- Add explicit game-time axes for player and match minute curves and join OpenDota validation by minute key instead of list position.
- Decode `CNETMsg_Tick` and sample interval state one network tick after the first rounded-minute crossing, matching Clarity's effective `@OnTickStart` phase.
- Remove only the observed one-unit earned-gold initialization offset at minute zero while preserving genuine nonzero pre-horn earnings.
- Tighten gold/XP curve gates to 0.25%, the review band to 0.05%, last-hit tolerance to `max(2, 0.25%)`, and deny tolerance to one unit.

## Rationale

The remaining curve residuals were caused by boundary phase rather than field extraction. The outer demo tick can differ from the decoded server tick, and the combat-log timestamp is event-driven rather than a continuously advancing sampling clock. A phase probe showed that the first tick crossing was one entity update behind OpenDota on the TI fixture; deferring exactly one decoded network tick eliminated those deltas, while delays of three or more ticks regressed the curves.

Across four replay fixtures, the aligned gold, XP, last-hit, and deny arrays were point-exact over 1,410 player-minute points per metric. On TI 2026 match 8956943534, all 56 minute keys and both advantage curves now match exactly.

Closes #67

## Testing

- [x] `.venv/bin/pre-commit run --all-files`
- [x] `.venv/bin/pytest -q -m 'not slow and not integration'` — 1,725 passed, 3 skipped, 62 deselected
- [x] `.venv/bin/pytest -q tests/test_intervals_axis_integration.py -m integration` — 2 passed with exact curve assertions
- [x] `.venv/bin/ruff check src/ tests/ scripts/validate_opendota.py`
- [x] `.venv/bin/mypy src/gem/` — no issues in 87 source files
- [x] `.venv/bin/python scripts/validate_opendota.py --match 8956943534` — 227 passed, 0 warnings, 0 failures, 1 known skip
- [x] `npm run docs:build`

## Notes

- [x] Generated protobuf files under `src/gem/proto/` were not edited manually.
- [x] Large replay artifacts are not committed.
- [x] Secrets and local credentials are not included.
