### PR TITLE
Make TI2026 the canonical replay fixture corpus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Curated TI2026 replay corpus.** The short, medium, and long TI2026 qualifier
+  replays are now named canonical, extended, and stress fixture tiers in the
+  committed OpenDota manifest. The new `scripts/sync_opendota_fixtures.py`
+  command downloads ignored full replays atomically and verifies their recorded
+  decompressed size and SHA-256 digest.
+
+### Changed
+- **Deterministic integration fixture selection.** Generic full-replay tests and
+  examples now use the explicit short TI2026 fixture instead of whichever local
+  replay happens to be found first. The DreamLeague performance baseline and
+  feature-specific regression fixtures remain available, while replaced medium
+  and long DreamLeague entries are retained as deprecated manifest records.
+
 ## [0.7.0] - 2026-09-02
 
 Completes exact offline OpenDota parity for current complete replays by using

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -425,7 +425,11 @@ scripts (`test_audit_camp_annotations.py`, `test_audit_opendota_fixture_constant
 
 - Fixtures live in `tests/fixtures/`; shared config in `tests/conftest.py`.
   Keep committed replay fixtures truncated. Full replay fixtures should be
-  local/ignored OpenDota downloads under `tests/fixtures/opendota/`.
+  local/ignored OpenDota downloads under `tests/fixtures/opendota/`. Synchronize
+  the canonical TI2026 fixture with
+  `uv run python scripts/sync_opendota_fixtures.py`; select broader tiers or exact
+  match IDs when required. The committed `manifest.json` is the source of truth
+  for fixture lifecycle, capabilities, integrity metadata, and replacements.
   Map/reference images for examples, reports, and camp-zone tooling live under
   `assets/maps/`, not `tests/fixtures/`.
 - `uv run pytest` skips `slow` and `integration` markers by default so local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,7 +206,13 @@ uv run pytest -m "not slow and not integration"
 - Tests live in `tests/` mirroring the module they cover; low-level binary tests
   are grouped under `tests/binary/`
 - Use synthetic binary fixtures (construct minimal valid byte sequences) rather than real replay files for unit tests
-- Keep committed replay fixtures truncated. Full replay fixtures should stay ignored/local under `tests/fixtures/opendota/`.
+- Keep committed replay fixtures truncated. Full replay fixtures stay ignored/local
+  under `tests/fixtures/opendota/`; synchronize the canonical TI2026 replay with
+  `uv run python scripts/sync_opendota_fixtures.py`. Use `--tier extended`,
+  `--tier stress`, or `--match <id>` for broader and feature-specific coverage.
+- Treat `tests/fixtures/opendota/manifest.json` as the source of truth for replay
+  lifecycle, tiers, capabilities, integrity metadata, and replacements. Deprecate
+  entries in the manifest instead of deleting their metadata.
 - Keep map/reference images for examples, reports, and camp-zone tooling under `assets/maps/`, not `tests/fixtures/`.
 - Real replay tests go in a `slow`/`integration` marked class
 - Test both the happy path and error conditions

--- a/docs/cookbook/bits-and-bytes-primer.md
+++ b/docs/cookbook/bits-and-bytes-primer.md
@@ -70,7 +70,9 @@ Why parser skips metadata:
 Example from the committed truncated fixture:
 
 - `ti14_finals_g3_xg_vs_falcons_truncated.dem` metadata: `278882831`, `278882714`
-- Full replay fixtures are intentionally kept as ignored local files under `tests/fixtures/opendota/`.
+- Full replay fixtures are intentionally kept as ignored local files under
+  `tests/fixtures/opendota/`. Synchronize the canonical TI2026 replay with
+  `uv run python scripts/sync_opendota_fixtures.py`.
 
 If magic mismatches, `DemoStream` raises immediately before parsing anything else.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,16 +25,16 @@ python examples/steam_match_info.py <match_id>            # Steam API integratio
 
 ## Replay fixtures (`opendota_parity.py` no-arg default)
 
-The full OpenDota validation replay and its sibling `<match_id>.opendota.json`
+The canonical short TI2026 replay and its sibling `<match_id>.opendota.json`
 (which powers the parity cross-check) are **local/ignored downloads, not committed**
 to the repo (see the root `CLAUDE.md` and `tests/fixtures/` notes). With no argument,
 `opendota_parity.py` prefers that download when present (full match + parity
 cross-check), and otherwise falls back to the committed but **truncated** TI14
 replay — which runs on a *partial* match with no OpenDota reference, and prints a
-heads-up saying so. For the complete experience, fetch a replay:
+heads-up saying so. For the complete experience, synchronize the canonical fixture:
 
 ```bash
-uv run python -c "import gem; gem.fetch_replay(8822520406, 'tests/fixtures/opendota')"
+uv run python scripts/sync_opendota_fixtures.py
 ```
 
 or pass any replay path with a sibling `<match_id>.opendota.json` to enable the

--- a/examples/extraction_demo.py
+++ b/examples/extraction_demo.py
@@ -571,7 +571,7 @@ def main() -> None:
         dem_path = sys.argv[1]
     else:
         dem_path = str(
-            Path(__file__).parent.parent / "tests" / "fixtures" / "opendota" / "8822520406.dem"
+            Path(__file__).parent.parent / "tests" / "fixtures" / "opendota" / "8868259993.dem"
         )
 
     print(f"Replay: {dem_path}")

--- a/examples/match_report.py
+++ b/examples/match_report.py
@@ -17,7 +17,7 @@ import gem
 from gem.reports import ReportAssets, apply_opendota_player_names_from_path, write_html_report
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-DEFAULT_DEM = REPO_ROOT / "tests" / "fixtures" / "opendota" / "8822520406.dem"
+DEFAULT_DEM = REPO_ROOT / "tests" / "fixtures" / "opendota" / "8868259993.dem"
 DEFAULT_MAP = REPO_ROOT / "assets" / "maps" / "Game_map_7.40.jpg"
 
 

--- a/examples/opendota_parity.py
+++ b/examples/opendota_parity.py
@@ -17,13 +17,13 @@ Usage:
     python examples/opendota_parity.py                      # default fixture (see below)
     python examples/opendota_parity.py path/to/replay.dem   # your own replay
 
-With no argument, the script prefers the full OpenDota validation replay
-(``tests/fixtures/opendota/8822520406.dem``) when that local/ignored download is
+With no argument, the script prefers the canonical TI2026 validation replay
+(``tests/fixtures/opendota/8868259993.dem``) when that local/ignored download is
 present — it ships the sibling ``.opendota.json`` that drives the parity
 cross-check. That replay is NOT committed, so on a fresh clone the script falls
 back to the committed but *truncated* TI14 fixture (partial match, no parity
-reference) and prints a heads-up. Fetch a full replay for the complete demo:
-``gem.fetch_replay(8822520406, "tests/fixtures/opendota")``.
+reference) and prints a heads-up. Synchronize the canonical replay for the complete demo:
+``uv run python scripts/sync_opendota_fixtures.py``.
 
 Notes on representation differences (intentional, called out inline below):
   * ``final_items`` keeps the ``item_`` *name* (``item_power_treads``); OpenDota
@@ -347,14 +347,14 @@ def report_catalog_helpers() -> None:
 # Default fixture resolution
 # ---------------------------------------------------------------------------
 
-# The full OpenDota validation replay (98 MB) is a local/ignored download — it is
+# The canonical TI2026 OpenDota validation replay is a local/ignored download — it is
 # NOT committed (see CLAUDE.md: "Full replay fixtures should be local/ignored
 # OpenDota downloads"). It is the *preferred* default because it ships a sibling
 # <match_id>.opendota.json that drives the parity cross-check. When it isn't
 # present, fall back to the committed (but truncated) TI14 replay so a fresh clone
 # still runs — at the cost of a partial match and no parity reference.
 _FIXTURES = Path(__file__).parent.parent / "tests" / "fixtures"
-_OPENDOTA_FIXTURE = _FIXTURES / "opendota" / "8822520406.dem"
+_OPENDOTA_FIXTURE = _FIXTURES / "opendota" / "8868259993.dem"
 _COMMITTED_FIXTURE = _FIXTURES / "ti14_finals_g3_xg_vs_falcons_truncated.dem"
 
 
@@ -390,8 +390,8 @@ def main() -> None:
         if resolved is None:
             print("No bundled replay found to demo against.")
             print(
-                "The full OpenDota fixture is a local/ignored download; fetch one with\n"
-                "  uv run python -c \"import gem; gem.fetch_replay(8822520406, 'tests/fixtures/opendota')\"\n"
+                "The full OpenDota fixture is a local/ignored download; sync it with\n"
+                "  uv run python scripts/sync_opendota_fixtures.py\n"
                 "or pass your own: python examples/opendota_parity.py path/to/replay.dem"
             )
             sys.exit(1)
@@ -402,7 +402,7 @@ def main() -> None:
                 "download isn't present). The match is partial — final items, building\n"
                 "status, and scores reflect only the captured portion, and there is no\n"
                 "OpenDota reference to cross-check against. For the full parity demo,\n"
-                "fetch a replay (see --help) or pass a path with a sibling .opendota.json.\n"
+                "sync the canonical replay or pass a path with a sibling .opendota.json.\n"
             )
 
     ref = load_opendota_ref(dem_path)

--- a/scripts/fetch_opendota_fixture.py
+++ b/scripts/fetch_opendota_fixture.py
@@ -9,6 +9,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import sys
 import urllib.error
@@ -52,6 +53,8 @@ def build_manifest_entry(
     *,
     fetched_at: str,
     note: str | None,
+    dem_size_bytes: int | None = None,
+    dem_sha256: str | None = None,
 ) -> dict[str, Any]:
     return {
         "match_id": match_id,
@@ -63,6 +66,8 @@ def build_manifest_entry(
         "lobby_type": opendota_payload.get("lobby_type"),
         "patch": opendota_payload.get("patch"),
         "replay_url": opendota_payload.get("replay_url"),
+        "dem_size_bytes": dem_size_bytes,
+        "dem_sha256": dem_sha256,
         "note": note,
     }
 
@@ -71,14 +76,32 @@ def update_manifest(manifest_path: Path, entry: dict[str, Any]) -> None:
     if manifest_path.exists():
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     else:
-        manifest = {"matches": []}
+        manifest = {"schema_version": 2, "matches": []}
 
-    matches = [m for m in manifest.get("matches", []) if m.get("match_id") != entry["match_id"]]
-    matches.append(entry)
+    matches = list(manifest.get("matches", []))
+    existing = next((m for m in matches if m.get("match_id") == entry["match_id"]), None)
+    merged = dict(existing) if isinstance(existing, dict) else {}
+    updates = entry
+    if isinstance(existing, dict) and entry.get("note") is None:
+        updates = {key: value for key, value in entry.items() if key != "note"}
+    merged.update(updates)
+    matches = [m for m in matches if m.get("match_id") != entry["match_id"]]
+    matches.append(merged)
     matches.sort(key=lambda m: int(m["match_id"]))
 
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
-    manifest_path.write_text(json.dumps({"matches": matches}, indent=2) + "\n", encoding="utf-8")
+    manifest["schema_version"] = 2
+    manifest["matches"] = matches
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+
+def file_sha256(path: Path) -> str:
+    """Return the SHA-256 digest for a replay without loading it all into memory."""
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def ensure_can_write_fixture(dem_path: Path, json_path: Path, *, force: bool) -> None:
@@ -117,7 +140,14 @@ def fetch_fixture(match_id: int, *, out_dir: Path, force: bool, note: str | None
         ) from exc
 
     write_opendota_snapshot(json_path, payload)
-    entry = build_manifest_entry(match_id, payload, fetched_at=utc_now_iso(), note=note)
+    entry = build_manifest_entry(
+        match_id,
+        payload,
+        fetched_at=utc_now_iso(),
+        note=note,
+        dem_size_bytes=dem_path.stat().st_size,
+        dem_sha256=file_sha256(dem_path),
+    )
     update_manifest(out_dir / "manifest.json", entry)
     return dem_path
 

--- a/scripts/fetch_opendota_fixture.py
+++ b/scripts/fetch_opendota_fixture.py
@@ -72,19 +72,24 @@ def build_manifest_entry(
     }
 
 
+def _load_manifest_for_update(manifest_path: Path) -> dict[str, Any]:
+    if not manifest_path.exists():
+        return {"schema_version": 2, "matches": []}
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(manifest, dict):
+        raise ValueError(f"Fixture manifest root must be an object: {manifest_path}")
+    schema_version = manifest.get("schema_version")
+    if schema_version != 2:
+        raise ValueError(
+            f"Fixture manifest uses schema_version {schema_version!r}; "
+            "migrate it to schema_version 2 before updating"
+        )
+    return manifest
+
+
 def update_manifest(manifest_path: Path, entry: dict[str, Any]) -> None:
-    if manifest_path.exists():
-        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-        if not isinstance(manifest, dict):
-            raise ValueError(f"Fixture manifest root must be an object: {manifest_path}")
-        schema_version = manifest.get("schema_version")
-        if schema_version != 2:
-            raise ValueError(
-                f"Fixture manifest uses schema_version {schema_version!r}; "
-                "migrate it to schema_version 2 before updating"
-            )
-    else:
-        manifest = {"schema_version": 2, "matches": []}
+    manifest = _load_manifest_for_update(manifest_path)
 
     matches = list(manifest.get("matches", []))
     existing = next((m for m in matches if m.get("match_id") == entry["match_id"]), None)
@@ -125,6 +130,9 @@ def write_opendota_snapshot(path: Path, payload: dict[str, Any]) -> None:
 
 
 def fetch_fixture(match_id: int, *, out_dir: Path, force: bool, note: str | None) -> Path:
+    manifest_path = out_dir / "manifest.json"
+    _load_manifest_for_update(manifest_path)
+
     from gem.replays.fetch import download_and_decompress
 
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -156,7 +164,7 @@ def fetch_fixture(match_id: int, *, out_dir: Path, force: bool, note: str | None
         dem_size_bytes=dem_path.stat().st_size,
         dem_sha256=file_sha256(dem_path),
     )
-    update_manifest(out_dir / "manifest.json", entry)
+    update_manifest(manifest_path, entry)
     return dem_path
 
 

--- a/scripts/fetch_opendota_fixture.py
+++ b/scripts/fetch_opendota_fixture.py
@@ -75,6 +75,14 @@ def build_manifest_entry(
 def update_manifest(manifest_path: Path, entry: dict[str, Any]) -> None:
     if manifest_path.exists():
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        if not isinstance(manifest, dict):
+            raise ValueError(f"Fixture manifest root must be an object: {manifest_path}")
+        schema_version = manifest.get("schema_version")
+        if schema_version != 2:
+            raise ValueError(
+                f"Fixture manifest uses schema_version {schema_version!r}; "
+                "migrate it to schema_version 2 before updating"
+            )
     else:
         manifest = {"schema_version": 2, "matches": []}
 

--- a/scripts/sync_opendota_fixtures.py
+++ b/scripts/sync_opendota_fixtures.py
@@ -170,13 +170,12 @@ def load_fixture_manifest(path: Path = DEFAULT_MANIFEST) -> list[FixtureSpec]:
 
     by_id = {spec.match_id: spec for spec in specs}
     for spec in specs:
-        if spec.status == "active":
-            if spec.source_url is None:
-                raise FixtureManifestError(f"active fixture {spec.match_id} has no download URL")
-            if spec.dem_size_bytes is None or spec.dem_sha256 is None:
-                raise FixtureManifestError(
-                    f"active fixture {spec.match_id} must define dem_size_bytes and dem_sha256"
-                )
+        if spec.dem_size_bytes is None or spec.dem_sha256 is None:
+            raise FixtureManifestError(
+                f"fixture {spec.match_id} must define dem_size_bytes and dem_sha256"
+            )
+        if spec.status == "active" and spec.source_url is None:
+            raise FixtureManifestError(f"active fixture {spec.match_id} has no download URL")
         if spec.status == "deprecated":
             replacement = by_id.get(spec.replaced_by) if spec.replaced_by is not None else None
             if replacement is None or replacement.status != "active":

--- a/scripts/sync_opendota_fixtures.py
+++ b/scripts/sync_opendota_fixtures.py
@@ -98,9 +98,9 @@ def _parse_spec(raw: object) -> FixtureSpec:
         raise FixtureManifestError(f"fixture {match_id}: name must be a non-empty string")
     if not isinstance(dem, str) or not dem or Path(dem).name != dem:
         raise FixtureManifestError(f"fixture {match_id}: dem must be a plain filename")
-    if tier not in VALID_TIERS:
+    if not isinstance(tier, str) or tier not in VALID_TIERS:
         raise FixtureManifestError(f"fixture {match_id}: invalid tier {tier!r}")
-    if status not in VALID_STATUSES:
+    if not isinstance(status, str) or status not in VALID_STATUSES:
         raise FixtureManifestError(f"fixture {match_id}: invalid status {status!r}")
 
     raw_capabilities = raw.get("capabilities", [])

--- a/scripts/sync_opendota_fixtures.py
+++ b/scripts/sync_opendota_fixtures.py
@@ -170,8 +170,13 @@ def load_fixture_manifest(path: Path = DEFAULT_MANIFEST) -> list[FixtureSpec]:
 
     by_id = {spec.match_id: spec for spec in specs}
     for spec in specs:
-        if spec.status == "active" and spec.source_url is None:
-            raise FixtureManifestError(f"active fixture {spec.match_id} has no download URL")
+        if spec.status == "active":
+            if spec.source_url is None:
+                raise FixtureManifestError(f"active fixture {spec.match_id} has no download URL")
+            if spec.dem_size_bytes is None or spec.dem_sha256 is None:
+                raise FixtureManifestError(
+                    f"active fixture {spec.match_id} must define dem_size_bytes and dem_sha256"
+                )
         if spec.status == "deprecated":
             replacement = by_id.get(spec.replaced_by) if spec.replaced_by is not None else None
             if replacement is None or replacement.status != "active":

--- a/scripts/sync_opendota_fixtures.py
+++ b/scripts/sync_opendota_fixtures.py
@@ -160,10 +160,13 @@ def load_fixture_manifest(path: Path = DEFAULT_MANIFEST) -> list[FixtureSpec]:
     specs = [_parse_spec(raw) for raw in raw_matches]
     ids = [spec.match_id for spec in specs]
     names = [spec.name for spec in specs]
+    dem_filenames = [spec.dem for spec in specs]
     if len(ids) != len(set(ids)):
         raise FixtureManifestError("fixture manifest contains duplicate match IDs")
     if len(names) != len(set(names)):
         raise FixtureManifestError("fixture manifest contains duplicate names")
+    if len(dem_filenames) != len(set(dem_filenames)):
+        raise FixtureManifestError("fixture manifest contains duplicate dem filenames")
 
     by_id = {spec.match_id: spec for spec in specs}
     for spec in specs:

--- a/scripts/sync_opendota_fixtures.py
+++ b/scripts/sync_opendota_fixtures.py
@@ -1,0 +1,322 @@
+"""Synchronize and verify curated OpenDota replay fixtures.
+
+Full ``.dem`` files remain ignored by Git. This command reads the committed
+fixture manifest, downloads selected replay tiers into the local fixture cache,
+and verifies recorded size and SHA-256 metadata before installing each file.
+
+Examples:
+    uv run python scripts/sync_opendota_fixtures.py
+    uv run python scripts/sync_opendota_fixtures.py --tier extended --tier stress
+    uv run python scripts/sync_opendota_fixtures.py --match 8822520406
+    uv run python scripts/sync_opendota_fixtures.py --all-active --verify-only
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import tempfile
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST = REPO_ROOT / "tests" / "fixtures" / "opendota" / "manifest.json"
+DEFAULT_OUT_DIR = DEFAULT_MANIFEST.parent
+
+VALID_STATUSES = frozenset({"active", "deprecated"})
+VALID_TIERS = frozenset(
+    {"performance-baseline", "canonical", "extended", "stress", "regression", "archive"}
+)
+_TIER_ORDER = {
+    "canonical": 0,
+    "extended": 1,
+    "stress": 2,
+    "performance-baseline": 3,
+    "regression": 4,
+    "archive": 5,
+}
+
+Downloader = Callable[[int, str, Path], Path]
+
+
+class FixtureManifestError(ValueError):
+    """Raised when fixture metadata or selection is invalid."""
+
+
+class FixtureIntegrityError(RuntimeError):
+    """Raised when a replay does not match its recorded integrity metadata."""
+
+
+@dataclass(frozen=True, slots=True)
+class FixtureSpec:
+    """Normalized manifest metadata for one replay fixture."""
+
+    match_id: int
+    name: str
+    dem: str
+    tier: str
+    status: str
+    capabilities: tuple[str, ...]
+    replay_url: str | None
+    artifact_url: str | None
+    dem_size_bytes: int | None
+    dem_sha256: str | None
+    replaced_by: int | None
+
+    @property
+    def source_url(self) -> str | None:
+        """Prefer a durable artifact URL over the original replay host."""
+        return self.artifact_url or self.replay_url
+
+
+def _optional_str(raw: dict[str, Any], key: str) -> str | None:
+    value = raw.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise FixtureManifestError(f"{key} must be a non-empty string or null")
+    return value
+
+
+def _parse_spec(raw: object) -> FixtureSpec:
+    if not isinstance(raw, dict):
+        raise FixtureManifestError("each manifest match must be an object")
+
+    match_id = raw.get("match_id")
+    if not isinstance(match_id, int) or isinstance(match_id, bool) or match_id <= 0:
+        raise FixtureManifestError("match_id must be a positive integer")
+
+    name = raw.get("name", f"match-{match_id}")
+    dem = raw.get("dem", f"{match_id}.dem")
+    tier = raw.get("tier", "regression")
+    status = raw.get("status", "active")
+    if not isinstance(name, str) or not name:
+        raise FixtureManifestError(f"fixture {match_id}: name must be a non-empty string")
+    if not isinstance(dem, str) or not dem or Path(dem).name != dem:
+        raise FixtureManifestError(f"fixture {match_id}: dem must be a plain filename")
+    if tier not in VALID_TIERS:
+        raise FixtureManifestError(f"fixture {match_id}: invalid tier {tier!r}")
+    if status not in VALID_STATUSES:
+        raise FixtureManifestError(f"fixture {match_id}: invalid status {status!r}")
+
+    raw_capabilities = raw.get("capabilities", [])
+    if not isinstance(raw_capabilities, list) or not all(
+        isinstance(value, str) and value for value in raw_capabilities
+    ):
+        raise FixtureManifestError(f"fixture {match_id}: capabilities must be strings")
+    capabilities = tuple(raw_capabilities)
+    if len(set(capabilities)) != len(capabilities):
+        raise FixtureManifestError(f"fixture {match_id}: capabilities must be unique")
+
+    size = raw.get("dem_size_bytes")
+    if size is not None and (not isinstance(size, int) or isinstance(size, bool) or size <= 0):
+        raise FixtureManifestError(f"fixture {match_id}: dem_size_bytes must be positive")
+
+    sha256 = _optional_str(raw, "dem_sha256")
+    if sha256 is not None:
+        sha256 = sha256.lower()
+        if len(sha256) != 64 or any(ch not in "0123456789abcdef" for ch in sha256):
+            raise FixtureManifestError(f"fixture {match_id}: dem_sha256 must be 64 hex digits")
+
+    replaced_by = raw.get("replaced_by")
+    if replaced_by is not None and (
+        not isinstance(replaced_by, int) or isinstance(replaced_by, bool) or replaced_by <= 0
+    ):
+        raise FixtureManifestError(f"fixture {match_id}: replaced_by must be a match ID or null")
+
+    return FixtureSpec(
+        match_id=match_id,
+        name=name,
+        dem=dem,
+        tier=tier,
+        status=status,
+        capabilities=capabilities,
+        replay_url=_optional_str(raw, "replay_url"),
+        artifact_url=_optional_str(raw, "artifact_url"),
+        dem_size_bytes=size,
+        dem_sha256=sha256,
+        replaced_by=replaced_by,
+    )
+
+
+def load_fixture_manifest(path: Path = DEFAULT_MANIFEST) -> list[FixtureSpec]:
+    """Load and validate the fixture manifest."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise FixtureManifestError(f"unable to read fixture manifest {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise FixtureManifestError("fixture manifest root must be an object")
+    if payload.get("schema_version") != 2:
+        raise FixtureManifestError("fixture manifest schema_version must be 2")
+    raw_matches = payload.get("matches")
+    if not isinstance(raw_matches, list):
+        raise FixtureManifestError("fixture manifest matches must be a list")
+
+    specs = [_parse_spec(raw) for raw in raw_matches]
+    ids = [spec.match_id for spec in specs]
+    names = [spec.name for spec in specs]
+    if len(ids) != len(set(ids)):
+        raise FixtureManifestError("fixture manifest contains duplicate match IDs")
+    if len(names) != len(set(names)):
+        raise FixtureManifestError("fixture manifest contains duplicate names")
+
+    by_id = {spec.match_id: spec for spec in specs}
+    for spec in specs:
+        if spec.status == "active" and spec.source_url is None:
+            raise FixtureManifestError(f"active fixture {spec.match_id} has no download URL")
+        if spec.status == "deprecated":
+            replacement = by_id.get(spec.replaced_by) if spec.replaced_by is not None else None
+            if replacement is None or replacement.status != "active":
+                raise FixtureManifestError(
+                    f"deprecated fixture {spec.match_id} must reference an active replacement"
+                )
+    return specs
+
+
+def select_fixture_specs(
+    specs: Iterable[FixtureSpec],
+    *,
+    tiers: Iterable[str] = (),
+    match_ids: Iterable[int] = (),
+    all_active: bool = False,
+    include_deprecated: bool = False,
+) -> list[FixtureSpec]:
+    """Select fixtures deterministically from manifest metadata."""
+    spec_list = list(specs)
+    tier_set = set(tiers)
+    id_set = set(match_ids)
+    unknown_tiers = tier_set - VALID_TIERS
+    if unknown_tiers:
+        raise FixtureManifestError(f"unknown fixture tier(s): {sorted(unknown_tiers)}")
+    known_ids = {spec.match_id for spec in spec_list}
+    missing_ids = id_set - known_ids
+    if missing_ids:
+        raise FixtureManifestError(f"unknown fixture match ID(s): {sorted(missing_ids)}")
+    if not tier_set and not id_set and not all_active:
+        tier_set.add("canonical")
+
+    selected: list[FixtureSpec] = []
+    for spec in spec_list:
+        matches = all_active or spec.tier in tier_set or spec.match_id in id_set
+        if not matches:
+            continue
+        if spec.status == "deprecated" and not include_deprecated:
+            if spec.match_id in id_set:
+                raise FixtureManifestError(
+                    f"fixture {spec.match_id} is deprecated; pass --include-deprecated"
+                )
+            continue
+        selected.append(spec)
+
+    if not selected:
+        raise FixtureManifestError("fixture selection is empty")
+    return sorted(selected, key=lambda spec: (_TIER_ORDER[spec.tier], spec.match_id))
+
+
+def file_sha256(path: Path) -> str:
+    """Return the SHA-256 digest for a file without loading it all into memory."""
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_fixture(spec: FixtureSpec, path: Path) -> None:
+    """Raise when a local replay differs from recorded manifest integrity data."""
+    if not path.is_file():
+        raise FixtureIntegrityError(f"fixture is missing: {path}")
+    actual_size = path.stat().st_size
+    if spec.dem_size_bytes is not None and actual_size != spec.dem_size_bytes:
+        raise FixtureIntegrityError(
+            f"fixture {spec.match_id} size mismatch: "
+            f"expected {spec.dem_size_bytes}, got {actual_size}"
+        )
+    if spec.dem_sha256 is not None:
+        actual_sha256 = file_sha256(path)
+        if actual_sha256 != spec.dem_sha256:
+            raise FixtureIntegrityError(
+                f"fixture {spec.match_id} SHA-256 mismatch: "
+                f"expected {spec.dem_sha256}, got {actual_sha256}"
+            )
+
+
+def _download_replay(match_id: int, replay_url: str, out_dir: Path) -> Path:
+    from gem.replays.fetch import download_and_decompress
+
+    return download_and_decompress(match_id, replay_url, out_dir)
+
+
+def sync_fixture(
+    spec: FixtureSpec,
+    out_dir: Path,
+    *,
+    force: bool = False,
+    verify_only: bool = False,
+    downloader: Downloader = _download_replay,
+) -> tuple[Path, bool]:
+    """Verify or atomically download one replay fixture."""
+    target = out_dir / spec.dem
+    if target.exists() and not force:
+        verify_fixture(spec, target)
+        return target, False
+    if verify_only:
+        verify_fixture(spec, target)
+        return target, False
+    if spec.source_url is None:
+        raise FixtureManifestError(f"fixture {spec.match_id} has no download URL")
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="gem-fixture-", dir=out_dir) as temp_name:
+        downloaded = downloader(spec.match_id, spec.source_url, Path(temp_name))
+        verify_fixture(spec, downloaded)
+        downloaded.replace(target)
+    return target, True
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--tier", action="append", choices=sorted(VALID_TIERS), default=[])
+    parser.add_argument("--match", dest="match_ids", action="append", type=int, default=[])
+    parser.add_argument("--all-active", action="store_true")
+    parser.add_argument("--include-deprecated", action="store_true")
+    parser.add_argument("--verify-only", action="store_true")
+    parser.add_argument("--force", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        specs = load_fixture_manifest(args.manifest)
+        selected = select_fixture_specs(
+            specs,
+            tiers=args.tier,
+            match_ids=args.match_ids,
+            all_active=args.all_active,
+            include_deprecated=args.include_deprecated,
+        )
+        for spec in selected:
+            path, downloaded = sync_fixture(
+                spec,
+                args.out,
+                force=args.force,
+                verify_only=args.verify_only,
+            )
+            action = "DOWNLOADED" if downloaded else "VERIFIED"
+            print(f"{action} {spec.name} ({spec.match_id}): {path}")
+    except (FixtureManifestError, FixtureIntegrityError, OSError, RuntimeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_opendota.py
+++ b/scripts/validate_opendota.py
@@ -93,8 +93,8 @@ def _build_hero_id_map() -> dict[int, str]:
 # Keep the default gate small and stable. Larger/edge replay fixtures are kept
 # in tests/fixtures/opendota/manifest.json and can be run explicitly with --match.
 REPLAYS: list[tuple[int, Path]] = [
-    (8822520406, OPENDOTA_FIXTURES_DIR / "8822520406.dem"),
-    (8822593932, OPENDOTA_FIXTURES_DIR / "8822593932.dem"),
+    (8868259993, OPENDOTA_FIXTURES_DIR / "8868259993.dem"),
+    (8860187335, OPENDOTA_FIXTURES_DIR / "8860187335.dem"),
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,19 @@ import pytest
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 OPENDOTA_FIXTURES_DIR = FIXTURES_DIR / "opendota"
+TI2026_SHORT_MATCH_ID = 8868259993
+TI2026_MEDIUM_MATCH_ID = 8860187335
+TI2026_LONG_MATCH_ID = 8856501050
+PERFORMANCE_BASELINE_MATCH_ID = 8822520406
+DEPRECATED_OPENDOTA_REPLAY_IDS = frozenset({8821954344, 8822593932})
+DEPRECATED_OPENDOTA_REPLAY_NAMES = frozenset(
+    f"{match_id}.dem" for match_id in DEPRECATED_OPENDOTA_REPLAY_IDS
+)
 PREFERRED_OPENDOTA_REPLAY_IDS = (
-    8822520406,
-    8822593932,
-    8821954344,
+    TI2026_SHORT_MATCH_ID,
+    TI2026_MEDIUM_MATCH_ID,
+    TI2026_LONG_MATCH_ID,
+    PERFORMANCE_BASELINE_MATCH_ID,
 )
 
 
@@ -17,20 +26,56 @@ def pytest_configure(config):
 
 
 def available_opendota_replay_paths() -> list[Path]:
-    """Return local OpenDota replay fixtures in stable preferred order."""
+    """Return non-deprecated local replay fixtures in stable preferred order."""
     preferred = [
         OPENDOTA_FIXTURES_DIR / f"{match_id}.dem"
         for match_id in PREFERRED_OPENDOTA_REPLAY_IDS
         if (OPENDOTA_FIXTURES_DIR / f"{match_id}.dem").exists()
     ]
     known = {path.name for path in preferred}
-    extra = sorted(path for path in OPENDOTA_FIXTURES_DIR.glob("*.dem") if path.name not in known)
+    extra = sorted(
+        path
+        for path in OPENDOTA_FIXTURES_DIR.glob("*.dem")
+        if path.name not in known and path.name not in DEPRECATED_OPENDOTA_REPLAY_NAMES
+    )
     return preferred + extra
 
 
+def _required_replay_path(match_id: int, role: str) -> Path:
+    path = OPENDOTA_FIXTURES_DIR / f"{match_id}.dem"
+    if not path.exists():
+        pytest.skip(
+            f"{role} replay fixture {match_id}.dem is not available; sync it with: "
+            f"uv run python scripts/sync_opendota_fixtures.py --match {match_id}"
+        )
+    return path
+
+
 @pytest.fixture(scope="session")
-def full_replay_path() -> Path:
-    paths = available_opendota_replay_paths()
-    if not paths:
-        pytest.skip("OpenDota integration replay fixture not available")
-    return paths[0]
+def ti2026_short_replay_path() -> Path:
+    """Return the canonical short TI2026 integration replay."""
+    return _required_replay_path(TI2026_SHORT_MATCH_ID, "TI2026 short canonical")
+
+
+@pytest.fixture(scope="session")
+def ti2026_medium_replay_path() -> Path:
+    """Return the extended medium-length TI2026 replay."""
+    return _required_replay_path(TI2026_MEDIUM_MATCH_ID, "TI2026 medium extended")
+
+
+@pytest.fixture(scope="session")
+def ti2026_long_replay_path() -> Path:
+    """Return the long TI2026 stress replay."""
+    return _required_replay_path(TI2026_LONG_MATCH_ID, "TI2026 long stress")
+
+
+@pytest.fixture(scope="session")
+def performance_baseline_replay_path() -> Path:
+    """Return the DreamLeague fixture used by performance baseline issue #143."""
+    return _required_replay_path(PERFORMANCE_BASELINE_MATCH_ID, "performance baseline")
+
+
+@pytest.fixture(scope="session")
+def full_replay_path(ti2026_short_replay_path: Path) -> Path:
+    """Compatibility alias for the canonical TI2026 integration replay."""
+    return ti2026_short_replay_path

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,39 @@
+# Replay fixtures
+
+Small `*_truncated.dem` files are committed for fast parser and fuzz coverage.
+Complete replay files are intentionally ignored and live locally under
+`tests/fixtures/opendota/`; their OpenDota JSON snapshots and
+`opendota/manifest.json` metadata are committed.
+
+Synchronize the canonical short TI2026 replay:
+
+```bash
+uv run python scripts/sync_opendota_fixtures.py
+```
+
+Select broader tiers or an exact regression fixture when needed:
+
+```bash
+uv run python scripts/sync_opendota_fixtures.py --tier extended --tier stress
+uv run python scripts/sync_opendota_fixtures.py --match 8855188139
+uv run python scripts/sync_opendota_fixtures.py --all-active --verify-only
+```
+
+The synchronizer downloads into a temporary directory, verifies the recorded
+decompressed size and SHA-256 digest, and only then installs the replay. A
+manifest `artifact_url` takes precedence when present; the original Valve
+`replay_url` remains the fallback source.
+
+## Fixture tiers
+
+- `canonical`: short TI2026 replay used by generic full-replay integration tests.
+- `extended`: medium TI2026 replay used by the default OpenDota parity gate.
+- `stress`: 93-minute TI2026 replay for explicit long-match validation.
+- `performance-baseline`: replay retained for comparison with performance issue #143.
+- `regression`: feature-specific replay selected by exact match ID.
+- `archive`: deprecated replay retained as metadata and available only with
+  `--include-deprecated`.
+
+Deprecation is metadata-only: keep the manifest entry, set `status` to
+`deprecated`, and point `replaced_by` at an active fixture. Do not commit full
+replays to normal Git history.

--- a/tests/fixtures/opendota/manifest.json
+++ b/tests/fixtures/opendota/manifest.json
@@ -1,100 +1,198 @@
 {
+  "schema_version": 2,
   "matches": [
     {
       "match_id": 8821954344,
+      "name": "dreamleague-s29-long",
       "dem": "8821954344.dem",
       "opendota_json": "8821954344.opendota.json",
+      "status": "deprecated",
+      "tier": "archive",
+      "capabilities": [
+        "long-match",
+        "opendota-parity"
+      ],
+      "replaced_by": 8856501050,
       "fetched_at": "2026-05-24T01:34:19Z",
       "duration": 5763,
       "game_mode": 2,
       "lobby_type": 1,
       "patch": 60,
       "replay_url": "http://replay272.valve.net/570/8821954344_416769358.dem.bz2",
-      "note": "DreamLeague Season 29 patch 60 long late-game fixture"
+      "artifact_url": null,
+      "dem_size_bytes": 324684755,
+      "dem_sha256": "56c794a8af0a38703fca4181930033619404eec2aa36b8cf3c84168b823429fd",
+      "note": "DreamLeague Season 29 patch 60 long late-game fixture; superseded as the default long stress role by TI2026 match 8856501050"
     },
     {
       "match_id": 8822520406,
+      "name": "dreamleague-s29-performance-baseline",
       "dem": "8822520406.dem",
       "opendota_json": "8822520406.opendota.json",
+      "status": "active",
+      "tier": "performance-baseline",
+      "capabilities": [
+        "opendota-parity",
+        "performance-baseline",
+        "short-match"
+      ],
+      "replaced_by": null,
       "fetched_at": "2026-05-24T01:33:43Z",
       "duration": 1397,
       "game_mode": 2,
       "lobby_type": 1,
       "patch": 60,
       "replay_url": "http://replay273.valve.net/570/8822520406_214683618.dem.bz2",
-      "note": "DreamLeague Season 29 patch 60 short playoff fixture"
+      "artifact_url": null,
+      "dem_size_bytes": 98983300,
+      "dem_sha256": "5f976ab73b2efb0e4eca9f7f14d5980f3aae5f63e7952e16a8497eeded57d39d",
+      "note": "DreamLeague Season 29 patch 60 short playoff fixture; retained through issues #144-#148 for comparison with performance baseline #143"
     },
     {
       "match_id": 8822593932,
+      "name": "dreamleague-s29-medium",
       "dem": "8822593932.dem",
       "opendota_json": "8822593932.opendota.json",
+      "status": "deprecated",
+      "tier": "archive",
+      "capabilities": [
+        "medium-match",
+        "opendota-parity"
+      ],
+      "replaced_by": 8860187335,
       "fetched_at": "2026-05-24T01:33:58Z",
       "duration": 2612,
       "game_mode": 2,
       "lobby_type": 1,
       "patch": 60,
       "replay_url": "http://replay274.valve.net/570/8822593932_1755614783.dem.bz2",
-      "note": "DreamLeague Season 29 patch 60 recent playoff fixture"
+      "artifact_url": null,
+      "dem_size_bytes": 146656180,
+      "dem_sha256": "0860d4bd6c50d82dbaf863cae244c8aaf9af78a1b53d0a5915988593db3177fa",
+      "note": "DreamLeague Season 29 patch 60 recent playoff fixture; superseded as the default medium validation role by TI2026 match 8860187335"
     },
     {
       "match_id": 8855188139,
+      "name": "regression-roshan-purchases-inventory",
       "dem": "8855188139.dem",
       "opendota_json": "8855188139.opendota.json",
+      "status": "active",
+      "tier": "regression",
+      "capabilities": [
+        "banner-plants",
+        "derived-kills",
+        "final-inventory",
+        "purchases",
+        "roshan-drops"
+      ],
+      "replaced_by": null,
       "fetched_at": "2026-06-17T13:13:24Z",
       "duration": 2419,
       "game_mode": 2,
       "lobby_type": 1,
       "patch": 60,
       "replay_url": "http://replay225.valve.net/570/8855188139_1436544844.dem.bz2",
-      "note": "Interval validation sample (--match only): end-game XP burst straddles the final minute boundary (closing push, ancient falls ~40:08); gem reads the true m_iTotalEarnedXP at 40:00 while OpenDota's last interval slot holds an earlier value. Per-player xp_t parity is tight; radiant_xp_adv/final drift is expected boundary jitter, not extraction error."
+      "artifact_url": null,
+      "dem_size_bytes": 184151707,
+      "dem_sha256": "3fa4e1e9b2e4168f421c975f8f591ad34e9de2ff01c92977ed20c19ab7866044",
+      "note": "Feature-specific regression fixture for Roshan drops, banner plants, purchases, final inventory, and derived kills"
     },
     {
       "match_id": 8855242704,
+      "name": "regression-final-interval-xp",
       "dem": "8855242704.dem",
       "opendota_json": "8855242704.opendota.json",
+      "status": "active",
+      "tier": "regression",
+      "capabilities": [
+        "final-interval-boundary",
+        "long-match",
+        "xp-advantage"
+      ],
+      "replaced_by": null,
       "fetched_at": "2026-06-17T13:03:31Z",
       "duration": 4176,
       "game_mode": 2,
       "lobby_type": 1,
       "patch": 60,
       "replay_url": "http://replay225.valve.net/570/8855242704_307043427.dem.bz2",
-      "note": "Interval validation sample (--match only): long replay that exposed the radiant_xp_adv source bug (combat-log XP override gave -94899 vs OpenDota -30499). After the fix, interval m_iTotalEarnedXP gives -30237. Kept as a regression sample; not in the default gate."
+      "artifact_url": null,
+      "dem_size_bytes": 300386331,
+      "dem_sha256": "8775c564a7062672443921ddc91f9b16235e16ec85368e6b3943b72fa32398cd",
+      "note": "Feature-specific regression fixture for the final interval XP source and boundary behavior"
     },
     {
       "match_id": 8856501050,
+      "name": "ti2026-long-stress",
       "dem": "8856501050.dem",
       "opendota_json": "8856501050.opendota.json",
+      "status": "active",
+      "tier": "stress",
+      "capabilities": [
+        "long-match",
+        "opendota-parity",
+        "ti2026"
+      ],
+      "replaced_by": null,
       "fetched_at": "2026-09-02T01:19:25Z",
       "duration": 5576,
       "game_mode": 2,
       "lobby_type": 1,
       "patch": 60,
       "replay_url": "http://replay225.valve.net/570/8856501050_1230793646.dem.bz2",
-      "note": "TI2026 China regional qualifier: long 93-minute fixture for proto-refresh OpenDota parity"
+      "artifact_url": null,
+      "dem_size_bytes": 385487555,
+      "dem_sha256": "0f7577525b995347ed9df0c793cc8661c2a9db4ee176bf35cb5dd940e5af17e2",
+      "note": "TI2026 China regional qualifier: long 93-minute fixture for stress, memory, and OpenDota parity validation"
     },
     {
       "match_id": 8860187335,
+      "name": "ti2026-medium-extended",
       "dem": "8860187335.dem",
       "opendota_json": "8860187335.opendota.json",
+      "status": "active",
+      "tier": "extended",
+      "capabilities": [
+        "medium-match",
+        "opendota-parity",
+        "ti2026"
+      ],
+      "replaced_by": null,
       "fetched_at": "2026-09-02T01:16:46Z",
       "duration": 3005,
       "game_mode": 2,
       "lobby_type": 1,
       "patch": 60,
       "replay_url": "http://replay152.valve.net/570/8860187335_670734759.dem.bz2",
-      "note": "TI2026 Southeast Asia regional qualifier: medium 50-minute fixture for proto-refresh OpenDota parity"
+      "artifact_url": null,
+      "dem_size_bytes": 212649245,
+      "dem_sha256": "b42f5d07d62d5c09a55c429dd7cb0f57c03c2f0c90e16e4397eb8c26d717cee4",
+      "note": "TI2026 Southeast Asia regional qualifier: medium 50-minute fixture for extended OpenDota parity validation"
     },
     {
       "match_id": 8868259993,
+      "name": "ti2026-short-canonical",
       "dem": "8868259993.dem",
       "opendota_json": "8868259993.opendota.json",
+      "status": "active",
+      "tier": "canonical",
+      "capabilities": [
+        "canonical-integration",
+        "opendota-parity",
+        "short-match",
+        "ti2026"
+      ],
+      "replaced_by": null,
       "fetched_at": "2026-09-02T01:16:29Z",
       "duration": 1142,
       "game_mode": 2,
       "lobby_type": 1,
       "patch": 60,
       "replay_url": "http://replay121.valve.net/570/8868259993_728230634.dem.bz2",
-      "note": "TI2026 North America regional qualifier: short 19-minute fixture for proto-refresh OpenDota parity"
+      "artifact_url": null,
+      "dem_size_bytes": 89720955,
+      "dem_sha256": "a0560e349ccd30d7f58a97747d33e3d2a6033c11d54a848fe3918a044650a622",
+      "note": "TI2026 North America regional qualifier: short 19-minute canonical integration and OpenDota parity fixture"
     }
   ]
 }

--- a/tests/test_ability_courier_draft_stuns.py
+++ b/tests/test_ability_courier_draft_stuns.py
@@ -428,7 +428,7 @@ class TestPhase8Integration:
             assert snap.team in (2, 3), f"Unexpected courier team {snap.team}"
 
     def test_draft_events_populated(self, match):
-        # TI14 finals is CM — should have bans and picks
+        # The canonical TI2026 fixture is CM — it should have bans and picks.
         assert len(match.draft) > 0
 
     def test_draft_picks_count(self, match):

--- a/tests/test_fetch_opendota_fixture.py
+++ b/tests/test_fetch_opendota_fixture.py
@@ -95,6 +95,21 @@ def test_update_manifest_replaces_existing_entry(tmp_path: Path) -> None:
     }
 
 
+def test_update_manifest_refuses_legacy_schema_without_rewriting(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    legacy_manifest = {
+        "schema_version": 1,
+        "matches": [{"match_id": 11, "dem": "11.dem"}],
+    }
+    original = json.dumps(legacy_manifest, indent=2) + "\n"
+    manifest_path.write_text(original, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="migrate it to schema_version 2"):
+        update_manifest(manifest_path, {"match_id": 22, "dem": "22.dem"})
+
+    assert manifest_path.read_text(encoding="utf-8") == original
+
+
 def test_update_manifest_preserves_curated_metadata(tmp_path: Path) -> None:
     manifest_path = tmp_path / "manifest.json"
     manifest_path.write_text(

--- a/tests/test_fetch_opendota_fixture.py
+++ b/tests/test_fetch_opendota_fixture.py
@@ -43,6 +43,8 @@ def test_build_manifest_entry_uses_stable_shape() -> None:
         "lobby_type": 1,
         "patch": 7.41,
         "replay_url": "https://replay.example/123.dem.bz2",
+        "dem_size_bytes": None,
+        "dem_sha256": None,
         "note": "7.41 facets regression",
     }
 
@@ -72,10 +74,11 @@ def test_update_manifest_creates_sorted_manifest(tmp_path: Path) -> None:
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 
     assert manifest == {
+        "schema_version": 2,
         "matches": [
             {"match_id": 11, "dem": "11.dem"},
             {"match_id": 22, "dem": "22.dem"},
-        ]
+        ],
     }
 
 
@@ -86,7 +89,44 @@ def test_update_manifest_replaces_existing_entry(tmp_path: Path) -> None:
 
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 
-    assert manifest == {"matches": [{"match_id": 11, "dem": "new.dem"}]}
+    assert manifest == {
+        "schema_version": 2,
+        "matches": [{"match_id": 11, "dem": "new.dem"}],
+    }
+
+
+def test_update_manifest_preserves_curated_metadata(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "matches": [
+                    {
+                        "match_id": 11,
+                        "name": "canonical-replay",
+                        "tier": "canonical",
+                        "dem": "old.dem",
+                        "note": "keep this curated explanation",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    update_manifest(manifest_path, {"match_id": 11, "dem": "new.dem"})
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["matches"] == [
+        {
+            "match_id": 11,
+            "name": "canonical-replay",
+            "tier": "canonical",
+            "dem": "new.dem",
+            "note": "keep this curated explanation",
+        }
+    ]
 
 
 def test_ensure_can_write_fixture_rejects_existing_outputs_without_force(tmp_path: Path) -> None:

--- a/tests/test_fetch_opendota_fixture.py
+++ b/tests/test_fetch_opendota_fixture.py
@@ -10,6 +10,7 @@ from scripts.fetch_opendota_fixture import (
     FixtureExistsError,
     build_manifest_entry,
     ensure_can_write_fixture,
+    fetch_fixture,
     main,
     parse_args,
     update_manifest,
@@ -108,6 +109,19 @@ def test_update_manifest_refuses_legacy_schema_without_rewriting(tmp_path: Path)
         update_manifest(manifest_path, {"match_id": 22, "dem": "22.dem"})
 
     assert manifest_path.read_text(encoding="utf-8") == original
+
+
+def test_fetch_fixture_checks_manifest_schema_before_writing_outputs(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    original = json.dumps({"schema_version": 1, "matches": []}, indent=2) + "\n"
+    manifest_path.write_text(original, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="migrate it to schema_version 2"):
+        fetch_fixture(22, out_dir=tmp_path, force=False, note=None)
+
+    assert manifest_path.read_text(encoding="utf-8") == original
+    assert not (tmp_path / "22.dem").exists()
+    assert not (tmp_path / "22.opendota.json").exists()
 
 
 def test_update_manifest_preserves_curated_metadata(tmp_path: Path) -> None:

--- a/tests/test_sync_opendota_fixtures.py
+++ b/tests/test_sync_opendota_fixtures.py
@@ -91,6 +91,17 @@ def test_load_fixture_manifest_rejects_duplicate_names(tmp_path: Path) -> None:
         load_fixture_manifest(path)
 
 
+def test_load_fixture_manifest_rejects_duplicate_dem_filenames(tmp_path: Path) -> None:
+    path = tmp_path / "manifest.json"
+    first = _entry(1, name="first", tier="canonical")
+    second = _entry(2, name="second", tier="extended")
+    second["dem"] = first["dem"]
+    _write_manifest(path, [first, second])
+
+    with pytest.raises(FixtureManifestError, match="duplicate dem filenames"):
+        load_fixture_manifest(path)
+
+
 @pytest.mark.parametrize(("field", "value"), [("tier", []), ("status", {})])
 def test_load_fixture_manifest_rejects_non_string_enum_fields(
     tmp_path: Path, field: str, value: object

--- a/tests/test_sync_opendota_fixtures.py
+++ b/tests/test_sync_opendota_fixtures.py
@@ -128,6 +128,25 @@ def test_load_fixture_manifest_requires_active_integrity_metadata(
         load_fixture_manifest(path)
 
 
+@pytest.mark.parametrize("field", ["dem_size_bytes", "dem_sha256"])
+def test_load_fixture_manifest_requires_deprecated_integrity_metadata(
+    tmp_path: Path, field: str
+) -> None:
+    path = tmp_path / "manifest.json"
+    deprecated = _entry(
+        1,
+        name="deprecated-missing-integrity",
+        tier="archive",
+        status="deprecated",
+        replaced_by=2,
+    )
+    deprecated[field] = None
+    _write_manifest(path, [deprecated, _entry(2, name="replacement", tier="canonical")])
+
+    with pytest.raises(FixtureManifestError, match="must define dem_size_bytes and dem_sha256"):
+        load_fixture_manifest(path)
+
+
 def test_load_fixture_manifest_rejects_inactive_replacement(tmp_path: Path) -> None:
     path = tmp_path / "manifest.json"
     _write_manifest(

--- a/tests/test_sync_opendota_fixtures.py
+++ b/tests/test_sync_opendota_fixtures.py
@@ -91,6 +91,19 @@ def test_load_fixture_manifest_rejects_duplicate_names(tmp_path: Path) -> None:
         load_fixture_manifest(path)
 
 
+@pytest.mark.parametrize(("field", "value"), [("tier", []), ("status", {})])
+def test_load_fixture_manifest_rejects_non_string_enum_fields(
+    tmp_path: Path, field: str, value: object
+) -> None:
+    path = tmp_path / "manifest.json"
+    entry = _entry(1, name="invalid", tier="canonical")
+    entry[field] = value
+    _write_manifest(path, [entry])
+
+    with pytest.raises(FixtureManifestError, match=rf"invalid {field}"):
+        load_fixture_manifest(path)
+
+
 def test_load_fixture_manifest_rejects_inactive_replacement(tmp_path: Path) -> None:
     path = tmp_path / "manifest.json"
     _write_manifest(

--- a/tests/test_sync_opendota_fixtures.py
+++ b/tests/test_sync_opendota_fixtures.py
@@ -36,8 +36,8 @@ def _entry(
         "capabilities": [tier],
         "replay_url": f"https://replay.example/{match_id}.dem.bz2",
         "artifact_url": None,
-        "dem_size_bytes": None,
-        "dem_sha256": None,
+        "dem_size_bytes": 1,
+        "dem_sha256": "0" * 64,
         "replaced_by": replaced_by,
     }
 
@@ -112,6 +112,19 @@ def test_load_fixture_manifest_rejects_non_string_enum_fields(
     _write_manifest(path, [entry])
 
     with pytest.raises(FixtureManifestError, match=rf"invalid {field}"):
+        load_fixture_manifest(path)
+
+
+@pytest.mark.parametrize("field", ["dem_size_bytes", "dem_sha256"])
+def test_load_fixture_manifest_requires_active_integrity_metadata(
+    tmp_path: Path, field: str
+) -> None:
+    path = tmp_path / "manifest.json"
+    entry = _entry(1, name="missing-integrity", tier="canonical")
+    entry[field] = None
+    _write_manifest(path, [entry])
+
+    with pytest.raises(FixtureManifestError, match="must define dem_size_bytes and dem_sha256"):
         load_fixture_manifest(path)
 
 

--- a/tests/test_sync_opendota_fixtures.py
+++ b/tests/test_sync_opendota_fixtures.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.sync_opendota_fixtures import (
+    DEFAULT_MANIFEST,
+    FixtureIntegrityError,
+    FixtureManifestError,
+    FixtureSpec,
+    file_sha256,
+    load_fixture_manifest,
+    select_fixture_specs,
+    sync_fixture,
+    verify_fixture,
+)
+
+
+def _entry(
+    match_id: int,
+    *,
+    name: str,
+    tier: str,
+    status: str = "active",
+    replaced_by: int | None = None,
+) -> dict[str, object]:
+    return {
+        "match_id": match_id,
+        "name": name,
+        "dem": f"{match_id}.dem",
+        "tier": tier,
+        "status": status,
+        "capabilities": [tier],
+        "replay_url": f"https://replay.example/{match_id}.dem.bz2",
+        "artifact_url": None,
+        "dem_size_bytes": None,
+        "dem_sha256": None,
+        "replaced_by": replaced_by,
+    }
+
+
+def _write_manifest(path: Path, entries: list[dict[str, object]]) -> None:
+    path.write_text(
+        json.dumps({"schema_version": 2, "matches": entries}),
+        encoding="utf-8",
+    )
+
+
+def test_load_fixture_manifest_validates_deprecated_replacement(tmp_path: Path) -> None:
+    path = tmp_path / "manifest.json"
+    _write_manifest(
+        path,
+        [
+            _entry(1, name="old", tier="archive", status="deprecated", replaced_by=2),
+            _entry(2, name="current", tier="canonical"),
+        ],
+    )
+
+    specs = load_fixture_manifest(path)
+
+    assert [spec.match_id for spec in specs] == [1, 2]
+    assert specs[0].replaced_by == 2
+
+
+def test_committed_manifest_defines_ti2026_tiers_and_integrity() -> None:
+    specs = load_fixture_manifest(DEFAULT_MANIFEST)
+    by_tier = {spec.tier: spec for spec in specs if "ti2026" in spec.capabilities}
+
+    assert by_tier["canonical"].match_id == 8868259993
+    assert by_tier["extended"].match_id == 8860187335
+    assert by_tier["stress"].match_id == 8856501050
+    for spec in specs:
+        assert spec.dem_size_bytes is not None
+        assert spec.dem_sha256 is not None
+
+
+def test_load_fixture_manifest_rejects_duplicate_names(tmp_path: Path) -> None:
+    path = tmp_path / "manifest.json"
+    _write_manifest(
+        path,
+        [
+            _entry(1, name="duplicate", tier="canonical"),
+            _entry(2, name="duplicate", tier="extended"),
+        ],
+    )
+
+    with pytest.raises(FixtureManifestError, match="duplicate names"):
+        load_fixture_manifest(path)
+
+
+def test_load_fixture_manifest_rejects_inactive_replacement(tmp_path: Path) -> None:
+    path = tmp_path / "manifest.json"
+    _write_manifest(
+        path,
+        [
+            _entry(1, name="old", tier="archive", status="deprecated", replaced_by=2),
+            _entry(2, name="also-old", tier="archive", status="deprecated", replaced_by=1),
+        ],
+    )
+
+    with pytest.raises(FixtureManifestError, match="active replacement"):
+        load_fixture_manifest(path)
+
+
+def test_selection_defaults_to_active_canonical() -> None:
+    specs = [
+        _spec(1, "canonical", "active"),
+        _spec(2, "extended", "active"),
+        _spec(3, "canonical", "deprecated", replaced_by=1),
+    ]
+
+    selected = select_fixture_specs(specs)
+
+    assert [spec.match_id for spec in selected] == [1]
+
+
+def test_explicit_deprecated_selection_requires_opt_in() -> None:
+    specs = [
+        _spec(1, "canonical", "active"),
+        _spec(2, "archive", "deprecated", replaced_by=1),
+    ]
+
+    with pytest.raises(FixtureManifestError, match="include-deprecated"):
+        select_fixture_specs(specs, match_ids=[2])
+
+    selected = select_fixture_specs(specs, match_ids=[2], include_deprecated=True)
+    assert [spec.match_id for spec in selected] == [2]
+
+
+def test_verify_fixture_checks_size_and_sha256(tmp_path: Path) -> None:
+    replay = tmp_path / "1.dem"
+    replay.write_bytes(b"demo replay")
+    spec = _spec(
+        1,
+        "canonical",
+        "active",
+        size=replay.stat().st_size,
+        sha256=hashlib.sha256(b"demo replay").hexdigest(),
+    )
+
+    verify_fixture(spec, replay)
+    assert file_sha256(replay) == spec.dem_sha256
+
+
+def test_verify_fixture_rejects_integrity_mismatch(tmp_path: Path) -> None:
+    replay = tmp_path / "1.dem"
+    replay.write_bytes(b"wrong")
+    spec = _spec(1, "canonical", "active", size=99)
+
+    with pytest.raises(FixtureIntegrityError, match="size mismatch"):
+        verify_fixture(spec, replay)
+
+
+def test_sync_fixture_downloads_to_temporary_path_before_install(tmp_path: Path) -> None:
+    payload = b"verified replay"
+    spec = _spec(
+        1,
+        "canonical",
+        "active",
+        size=len(payload),
+        sha256=hashlib.sha256(payload).hexdigest(),
+    )
+    download_dirs: list[Path] = []
+
+    def downloader(match_id: int, replay_url: str, out_dir: Path) -> Path:
+        assert match_id == 1
+        assert replay_url.endswith("1.dem.bz2")
+        download_dirs.append(out_dir)
+        path = out_dir / "1.dem"
+        path.write_bytes(payload)
+        return path
+
+    path, downloaded = sync_fixture(spec, tmp_path, downloader=downloader)
+
+    assert downloaded is True
+    assert path == tmp_path / "1.dem"
+    assert path.read_bytes() == payload
+    assert download_dirs and download_dirs[0] != tmp_path
+    assert not download_dirs[0].exists()
+
+
+def test_sync_fixture_reuses_verified_local_file(tmp_path: Path) -> None:
+    replay = tmp_path / "1.dem"
+    replay.write_bytes(b"local")
+    spec = _spec(1, "canonical", "active", size=5)
+
+    path, downloaded = sync_fixture(spec, tmp_path)
+
+    assert path == replay
+    assert downloaded is False
+
+
+def test_failed_forced_download_does_not_replace_existing_fixture(tmp_path: Path) -> None:
+    replay = tmp_path / "1.dem"
+    replay.write_bytes(b"known good")
+    expected = b"replacement"
+    spec = _spec(
+        1,
+        "canonical",
+        "active",
+        size=len(expected),
+        sha256=hashlib.sha256(expected).hexdigest(),
+    )
+
+    def bad_downloader(match_id: int, replay_url: str, out_dir: Path) -> Path:
+        path = out_dir / f"{match_id}.dem"
+        path.write_bytes(b"corrupt")
+        return path
+
+    with pytest.raises(FixtureIntegrityError, match="size mismatch"):
+        sync_fixture(spec, tmp_path, force=True, downloader=bad_downloader)
+
+    assert replay.read_bytes() == b"known good"
+
+
+def _spec(
+    match_id: int,
+    tier: str,
+    status: str,
+    *,
+    replaced_by: int | None = None,
+    size: int | None = None,
+    sha256: str | None = None,
+) -> FixtureSpec:
+    return FixtureSpec(
+        match_id=match_id,
+        name=f"fixture-{match_id}",
+        dem=f"{match_id}.dem",
+        tier=tier,
+        status=status,
+        capabilities=(tier,),
+        replay_url=f"https://replay.example/{match_id}.dem.bz2",
+        artifact_url=None,
+        dem_size_bytes=size,
+        dem_sha256=sha256,
+        replaced_by=replaced_by,
+    )


### PR DESCRIPTION
## Summary

- make three TI2026 matches the named canonical short, medium, and long replay corpus
- add manifest v2 lifecycle, capability, artifact, size, and SHA-256 metadata
- add atomic fixture sync/verification plus deterministic pytest fixtures and defaults
- deprecate the replaceable legacy medium/long fixtures while retaining the performance baseline and specialized regressions

## Rationale

- keep a current, reproducible integration corpus without committing large `.dem` artifacts
- make fixture roles and replacement policy explicit while preserving the existing performance work tracked by #143

## Testing

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src` (also checked both fixture scripts)
- [x] `uv run pytest tests/ -m "not integration"` (default suite: 1,756 passed, 3 skipped)
- [x] Docs build, if docs changed (`cd docs && npm run docs:build`)
- [x] Canonical TI2026 integration coverage (37 passed)
- [x] Default OpenDota parity: 651 passed, 2 skipped, 0 warnings/failures/errors
- [x] Long-match stress parity: 331 passed, 1 skipped, 0 warnings/failures/errors
- [x] Active and deprecated fixture integrity verification

## Notes

- [x] Generated protobuf files under `src/gem/proto/` were not edited manually.
- [x] Large replay artifacts are not committed unless explicitly required for tests.
- [x] Secrets and local credentials are not included.

Closes #149
