### PR TITLE
Optimize entity callback dispatch by class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   decompressed size and SHA-256 digest.
 
 ### Changed
+- **Class-aware entity callback dispatch.** Built-in entity handlers are now
+  precompiled into ordered class-ID-specific dispatch tables, avoiding callbacks
+  for entity classes they do not consume while preserving catch-all callbacks and
+  handler ordering.
 - **Deterministic integration fixture selection.** Generic full-replay tests and
   examples now use the explicit short TI2026 fixture instead of whichever local
   replay happens to be found first. The DreamLeague performance baseline and

--- a/src/gem/extractors/courier.py
+++ b/src/gem/extractors/courier.py
@@ -76,7 +76,10 @@ class CourierExtractor:
             parser: The ``ReplayParser`` instance to attach to.
         """
         self._parser = parser
-        parser.on_entity(self._on_entity)
+        parser._on_entity_filtered(
+            self._on_entity,
+            class_prefixes=("CDOTA_Unit_Courier",),
+        )
 
     def _on_entity(self, entity: Entity, op: EntityOp) -> None:
         cls = entity.get_class_name()

--- a/src/gem/extractors/draft.py
+++ b/src/gem/extractors/draft.py
@@ -166,7 +166,10 @@ class DraftExtractor:
             parser: The ``ReplayParser`` instance to attach to.
         """
         self._parser = parser
-        parser.on_entity(self._on_entity)
+        parser._on_entity_filtered(
+            self._on_entity,
+            class_names=("CDOTAGamerulesProxy", "CDOTA_PlayerResource"),
+        )
 
     def _resolve_name(self, hero_id: int) -> str:
         """Resolve a hero_id to an NPC name.

--- a/src/gem/extractors/intervals.py
+++ b/src/gem/extractors/intervals.py
@@ -166,7 +166,18 @@ class IntervalExtractor:
     def attach(self, parser: ReplayParser) -> None:
         """Register parser callbacks."""
         self._parser = parser
-        parser.on_entity(self._on_entity)
+        parser._on_entity_filtered(
+            self._on_entity,
+            class_names=(
+                "CDOTAGamerulesProxy",
+                "CDOTA_PlayerResource",
+                "CDOTADataRadiant",
+                "CDOTA_DataRadiant",
+                "CDOTADataDire",
+                "CDOTA_DataDire",
+            ),
+            class_prefixes=(_HERO_CLASS_PREFIX,),
+        )
         parser.on_game_end(self._on_game_end)
         on_tick_start = getattr(parser, "on_tick_start", None)
         if callable(on_tick_start):

--- a/src/gem/extractors/objectives.py
+++ b/src/gem/extractors/objectives.py
@@ -312,7 +312,10 @@ class ObjectivesExtractor:
         self._parser = parser
         parser.on_combat_log_entry(self._on_combat_log)
         parser.on_chat_event(self._on_chat_event)
-        parser.on_entity(self._on_entity)
+        parser._on_entity_filtered(
+            self._on_entity,
+            class_names=(*_ROSHAN_ITEM_DROPS, _BANNER_UNIT_CLASS),
+        )
 
     def _on_entity(self, entity: Entity, op: EntityOp) -> None:
         name = entity.get_class_name()

--- a/src/gem/extractors/players.py
+++ b/src/gem/extractors/players.py
@@ -136,7 +136,19 @@ class PlayerExtractor:
             parser: The ``ReplayParser`` instance to attach to.
         """
         self._parser = parser
-        parser.on_entity(self._on_entity)
+        parser._on_entity_filtered(
+            self._on_entity,
+            class_names=(
+                "CDOTAGamerulesProxy",
+                "CDOTAPlayerController",
+                "CDOTADataRadiant",
+                "CDOTA_DataRadiant",
+                "CDOTADataDire",
+                "CDOTA_DataDire",
+                "CDOTA_PlayerResource",
+            ),
+            class_prefixes=(_HERO_CLASS_PREFIX,),
+        )
         parser.on_combat_log_entry(self._on_combat_log_entry)
         if self._minute_snapshots:
             parser.on_game_start(self._on_game_start)

--- a/src/gem/extractors/wards.py
+++ b/src/gem/extractors/wards.py
@@ -153,7 +153,11 @@ class WardsExtractor:
         """
         self._parser = parser
         parser.on_combat_log_entry(self._on_combat_log)
-        parser.on_entity(self._on_entity)
+        parser._on_entity_filtered(
+            self._on_entity,
+            class_names=_WARD_CLASSES,
+            class_prefixes=("CDOTA_Unit_Hero_",),
+        )
 
     @property
     def _tick(self) -> int:

--- a/src/gem/parser.py
+++ b/src/gem/parser.py
@@ -46,7 +46,8 @@ Reference: manta/parser.go, manta/demo_packet.go, manta/game_event.go
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from pathlib import Path
 
 # Proto side-effect import order is critical
@@ -144,6 +145,20 @@ ChatEventCallback = Callable[["CDOTAUserMsg_ChatEvent", int], None]
 NeutralItemFoundCallback = Callable[["NeutralItemFoundEvent"], None]
 
 
+@dataclass(frozen=True, slots=True)
+class _EntityCallbackRegistration:
+    """A pending catch-all or internally filtered entity callback."""
+
+    callback: EntityCallback
+    class_names: frozenset[str] = frozenset()
+    class_prefixes: tuple[str, ...] = ()
+
+    @property
+    def filtered(self) -> bool:
+        """Return whether this registration has a class filter."""
+        return bool(self.class_names or self.class_prefixes)
+
+
 def _read_inner_messages(data: bytes) -> list[tuple[int, bytes]]:
     """Unpack the inner message sequence from a CDemoPacket.data blob.
 
@@ -198,7 +213,7 @@ class ReplayParser:
         self.entity_manager: EntityManager | None = None
         self.game_event_manager = GameEventManager()
         self.combat_log = CombatLogProcessor()
-        self._entity_callbacks: list[EntityCallback] = [self._on_entity_game_start]
+        self._entity_callbacks: list[_EntityCallbackRegistration] = []
         self._tick_start_callbacks: list[TickStartCallback] = []
         self._chat_callbacks: list[ChatCallback] = []
         self._chat_event_callbacks: list[ChatEventCallback] = []
@@ -241,6 +256,10 @@ class ReplayParser:
         self._pending_game_end_tick: int | None = None
         self._game_start_time_s: int | None = None
         self._combat_log_game_start_time_s: int | None = None
+        self._on_entity_filtered(
+            self._on_entity_game_start,
+            class_names=("CDOTAGamerulesProxy",),
+        )
 
     # ------------------------------------------------------------------
     # Public callback registration
@@ -252,9 +271,42 @@ class ReplayParser:
         Args:
             callback: ``(Entity, EntityOp) -> None``.
         """
-        self._entity_callbacks.append(callback)
-        if self.entity_manager is not None:
-            self.entity_manager.on_entity(callback)
+        self._register_entity_callback(_EntityCallbackRegistration(callback=callback))
+
+    def _on_entity_filtered(
+        self,
+        callback: EntityCallback,
+        *,
+        class_names: Iterable[str] = (),
+        class_prefixes: Iterable[str] = (),
+    ) -> None:
+        """Register an internal callback for selected entity classes."""
+        names = frozenset(class_names)
+        prefixes = tuple(dict.fromkeys(class_prefixes))
+        if not names and not prefixes:
+            raise ValueError("filtered entity callbacks require a class name or prefix")
+        if any(not value for value in names) or any(not value for value in prefixes):
+            raise ValueError("entity class names and prefixes must be non-empty")
+        self._register_entity_callback(
+            _EntityCallbackRegistration(
+                callback=callback,
+                class_names=names,
+                class_prefixes=prefixes,
+            )
+        )
+
+    def _register_entity_callback(self, registration: _EntityCallbackRegistration) -> None:
+        self._entity_callbacks.append(registration)
+        if self.entity_manager is None:
+            return
+        if registration.filtered:
+            self.entity_manager._on_entity_filtered(
+                registration.callback,
+                class_names=registration.class_names,
+                class_prefixes=registration.class_prefixes,
+            )
+        else:
+            self.entity_manager.on_entity(registration.callback)
 
     def on_tick_start(self, callback: TickStartCallback) -> None:
         """Register a handler called before the current tick's entity deltas.
@@ -648,8 +700,15 @@ class ReplayParser:
     def _on_send_tables(self, data: bytes) -> None:
         serializers = parse_send_tables(data, self.game_build)
         self.entity_manager = EntityManager(serializers, self.string_tables)
-        for cb in self._entity_callbacks:
-            self.entity_manager.on_entity(cb)
+        for registration in self._entity_callbacks:
+            if registration.filtered:
+                self.entity_manager._on_entity_filtered(
+                    registration.callback,
+                    class_names=registration.class_names,
+                    class_prefixes=registration.class_prefixes,
+                )
+            else:
+                self.entity_manager.on_entity(registration.callback)
         # Apply ServerInfo if it arrived before the send tables
         if self._pending_server_info is not None:
             self._on_server_info(self._pending_server_info)

--- a/src/gem/state/entities.py
+++ b/src/gem/state/entities.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import enum
 import math
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import Any
 
@@ -345,15 +345,33 @@ def _resolve_in_field(f: Field, fp: FieldPath, name: str, depth: int) -> bool:
 EntityHandler = Callable[[Entity, EntityOp], None]
 
 
+@dataclass(frozen=True, slots=True)
+class _EntityHandlerRegistration:
+    """One ordered catch-all or class-filtered entity handler registration."""
+
+    handler: EntityHandler
+    class_names: frozenset[str] = frozenset()
+    class_prefixes: tuple[str, ...] = ()
+
+    def matches(self, class_name: str) -> bool:
+        """Return whether this registration consumes *class_name*."""
+        if not self.class_names and not self.class_prefixes:
+            return True
+        return class_name in self.class_names or class_name.startswith(self.class_prefixes)
+
+
 class EntityTracker:
-    """Manages entity event handler registration and dispatch.
+    """Manages ordered entity handler registration and class-aware dispatch.
 
     Attributes:
-        _handlers: List of registered EntityHandler callables.
+        _registrations: Ordered catch-all and filtered handler registrations.
+        _handlers_by_class_id: Precompiled handlers for each known entity class.
     """
 
     def __init__(self) -> None:
-        self._handlers: list[EntityHandler] = []
+        self._registrations: list[_EntityHandlerRegistration] = []
+        self._class_names_by_id: dict[int, str] | None = None
+        self._handlers_by_class_id: dict[int, tuple[EntityHandler, ...]] = {}
 
     def on_entity(self, handler: EntityHandler) -> None:
         """Register a handler to be called on entity events.
@@ -361,7 +379,50 @@ class EntityTracker:
         Args:
             handler: Callable ``(Entity, EntityOp) -> None``.
         """
-        self._handlers.append(handler)
+        self._register(_EntityHandlerRegistration(handler=handler))
+
+    def _on_entity_filtered(
+        self,
+        handler: EntityHandler,
+        *,
+        class_names: Iterable[str] = (),
+        class_prefixes: Iterable[str] = (),
+    ) -> None:
+        """Register an internal handler for selected entity classes."""
+        names = frozenset(class_names)
+        prefixes = tuple(dict.fromkeys(class_prefixes))
+        if not names and not prefixes:
+            raise ValueError("filtered entity handlers require a class name or prefix")
+        if any(not value for value in names) or any(not value for value in prefixes):
+            raise ValueError("entity class names and prefixes must be non-empty")
+        self._register(
+            _EntityHandlerRegistration(
+                handler=handler,
+                class_names=names,
+                class_prefixes=prefixes,
+            )
+        )
+
+    def _register(self, registration: _EntityHandlerRegistration) -> None:
+        self._registrations.append(registration)
+        if self._class_names_by_id is None:
+            return
+        for class_id, class_name in self._class_names_by_id.items():
+            if registration.matches(class_name):
+                handlers = self._handlers_by_class_id[class_id]
+                self._handlers_by_class_id[class_id] = (*handlers, registration.handler)
+
+    def _on_class_info(self, classes: Iterable[ClassInfo]) -> None:
+        """Compile ordered handler tuples for the supplied entity classes."""
+        self._class_names_by_id = {cls.class_id: cls.name for cls in classes}
+        self._handlers_by_class_id = {
+            class_id: tuple(
+                registration.handler
+                for registration in self._registrations
+                if registration.matches(class_name)
+            )
+            for class_id, class_name in self._class_names_by_id.items()
+        }
 
     def _dispatch(self, entity: Entity, op: EntityOp) -> None:
         """Invoke all registered handlers for the given entity event.
@@ -370,7 +431,16 @@ class EntityTracker:
             entity: The entity that changed.
             op: The EntityOp bitmask.
         """
-        for h in self._handlers:
+        handlers = self._handlers_by_class_id.get(entity.cls.class_id)
+        if handlers is None:
+            # EntityManager cannot dispatch an unknown class in a real replay,
+            # but preserve direct/synthetic tracker behavior before class info.
+            handlers = tuple(
+                registration.handler
+                for registration in self._registrations
+                if registration.matches(entity.cls.name)
+            )
+        for h in handlers:
             h(entity, op)
 
 
@@ -418,6 +488,20 @@ class EntityManager:
         """
         self.tracker.on_entity(handler)
 
+    def _on_entity_filtered(
+        self,
+        handler: EntityHandler,
+        *,
+        class_names: Iterable[str] = (),
+        class_prefixes: Iterable[str] = (),
+    ) -> None:
+        """Register an internal handler for selected entity classes."""
+        self.tracker._on_entity_filtered(
+            handler,
+            class_names=class_names,
+            class_prefixes=class_prefixes,
+        )
+
     # ------------------------------------------------------------------
     # Handlers
     # ------------------------------------------------------------------
@@ -455,6 +539,7 @@ class EntityManager:
             self.classes_by_id[class_id] = ci
             self.classes_by_name[net_name] = ci
 
+        self.tracker._on_class_info(self.classes_by_id.values())
         self._class_info_ready = True
         self._update_baselines()
 

--- a/tests/test_ability_courier_draft_stuns.py
+++ b/tests/test_ability_courier_draft_stuns.py
@@ -41,6 +41,9 @@ class FakeParser:
     def on_entity(self, handler) -> None:
         self._entity_handlers.append(handler)
 
+    def _on_entity_filtered(self, handler, **_filters) -> None:
+        self.on_entity(handler)
+
     def fire_entity(self, entity, op) -> None:
         for h in self._entity_handlers:
             h(entity, op)

--- a/tests/test_draft_extractor.py
+++ b/tests/test_draft_extractor.py
@@ -485,6 +485,9 @@ class TestCheckDraftIdempotency:
             def on_entity(self, _):
                 pass
 
+            def _on_entity_filtered(self, handler, **_filters):
+                self.on_entity(handler)
+
         ext = DE()
         fp = FakeParser()
         ext.attach(fp)
@@ -524,6 +527,9 @@ class TestOnEntity:
 
             def on_entity(self, h):
                 self._handlers.append(h)
+
+            def _on_entity_filtered(self, h, **_filters):
+                self.on_entity(h)
 
         return FakeParser()
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -205,8 +205,13 @@ class FakeClass:
         self.serializer = None
 
 
-def _entity(name: str = "TestClass", index: int = 0, serial: int = 0) -> Entity:
-    return Entity(index=index, serial=serial, cls=FakeClass(name))
+def _entity(
+    name: str = "TestClass",
+    index: int = 0,
+    serial: int = 0,
+    class_id: int = 1,
+) -> Entity:
+    return Entity(index=index, serial=serial, cls=FakeClass(name, class_id))
 
 
 def _fp(*path: int) -> FieldPath:
@@ -599,6 +604,117 @@ class TestEntityTrackerMultiHandler:
         tracker._dispatch(e, EntityOp.UPDATED)
         assert received[0] is e
 
+    @pytest.mark.parametrize(
+        "op",
+        [
+            EntityOp.CREATED,
+            EntityOp.UPDATED,
+            EntityOp.ENTERED,
+            EntityOp.LEFT,
+            EntityOp.DELETED,
+            EntityOp.CREATED_ENTERED,
+            EntityOp.UPDATED_ENTERED,
+            EntityOp.DELETED_LEFT,
+        ],
+    )
+    def test_generic_and_filtered_handlers_receive_every_operation(self, op):
+        tracker = EntityTracker()
+        received = []
+        tracker.on_entity(lambda _e, value: received.append(("generic", value)))
+        tracker._on_entity_filtered(
+            lambda _e, value: received.append(("filtered", value)),
+            class_names=("ExactClass",),
+        )
+        tracker._on_class_info([ClassInfo(7, "ExactClass", None)])
+
+        tracker._dispatch(_entity("ExactClass", class_id=7), op)
+
+        assert received == [("generic", op), ("filtered", op)]
+
+    def test_exact_and_prefix_filters_ignore_nonmatching_classes(self):
+        tracker = EntityTracker()
+        received = []
+        tracker._on_entity_filtered(
+            lambda entity, _op: received.append(("exact", entity.get_class_name())),
+            class_names=("ExactClass",),
+        )
+        tracker._on_entity_filtered(
+            lambda entity, _op: received.append(("prefix", entity.get_class_name())),
+            class_prefixes=("Hero_",),
+        )
+        tracker._on_class_info(
+            [
+                ClassInfo(1, "ExactClass", None),
+                ClassInfo(2, "Hero_Axe", None),
+                ClassInfo(3, "OtherClass", None),
+            ]
+        )
+
+        tracker._dispatch(_entity("ExactClass", class_id=1), EntityOp.UPDATED)
+        tracker._dispatch(_entity("Hero_Axe", class_id=2), EntityOp.UPDATED)
+        tracker._dispatch(_entity("OtherClass", class_id=3), EntityOp.UPDATED)
+
+        assert received == [("exact", "ExactClass"), ("prefix", "Hero_Axe")]
+
+    def test_registration_order_is_preserved_before_and_after_class_info(self):
+        tracker = EntityTracker()
+        received = []
+        tracker.on_entity(lambda _e, _op: received.append("generic-before"))
+        tracker._on_entity_filtered(
+            lambda _e, _op: received.append("filtered-before"),
+            class_prefixes=("Hero_",),
+        )
+        tracker._on_class_info([ClassInfo(4, "Hero_Axe", None)])
+        tracker._on_entity_filtered(
+            lambda _e, _op: received.append("filtered-after"),
+            class_names=("Hero_Axe",),
+        )
+        tracker.on_entity(lambda _e, _op: received.append("generic-after"))
+
+        tracker._dispatch(_entity("Hero_Axe", class_id=4), EntityOp.CREATED_ENTERED)
+
+        assert received == [
+            "generic-before",
+            "filtered-before",
+            "filtered-after",
+            "generic-after",
+        ]
+
+    def test_overlapping_filters_and_recompile_do_not_duplicate_handler(self):
+        tracker = EntityTracker()
+        received = []
+        tracker._on_entity_filtered(
+            lambda _e, _op: received.append("matched"),
+            class_names=("Hero_Axe",),
+            class_prefixes=("Hero_",),
+        )
+        classes = [ClassInfo(5, "Hero_Axe", None)]
+        tracker._on_class_info(classes)
+        tracker._on_class_info(classes)
+
+        tracker._dispatch(_entity("Hero_Axe", class_id=5), EntityOp.UPDATED)
+
+        assert received == ["matched"]
+
+    def test_filtered_handler_matches_before_class_info_for_direct_dispatch(self):
+        tracker = EntityTracker()
+        received = []
+        tracker._on_entity_filtered(
+            lambda entity, _op: received.append(entity.get_class_name()),
+            class_prefixes=("Hero_",),
+        )
+
+        tracker._dispatch(_entity("Hero_Axe"), EntityOp.UPDATED)
+        tracker._dispatch(_entity("OtherClass"), EntityOp.UPDATED)
+
+        assert received == ["Hero_Axe"]
+
+    def test_filtered_handler_requires_a_nonempty_filter(self):
+        tracker = EntityTracker()
+
+        with pytest.raises(ValueError, match="require a class name or prefix"):
+            tracker._on_entity_filtered(lambda _e, _op: None)
+
 
 # ---------------------------------------------------------------------------
 # ClassInfo
@@ -699,6 +815,37 @@ class TestEntityManagerClassInfo:
 
         em.on_class_info(Msg())
         assert em._class_info_ready is True
+
+    def test_class_info_compiles_filtered_handlers(self):
+        em = self._make_em()
+        received = []
+        em._on_entity_filtered(
+            lambda entity, _op: received.append(entity.get_class_name()),
+            class_prefixes=("CDOTA_Unit_Hero_",),
+        )
+
+        class HeroClass:
+            class_id = 1
+            network_name = "CDOTA_Unit_Hero_Axe"
+
+        class OtherClass:
+            class_id = 2
+            network_name = "CDOTA_BaseNPC"
+
+        class Msg:
+            classes = [HeroClass(), OtherClass()]
+
+        em.on_class_info(Msg())
+        em.tracker._dispatch(
+            Entity(index=0, serial=0, cls=em.classes_by_id[1]),
+            EntityOp.CREATED_ENTERED,
+        )
+        em.tracker._dispatch(
+            Entity(index=1, serial=0, cls=em.classes_by_id[2]),
+            EntityOp.CREATED_ENTERED,
+        )
+
+        assert received == ["CDOTA_Unit_Hero_Axe"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_intervals_extractor.py
+++ b/tests/test_intervals_extractor.py
@@ -41,6 +41,9 @@ class FakeParser:
     def on_entity(self, handler):
         self.entity_handlers.append(handler)
 
+    def _on_entity_filtered(self, handler, **_filters):
+        self.on_entity(handler)
+
     def on_game_end(self, handler):
         self.game_end_handlers.append(handler)
 

--- a/tests/test_ml_running_totals.py
+++ b/tests/test_ml_running_totals.py
@@ -50,6 +50,9 @@ class FakeParser:
     def on_entity(self, handler) -> None:
         self._entity_handlers.append(handler)
 
+    def _on_entity_filtered(self, handler, **_filters) -> None:
+        self.on_entity(handler)
+
     def on_combat_log_entry(self, handler) -> None:
         self._combat_log_handlers.append(handler)
 

--- a/tests/test_objectives_extractor.py
+++ b/tests/test_objectives_extractor.py
@@ -53,6 +53,9 @@ class FakeParser:
     def on_entity(self, handler) -> None:
         self._entity_handlers.append(handler)
 
+    def _on_entity_filtered(self, handler, **_filters) -> None:
+        self.on_entity(handler)
+
     def on_game_start(self, handler) -> None:
         pass
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 import logging
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import gem.parser as parser_module
 import gem.results.models as model_module
 from gem.binary.reader import BitReader
@@ -356,7 +358,8 @@ class TestCallbackRegistration:
             return None
 
         p.on_entity(cb)
-        assert cb in p._entity_callbacks
+        assert p._entity_callbacks[-1].callback is cb
+        assert p._entity_callbacks[-1].filtered is False
 
     def test_on_entity_also_registers_with_entity_manager_when_present(self):
         p = ReplayParser(b"")
@@ -380,8 +383,116 @@ class TestCallbackRegistration:
 
         p.on_entity(cb1)
         p.on_entity(cb2)
-        user_callbacks = [cb for cb in p._entity_callbacks if cb in {cb1, cb2}]
+        user_callbacks = [
+            registration.callback
+            for registration in p._entity_callbacks
+            if registration.callback in {cb1, cb2}
+        ]
         assert user_callbacks == [cb1, cb2]
+
+    def test_internal_game_start_callback_is_gamerules_filtered(self):
+        p = ReplayParser(b"")
+
+        registration = p._entity_callbacks[0]
+
+        assert registration.callback == p._on_entity_game_start
+        assert registration.class_names == frozenset({"CDOTAGamerulesProxy"})
+        assert registration.class_prefixes == ()
+
+    def test_filtered_callback_registers_with_existing_entity_manager(self):
+        p = ReplayParser(b"")
+        em = MagicMock()
+        p.entity_manager = em
+
+        def cb(e, op):
+            return None
+
+        p._on_entity_filtered(
+            cb,
+            class_names=("ExactClass",),
+            class_prefixes=("Prefix_",),
+        )
+
+        em._on_entity_filtered.assert_called_once_with(
+            cb,
+            class_names=frozenset({"ExactClass"}),
+            class_prefixes=("Prefix_",),
+        )
+
+    def test_filtered_callback_requires_a_nonempty_filter(self):
+        p = ReplayParser(b"")
+
+        with pytest.raises(ValueError, match="require a class name or prefix"):
+            p._on_entity_filtered(lambda _e, _op: None)
+
+    def test_built_in_extractors_register_only_consumed_classes(self):
+        from gem.extractors.courier import CourierExtractor
+        from gem.extractors.draft import DraftExtractor
+        from gem.extractors.intervals import IntervalExtractor
+        from gem.extractors.objectives import ObjectivesExtractor
+        from gem.extractors.players import PlayerExtractor
+        from gem.extractors.wards import WardsExtractor
+
+        p = ReplayParser(b"")
+        expected = [
+            (
+                PlayerExtractor(),
+                {
+                    "CDOTAGamerulesProxy",
+                    "CDOTAPlayerController",
+                    "CDOTADataRadiant",
+                    "CDOTA_DataRadiant",
+                    "CDOTADataDire",
+                    "CDOTA_DataDire",
+                    "CDOTA_PlayerResource",
+                },
+                ("CDOTA_Unit_Hero_",),
+            ),
+            (
+                IntervalExtractor(),
+                {
+                    "CDOTAGamerulesProxy",
+                    "CDOTA_PlayerResource",
+                    "CDOTADataRadiant",
+                    "CDOTA_DataRadiant",
+                    "CDOTADataDire",
+                    "CDOTA_DataDire",
+                },
+                ("CDOTA_Unit_Hero_",),
+            ),
+            (
+                ObjectivesExtractor(),
+                {
+                    "CDOTA_Item_Aegis",
+                    "CDOTA_Item_Cheese",
+                    "CDOTA_Item_RefresherOrb_Shard",
+                    "CDOTA_Item_Roshans_Banner",
+                    "CDOTA_Unit_Roshans_Banner",
+                },
+                (),
+            ),
+            (
+                WardsExtractor(),
+                {"CDOTA_NPC_Observer_Ward", "CDOTA_NPC_Observer_Ward_TrueSight"},
+                ("CDOTA_Unit_Hero_",),
+            ),
+            (CourierExtractor(), set(), ("CDOTA_Unit_Courier",)),
+            (
+                DraftExtractor(),
+                {"CDOTAGamerulesProxy", "CDOTA_PlayerResource"},
+                (),
+            ),
+        ]
+
+        for extractor, class_names, class_prefixes in expected:
+            extractor.attach(p)
+            registration = next(
+                registration
+                for registration in reversed(p._entity_callbacks)
+                if registration.callback == extractor._on_entity
+            )
+            assert registration.class_names == frozenset(class_names)
+            assert registration.class_prefixes == class_prefixes
 
     def test_on_tick_start_appends_callback(self):
         p = ReplayParser(b"")

--- a/tests/test_players_extractor.py
+++ b/tests/test_players_extractor.py
@@ -202,6 +202,9 @@ class FakeParser:
     def on_entity(self, h):
         self._handlers.append(h)
 
+    def _on_entity_filtered(self, h, **_filters):
+        self.on_entity(h)
+
     def on_combat_log_entry(self, h):
         pass
 

--- a/tests/test_wards_extractor.py
+++ b/tests/test_wards_extractor.py
@@ -89,6 +89,9 @@ class FakeParser:
     def on_entity(self, h):
         self._ent_handlers.append(h)
 
+    def _on_entity_filtered(self, h, **_filters):
+        self.on_entity(h)
+
 
 def _ward_extractor(tick: int = 0) -> tuple[WardsExtractor, FakeParser]:
     ext = WardsExtractor()


### PR DESCRIPTION
## Summary

- compile ordered entity-handler tuples by class ID after class info is available
- preserve the public catch-all callback behavior and registration order before and after class initialization
- route the parser gamerules handler and built-in extractors only to exact classes or prefixes they consume
- add lifecycle, operation, ordering, overlap, and built-in registration coverage

## Performance

Measured on tests/fixtures/opendota/8822520406.dem using three fresh uninstrumented processes per version:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Median elapsed | 122.06 s | 86.59 s | -29.1% |
| Median peak RSS | 223,805,440 B | 224,346,112 B | +0.24% |
| Built-in callback invocations | 36,890,700 | 5,381,400 | -85.41% |

The normalized ParsedMatch remained byte-identical at 33,045,789 bytes with SHA-256 5af5fe7a53b4806469828d1e3dc6550b662a2592179c87f692e4e381f695243e.

## Testing

- [x] uv run pytest tests/ -m "not integration" — 1,783 passed, 3 skipped
- [x] canonical TI2026 integration gate — 37 passed
- [x] default TI2026 OpenDota parity — 651 passed, 2 skipped, 0 warnings/failures/errors
- [x] long TI2026 stress parity — 331 passed, 1 skipped, 0 warnings/failures/errors
- [x] uv run ruff check .
- [x] uv run ruff format --check .
- [x] uv run mypy src

Closes #144