### PR TITLE
Align OpenDota postgame scalars and minute-zero curves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Exact minute-zero interval phase.** Minute zero is now sampled immediately
+  from the preceding observed team-data frame, while later minute boundaries
+  retain their one-tick deferral. This excludes transient initialization values
+  and same-tick bounty payouts without zeroing or subtracting legitimate
+  pre-horn earnings, closing the remaining TI2026 gold-curve residuals under the
+  strict 0.25% gate.
+- **Exact offline postgame scalars.** Complete replays now decode the embedded
+  `DOTA_UM_MatchDetails` / `CMsgDOTAMatch` summary and use its exact duration,
+  `hero_damage`, `tower_damage`, `hero_healing`, GPM, and XPM values. Derived
+  `total_gold` / `total_xp` now match OpenDota exactly without a network call;
+  combat-log reconstruction and explicit API enrichment remain fallbacks.
+
 ## [0.6.0] - 2026-09-02
 
 Aligns Gem's minute-level gold, XP, last-hit, and deny curves exactly with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,6 +382,7 @@ Key message classes used throughout the parser:
 - `demo_pb2` — `CDemoSendTables`, `CDemoClassInfo`, `CDemoFullPacket`
 - `netmessages_pb2` — `CSVCMsg_PacketEntities`, `CSVCMsg_CreateStringTable`, `CSVCMsg_FlattenedSerializer`
 - `dota_shared_enums_pb2` — `CMsgDOTACombatLogEntry` (S2 combat log; *not* in `dota_commonmessages_pb2`)
+- `dota_gcmessages_common_pb2` — `CMsgDOTAMatch` (embedded postgame match summary)
 - `dota_usermessages_pb2` — `CDOTAUserMsg_*` (chat, rune, found-neutral-item, etc.)
 
 ## Status
@@ -405,8 +406,9 @@ In flight / deferred:
 - **Rust extension** (PyO3 + maturin) for a 3–5× speedup. Deferred.
 - **Buyback cost breakdown** (reliable/unreliable gold) — see the deferred
   section above and issue #119.
-- Documented OpenDota-parity boundaries (replay vs Game-Coordinator data) tracked
-  in issues #67 / #68 / #93 — these are GC-only and exact only via API enrichment.
+- Permanent postgame buff/flag parity from the embedded Game Coordinator summary
+  is tracked in issue #93. Headline combat scalars and GPM/XPM are already decoded
+  exactly from that summary; API enrichment remains an optional override/fallback.
 
 `CHANGELOG.md` is the per-release record; consult it before assuming a feature's
 state rather than trusting a static table here.

--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ In short: think of `ParsedMatch` as one container holding both **per-player summ
 |---|---|
 | Hero picks and bans with timestamps | `ParsedMatch.draft` |
 | Per-player K/D/A + core combat summaries | `ParsedPlayer.kills` / `.deaths` / `.assists` / `.damage` |
+| Exact postgame damage/healing + GPM/XPM scalars | `ParsedPlayer.hero_damage` / `.tower_damage` / `.hero_healing` / `.gold_per_min` / `.xp_per_min` |
 | Gold / XP / net-worth time series | `ParsedPlayer.times`, `.gold_t`, `.xp_t`, `.net_worth_t` |
 | Minute-aligned economy/XP series | `ParsedPlayer.game_times_min`, `.times_min`, `.total_earned_gold_t_min`, `.total_earned_xp_t_min` |
 | Radiant gold / XP advantage curves | `ParsedMatch.game_times_min`, `.radiant_gold_adv`, `.radiant_xp_adv` |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -43,7 +43,7 @@ def to_dict(match: ParsedMatch) -> dict[str, Any]
 
 Convert a :class:`ParsedMatch` to a JSON-serializable dictionary.
 
-Source: [src/gem/api.py:245](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/api.py#L245)
+Source: [src/gem/api.py:249](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/api.py#L249)
 
 ### `to_json`
 
@@ -53,7 +53,7 @@ def to_json(match: ParsedMatch, *, indent: int | None = None, sort_keys: bool = 
 
 Serialize a :class:`ParsedMatch` to a JSON string.
 
-Source: [src/gem/api.py:250](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/api.py#L250)
+Source: [src/gem/api.py:254](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/api.py#L254)
 
 ### `parse_to_json`
 
@@ -63,7 +63,7 @@ def parse_to_json(path: str | Path, *, indent: int | None = None, sort_keys: boo
 
 Parse a replay and return the result as JSON.
 
-Source: [src/gem/api.py:255](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/api.py#L255)
+Source: [src/gem/api.py:259](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/api.py#L259)
 
 ### `parse_to_dataframe`
 
@@ -73,7 +73,7 @@ def parse_to_dataframe(path: str | Path) -> dict[str, pd.DataFrame]
 
 Parse a replay and return tabular projections as pandas DataFrames.
 
-Source: [src/gem/api.py:260](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/api.py#L260)
+Source: [src/gem/api.py:264](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/api.py#L264)
 
 ### `to_parquet`
 
@@ -83,7 +83,7 @@ def to_parquet(match: ParsedMatch, output_dir: str | Path, *, index: bool = Fals
 
 Export DataFrame projections for a parsed match to parquet files.
 
-Source: [src/gem/api.py:282](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/api.py#L282)
+Source: [src/gem/api.py:286](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/api.py#L286)
 
 ### `parse_to_parquet`
 
@@ -93,4 +93,4 @@ def parse_to_parquet(path: str | Path, output_dir: str | Path, *, index: bool = 
 
 Parse a replay and export DataFrame projections to parquet files.
 
-Source: [src/gem/api.py:313](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/api.py#L313)
+Source: [src/gem/api.py:317](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/api.py#L317)

--- a/docs/reference/assembly.md
+++ b/docs/reference/assembly.md
@@ -22,4 +22,4 @@ def build_parsed_match(parser: ReplayParser, player_ext: PlayerExtractor, obj_ex
 
 Assemble a :class:`ParsedMatch` from extractor state after a completed parse.
 
-Source: [src/gem/results/assembly.py:865](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/assembly.py#L865)
+Source: [src/gem/results/assembly.py:875](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/assembly.py#L875)

--- a/docs/reference/assembly.md
+++ b/docs/reference/assembly.md
@@ -22,4 +22,4 @@ def build_parsed_match(parser: ReplayParser, player_ext: PlayerExtractor, obj_ex
 
 Assemble a :class:`ParsedMatch` from extractor state after a completed parse.
 
-Source: [src/gem/results/assembly.py:833](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/assembly.py#L833)
+Source: [src/gem/results/assembly.py:865](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/assembly.py#L865)

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -279,7 +279,7 @@ class ParsedMatch
 
 Top-level parsed output for a single Dota 2 replay.
 
-Source: [src/gem/results/models.py:535](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/models.py#L535)
+Source: [src/gem/results/models.py:544](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/models.py#L544)
 
 #### Dataclass fields
 
@@ -338,7 +338,7 @@ Signature: `def ParsedMatch.duration_seconds(self) -> float`
 
 Game duration in seconds, derived from ``game_start_tick`` and ``game_end_tick``.
 
-Source: [src/gem/results/models.py:671](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/models.py#L671)
+Source: [src/gem/results/models.py:688](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/models.py#L688)
 
 ##### `duration_minutes`
 
@@ -346,4 +346,4 @@ Signature: `def ParsedMatch.duration_minutes(self) -> float`
 
 Game duration in minutes, derived from ``game_start_tick`` and ``game_end_tick``.
 
-Source: [src/gem/results/models.py:677](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/models.py#L677)
+Source: [src/gem/results/models.py:694](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/models.py#L694)

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -279,7 +279,7 @@ class ParsedMatch
 
 Top-level parsed output for a single Dota 2 replay.
 
-Source: [src/gem/results/models.py:542](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/models.py#L542)
+Source: [src/gem/results/models.py:535](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/models.py#L535)
 
 #### Dataclass fields
 
@@ -338,7 +338,7 @@ Signature: `def ParsedMatch.duration_seconds(self) -> float`
 
 Game duration in seconds, derived from ``game_start_tick`` and ``game_end_tick``.
 
-Source: [src/gem/results/models.py:678](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/models.py#L678)
+Source: [src/gem/results/models.py:671](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/models.py#L671)
 
 ##### `duration_minutes`
 
@@ -346,4 +346,4 @@ Signature: `def ParsedMatch.duration_minutes(self) -> float`
 
 Game duration in minutes, derived from ``game_start_tick`` and ``game_end_tick``.
 
-Source: [src/gem/results/models.py:684](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/models.py#L684)
+Source: [src/gem/results/models.py:677](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/results/models.py#L677)

--- a/docs/reference/parser.md
+++ b/docs/reference/parser.md
@@ -18,7 +18,7 @@ class ReplayParser
 
 Drives a full Source 2 replay parse, wiring all subsystems together.
 
-Source: [src/gem/parser.py:162](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L162)
+Source: [src/gem/parser.py:168](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L168)
 
 #### Methods
 
@@ -28,7 +28,7 @@ Signature: `def ReplayParser.on_entity(self, callback: EntityCallback) -> None`
 
 Register a handler called for every entity create/update/delete.
 
-Source: [src/gem/parser.py:241](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L241)
+Source: [src/gem/parser.py:249](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L249)
 
 ##### `on_tick_start`
 
@@ -36,7 +36,7 @@ Signature: `def ReplayParser.on_tick_start(self, callback: TickStartCallback) ->
 
 Register a handler called before the current tick's entity deltas.
 
-Source: [src/gem/parser.py:251](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L251)
+Source: [src/gem/parser.py:259](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L259)
 
 ##### `on_game_event`
 
@@ -44,7 +44,7 @@ Signature: `def ReplayParser.on_game_event(self, name: str, handler: GameEventHa
 
 Register a handler for the named game event.
 
-Source: [src/gem/parser.py:306](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L306)
+Source: [src/gem/parser.py:314](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L314)
 
 ##### `on_combat_log_entry`
 
@@ -52,7 +52,7 @@ Signature: `def ReplayParser.on_combat_log_entry(self, handler: CombatLogHandler
 
 Register a handler for all combat log entries (S1 + S2).
 
-Source: [src/gem/parser.py:315](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L315)
+Source: [src/gem/parser.py:323](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L323)
 
 ##### `on_chat_message`
 
@@ -60,7 +60,7 @@ Signature: `def ReplayParser.on_chat_message(self, handler: ChatCallback) -> Non
 
 Register a handler for all-chat and team-chat messages.
 
-Source: [src/gem/parser.py:323](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L323)
+Source: [src/gem/parser.py:331](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L331)
 
 ##### `on_chat_event`
 
@@ -68,7 +68,7 @@ Signature: `def ReplayParser.on_chat_event(self, handler: ChatEventCallback) -> 
 
 Register a handler for all CDOTAUserMsg_ChatEvent messages.
 
-Source: [src/gem/parser.py:331](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L331)
+Source: [src/gem/parser.py:339](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L339)
 
 ##### `on_neutral_item_found`
 
@@ -76,7 +76,7 @@ Signature: `def ReplayParser.on_neutral_item_found(self, handler: NeutralItemFou
 
 Register a handler for neutral item found messages.
 
-Source: [src/gem/parser.py:339](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L339)
+Source: [src/gem/parser.py:347](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L347)
 
 ##### `on_game_start`
 
@@ -84,7 +84,7 @@ Signature: `def ReplayParser.on_game_start(self, callback: Callable[[int], None]
 
 Register a handler called once when game time reaches zero.
 
-Source: [src/gem/parser.py:347](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L347)
+Source: [src/gem/parser.py:355](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L355)
 
 ##### `on_game_end`
 
@@ -92,7 +92,7 @@ Signature: `def ReplayParser.on_game_end(self, callback: Callable[[int], None]) 
 
 Register a handler called once when the ancient is destroyed.
 
-Source: [src/gem/parser.py:359](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L359)
+Source: [src/gem/parser.py:367](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L367)
 
 ##### `stop_after_tick`
 
@@ -100,7 +100,7 @@ Signature: `def ReplayParser.stop_after_tick(self, tick: int) -> None`
 
 Stop parsing after this tick (inclusive).
 
-Source: [src/gem/parser.py:399](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L399)
+Source: [src/gem/parser.py:407](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L407)
 
 ##### `parse`
 
@@ -108,4 +108,4 @@ Signature: `def ReplayParser.parse(self) -> None`
 
 Parse the replay from start to finish (or until stop_after_tick).
 
-Source: [src/gem/parser.py:411](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L411)
+Source: [src/gem/parser.py:419](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L419)

--- a/scripts/validate_opendota.py
+++ b/scripts/validate_opendota.py
@@ -434,6 +434,10 @@ _POSTGAME_SUMMARY_NOTE = (
     "Exact comparison of the replay-embedded CMsgDOTAMatch postgame summary "
     "with OpenDota's corresponding Game Coordinator scalar."
 )
+_POSTGAME_SUMMARY_MISSING_NOTE = (
+    "Exact comparison skipped because this replay did not embed the corresponding "
+    "CMsgDOTAMatch field; gem retained its documented fallback value."
+)
 
 _NET_WORTH_TOLERANCE = 0.08
 # Advantage and player minute curves: gem decodes CNETMsg_Tick, samples minute
@@ -714,13 +718,14 @@ def validate_match(
     od_dir_status = od.get("tower_status_dire", 0x7FF)
     od_tower_kills = bin(0x7FF ^ od_rad_status).count("1") + bin(0x7FF ^ od_dir_status).count("1")
     result.match_fields.append(FieldResult("tower_kills", gem_tower_kills, od_tower_kills))
+    exact_duration = "duration" in getattr(m, "_match_details_fields", ())
     result.match_fields.append(
         FieldResult(
             "duration",
             m.duration,
             od.get("duration"),
-            skip=od.get("duration") is None,
-            note=_POSTGAME_SUMMARY_NOTE,
+            skip=od.get("duration") is None or not exact_duration,
+            note=(_POSTGAME_SUMMARY_NOTE if exact_duration else _POSTGAME_SUMMARY_MISSING_NOTE),
         )
     )
 
@@ -870,13 +875,16 @@ def validate_match(
             "total_xp",
         ):
             reference_value = od_player.get(field_name)
+            exact_field = field_name in getattr(gp, "_match_details_fields", ())
             fields.append(
                 FieldResult(
                     f"{label}/{field_name}",
                     getattr(gp, field_name),
                     reference_value,
-                    skip=reference_value is None,
-                    note=_POSTGAME_SUMMARY_NOTE,
+                    skip=reference_value is None or not exact_field,
+                    note=(
+                        _POSTGAME_SUMMARY_NOTE if exact_field else _POSTGAME_SUMMARY_MISSING_NOTE
+                    ),
                 )
             )
 

--- a/scripts/validate_opendota.py
+++ b/scripts/validate_opendota.py
@@ -2,21 +2,22 @@
 
 For each configured replay, parses the .dem file with gem, fetches match data
 from the OpenDota API, and diffs key fields: total kills, per-player net_worth,
-last_hits, denies, hero deaths, tower kills, and teamfight count.
+last_hits, denies, hero deaths, tower kills, exact postgame combat/rate scalars,
+and teamfight count.
 
 Notes on expected discrepancies
 --------------------------------
-OpenDota's scalar per-player stats (``kills``, ``deaths``, ``last_hits``,
-``net_worth``) are sourced from the Steam API ``GetMatchDetails`` endpoint,
-which records the final game-state snapshot taken by the server at game-end.
-gem forces a terminal entity sample at the game-end tick and samples ``_min``
-arrays at exact non-negative 60-second game-time boundaries. Terminal scalars
-are compared only with terminal scalars; minute curves are joined to OpenDota's
-array indices through gem's explicit game-time axes before their values are
-compared. ``net_worth`` is the least stable scalar here: the replay-exposed
-``m_iNetWorth`` / ``m_vecDataTeam.*.m_iNetWorth`` values can diverge slightly
-from Steam's final server scalar, so the validator uses a looser tolerance for
-that field than it does for kills / last hits / denies.
+OpenDota's scalar per-player stats are sourced from the Steam API
+``GetMatchDetails`` endpoint, which records the final game-state snapshot taken
+by the server at game-end. Complete replays embed the corresponding
+``CMsgDOTAMatch`` postgame summary, so gem compares its duration, combat totals,
+and GPM/XPM-derived totals exactly. Other terminal fields come from the final
+entity sample. Minute curves are joined to OpenDota's array indices through
+gem's explicit game-time axes before their values are compared. ``net_worth``
+is the least stable scalar here: the replay-exposed ``m_iNetWorth`` /
+``m_vecDataTeam.*.m_iNetWorth`` values can diverge slightly from Steam's final
+server scalar, so the validator uses a looser tolerance for that field than it
+does for kills / last hits / denies.
 
 OpenDota data availability
 --------------------------
@@ -429,15 +430,17 @@ _TERMINAL_NOTE = (
     "game-end tick; OpenDota's scalar comes from Steam's final server snapshot. "
     "Replay-exposed m_iNetWorth can still differ slightly from the Steam scalar."
 )
+_POSTGAME_SUMMARY_NOTE = (
+    "Exact comparison of the replay-embedded CMsgDOTAMatch postgame summary "
+    "with OpenDota's corresponding Game Coordinator scalar."
+)
 
 _NET_WORTH_TOLERANCE = 0.08
-# Advantage and player minute curves: gem decodes CNETMsg_Tick, queues the first
-# rounded-minute crossing, and samples the reconstructed entity table at the
-# following tick start. This reproduces Clarity's effective @OnTickStart phase;
-# the minute-zero m_iTotalEarnedGold offset is removed without zeroing genuine
-# pre-horn earnings. Across four replay fixtures (1,410 player-minute points per
-# metric, including the 2026 TI sample), gold/XP/LH/DN and both advantage curves
-# are point-exact after this alignment. The remaining nonzero gates are narrow
+# Advantage and player minute curves: gem decodes CNETMsg_Tick, samples minute
+# zero immediately from the pre-update entity table, and queues later rounded-
+# minute crossings for the following tick start. This reproduces Clarity's
+# effective @OnTickStart phase while preserving genuine pre-horn earnings and
+# excluding same-tick bounty payouts. The remaining nonzero gates are narrow
 # portability headroom for unseen patches: a one-creep boundary regression is
 # warned immediately and meaningful frame/clock drift fails.
 _GOLD_ADV_TOLERANCE = 0.0025
@@ -711,6 +714,15 @@ def validate_match(
     od_dir_status = od.get("tower_status_dire", 0x7FF)
     od_tower_kills = bin(0x7FF ^ od_rad_status).count("1") + bin(0x7FF ^ od_dir_status).count("1")
     result.match_fields.append(FieldResult("tower_kills", gem_tower_kills, od_tower_kills))
+    result.match_fields.append(
+        FieldResult(
+            "duration",
+            m.duration,
+            od.get("duration"),
+            skip=od.get("duration") is None,
+            note=_POSTGAME_SUMMARY_NOTE,
+        )
+    )
 
     if mode in {"parsed", "full"}:
         # Teamfight detection — compare against an OpenDota-compatible projection
@@ -847,6 +859,26 @@ def validate_match(
                 note=_TERMINAL_NOTE,
             )
         )
+
+        for field_name in (
+            "hero_damage",
+            "tower_damage",
+            "hero_healing",
+            "gold_per_min",
+            "xp_per_min",
+            "total_gold",
+            "total_xp",
+        ):
+            reference_value = od_player.get(field_name)
+            fields.append(
+                FieldResult(
+                    f"{label}/{field_name}",
+                    getattr(gp, field_name),
+                    reference_value,
+                    skip=reference_value is None,
+                    note=_POSTGAME_SUMMARY_NOTE,
+                )
+            )
 
         if mode in {"parsed", "full"}:
             fields.extend(
@@ -1124,7 +1156,7 @@ def main() -> None:
         choices=("scalar", "parsed", "full"),
         default="full",
         help=(
-            "Validation mode: scalar=end-state scoreboard parity only; "
+            "Validation mode: scalar=end-state scoreboard/postgame parity; "
             "parsed=scalar plus OpenDota replay-parser fields; full=current alias for parsed."
         ),
     )

--- a/src/gem/api.py
+++ b/src/gem/api.py
@@ -234,7 +234,11 @@ def find_player(match: ParsedMatch, hero: str) -> ParsedPlayer | None:
 def _to_json_compatible(value: Any) -> Any:
     """Recursively convert values to JSON-compatible Python types."""
     if is_dataclass(value):
-        return {f.name: _to_json_compatible(getattr(value, f.name)) for f in fields(value)}
+        return {
+            f.name: _to_json_compatible(getattr(value, f.name))
+            for f in fields(value)
+            if f.metadata.get("serialize", True)
+        }
     if isinstance(value, Mapping):
         return {str(k): _to_json_compatible(v) for k, v in value.items()}
     if isinstance(value, (list, tuple, set)):

--- a/src/gem/combat/aggregator.py
+++ b/src/gem/combat/aggregator.py
@@ -122,14 +122,10 @@ class _ParsedPlayerAgg:
     runes_log: list[CombatLogEntry] = field(default_factory=list)
     buyback_log: list[CombatLogEntry] = field(default_factory=list)
     stuns_dealt: float = 0.0
-    # OpenDota-style combat scalars, reconstructed from the combat log by
-    # crediting the damage *source* (see _accumulate_hero_tower_damage). Offline
-    # accuracy vs OpenDota across five fixtures: tower_damage ~exact (~99.97%),
-    # hero_damage ~90%. hero_damage/hero_healing residuals are not a filter gap —
-    # OpenDota's headline scalars are Game-Coordinator (CMsgGameMatchSignOut)
-    # values that account for in-engine mitigation the combat log cannot see, so
-    # they are unclosable offline; they are exactly overwritten when the match is
-    # enriched from the API (gem.replays.fetch.apply_api_rates).
+    # OpenDota-style combat scalars reconstructed from the combat log by
+    # crediting the damage *source* (see _accumulate_hero_tower_damage). Assembly
+    # uses these as a fallback, then overlays exact Game Coordinator values from
+    # the replay-embedded CMsgDOTAMatch postgame summary when available.
     hero_damage: int = 0
     tower_damage: int = 0
     hero_healing: int = 0
@@ -243,15 +239,11 @@ class _CombatAggregator:
         combat log carries no illusion marker on the source name), keeping the
         scalar consistent with the per-target ``damage`` dict.
 
-        Accuracy vs OpenDota's per-player scalars, measured across five OpenDota
-        fixtures: ``tower_damage`` is essentially exact (~99.97%, the combat-log
-        building sum equals the Game Coordinator value); ``hero_damage`` is a gross
-        combat-log over-estimate (~63–90%). The ``hero_damage``/``hero_healing``
-        residual is **not** a filter gap: OpenDota's headline scalars are
-        Game-Coordinator (``CMsgGameMatchSignOut``) values that account for
-        in-engine mitigation and an engine-internal illusion split the combat log
-        does not expose, so they are unclosable offline. Exact values come from the
-        API via ``apply_api_rates`` / ``enrich_with_api_rates``.
+        These counters are fallback estimates: the combat log does not expose all
+        of the in-engine mitigation and illusion accounting represented by the
+        headline Game Coordinator values. Match assembly overlays exact values
+        from the replay-embedded ``CMsgDOTAMatch`` summary when present; explicit
+        API enrichment can overwrite them as well.
 
         Args:
             source_pid: The resolved damage-source player slot 0-9.

--- a/src/gem/extractors/README.md
+++ b/src/gem/extractors/README.md
@@ -175,14 +175,15 @@ Three subtle behaviours distinguish it from the dense player sampler:
 - **Network-tick clock**: `ReplayParser` decodes `CNETMsg_Tick` and refreshes
   `game_time_s` from that server tick (including pause ticks), rather than the
   unrelated outer demo tick or the latest, possibly stale combat-log event.
-- **Clarity phase** (`_on_tick_start`): the first rounded-minute crossing is
-  queued and sampled at the following network tick start. This includes the
-  crossing tick's entity deltas but precedes the next tick's deltas, matching
-  OpenDota's effective `@OnTickStart` read. Parsers without the new callback
-  retain the two-frame entity-callback fallback.
-- **Minute-zero offset**: the production path subtracts the observed one-unit
-  earned-gold initialization offset while preserving genuine
-  pre-horn earnings. `_emit_final_boundary` remains a live terminal read.
+- **Clarity phase** (`_on_tick_start`): minute zero is sampled immediately from
+  the preceding observed team-data frame, preventing transient initialization
+  values and same-tick bounty payouts from leaking backward. Later rounded-minute
+  crossings are sampled at the following network tick start, including the
+  crossing tick's entity deltas but preceding the next tick's. Parsers without
+  the callback retain the two-frame entity fallback.
+- **Raw minute-zero counters**: no blanket zeroing or numeric compensation is
+  applied, so legitimate pre-horn earnings remain intact.
+  `_emit_final_boundary` remains a live terminal read.
 
 It also carries terminal scalar counters (`team_counters`) read from the same
 `m_vecDataTeam` entry (camps/creeps stacked, wards placed, rune pickups, tower

--- a/src/gem/extractors/intervals.py
+++ b/src/gem/extractors/intervals.py
@@ -128,7 +128,8 @@ class IntervalExtractor:
         self._data_dire: Entity | None = None
         # Per-team-slot team-data history, kept to the two most recent observed
         # frames as ``(observed_tick, (gold, xp, lh, dn, net_worth))``. The
-        # production tick-start path reads ``cur`` after its one-tick deferral.
+        # production tick-start path reads ``cur`` after its one-tick deferral
+        # for regular boundaries; minute zero reads it immediately.
         # ``prev`` preserves the entity-callback compatibility path, where the
         # latest frame strictly before a crossing is required. Entities mutate
         # in place, so values are copied eagerly rather than held by reference.
@@ -148,9 +149,11 @@ class IntervalExtractor:
         self._next_interval_s: int | None = None
         self._tick_start_driven = False
         # Clarity's @OnTickStart interval read is effectively one decoded net
-        # tick after the first CNETMsg_Tick whose rounded clock reaches the
-        # boundary. Queue that first crossing and emit at the next tick start,
-        # after the crossing tick's entity deltas but before the next tick's.
+        # tick after the first CNETMsg_Tick whose rounded clock reaches regular
+        # boundaries. Minute zero is different: it is read immediately, before
+        # same-tick bounty/entity deltas. Queue regular crossings and emit at the
+        # next tick start, after the crossing tick's entity deltas but before the
+        # next tick's.
         self._pending_tick_start_boundary: tuple[int, int] | None = None
         self._last_queued_time_s: int | None = None
         self._last_clock_tick: int | None = None
@@ -223,13 +226,15 @@ class IntervalExtractor:
         self._ended = True
 
     def _on_tick_start(self, net_tick: int) -> None:
-        """Queue a crossing, then sample before the following tick's updates.
+        """Sample minute zero immediately; defer later crossings one tick.
 
         ``ReplayParser`` refreshes ``game_time_s`` from ``net_tick`` before
-        invoking this callback. Clarity's ``@OnTickStart`` interval handler is
-        one network tick later than the first rounded-clock crossing observed
-        here. Deferring to the following callback includes the crossing tick's
-        entity deltas while still reading before the next tick's mutations.
+        invoking this callback. At minute zero, Clarity reads the pre-update
+        entity table immediately; delaying would incorrectly include same-tick
+        bounty payouts. At later boundaries its interval output aligns one
+        network tick after the first rounded-clock crossing observed here, so
+        deferring includes the crossing tick's entity deltas while still reading
+        before the next tick's mutations.
 
         Args:
             net_tick: Decoded ``CNETMsg_Tick.tick`` value.
@@ -244,14 +249,23 @@ class IntervalExtractor:
             and game_time_s % self._interval_s == 0
             and game_time_s != self._last_queued_time_s
         ):
-            self._pending_tick_start_boundary = (game_time_s, net_tick)
             self._last_queued_time_s = game_time_s
+            if game_time_s == 0 and self._last_emitted_time_s is None:
+                self._try_emit(game_time_s, use_live=False, prefer_previous=True)
+                if self._last_emitted_time_s == game_time_s:
+                    return
+            self._pending_tick_start_boundary = (game_time_s, net_tick)
 
         pending = self._pending_tick_start_boundary
         if pending is None or net_tick <= pending[1]:
             return
         boundary_time_s = pending[0]
-        self._try_emit(boundary_time_s, use_live=True)
+        initial_boundary = boundary_time_s == 0 and self._last_emitted_time_s is None
+        self._try_emit(
+            boundary_time_s,
+            use_live=not initial_boundary,
+            prefer_previous=initial_boundary,
+        )
         if self._last_emitted_time_s == boundary_time_s:
             self._pending_tick_start_boundary = None
 
@@ -336,6 +350,7 @@ class IntervalExtractor:
         game_time_s: int | None,
         *,
         use_live: bool,
+        prefer_previous: bool = False,
         require_fresh_clock: bool = False,
     ) -> None:
         """Emit one complete interval batch when ``game_time_s`` is eligible."""
@@ -375,7 +390,11 @@ class IntervalExtractor:
         if self._next_interval_s is not None and boundary_time_s < self._next_interval_s:
             return
 
-        emitted = self._emit(boundary_time_s, use_live=use_live or initial_boundary)
+        emitted = self._emit(
+            boundary_time_s,
+            use_live=use_live or (initial_boundary and not prefer_previous),
+            prefer_previous=prefer_previous,
+        )
         if emitted:
             if initial_boundary:
                 self._initial_boundary_pending = False
@@ -532,13 +551,15 @@ class IntervalExtractor:
         emit_tick: int,
         *,
         use_live: bool = False,
+        prefer_previous: bool = False,
     ) -> tuple[int, int, int, int, int]:
         """Return the team-data values for an interval boundary.
 
         Normal boundaries use the latest recorded frame strictly before the
-        crossing tick, matching OpenDota's entity dispatch order. Initial and
-        terminal boundaries set ``use_live`` because they are snapshots of the
-        currently observed counters rather than crossing-tick nudges.
+        crossing tick, matching OpenDota's entity dispatch order. Tick-driven
+        minute zero prefers the prior observed frame because Gem detects the
+        rounded clock crossing one entity update after Clarity; terminal and
+        compatibility-path boundaries can select the live frame explicitly.
 
         Args:
             team: ``TEAM_RADIANT`` or ``TEAM_DIRE``.
@@ -546,6 +567,7 @@ class IntervalExtractor:
             data_entity: The live data entity for the team (fallback source).
             emit_tick: The tick of the boundary emit.
             use_live: Select the current frame without the boundary nudge.
+            prefer_previous: Select the prior observed frame when available.
 
         Returns:
             ``(gold, xp, lh, dn, net_worth)`` for the boundary frame.
@@ -553,11 +575,16 @@ class IntervalExtractor:
         cur = self._cur_data_radiant if team == TEAM_RADIANT else self._cur_data_dire
         prev = self._prev_data_radiant if team == TEAM_RADIANT else self._prev_data_dire
         cur_frame = cur.get(team_slot)
+        prev_frame = prev.get(team_slot)
+        if prefer_previous:
+            if prev_frame is not None:
+                return prev_frame[1]
+            if cur_frame is not None:
+                return cur_frame[1]
         if use_live and cur_frame is not None:
             return cur_frame[1]
         if cur_frame is not None and cur_frame[0] < emit_tick:
             return cur_frame[1]
-        prev_frame = prev.get(team_slot)
         if prev_frame is not None and prev_frame[0] < emit_tick:
             return prev_frame[1]
         prefix = team_data_prefix(team_slot)
@@ -569,7 +596,13 @@ class IntervalExtractor:
             _int_or_zero(data_entity.get_int32(f"{prefix}.m_iNetWorth")),
         )
 
-    def _emit(self, game_time_s: int, *, use_live: bool = False) -> bool:
+    def _emit(
+        self,
+        game_time_s: int,
+        *,
+        use_live: bool = False,
+        prefer_previous: bool = False,
+    ) -> bool:
         emitted = False
         tick = self._parser.tick if self._parser is not None else 0
 
@@ -588,14 +621,8 @@ class IntervalExtractor:
                 data_entity,
                 tick,
                 use_live=use_live,
+                prefer_previous=prefer_previous,
             )
-            # The live team-data baseline is consistently one earned-gold unit
-            # above OpenDota at minute zero. Remove only that initialization
-            # offset in the production tick-start path. Genuine nonzero pre-horn
-            # earnings remain intact (e.g. 322 -> 321, not 322 -> 0), and legacy
-            # parser adapters retain their raw values.
-            if self._tick_start_driven and game_time_s == 0 and gold > 0:
-                gold -= 1
             player_slot = team_slot if team == TEAM_RADIANT else 128 + team_slot
             self.snapshots.append(
                 IntervalSnapshot(

--- a/src/gem/parser.py
+++ b/src/gem/parser.py
@@ -36,6 +36,9 @@ Relevant inner IDs:
   svc_UserMessage                 =  72
   GE_Source1LegacyGameEventList   = 205
   GE_Source1LegacyGameEvent       = 207
+  DOTA_UM_CombatLogDataHLTV       = 554  (direct)
+  DOTA_UM_MatchMetadata           = 557  (direct)
+  DOTA_UM_MatchDetails            = 558  (direct postgame summary)
 
 Reference: manta/parser.go, manta/demo_packet.go, manta/game_event.go
 """
@@ -60,6 +63,7 @@ from gem.proto import (
     networkbasetypes_pb2,  # noqa: F401
 )
 from gem.proto.demo_pb2 import CDemoClassInfo, CDemoFileInfo, CDemoFullPacket, CDemoPacket
+from gem.proto.dota_gcmessages_common_pb2 import CMsgDOTAMatch
 from gem.proto.dota_match_metadata_pb2 import CDOTAMatchMetadataFile
 from gem.proto.dota_shared_enums_pb2 import CMsgDOTACombatLogEntry
 from gem.proto.dota_usermessages_pb2 import (
@@ -67,6 +71,7 @@ from gem.proto.dota_usermessages_pb2 import (
     CDOTAUserMsg_ChatMessage,
     CDOTAUserMsg_CombatLogBulkData,
     CDOTAUserMsg_FoundNeutralItem,
+    DOTA_UM_MatchDetails,
     DOTA_UM_MatchMetadata,
 )
 from gem.proto.gameevents_pb2 import (
@@ -117,6 +122,7 @@ _DOTA_UM_COMBAT_LOG_BULK_DATA = 470  # CDOTAUserMsg_CombatLogBulkData (alternate
 _DOTA_UM_COMBAT_LOG_HLTV = 554  # CMsgDOTACombatLogEntry (direct, one entry per message)
 _DOTA_UM_CHAT_EVENT = 466  # CDOTAUserMsg_ChatEvent (direct)
 _DOTA_UM_MATCH_METADATA = DOTA_UM_MatchMetadata  # CDOTAMatchMetadataFile (direct)
+_DOTA_UM_MATCH_DETAILS = DOTA_UM_MatchDetails  # CMsgDOTAMatch postgame summary (direct)
 _DOTA_UM_FOUND_NEUTRAL_ITEM = 593  # CDOTAUserMsg_FoundNeutralItem (direct)
 _DOTA_UM_CHAT_MESSAGE = 612  # CDOTAUserMsg_ChatMessage (direct)
 
@@ -179,6 +185,7 @@ class ReplayParser:
         entity_manager: Live entity table.
         game_event_manager: Game event schema and handler registry.
         combat_log: Combat log processor for S1 and S2 entries.
+        match_details: Embedded ``CMsgDOTAMatch`` postgame summary, when present.
     """
 
     def __init__(self, source: str | Path | bytes) -> None:
@@ -203,6 +210,7 @@ class ReplayParser:
         self.game_mode: int = 0
         self.leagueid: int = 0
         self.match_metadata: CDOTAMatchMetadataFile | None = None
+        self.match_details: CMsgDOTAMatch | None = None
         self.radiant_win: bool | None = None
         self.game_start_tick: int | None = None
         self.game_time_s: int | None = None
@@ -624,6 +632,9 @@ class ReplayParser:
         elif type_id == _DOTA_UM_MATCH_METADATA:
             self._on_match_metadata(payload)
 
+        elif type_id == _DOTA_UM_MATCH_DETAILS:
+            self._on_match_details(payload)
+
         elif type_id == _DOTA_UM_FOUND_NEUTRAL_ITEM:
             self._emit_neutral_item_found(payload)
 
@@ -699,6 +710,8 @@ class ReplayParser:
                         self._mark_game_end(self.tick)
         elif msg.msg_type == _DOTA_UM_MATCH_METADATA:
             self._on_match_metadata(msg.msg_data)
+        elif msg.msg_type == _DOTA_UM_MATCH_DETAILS:
+            self._on_match_details(msg.msg_data)
 
     def _combat_log_game_time_s(self, msg: CMsgDOTACombatLogEntry) -> int | None:
         """Return OpenDota-style game-relative combat-log time for an S2 entry.
@@ -736,6 +749,14 @@ class ReplayParser:
         metadata = CDOTAMatchMetadataFile()
         metadata.ParseFromString(payload)
         self.match_metadata = metadata
+
+    def _on_match_details(self, payload: bytes) -> None:
+        """Store the embedded Game Coordinator postgame match summary."""
+        details = CMsgDOTAMatch()
+        details.ParseFromString(payload)
+        self.match_details = details
+        if not self.match_id and details.HasField("match_id"):
+            self.match_id = int(details.match_id)
 
     def _emit_chat_message(self, payload: bytes) -> None:
         if not self._chat_callbacks:

--- a/src/gem/replays/README.md
+++ b/src/gem/replays/README.md
@@ -24,10 +24,10 @@ parse_many([paths]) ──── ProcessPoolExecutor ─────┘   (one w
 
 - **`fetch.py`** is I/O over the network: resolve the replay URL, stream-download
   the bz2 blob, decompress to `.dem`. `enrich_with_api_rates` / `apply_api_rates`
-  are a separate opt-in step that overlays OpenDota's published
-  `hero_damage`/`tower_damage`/`gpm`/`xpm` scalars onto a `ParsedMatch` (these are
-  GC values the replay alone cannot reproduce exactly — see issue #68 and the
-  repo `Known limitations`).
+  are a separate opt-in step that can overwrite OpenDota's published
+  `hero_damage`/`tower_damage`/`hero_healing`/`gpm`/`xpm` scalars on a
+  `ParsedMatch`. Complete current replays already provide the same exact values
+  in their embedded `CMsgDOTAMatch` postgame summary.
 - **`batch.py`** is CPU parallelism: each replay is parsed in its own process
   (`_parse_one`), so a failed replay yields a `ParseResult` with the exception
   rather than aborting the whole run. `parse_many_to_dataframe` /
@@ -40,8 +40,8 @@ parse_many([paths]) ──── ProcessPoolExecutor ─────┘   (one w
   `gem.parse()`.
 - It does **not** require network access for `batch.py`. Only `fetch.py` reaches
   the network; bulk parsing of local files is fully offline.
-- `apply_api_rates` does **not** change replay-derived fields — it only overlays
-  GC scalars, and it is opt-in. Plain `gem.parse()` never calls the network.
+- `apply_api_rates` only overlays the supplied GC scalars, and it is opt-in.
+  Plain `gem.parse()` never calls the network.
 
 ## Pitfalls
 

--- a/src/gem/replays/fetch.py
+++ b/src/gem/replays/fetch.py
@@ -166,17 +166,18 @@ def _opendota_slot_to_player_id(player_slot: int) -> int:
 
 
 def apply_api_rates(match: ParsedMatch, opendota_match: dict) -> ParsedMatch:
-    """Populate API-sourced per-minute rates and totals on a parsed match.
+    """Apply API-sourced rates, totals, and combat scalars to a parsed match.
 
-    ``gold_per_min``/``xp_per_min`` are not present in the replay — they come from
-    the Steam GC match summary (also exposed by the OpenDota match API). This
-    helper maps those per-player rates onto :class:`~gem.results.models.ParsedPlayer`
-    and derives ``total_gold``/``total_xp`` with OpenDota's exact formula
-    ``floor(rate * duration / 60)``. The pure mapping is kept separate from the
+    Complete replays already expose these Game Coordinator values through their
+    embedded ``CMsgDOTAMatch`` postgame summary. This helper remains useful as an
+    explicit override or as a fallback for older/truncated replays: it maps
+    per-player rates and combat scalars from an OpenDota/Steam response and
+    derives ``total_gold``/``total_xp`` with OpenDota's exact formula
+    ``floor(rate * duration / 60)``. The pure mapping stays separate from the
     network call so it can be tested against fixtures offline.
 
     Players are matched by OpenDota ``player_slot`` (Radiant 0-4, Dire 128-132).
-    Missing rates leave the corresponding fields at ``0``.
+    Missing API fields leave the corresponding parsed values unchanged.
 
     Args:
         match: A :class:`~gem.results.models.ParsedMatch` to enrich in place.
@@ -237,13 +238,13 @@ def fetch_opendota_match(match_id: int) -> dict:
 
 
 def enrich_with_api_rates(match: ParsedMatch, match_id: int) -> ParsedMatch:
-    """Fetch OpenDota match rates and apply them to a parsed match.
+    """Fetch OpenDota match scalars and apply them to a parsed match.
 
-    Opt-in enrichment for the API-only fields (``gold_per_min``, ``xp_per_min``,
-    ``total_gold``, ``total_xp``). ``gem.parse`` never makes network calls and
-    leaves these at ``0``; call this afterwards to fill them from the OpenDota
-    match API (keyless). Thin wrapper over :func:`fetch_opendota_match` plus
-    :func:`apply_api_rates`.
+    Opt-in API override/fallback for ``gold_per_min``, ``xp_per_min``, derived
+    totals, and headline combat scalars. ``gem.parse`` never makes network calls;
+    on complete current replays it normally obtains the same values from the
+    embedded postgame summary. This is a thin wrapper over
+    :func:`fetch_opendota_match` plus :func:`apply_api_rates`.
 
     Args:
         match: A parsed match to enrich in place.

--- a/src/gem/results/assembly.py
+++ b/src/gem/results/assembly.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from gem.extractors.players import PlayerExtractor
     from gem.extractors.wards import WardEvent, WardsExtractor
     from gem.parser import ReplayParser
+    from gem.proto.dota_gcmessages_common_pb2 import CMsgDOTAMatch
     from gem.results.models import (
         ChatEntry,
         NeutralItemFoundEvent,
@@ -40,8 +41,8 @@ _LANE_GRID = 64
 _LANE_WINDOW = 600 * 30
 
 
-def _metadata_slot_to_player_id(player_slot: int) -> int | None:
-    """Convert match-metadata player slots to gem player ids."""
+def _player_slot_to_player_id(player_slot: int) -> int | None:
+    """Convert a Dota player slot to a gem player id."""
     if 0 <= player_slot <= 4:
         return player_slot
     if 128 <= player_slot <= 132:
@@ -54,7 +55,7 @@ def _player_id_to_player_slot(player_id: int) -> int:
 
     OpenDota encodes Radiant players as ``0-4`` and Dire players as ``128-132``
     in ``player_slot`` fields, while the ``slot`` field stays ``0-9``. This is the
-    inverse of :func:`_metadata_slot_to_player_id`.
+    inverse of :func:`_player_slot_to_player_id`.
 
     Args:
         player_id: gem logical player id, 0-9 (0-4 Radiant, 5-9 Dire).
@@ -63,6 +64,37 @@ def _player_id_to_player_slot(player_id: int) -> int:
         The OpenDota ``player_slot`` (0-4 for Radiant, 128-132 for Dire).
     """
     return player_id if player_id < 5 else 128 + (player_id - 5)
+
+
+def _apply_match_details_scalars(match: ParsedMatch, details: CMsgDOTAMatch | None) -> None:
+    """Overlay exact terminal scalars from the replay's postgame summary.
+
+    Proto2 presence checks are intentional: an explicitly encoded zero is an
+    authoritative result, while an absent field leaves the existing replay
+    reconstruction/default untouched. This keeps truncated and older replays on
+    their current fallback path.
+    """
+    if details is None:
+        return
+
+    for source in details.players:
+        if not source.HasField("player_slot"):
+            continue
+        player_id = _player_slot_to_player_id(source.player_slot)
+        if player_id is None or player_id >= len(match.players):
+            continue
+
+        player = match.players[player_id]
+        for field_name in ("hero_damage", "tower_damage", "hero_healing"):
+            if source.HasField(field_name):
+                setattr(player, field_name, int(getattr(source, field_name)))
+
+        if source.HasField("gold_per_min"):
+            player.gold_per_min = int(source.gold_per_min)
+            player.total_gold = (player.gold_per_min * match.duration) // 60
+        if source.HasField("xp_per_min"):
+            player.xp_per_min = int(source.xp_per_min)
+            player.total_xp = (player.xp_per_min * match.duration) // 60
 
 
 def _tick_game_seconds(tick: int, game_start_tick: int | None) -> int:
@@ -694,8 +726,8 @@ def _populate_player_series(
                 )
             pp.buybacks = buybacks
             pp.stuns_dealt = agg.stuns_dealt
-            # OpenDota-style combat scalars (combat-log reconstruction; exact via
-            # apply_api_rates). Best-effort offline estimates.
+            # Best-effort combat-log fallbacks. The embedded postgame summary is
+            # applied after this loop when available.
             pp.hero_damage = agg.hero_damage
             pp.tower_damage = agg.tower_damage
             pp.hero_healing = agg.hero_healing
@@ -880,6 +912,11 @@ def build_parsed_match(
     if radiant_win is None:
         radiant_win = _radiant_win_from_ancient(all_entries)
 
+    match_details = getattr(parser, "match_details", None)
+    duration = getattr(parser, "duration_s", None) or 0
+    if match_details is not None and match_details.HasField("duration"):
+        duration = int(match_details.duration)
+
     match = ParsedMatch(
         match_id=parser.match_id,
         game_mode=parser.game_mode,
@@ -902,7 +939,7 @@ def build_parsed_match(
         draft=draft_ext.draft_events,
         game_start_tick=parser.game_start_tick,
         game_end_tick=parser.tick,
-        duration=getattr(parser, "duration_s", None) or 0,
+        duration=duration,
     )
 
     # Post-process buybacks (7b).
@@ -958,11 +995,16 @@ def build_parsed_match(
         radiant_win=radiant_win,
     )
 
+    # Complete replays carry an embedded CMsgDOTAMatch postgame summary. Its
+    # terminal combat scalars and GPM/XPM are the same Game Coordinator values
+    # exposed by OpenDota, so they take precedence over combat-log estimates.
+    _apply_match_details_scalars(match, match_details)
+
     match_metadata = getattr(parser, "match_metadata", None)
     metadata = getattr(match_metadata, "metadata", None)
     for team in getattr(metadata, "teams", []) or []:
         for metadata_player in getattr(team, "players", []) or []:
-            metadata_player_id = _metadata_slot_to_player_id(metadata_player.player_slot)
+            metadata_player_id = _player_slot_to_player_id(metadata_player.player_slot)
             if metadata_player_id is not None:
                 match.players[metadata_player_id].ability_upgrades_arr = list(
                     metadata_player.ability_upgrades

--- a/src/gem/results/assembly.py
+++ b/src/gem/results/assembly.py
@@ -71,11 +71,14 @@ def _apply_match_details_scalars(match: ParsedMatch, details: CMsgDOTAMatch | No
 
     Proto2 presence checks are intentional: an explicitly encoded zero is an
     authoritative result, while an absent field leaves the existing replay
-    reconstruction/default untouched. This keeps truncated and older replays on
-    their current fallback path.
+    reconstruction/default untouched. Internal per-field provenance lets the
+    validator distinguish these exact values from fallbacks without changing
+    the public serialized output.
     """
     if details is None:
         return
+    if details.HasField("duration"):
+        match._match_details_fields.add("duration")
 
     for source in details.players:
         if not source.HasField("player_slot"):
@@ -88,13 +91,20 @@ def _apply_match_details_scalars(match: ParsedMatch, details: CMsgDOTAMatch | No
         for field_name in ("hero_damage", "tower_damage", "hero_healing"):
             if source.HasField(field_name):
                 setattr(player, field_name, int(getattr(source, field_name)))
+                player._match_details_fields.add(field_name)
 
         if source.HasField("gold_per_min"):
             player.gold_per_min = int(source.gold_per_min)
             player.total_gold = (player.gold_per_min * match.duration) // 60
+            player._match_details_fields.add("gold_per_min")
+            if "duration" in match._match_details_fields:
+                player._match_details_fields.add("total_gold")
         if source.HasField("xp_per_min"):
             player.xp_per_min = int(source.xp_per_min)
             player.total_xp = (player.xp_per_min * match.duration) // 60
+            player._match_details_fields.add("xp_per_min")
+            if "duration" in match._match_details_fields:
+                player._match_details_fields.add("total_xp")
 
 
 def _tick_game_seconds(tick: int, game_start_tick: int | None) -> int:

--- a/src/gem/results/models.py
+++ b/src/gem/results/models.py
@@ -375,34 +375,27 @@ class ParsedPlayer:
         kills_per_min: Kills divided by match duration in minutes
             (``kills / (ParsedMatch.duration / 60)``). Unrounded float matching
             OpenDota's ``kills_per_min``. ``0.0`` when duration is unknown.
-        hero_damage: Damage dealt to enemy heroes, reconstructed from the combat
-            log by crediting the damage source (``damage_source_name``) to
-            non-illusion hero targets. Best-effort offline estimate (~90% vs
-            OpenDota across fixtures). The residual is **not** a filter gap:
-            OpenDota's headline ``hero_damage`` is a Game-Coordinator
-            (``CMsgGameMatchSignOut``) value that accounts for in-engine
-            mitigation the combat log cannot see, so it is unclosable offline.
-            Overwritten with the exact API value by
-            :func:`gem.replays.fetch.apply_api_rates`.
+        hero_damage: Damage dealt to enemy heroes. Complete replays source the
+            exact Game Coordinator value from the embedded ``CMsgDOTAMatch``
+            postgame summary. Older or truncated replays fall back to combat-log
+            reconstruction; :func:`gem.replays.fetch.apply_api_rates` can still
+            overwrite it from an explicit API response.
         tower_damage: Damage dealt to building structures (towers, barracks,
-            fort/ancient), reconstructed from the combat log by damage source.
-            Essentially exact offline (~99.97% vs OpenDota — the building sum
-            equals the GC value); refreshed exactly via ``apply_api_rates``.
+            fort/ancient). Uses the embedded postgame summary when present and
+            combat-log reconstruction otherwise; ``apply_api_rates`` can
+            explicitly overwrite it.
         hero_healing: Healing given to allied heroes (excluding self-heal),
-            credited to the heal source, from the combat log. Best-effort offline
-            estimate; OpenDota's headline value is GC-sourced (self-heal-excluded,
-            mitigation-aware) and exact via ``apply_api_rates``.
-        gold_per_min: Gold per minute. NOT derivable from the replay — sourced
-            from the Steam GC / OpenDota match API. ``0`` until populated by
-            :func:`gem.replays.fetch.enrich_with_api_rates`. See
-            ``opendota-gpm-is-steam-api`` (the team-data earned-gold counter is a
-            different quantity and does not match OpenDota's value).
-        xp_per_min: XP per minute. Same API provenance as ``gold_per_min``;
-            ``0`` until enriched.
+            using the embedded postgame summary when present and combat-log
+            reconstruction otherwise. Can be overwritten via ``apply_api_rates``.
+        gold_per_min: Game Coordinator gold per minute from the replay-embedded
+            postgame summary. ``0`` when that summary/field is absent; optional
+            API enrichment can overwrite it.
+        xp_per_min: Game Coordinator XP per minute, with the same embedded-summary
+            and optional API provenance as ``gold_per_min``.
         total_gold: Total gold, ``floor(gold_per_min * duration / 60)`` (OpenDota's
-            own formula). ``0`` until ``gold_per_min`` is enriched.
+            own formula). ``0`` when ``gold_per_min`` is unavailable.
         total_xp: Total XP, ``floor(xp_per_min * duration / 60)``. ``0`` until
-            ``xp_per_min`` is enriched.
+            ``xp_per_min`` is available.
     """
 
     player_id: int
@@ -604,12 +597,12 @@ class ParsedMatch:
         game_start_tick: Absolute tick when the game clock started (creeps spawn).
             ``None`` if the transition was not observed.
         game_end_tick: Absolute tick of the final parser tick.
-        duration: OpenDota-style match duration in seconds — the horn-anchored
-            combat-log time at GAME_STATE==6 (ancient destroyed). Matches
-            OpenDota's ``duration`` to within ~1s (sub-second rounding). ``0`` if
-            the postGame transition was not observed. Distinct from the
-            tick-derived ``duration_seconds`` property, which spans the raw parser
-            ticks and includes pre/post-game time.
+        duration: OpenDota-style match duration in seconds. Complete replays use
+            the exact value from the embedded ``CMsgDOTAMatch`` postgame summary;
+            otherwise this falls back to horn-anchored combat-log time at
+            GAME_STATE==6 (ancient destroyed). ``0`` if neither is available.
+            Distinct from the tick-derived ``duration_seconds`` property, which
+            spans the raw parser ticks and includes pre/post-game time.
         radiant_score: Radiant's final kill score (sum of Radiant players'
             kills), mirroring OpenDota's ``radiant_score``.
         dire_score: Dire's final kill score (sum of Dire players' kills),

--- a/src/gem/results/models.py
+++ b/src/gem/results/models.py
@@ -516,6 +516,15 @@ class ParsedPlayer:
     # Append-only: ParsedPlayer is a public dataclass and supports positional
     # construction, so new fields go last to avoid shifting existing callers.
     game_times_min: list[int] = field(default_factory=list)
+    # Internal provenance for values copied from CMsgDOTAMatch. The serializer
+    # omits this implementation detail from the public ParsedPlayer shape.
+    _match_details_fields: set[str] = field(
+        default_factory=set,
+        init=False,
+        repr=False,
+        compare=False,
+        metadata={"serialize": False},
+    )
 
     def __repr__(self) -> str:
         hero = self.hero_name.removeprefix("npc_dota_hero_") if self.hero_name else "unknown"
@@ -666,6 +675,14 @@ class ParsedMatch:
     # inserting them there would silently misalign positional callers.)
     banner_plants: list[BannerPlant] = field(default_factory=list)
     game_times_min: list[int] = field(default_factory=list)
+    # Internal provenance for match-level values copied from CMsgDOTAMatch.
+    _match_details_fields: set[str] = field(
+        default_factory=set,
+        init=False,
+        repr=False,
+        compare=False,
+        metadata={"serialize": False},
+    )
 
     @property
     def duration_seconds(self) -> float:

--- a/tests/test_intervals_axis_integration.py
+++ b/tests/test_intervals_axis_integration.py
@@ -1,9 +1,10 @@
 """Integration lock-in for OpenDota's tick-start interval boundary.
 
 OpenDota reads interval entities from Clarity's ``@OnTickStart`` callback. Gem
-decodes ``CNETMsg_Tick``, queues the first rounded-minute crossing, and samples
-before the following tick's entity deltas to reproduce Clarity's effective
-phase. This fixture locks in point-level parity against the published arrays.
+decodes ``CNETMsg_Tick``, samples minute zero immediately, and queues later
+rounded-minute crossings for the following tick start to reproduce Clarity's
+effective phase. This fixture locks in point-level parity against the published
+arrays.
 
 Marked ``slow`` + ``integration`` — needs a real ``.dem`` plus its ``.opendota.json``.
 """

--- a/tests/test_intervals_extractor.py
+++ b/tests/test_intervals_extractor.py
@@ -411,6 +411,20 @@ def _radiant_data_with(gold: int, xp: int, lh: int, dn: int, net_worth: int) -> 
     )
 
 
+def _dire_data_with(gold: int, xp: int, lh: int, dn: int, net_worth: int) -> Entity:
+    """Dire data entity carrying explicit team-slot-4 totals."""
+    return _ent(
+        "CDOTA_DataDire",
+        **{
+            "m_vecDataTeam.0004.m_iTotalEarnedGold": gold,
+            "m_vecDataTeam.0004.m_iTotalEarnedXP": xp,
+            "m_vecDataTeam.0004.m_iLastHitCount": lh,
+            "m_vecDataTeam.0004.m_iDenyCount": dn,
+            "m_vecDataTeam.0004.m_iNetWorth": net_worth,
+        },
+    )
+
+
 def test_tick_start_defers_crossing_by_one_net_tick():
     """Production sampling includes crossing-tick but not next-tick deltas."""
     ext = IntervalExtractor()
@@ -440,22 +454,97 @@ def test_tick_start_defers_crossing_by_one_net_tick():
     assert radiant.dn == 5
 
 
-def test_tick_start_removes_only_minute_zero_gold_offset():
+def test_tick_start_samples_minute_zero_before_same_tick_bounty_delta():
     ext = IntervalExtractor()
     parser = TickStartFakeParser(tick=1800, game_time_s=0)
     ext.attach(parser)  # type: ignore[arg-type]
     ext._on_entity(_player_resource(), EntityOp.UPDATED)
-    ext._on_entity(_radiant_data_with(322, 40, 0, 0, 922), EntityOp.UPDATED)
-    ext._on_entity(_dire_data(), EntityOp.UPDATED)
+    ext._on_entity(_radiant_data_with(0, 0, 0, 0, 600), EntityOp.UPDATED)
+    ext._on_entity(_zero_dire_data(), EntityOp.UPDATED)
 
+    # Minute zero is OpenDota's immediate @OnTickStart read. A team-wide bounty
+    # payout arriving later in this same tick must not leak into that boundary.
     parser.fire_tick_start(6000)
+    assert [snap.gold for snap in ext.snapshots] == [0, 0]
+
+    ext._on_entity(_radiant_data_with(40, 0, 0, 0, 640), EntityOp.UPDATED)
     parser.tick = 1801
     parser.fire_tick_start(6001)
 
+    assert [snap.gold for snap in ext.snapshots] == [0, 0]
+
+
+def test_tick_start_minute_zero_prefers_previous_team_data_frame():
+    ext = IntervalExtractor()
+    parser = TickStartFakeParser(tick=1798, game_time_s=0)
+    ext.attach(parser)  # type: ignore[arg-type]
+    ext._on_entity(_player_resource(), EntityOp.UPDATED)
+
+    # The frame visible to OpenDota's minute-zero callback has all counters at
+    # zero. Gem receives one newer team-data frame before its rounded game clock
+    # reaches zero; that frame contains the engine's transient starting gold.
+    ext._on_entity(_zero_radiant_data(), EntityOp.UPDATED)
+    ext._on_entity(_zero_dire_data(), EntityOp.UPDATED)
+    parser.tick = 1799
+    ext._on_entity(_radiant_data_with(1, 2, 3, 4, 605), EntityOp.UPDATED)
+    ext._on_entity(_dire_data_with(1, 2, 3, 4, 605), EntityOp.UPDATED)
+
+    parser.tick = 1800
+    parser.fire_tick_start(6000)
+
+    assert [snap.gold for snap in ext.snapshots] == [0, 0]
+    assert [snap.xp for snap in ext.snapshots] == [0, 0]
+    assert [snap.lh for snap in ext.snapshots] == [0, 0]
+    assert [snap.dn for snap in ext.snapshots] == [0, 0]
+    assert [snap.net_worth for snap in ext.snapshots] == [600, 600]
+
+
+def test_tick_start_delayed_minute_zero_retains_previous_frame_phase():
+    ext = IntervalExtractor()
+    parser = TickStartFakeParser(tick=1798, game_time_s=0)
+    ext.attach(parser)  # type: ignore[arg-type]
+
+    ext._on_entity(_zero_radiant_data(), EntityOp.UPDATED)
+    ext._on_entity(_zero_dire_data(), EntityOp.UPDATED)
+    parser.tick = 1799
+    ext._on_entity(_radiant_data_with(1, 0, 0, 0, 601), EntityOp.UPDATED)
+    ext._on_entity(_dire_data_with(1, 0, 0, 0, 601), EntityOp.UPDATED)
+
+    # The initial callback cannot emit until PlayerResource establishes logical
+    # slots. Its next-tick retry must keep minute zero's prior-frame semantics.
+    parser.tick = 1800
+    parser.fire_tick_start(6000)
+    assert ext.snapshots == []
+    ext._on_entity(_player_resource(), EntityOp.UPDATED)
+
+    parser.tick = 1801
+    parser.fire_tick_start(6001)
+
+    assert [snap.gold for snap in ext.snapshots] == [0, 0]
+
+
+def test_tick_start_preserves_nonzero_minute_zero_gold():
+    ext = IntervalExtractor()
+    parser = TickStartFakeParser(tick=1798, game_time_s=0)
+    ext.attach(parser)  # type: ignore[arg-type]
+    ext._on_entity(_player_resource(), EntityOp.UPDATED)
+
+    # Real pre-horn earnings can already be present in both adjacent frames.
+    # Selecting the prior frame must preserve those values verbatim rather than
+    # applying a blanket minute-zero normalization.
+    ext._on_entity(_radiant_data_with(322, 40, 0, 0, 922), EntityOp.UPDATED)
+    ext._on_entity(_dire_data(), EntityOp.UPDATED)
+    parser.tick = 1799
+    ext._on_entity(_radiant_data_with(322, 40, 0, 0, 922), EntityOp.UPDATED)
+    ext._on_entity(_dire_data(), EntityOp.UPDATED)
+
+    parser.tick = 1800
+    parser.fire_tick_start(6000)
+
     radiant = next(s for s in ext.snapshots if s.team == 2)
     dire = next(s for s in ext.snapshots if s.team == 3)
-    assert radiant.gold == 321
-    assert dire.gold == 599
+    assert radiant.gold == 322
+    assert dire.gold == 600
     assert radiant.xp == 40
 
 

--- a/tests/test_match_builder.py
+++ b/tests/test_match_builder.py
@@ -674,11 +674,13 @@ class TestBuildParsedMatchPlayerCombatFields:
 
 
 class TestBuildParsedMatchMatchDetails:
-    def _build(self):
+    def _build(self, *, include_duration: bool = True):
         from gem.combat.aggregator import _ParsedPlayerAgg
         from gem.proto.dota_gcmessages_common_pb2 import CMsgDOTAMatch
 
-        details = CMsgDOTAMatch(duration=3351)
+        details = CMsgDOTAMatch()
+        if include_duration:
+            details.duration = 3351
         radiant = details.players.add(player_slot=0)
         radiant.hero_damage = 0
         radiant.tower_damage = 2345
@@ -715,7 +717,10 @@ class TestBuildParsedMatchMatchDetails:
         return match
 
     def test_embedded_duration_is_authoritative(self):
-        assert self._build().duration == 3351
+        match = self._build()
+
+        assert match.duration == 3351
+        assert match._match_details_fields == {"duration"}
 
     def test_embedded_scalars_override_combat_reconstruction_by_slot(self):
         match = self._build()
@@ -724,9 +729,13 @@ class TestBuildParsedMatchMatchDetails:
         assert match.players[0].tower_damage == 2345
         # Absent proto fields retain the combat-log fallback.
         assert match.players[0].hero_healing == 333
+        assert "hero_healing" not in match.players[0]._match_details_fields
         assert match.players[5].hero_damage == 34567
         assert match.players[5].tower_damage == 0
         assert match.players[5].hero_healing == 456
+        assert {"hero_damage", "tower_damage", "hero_healing"}.issubset(
+            match.players[5]._match_details_fields
+        )
 
     def test_embedded_rates_derive_opendota_totals(self):
         match = self._build()
@@ -739,6 +748,21 @@ class TestBuildParsedMatchMatchDetails:
         assert match.players[5].total_gold == 0
         assert match.players[5].xp_per_min == 589
         assert match.players[5].total_xp == (589 * 3351) // 60
+        assert {
+            "gold_per_min",
+            "xp_per_min",
+            "total_gold",
+            "total_xp",
+        }.issubset(match.players[5]._match_details_fields)
+
+    def test_derived_totals_are_not_exact_without_embedded_duration(self):
+        match = self._build(include_duration=False)
+
+        assert match.duration == 3350
+        assert match._match_details_fields == set()
+        assert {"gold_per_min", "xp_per_min"}.issubset(match.players[0]._match_details_fields)
+        assert "total_gold" not in match.players[0]._match_details_fields
+        assert "total_xp" not in match.players[0]._match_details_fields
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_match_builder.py
+++ b/tests/test_match_builder.py
@@ -84,6 +84,7 @@ def _make_parser(
     leagueid: int = 0,
     entity_manager=None,
     match_metadata=None,
+    match_details=None,
     duration_s: int | None = None,
 ) -> MagicMock:
     p = MagicMock()
@@ -95,6 +96,7 @@ def _make_parser(
     p.leagueid = leagueid
     p.entity_manager = entity_manager
     p.match_metadata = match_metadata
+    p.match_details = match_details
     p.duration_s = duration_s
     return p
 
@@ -664,6 +666,79 @@ class TestBuildParsedMatchPlayerCombatFields:
         assert pp.damage_by_type == agg3.damage_by_type
         assert pp.ability_uses == agg3.ability_uses
         assert pp.stuns_dealt == pytest.approx(2.5)
+
+
+# ---------------------------------------------------------------------------
+# Embedded postgame match details
+# ---------------------------------------------------------------------------
+
+
+class TestBuildParsedMatchMatchDetails:
+    def _build(self):
+        from gem.combat.aggregator import _ParsedPlayerAgg
+        from gem.proto.dota_gcmessages_common_pb2 import CMsgDOTAMatch
+
+        details = CMsgDOTAMatch(duration=3351)
+        radiant = details.players.add(player_slot=0)
+        radiant.hero_damage = 0
+        radiant.tower_damage = 2345
+        radiant.gold_per_min = 612
+        radiant.xp_per_min = 701
+
+        dire = details.players.add(player_slot=128)
+        dire.hero_damage = 34567
+        dire.tower_damage = 0
+        dire.hero_healing = 456
+        dire.gold_per_min = 0
+        dire.xp_per_min = 589
+
+        # Invalid player slots in a postgame summary must be ignored safely.
+        details.players.add(player_slot=200, hero_damage=999999)
+        details.players.add(hero_damage=888888)
+
+        radiant_agg = _ParsedPlayerAgg(hero_damage=111, tower_damage=222, hero_healing=333)
+        dire_agg = _ParsedPlayerAgg(hero_damage=444, tower_damage=555, hero_healing=666)
+        combat_agg = MagicMock()
+        combat_agg.players = {0: radiant_agg, 5: dire_agg}
+
+        match = build_parsed_match(
+            _make_parser(match_details=details, duration_s=3350),
+            _make_player_ext(),
+            _make_obj_ext(),
+            _make_ward_ext(),
+            _make_courier_ext(),
+            _make_draft_ext(),
+            combat_agg,
+            [],
+            [],
+        )
+        return match
+
+    def test_embedded_duration_is_authoritative(self):
+        assert self._build().duration == 3351
+
+    def test_embedded_scalars_override_combat_reconstruction_by_slot(self):
+        match = self._build()
+
+        assert match.players[0].hero_damage == 0
+        assert match.players[0].tower_damage == 2345
+        # Absent proto fields retain the combat-log fallback.
+        assert match.players[0].hero_healing == 333
+        assert match.players[5].hero_damage == 34567
+        assert match.players[5].tower_damage == 0
+        assert match.players[5].hero_healing == 456
+
+    def test_embedded_rates_derive_opendota_totals(self):
+        match = self._build()
+
+        assert match.players[0].gold_per_min == 612
+        assert match.players[0].xp_per_min == 701
+        assert match.players[0].total_gold == (612 * 3351) // 60
+        assert match.players[0].total_xp == (701 * 3351) // 60
+        assert match.players[5].gold_per_min == 0
+        assert match.players[5].total_gold == 0
+        assert match.players[5].xp_per_min == 589
+        assert match.players[5].total_xp == (589 * 3351) // 60
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -78,9 +78,9 @@ class TestParsedMatchFieldOrder:
     def test_additive_fields_remain_at_the_tail(self):
         import dataclasses
 
-        fields = [f.name for f in dataclasses.fields(ParsedMatch)]
+        fields = [f.name for f in dataclasses.fields(ParsedMatch) if f.init]
         assert fields[-2:] == ["banner_plants", "game_times_min"], (
-            "new ParsedMatch fields must be appended to preserve positional "
+            "new constructor fields must be appended to preserve positional "
             f"construction; current order tail: {fields[-3:]}"
         )
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -32,6 +32,7 @@ from gem.parser import (
     _DOTA_UM_CHAT_MESSAGE,
     _DOTA_UM_COMBAT_LOG_DATA,
     _DOTA_UM_COMBAT_LOG_HLTV,
+    _DOTA_UM_MATCH_DETAILS,
     _DOTA_UM_MATCH_METADATA,
     _NET_TICK,
     _SVC_CREATE_STRING_TABLE,
@@ -197,6 +198,10 @@ class TestReplayParserInit:
     def test_match_metadata_starts_none(self):
         p = ReplayParser(b"")
         assert p.match_metadata is None
+
+    def test_match_details_starts_none(self):
+        p = ReplayParser(b"")
+        assert p.match_details is None
 
     def test_radiant_win_starts_none(self):
         p = ReplayParser(b"")
@@ -730,6 +735,41 @@ class TestDispatchInnerRouting:
         assert p.match_metadata is not None
         assert p.match_metadata.match_id == 67890
         assert list(p.match_metadata.metadata.teams[0].players[0].ability_upgrades) == [9, 8]
+
+    def test_direct_match_details_is_stored_and_supplies_missing_match_id(self):
+        from gem.proto.dota_gcmessages_common_pb2 import CMsgDOTAMatch
+
+        p = ReplayParser(b"")
+        details = CMsgDOTAMatch(match_id=8956943534, duration=3351)
+        player = details.players.add(player_slot=128)
+        player.hero_damage = 12345
+        player.gold_per_min = 612
+
+        p._dispatch_inner(_DOTA_UM_MATCH_DETAILS, details.SerializeToString())
+
+        assert p.match_details is not None
+        assert p.match_details.duration == 3351
+        assert p.match_details.players[0].hero_damage == 12345
+        assert p.match_id == 8956943534
+
+    def test_wrapped_match_details_is_stored_without_overwriting_match_id(self):
+        from gem.proto.dota_gcmessages_common_pb2 import CMsgDOTAMatch
+        from gem.proto.netmessages_pb2 import CSVCMsg_UserMessage
+
+        p = ReplayParser(b"")
+        p.match_id = 777
+        details = CMsgDOTAMatch(match_id=8956943534, duration=3351)
+        details.players.add(player_slot=0, xp_per_min=701)
+        user_msg = CSVCMsg_UserMessage(
+            msg_type=_DOTA_UM_MATCH_DETAILS,
+            msg_data=details.SerializeToString(),
+        )
+
+        p._dispatch_inner(_SVC_USER_MESSAGE, user_msg.SerializeToString())
+
+        assert p.match_details is not None
+        assert p.match_details.players[0].xp_per_min == 701
+        assert p.match_id == 777
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -55,6 +55,16 @@ class TestSerializationHelpers:
         assert data["opendota_teamfights"][0]["start"] == 10
         assert data["opendota_teamfights"][0]["players"][0]["damage"] == 0
 
+    def test_to_dict_omits_internal_match_details_provenance(self):
+        match = ParsedMatch(match_id=7)
+        match._match_details_fields.add("duration")
+        match.players[0]._match_details_fields.add("hero_damage")
+
+        data = gem.to_dict(match)
+
+        assert "_match_details_fields" not in data
+        assert "_match_details_fields" not in data["players"][0]
+
     def test_parse_to_json_uses_parse_result(self, monkeypatch):
         fake_match = ParsedMatch(match_id=999)
 

--- a/tests/test_validate_opendota.py
+++ b/tests/test_validate_opendota.py
@@ -203,12 +203,22 @@ def test_scalar_validation_gates_embedded_postgame_fields_exactly(tmp_path, monk
         xp_per_min=700,
         total_gold=1200,
         total_xp=1400,
+        _match_details_fields={
+            "hero_damage",
+            "tower_damage",
+            "hero_healing",
+            "gold_per_min",
+            "xp_per_min",
+            "total_gold",
+            "total_xp",
+        },
     )
     parsed = SimpleNamespace(
         players=[player],
         radiant_win=True,
         towers=[],
         duration=120,
+        _match_details_fields={"duration"},
     )
     monkeypatch.setattr(gem, "parse", lambda _: parsed)
     opendota = {
@@ -243,4 +253,79 @@ def test_scalar_validation_gates_embedded_postgame_fields_exactly(tmp_path, monk
     assert fields["npc_dota_hero_axe/hero_damage"].tolerance == 0
     assert fields["npc_dota_hero_axe/gold_per_min"].tolerance == 0
     assert fields["npc_dota_hero_axe/total_xp"].tolerance == 0
+    assert fields["duration"].status == "PASS"
+    assert fields["npc_dota_hero_axe/hero_damage"].status == "PASS"
+    assert fields["npc_dota_hero_axe/total_xp"].status == "PASS"
+    assert result.failed == 0
+
+
+def test_scalar_validation_skips_postgame_fields_without_exact_provenance(
+    tmp_path, monkeypatch
+) -> None:
+    fixture = tmp_path / "match.dem"
+    fixture.write_bytes(b"synthetic")
+    player = SimpleNamespace(
+        player_id=0,
+        hero_name="npc_dota_hero_axe",
+        kills=3,
+        deaths=2,
+        net_worth=12000,
+        last_hits=150,
+        denies=7,
+        hero_damage=99999,
+        tower_damage=99999,
+        hero_healing=99999,
+        gold_per_min=0,
+        xp_per_min=0,
+        total_gold=0,
+        total_xp=0,
+        _match_details_fields=set(),
+    )
+    parsed = SimpleNamespace(
+        players=[player],
+        radiant_win=True,
+        towers=[],
+        duration=119,
+        _match_details_fields=set(),
+    )
+    monkeypatch.setattr(gem, "parse", lambda _: parsed)
+    opendota = {
+        "players": [
+            {
+                "player_slot": 0,
+                "hero_id": 2,
+                "kills": 3,
+                "deaths": 2,
+                "net_worth": 12000,
+                "last_hits": 150,
+                "denies": 7,
+                "hero_damage": 23456,
+                "tower_damage": 3456,
+                "hero_healing": 789,
+                "gold_per_min": 600,
+                "xp_per_min": 700,
+                "total_gold": 1200,
+                "total_xp": 1400,
+            }
+        ],
+        "radiant_win": True,
+        "tower_status_radiant": 0x7FF,
+        "tower_status_dire": 0x7FF,
+        "duration": 120,
+    }
+
+    result = validate_match(1, fixture, od=opendota, mode="scalar")
+
+    fields = {field.name: field for field in result.all_fields}
+    exact_names = {
+        "duration",
+        "npc_dota_hero_axe/hero_damage",
+        "npc_dota_hero_axe/tower_damage",
+        "npc_dota_hero_axe/hero_healing",
+        "npc_dota_hero_axe/gold_per_min",
+        "npc_dota_hero_axe/xp_per_min",
+        "npc_dota_hero_axe/total_gold",
+        "npc_dota_hero_axe/total_xp",
+    }
+    assert all(fields[name].status == "SKIP" for name in exact_names)
     assert result.failed == 0

--- a/tests/test_validate_opendota.py
+++ b/tests/test_validate_opendota.py
@@ -1,9 +1,13 @@
 """Unit tests for local OpenDota validator helpers."""
 
+from types import SimpleNamespace
+
+import gem
 from gem.combat.log import CombatLogEntry
 from scripts.validate_opendota import (
     _compare_opendota_player_array,
     _opendota_teamfights_from_combat_log,
+    validate_match,
 )
 
 
@@ -179,3 +183,64 @@ def test_player_count_curve_comparison_can_scale_absolute_error_threshold() -> N
     assert fields[2].ref_value == 15
     assert fields[3].gem_value == 15
     assert fields[3].ref_value == 15
+
+
+def test_scalar_validation_gates_embedded_postgame_fields_exactly(tmp_path, monkeypatch) -> None:
+    fixture = tmp_path / "match.dem"
+    fixture.write_bytes(b"synthetic")
+    player = SimpleNamespace(
+        player_id=0,
+        hero_name="npc_dota_hero_axe",
+        kills=3,
+        deaths=2,
+        net_worth=12000,
+        last_hits=150,
+        denies=7,
+        hero_damage=23456,
+        tower_damage=3456,
+        hero_healing=789,
+        gold_per_min=600,
+        xp_per_min=700,
+        total_gold=1200,
+        total_xp=1400,
+    )
+    parsed = SimpleNamespace(
+        players=[player],
+        radiant_win=True,
+        towers=[],
+        duration=120,
+    )
+    monkeypatch.setattr(gem, "parse", lambda _: parsed)
+    opendota = {
+        "players": [
+            {
+                "player_slot": 0,
+                "hero_id": 2,
+                "kills": 3,
+                "deaths": 2,
+                "net_worth": 12000,
+                "last_hits": 150,
+                "denies": 7,
+                "hero_damage": 23456,
+                "tower_damage": 3456,
+                "hero_healing": 789,
+                "gold_per_min": 600,
+                "xp_per_min": 700,
+                "total_gold": 1200,
+                "total_xp": 1400,
+            }
+        ],
+        "radiant_win": True,
+        "tower_status_radiant": 0x7FF,
+        "tower_status_dire": 0x7FF,
+        "duration": 120,
+    }
+
+    result = validate_match(1, fixture, od=opendota, mode="scalar")
+
+    fields = {field.name: field for field in result.all_fields}
+    assert fields["duration"].tolerance == 0
+    assert fields["npc_dota_hero_axe/hero_damage"].tolerance == 0
+    assert fields["npc_dota_hero_axe/gold_per_min"].tolerance == 0
+    assert fields["npc_dota_hero_axe/total_xp"].tolerance == 0
+    assert result.failed == 0


### PR DESCRIPTION
## Summary

- Decode direct and wrapped DOTA_UM_MatchDetails messages into the embedded CMsgDOTAMatch postgame summary.
- Overlay exact duration, damage, healing, GPM, XPM, total-gold, and total-XP values while retaining replay reconstruction and API fallbacks when fields are absent.
- Track field-level match-details provenance internally so exact validator gates skip fallback values on older, truncated, or partially populated replays.
- Align minute zero to the preceding observed team-data frame while keeping later minute boundaries on the established one-tick deferral.
- Strengthen OpenDota validation and document the updated offline parity contract.

## Rationale

OpenDota publishes these headline scalars from the Game Coordinator summary rather than its combat-log reconstruction. Complete replay files contain the same CMsgDOTAMatch data, so Gem can now produce exact values offline. The remaining TI2026 curve failures came from a minute-zero phase difference: Gem observed one transient initialization frame beyond the state read by Clarity. Selecting the preceding frame closes that gap without zeroing or subtracting legitimate pre-horn earnings.

Closes #68

## Testing

- [x] uv run ruff check .
- [x] uv run ruff format --check .
- [x] uv run mypy src
- [x] uv run pytest -q — 1738 passed, 3 skipped, 62 deselected
- [x] uv run pytest tests/test_intervals_axis_integration.py -m integration -q — 2 passed
- [x] npm run docs:build
- [x] OpenDota full validation 8856501050 — 301 passed, 0 warned, 0 failed, 1 skipped
- [x] OpenDota full validation 8860187335 — 296 passed, 0 warned, 0 failed, 1 skipped
- [x] OpenDota full validation 8868259993 — 295 passed, 0 warned, 0 failed, 1 skipped
- [x] OpenDota full validation 8956943534 — 298 passed, 0 warned, 0 failed, 1 skipped

All tested gold and XP advantage curves have 0.0 maximum error against OpenDota.

## Notes

- [x] Generated protobuf files under src/gem/proto were not edited manually.
- [x] Large replay artifacts are not committed.
- [x] Secrets and local credentials are not included.
- [x] Parser ordering was cross-checked against refs/manta, refs/clarity, and refs/parser.
- [x] Review feedback about fallback validation was addressed with field-level provenance and regression coverage.
- Downloaded replay files, diagnostic scripts, and generated test/build caches were removed before handoff.