### PR TITLE
Optimize per-entity hot-loop work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   decompressed size and SHA-256 digest.
 
 ### Changed
+- **Lower per-entity parser overhead.** Replay parsing now skips unused
+  entity-operation result tuples, deduplicates player sampling checks per tick,
+  and caches stable hero-name resolution without changing parsed output.
 - **Class-aware entity callback dispatch.** Built-in entity handlers are now
   precompiled into ordered class-ID-specific dispatch tables, avoiding callbacks
   for entity classes they do not consume while preserving catch-all callbacks and

--- a/src/gem/extractors/intervals.py
+++ b/src/gem/extractors/intervals.py
@@ -146,6 +146,13 @@ class IntervalExtractor:
         self._player_team: dict[int, int] = {}
         self._player_team_slot: dict[int, int] = {}
         self._hero_names: dict[int, str] = {}
+        # entity index → (serial, class name, player id, NPC name, stable)
+        self._hero_name_by_entity: dict[int, tuple[int, str, int, str, bool]] = {}
+        # player id → entity identity currently supplying its hero name
+        self._hero_name_sources: dict[int, tuple[int, int]] = {}
+        # (class name, EntityNames table id, item index) → canonical NPC name
+        self._canonical_hero_names: dict[tuple[str, int, int], str] = {}
+        self._fallback_hero_names: dict[str, str] = {}
         self._next_interval_s: int | None = None
         self._tick_start_driven = False
         # Clarity's @OnTickStart interval read is effectively one decoded net
@@ -286,7 +293,8 @@ class IntervalExtractor:
         if cls == "CDOTAGamerulesProxy":
             if not op.has(EntityOp.DELETED):
                 self._last_clock_tick = self._parser.tick if self._parser is not None else None
-                self._maybe_emit()
+                if not self._tick_start_driven:
+                    self._maybe_emit()
             return
 
         if cls == "CDOTA_PlayerResource":
@@ -298,7 +306,8 @@ class IntervalExtractor:
             else:
                 self._player_resource = entity
                 self._refresh_player_mappings()
-                self._maybe_emit()
+                if not self._tick_start_driven:
+                    self._maybe_emit()
             return
 
         if cls in ("CDOTADataRadiant", "CDOTA_DataRadiant"):
@@ -308,7 +317,8 @@ class IntervalExtractor:
                 self._data_radiant = entity
                 self._record_team_data(entity, self._cur_data_radiant, self._prev_data_radiant)
                 self._record_team_counters(entity, TEAM_RADIANT)
-                self._maybe_emit()
+                if not self._tick_start_driven:
+                    self._maybe_emit()
             return
 
         if cls in ("CDOTADataDire", "CDOTA_DataDire"):
@@ -318,18 +328,55 @@ class IntervalExtractor:
                 self._data_dire = entity
                 self._record_team_data(entity, self._cur_data_dire, self._prev_data_dire)
                 self._record_team_counters(entity, TEAM_DIRE)
-                self._maybe_emit()
+                if not self._tick_start_driven:
+                    self._maybe_emit()
             return
 
         if cls.startswith(_HERO_CLASS_PREFIX):
+            idx = entity.get_index()
+            serial = entity.get_serial()
+            if op.has(EntityOp.DELETED):
+                self._remove_hero_name_entity(idx, serial)
+                return
+
             player_id = _player_id_from_entity(entity)
             if player_id is None:
                 return
-            if op.has(EntityOp.DELETED):
-                self._hero_names.pop(player_id, None)
+
+            cached = self._hero_name_by_entity.get(idx)
+            if cached is not None and (cached[0] != serial or cached[1] != cls):
+                self._remove_hero_name_entity(idx, cached[0])
+                cached = None
+
+            if cached is not None and cached[4]:
+                hero_name = cached[3]
+                stable = True
             else:
-                self._hero_names[player_id] = self._hero_name(entity)
+                hero_name, stable = self._hero_name(entity)
+
+            if cached is not None and cached[2] != player_id:
+                old_player_id = cached[2]
+                if self._hero_name_sources.get(old_player_id) == (idx, serial):
+                    self._hero_name_sources.pop(old_player_id, None)
+                    self._hero_names.pop(old_player_id, None)
+
+            self._hero_name_by_entity[idx] = (serial, cls, player_id, hero_name, stable)
+            self._hero_name_sources[player_id] = (idx, serial)
+            self._hero_names[player_id] = hero_name
+            if not self._tick_start_driven:
                 self._maybe_emit()
+
+    def _remove_hero_name_entity(self, index: int, serial: int) -> None:
+        """Remove cached hero-name state owned by one entity identity."""
+        cached = self._hero_name_by_entity.get(index)
+        if cached is None or cached[0] != serial:
+            return
+
+        self._hero_name_by_entity.pop(index, None)
+        player_id = cached[2]
+        if self._hero_name_sources.get(player_id) == (index, serial):
+            self._hero_name_sources.pop(player_id, None)
+            self._hero_names.pop(player_id, None)
 
     def _refresh_player_mappings(self) -> None:
         """Build OpenDota logical slot mappings from ``CDOTA_PlayerResource``.
@@ -655,7 +702,9 @@ class IntervalExtractor:
 
         return emitted
 
-    def _hero_name(self, entity: Entity) -> str:
+    def _hero_name(self, entity: Entity) -> tuple[str, bool]:
+        """Return a hero NPC name and whether its table identity is stable."""
+        class_name = entity.get_class_name()
         entity_names = (
             self._parser.string_tables.get_by_name("EntityNames")
             if self._parser is not None and self._parser.string_tables is not None
@@ -668,10 +717,20 @@ class IntervalExtractor:
             if name_idx is not None and name_idx >= 0:
                 item = entity_names.items.get(name_idx)
                 if item is not None:
-                    return item[0] if isinstance(item, tuple) else str(item)
+                    key = (class_name, entity_names.index, name_idx)
+                    cached = self._canonical_hero_names.get(key)
+                    if cached is not None:
+                        return cached, True
+                    name = item[0] if isinstance(item, tuple) else str(item)
+                    self._canonical_hero_names[key] = name
+                    return name, True
 
-        ending = entity.get_class_name()[len(_HERO_CLASS_PREFIX) :].replace("_", "")
-        return "npc_dota_hero" + re.sub(r"([A-Z])", r"_\1", ending).lower()
+        cached_fallback = self._fallback_hero_names.get(class_name)
+        if cached_fallback is None:
+            ending = class_name[len(_HERO_CLASS_PREFIX) :].replace("_", "")
+            cached_fallback = "npc_dota_hero" + re.sub(r"([A-Z])", r"_\1", ending).lower()
+            self._fallback_hero_names[class_name] = cached_fallback
+        return cached_fallback, False
 
 
 def _int_or_zero(value: int | None) -> int:

--- a/src/gem/extractors/players.py
+++ b/src/gem/extractors/players.py
@@ -94,10 +94,13 @@ class PlayerExtractor:
         self._game_start_tick: int | None = None
         self._game_end_tick: int | None = None
         self._last_minute: int = -1  # last game-minute index sampled
+        self._last_sample_check_tick: int | None = None
         # entity index → Entity (mutable reference; entity is updated in place)
         self._heroes: dict[int, Entity] = {}
         # npc_name → Entity (for external position lookups)
         self._heroes_by_npc: dict[str, Entity] = {}
+        # Hero class name → combat-log NPC aliases.
+        self._hero_aliases_by_class: dict[str, tuple[str, str]] = {}
         # player_id → Entity (CDOTAPlayerController)
         self._controllers: dict[int, Entity] = {}
         # CDOTADataRadiant / CDOTADataDire entities (authoritative gold/LH/DN per team)
@@ -158,6 +161,16 @@ class PlayerExtractor:
         self._game_start_tick = game_start_tick
         # Align the 150-tick sampler to game start so both series share origin
         self._last_sample = game_start_tick
+        # The first relevant entity in this tick can arrive before the parser's
+        # gamerules callback establishes game time. Preserve the minute-zero
+        # snapshot here while ordinary eligibility checks remain once per tick.
+        game_time_s = getattr(self._parser, "game_time_s", None)
+        if game_time_s == 0 and self._last_sample_check_tick == game_start_tick:
+            self._maybe_sample_minute(game_start_tick)
+        elif game_time_s is None:
+            # Compatibility parsers without a game-time clock establish minute
+            # zero from the next relevant entity callback, as before.
+            self._last_sample_check_tick = None
 
     def _on_game_end(self, tick: int) -> None:
         # Force a final snapshot at the exact game-end tick so lh/nw/gold
@@ -377,29 +390,25 @@ class PlayerExtractor:
 
     def _on_entity(self, entity: Entity, op: EntityOp) -> None:
         cls = entity.get_class_name()
+        should_sample = False
 
         if cls == "CDOTAGamerulesProxy":
             if not op.has(EntityOp.DELETED):
-                self._maybe_sample()
+                should_sample = True
 
         elif cls.startswith(_HERO_CLASS_PREFIX):
             idx = entity.get_index()
-            ending = cls[len(_HERO_CLASS_PREFIX) :]
-            # Register two name forms to cover inconsistent combat log names.
-            # "combatLogName":  simple lowercase ("npc_dota_hero_templarassassin")
-            # "combatLogName2": insert _ before each capital ("npc_dota_hero_templar_assassin")
-            # Reference: refs/parser/src/main/java/opendota/Parse.java
-            npc1 = "npc_dota_hero_" + ending.lower()
-            npc2 = "npc_dota_hero" + re.sub(r"([A-Z])", r"_\1", ending.replace("_", "")).lower()
             if op.has(EntityOp.DELETED):
-                self._heroes.pop(idx, None)
-                self._heroes_by_npc.pop(npc1, None)
-                self._heroes_by_npc.pop(npc2, None)
+                self._remove_hero(entity)
             else:
+                previous = self._heroes.get(idx)
+                if previous is not None and previous.get_serial() != entity.get_serial():
+                    self._remove_hero(previous)
+                npc1, npc2 = self._hero_aliases(cls)
                 self._heroes[idx] = entity
                 self._heroes_by_npc[npc1] = entity
                 self._heroes_by_npc[npc2] = entity
-                self._maybe_sample()
+                should_sample = True
 
         elif cls == "CDOTAPlayerController":
             pid = _player_id_from_entity(entity)
@@ -408,17 +417,17 @@ class PlayerExtractor:
                     self._controllers.pop(pid, None)
                 else:
                     self._controllers[pid] = entity
-                    self._maybe_sample()
+                    should_sample = True
 
         elif cls in ("CDOTADataRadiant", "CDOTA_DataRadiant"):
             self._data_radiant = None if op.has(EntityOp.DELETED) else entity
             if not op.has(EntityOp.DELETED):
-                self._maybe_sample()
+                should_sample = True
 
         elif cls in ("CDOTADataDire", "CDOTA_DataDire"):
             self._data_dire = None if op.has(EntityOp.DELETED) else entity
             if not op.has(EntityOp.DELETED):
-                self._maybe_sample()
+                should_sample = True
 
         elif cls == "CDOTA_PlayerResource":
             if op.has(EntityOp.DELETED):
@@ -426,7 +435,41 @@ class PlayerExtractor:
             else:
                 self._player_resource = entity
                 self._refresh_team_slots()
+                should_sample = True
+
+        if should_sample and self._parser is not None:
+            tick = self._parser.tick
+            if tick != self._last_sample_check_tick:
+                self._last_sample_check_tick = tick
                 self._maybe_sample()
+
+    def _hero_aliases(self, class_name: str) -> tuple[str, str]:
+        """Return cached combat-log aliases for a hero entity class."""
+        cached = self._hero_aliases_by_class.get(class_name)
+        if cached is not None:
+            return cached
+
+        ending = class_name[len(_HERO_CLASS_PREFIX) :]
+        # Register two name forms to cover inconsistent combat log names.
+        # Reference: refs/parser/src/main/java/opendota/Parse.java
+        aliases = (
+            "npc_dota_hero_" + ending.lower(),
+            "npc_dota_hero" + re.sub(r"([A-Z])", r"_\1", ending.replace("_", "")).lower(),
+        )
+        self._hero_aliases_by_class[class_name] = aliases
+        return aliases
+
+    def _remove_hero(self, entity: Entity) -> None:
+        """Remove hero mappings only when they still belong to this identity."""
+        idx = entity.get_index()
+        current = self._heroes.get(idx)
+        if current is None or current.get_serial() != entity.get_serial():
+            return
+
+        self._heroes.pop(idx, None)
+        for npc_name in self._hero_aliases(current.get_class_name()):
+            if self._heroes_by_npc.get(npc_name) is current:
+                self._heroes_by_npc.pop(npc_name, None)
 
     def _refresh_team_slots(self) -> None:
         """Build the logical→resource remap and read m_iTeamSlot per player.
@@ -473,7 +516,16 @@ class PlayerExtractor:
             return
 
         # Minute-boundary sampling (OpenDota-aligned)
-        minute_fired = False
+        minute_fired = self._maybe_sample_minute(tick)
+
+        # Regular interval sampling — skip if minute boundary just fired at same tick
+        if tick - self._last_sample >= self._sample_interval:
+            self._last_sample = tick
+            if not minute_fired:
+                self._sample(tick, minute=False)
+
+    def _maybe_sample_minute(self, tick: int) -> bool:
+        """Sample a newly reached minute boundary and report whether it fired."""
         if self._minute_snapshots and self._game_start_tick is not None:
             game_time_s = getattr(self._parser, "game_time_s", None)
             if game_time_s is not None and game_time_s >= 0 and game_time_s % 60 == 0:
@@ -487,13 +539,8 @@ class PlayerExtractor:
             if current_minute is not None and current_minute > self._last_minute:
                 self._last_minute = current_minute
                 self._sample(tick, minute=True)
-                minute_fired = True
-
-        # Regular interval sampling — skip if minute boundary just fired at same tick
-        if tick - self._last_sample >= self._sample_interval:
-            self._last_sample = tick
-            if not minute_fired:
-                self._sample(tick, minute=False)
+                return True
+        return False
 
     def _hero_handle_for_player(self, player_id: int) -> int | None:
         ctrl = self._controllers.get(player_id)

--- a/src/gem/parser.py
+++ b/src/gem/parser.py
@@ -640,7 +640,7 @@ class ReplayParser:
         ):
             pe_msg = CSVCMsg_PacketEntities()
             pe_msg.ParseFromString(payload)
-            self.entity_manager.on_packet_entities(pe_msg)
+            self.entity_manager._on_packet_entities(pe_msg)
 
         elif type_id == _SVC_USER_MESSAGE:
             um_msg = CSVCMsg_UserMessage()

--- a/src/gem/state/entities.py
+++ b/src/gem/state/entities.py
@@ -556,18 +556,31 @@ class EntityManager:
         Returns:
             List of (Entity, EntityOp) tuples in the order they were processed.
         """
+        results: list[tuple[Entity, EntityOp]] = []
+        self._decode_packet_entities(msg, results)
+        return results
+
+    def _on_packet_entities(self, msg: object) -> None:
+        """Decode packet entities without collecting unused operation tuples."""
+        self._decode_packet_entities(msg, None)
+
+    def _decode_packet_entities(
+        self,
+        msg: object,
+        results: list[tuple[Entity, EntityOp]] | None,
+    ) -> None:
+        """Decode and dispatch packet entities into an optional result sink."""
         is_delta: bool = msg.legacy_is_delta  # type: ignore[attr-defined]
         updates: int = msg.updated_entries  # type: ignore[attr-defined]
         entity_data: bytes = msg.entity_data  # type: ignore[attr-defined]
 
         if not is_delta:
             if self._full_packets > 0:
-                return []
+                return
             self._full_packets += 1
 
         r = BitReader(entity_data)
         index = -1
-        results: list[tuple[Entity, EntityOp]] = []
 
         for _ in range(updates):
             index += r.read_ubit_var() + 1
@@ -637,9 +650,8 @@ class EntityManager:
                     entity.active = False
 
             self.tracker._dispatch(entity, op)
-            results.append((entity, op))
-
-        return results
+            if results is not None:
+                results.append((entity, op))
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1169,6 +1169,28 @@ class TestEntityManagerPacketEntities:
         assert len(dispatched) == 1
         assert dispatched[0][0] is e
 
+    def test_internal_packet_path_dispatches_without_results(self):
+        """The parser-only path applies updates without building result tuples."""
+        em = self._make_em()
+        e = _entity("Hero", index=0, serial=0)
+        em.entities[0] = e
+        dispatched = []
+        em.on_entity(lambda ent, op: dispatched.append((ent, op)))
+
+        data = self._pack_bits([0, 0, 0, 0, 0, 0, 1, 0])
+
+        class Msg:
+            legacy_is_delta = True
+            updated_entries = 1
+            entity_data = data
+
+        result = em._on_packet_entities(Msg())
+
+        assert result is None
+        assert len(dispatched) == 1
+        assert dispatched[0][0] is e
+        assert e.active is False
+
     @staticmethod
     def _pack_bits(raw_bits: list[int]) -> bytes:
         while len(raw_bits) % 8:

--- a/tests/test_intervals_extractor.py
+++ b/tests/test_intervals_extractor.py
@@ -6,6 +6,7 @@ import pytest
 
 from gem.extractors.intervals import IntervalExtractor
 from gem.state.entities import Entity, EntityOp
+from gem.state.string_table import StringTable, StringTables
 
 
 class FakeClass:
@@ -455,6 +456,99 @@ def test_tick_start_defers_crossing_by_one_net_tick():
     assert radiant.xp == 1100
     assert radiant.lh == 30
     assert radiant.dn == 5
+
+
+def test_tick_start_entity_updates_do_not_attempt_entity_side_emit():
+    ext = IntervalExtractor()
+    parser = TickStartFakeParser(tick=1700, game_time_s=58)
+    ext.attach(parser)  # type: ignore[arg-type]
+    calls = []
+    ext._maybe_emit = lambda: calls.append(parser.tick)  # type: ignore[method-assign]
+
+    ext._on_entity(_player_resource(), EntityOp.UPDATED)
+    ext._on_entity(_radiant_data(), EntityOp.UPDATED)
+    ext._on_entity(_dire_data(), EntityOp.UPDATED)
+    ext._on_entity(_ent("CDOTAGamerulesProxy"), EntityOp.UPDATED)
+    ext._on_entity(_ent("CDOTA_Unit_Hero_Axe", m_nPlayerID=0), EntityOp.UPDATED)
+
+    assert calls == []
+    assert ext._player_resource is not None
+    assert ext._data_radiant is not None
+    assert ext._hero_names[0] == "npc_dota_hero_axe"
+
+
+def test_interval_hero_name_retries_until_canonical_table_item_exists():
+    ext = IntervalExtractor()
+    parser = FakeParser()
+    parser.string_tables = StringTables()
+    ext.attach(parser)
+    hero = _ent(
+        "CDOTA_Unit_Hero_QueenOfPain",
+        index=10,
+        serial=3,
+        m_nPlayerID=0,
+        **{"m_pEntity.m_nameStringableIndex": 7},
+    )
+
+    ext._on_entity(hero, EntityOp.UPDATED)
+    assert ext._hero_names[0] == "npc_dota_hero_queen_of_pain"
+    assert ext._hero_name_by_entity[10][4] is False
+
+    names = StringTable(index=0, name="EntityNames")
+    names.items[7] = ("npc_dota_hero_queenofpain", b"")
+    parser.string_tables.add(names)
+    ext._on_entity(hero, EntityOp.UPDATED)
+
+    assert ext._hero_names[0] == "npc_dota_hero_queenofpain"
+    assert ext._hero_name_by_entity[10][4] is True
+    assert len(ext._canonical_hero_names) == 1
+
+
+def test_interval_hero_name_source_survives_stale_delete_and_slot_recycle():
+    ext = IntervalExtractor()
+    parser = FakeParser()
+    parser.string_tables = StringTables()
+    names = StringTable(index=0, name="EntityNames")
+    names.items.update(
+        {
+            1: ("npc_dota_hero_axe", b""),
+            2: ("npc_dota_hero_pudge", b""),
+        }
+    )
+    parser.string_tables.add(names)
+    ext.attach(parser)
+    old = _ent(
+        "CDOTA_Unit_Hero_Axe",
+        index=10,
+        serial=1,
+        m_nPlayerID=0,
+        **{"m_pEntity.m_nameStringableIndex": 1},
+    )
+    reconnect = _ent(
+        "CDOTA_Unit_Hero_Axe",
+        index=11,
+        serial=1,
+        m_nPlayerID=0,
+        **{"m_pEntity.m_nameStringableIndex": 1},
+    )
+    replacement = _ent(
+        "CDOTA_Unit_Hero_Pudge",
+        index=11,
+        serial=2,
+        m_nPlayerID=2,
+        **{"m_pEntity.m_nameStringableIndex": 2},
+    )
+
+    ext._on_entity(old, EntityOp.CREATED)
+    ext._on_entity(reconnect, EntityOp.CREATED)
+    ext._on_entity(old, EntityOp.DELETED)
+    assert ext._hero_names[0] == "npc_dota_hero_axe"
+
+    ext._on_entity(replacement, EntityOp.CREATED)
+    ext._on_entity(reconnect, EntityOp.DELETED)
+
+    assert 0 not in ext._hero_names
+    assert ext._hero_names[1] == "npc_dota_hero_pudge"
 
 
 def test_tick_start_samples_minute_zero_before_same_tick_bounty_delta():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -719,6 +719,20 @@ class TestDispatchInnerRouting:
         p._dispatch_inner(_SVC_PACKET_ENTITIES, b"\x00" * 4)
         em.on_packet_entities.assert_not_called()
 
+    def test_svc_packet_entities_uses_non_collecting_path(self):
+        from gem.proto.netmessages_pb2 import CSVCMsg_PacketEntities
+
+        p = ReplayParser(b"")
+        em = MagicMock()
+        em.class_id_size = 1
+        p.entity_manager = em
+        message = CSVCMsg_PacketEntities(legacy_is_delta=True)
+
+        p._dispatch_inner(_SVC_PACKET_ENTITIES, message.SerializeToString())
+
+        em._on_packet_entities.assert_called_once()
+        em.on_packet_entities.assert_not_called()
+
     def test_svc_user_message_dispatches_to_on_user_message(self):
         p = ReplayParser(b"")
         from gem.proto.netmessages_pb2 import CSVCMsg_UserMessage

--- a/tests/test_players_extractor.py
+++ b/tests/test_players_extractor.py
@@ -407,6 +407,36 @@ class TestOnEntityHero:
         ext._on_entity(e, EntityOp.DELETED)
         assert 5 not in ext._heroes
 
+    def test_hero_alias_normalization_is_cached_by_class(self):
+        ext = PlayerExtractor()
+        parser = FakeParser()
+        ext.attach(parser)
+
+        ext._on_entity(_hero("TemplarAssassin", index=5), EntityOp.CREATED)
+        ext._on_entity(_hero("TemplarAssassin", index=6), EntityOp.CREATED)
+
+        assert ext._hero_aliases_by_class == {
+            "CDOTA_Unit_Hero_TemplarAssassin": (
+                "npc_dota_hero_templarassassin",
+                "npc_dota_hero_templar_assassin",
+            )
+        }
+
+    def test_recycled_hero_slot_removes_only_old_identity(self):
+        ext = PlayerExtractor()
+        parser = FakeParser()
+        ext.attach(parser)
+        old = _hero("Axe", index=5, serial=1)
+        replacement = _hero("Pudge", index=5, serial=2)
+
+        ext._on_entity(old, EntityOp.CREATED)
+        ext._on_entity(replacement, EntityOp.CREATED)
+        ext._on_entity(old, EntityOp.DELETED)
+
+        assert ext._heroes[5] is replacement
+        assert "npc_dota_hero_axe" not in ext._heroes_by_npc
+        assert ext._heroes_by_npc["npc_dota_hero_pudge"] is replacement
+
     def test_controller_registered(self):
         ext = PlayerExtractor()
         parser = FakeParser()
@@ -562,6 +592,67 @@ class TestHeroPos:
 
 
 class TestMaybeSample:
+    def test_entity_sampling_check_runs_once_per_tick(self):
+        ext = PlayerExtractor()
+        parser = FakeParser(tick=300)
+        ext.attach(parser)
+        calls = []
+        ext._maybe_sample = lambda: calls.append(parser.tick)  # type: ignore[method-assign]
+
+        ext._on_entity(_hero("Axe", index=1), EntityOp.UPDATED)
+        ext._on_entity(_ent("CDOTADataRadiant"), EntityOp.UPDATED)
+        ext._on_entity(_ent("CDOTAGamerulesProxy"), EntityOp.UPDATED)
+        parser.tick = 301
+        ext._on_entity(_ent("CDOTADataDire"), EntityOp.UPDATED)
+
+        assert calls == [300, 301]
+
+    def test_deletion_does_not_consume_tick_sampling_check(self):
+        ext = PlayerExtractor()
+        parser = FakeParser(tick=300)
+        ext.attach(parser)
+        hero = _hero("Axe", index=1, serial=2)
+        ext._heroes[1] = hero
+        calls = []
+        ext._maybe_sample = lambda: calls.append(parser.tick)  # type: ignore[method-assign]
+
+        ext._on_entity(hero, EntityOp.DELETED)
+        ext._on_entity(_ent("CDOTADataRadiant"), EntityOp.UPDATED)
+
+        assert calls == [300]
+
+    def test_game_start_preserves_late_minute_zero_sample(self):
+        ext = PlayerExtractor(sample_interval=0)
+        parser = FakeParser(tick=300, game_time_s=None)
+        ext.attach(parser)
+        samples = []
+        ext._sample = (  # type: ignore[method-assign]
+            lambda tick, minute=False: samples.append((tick, minute))
+        )
+
+        ext._on_entity(_hero("Axe", index=1), EntityOp.UPDATED)
+        parser.game_time_s = 0
+        ext._on_game_start(parser.tick)
+        ext._on_entity(_ent("CDOTAGamerulesProxy"), EntityOp.UPDATED)
+
+        assert samples == [(300, False), (300, True)]
+
+    def test_game_start_leaves_first_entity_to_take_minute_zero_sample(self):
+        ext = PlayerExtractor(sample_interval=9999)
+        parser = FakeParser(tick=300, game_time_s=0)
+        ext.attach(parser)
+        samples = []
+        ext._sample = (  # type: ignore[method-assign]
+            lambda tick, minute=False: samples.append((tick, minute))
+        )
+
+        ext._on_game_start(parser.tick)
+        assert samples == []
+
+        ext._on_entity(_ent("CDOTAGamerulesProxy"), EntityOp.UPDATED)
+
+        assert samples == [(300, True)]
+
     def test_sample_taken_when_interval_elapsed(self):
         ext = PlayerExtractor(sample_interval=100)
         parser = FakeParser(tick=200)


### PR DESCRIPTION
## Summary

- add a parser-only packet-entity path that skips unused per-update result tuples while preserving the public ordered result list
- deduplicate player sampling eligibility checks by parser tick, including the minute-zero lifecycle edge case
- cache player hero aliases and interval hero names with serial-safe deletion, reconnect, and recycled-slot handling
- skip interval entity-side emit calls when tick-start sampling owns the boundary

## Performance

Measured on `tests/fixtures/opendota/8822520406.dem` using three fresh uninstrumented public parses:

| Metric | Post-#144 baseline | This PR | Change |
| --- | ---: | ---: | ---: |
| Median elapsed | 86.59 s | 76.59 s | -11.5% |
| Median peak RSS | 224,346,112 B | 223,870,976 B | -0.2% |

This PRs three runs were 76.57 s, 76.77 s, and 76.59 s, with peak RSS of 224,280,576 B, 223,789,056 B, and 223,870,976 B.

Instrumented call counts on the same fixture:

| Hot path | Before | After |
| --- | ---: | ---: |
| Player sampling eligibility | 2,169,002 | 51,312 |
| Interval hero-name resolution | 1,330,198 | 42 |
| Packet-entity messages using non-collecting path | 0 | 51,370 |

The normalized `ParsedMatch` remains byte-identical at 33,045,789 bytes with SHA-256 `5af5fe7a53b4806469828d1e3dc6550b662a2592179c87f692e4e381f695243e`.

## Testing

- [x] `uv run pytest tests/ -m "not integration" -q` — 1,793 passed, 3 skipped
- [x] canonical TI2026 integration gate — 37 passed
- [x] retained OpenDota interval-axis regression — 2 passed
- [x] canonical and medium TI2026 OpenDota parity — 651 passed, 2 skipped, 0 warnings/failures/errors
- [x] long TI2026 stress parity — 331 passed, 1 skipped, 0 warnings/failures/errors
- [x] `uv run ruff format --check src tests`
- [x] `uv run ruff check src tests`
- [x] `uv run mypy src/gem`

Closes #145