### PR TITLE
perf: reduce FieldState traversal overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   decompressed size and SHA-256 digest.
 
 ### Changed
+- **Faster entity field traversal.** Nested entity field reads and writes now
+  inline their slot and child checks, reducing core decoder overhead without
+  changing the stored state model or missing-value behavior.
 - **Lower per-entity parser overhead.** Replay parsing now skips unused
   entity-operation result tuples, deduplicates player sampling checks per tick,
   and caches stable hero-name resolution without changing parsed output.

--- a/src/gem/schema/field_state.py
+++ b/src/gem/schema/field_state.py
@@ -47,17 +47,19 @@ class FieldState:
         Returns:
             The stored value, or None if the slot is empty/missing.
         """
-        node: FieldState = self
-        for i in range(fp.last + 1):
-            z = fp.path[i]
-            if not node._has_slot(z):
+        path = fp.path
+        last = fp.last
+        state = self._state
+        for i in range(last + 1):
+            idx = path[i]
+            if len(state) < idx + 2:
                 return None
-            if i == fp.last:
-                return node._state[z]
-            child = node._state[z]
-            if not self._is_child(child):
+            if i == last:
+                return state[idx]
+            child = state[idx]
+            if not isinstance(child, FieldState):
                 return None
-            node = child
+            state = child._state
         return None
 
     def set(self, fp: FieldPath, value: FieldValue) -> None:
@@ -71,16 +73,22 @@ class FieldState:
             fp: A FieldPath produced by read_field_paths.
             value: The decoded value to store.
         """
-        node: FieldState = self
-        for i in range(fp.last + 1):
-            z = fp.path[i]
-            node._ensure(z)
-            if i == fp.last:
-                if not self._is_child(node._state[z]):
-                    node._state[z] = value
+        path = fp.path
+        last = fp.last
+        state = self._state
+        for i in range(last + 1):
+            idx = path[i]
+            current_len = len(state)
+            if current_len < idx + 2:
+                new_len = max(idx + 2, current_len * 2)
+                state.extend([None] * (new_len - current_len))
+
+            current = state[idx]
+            if i == last:
+                if not isinstance(current, FieldState):
+                    state[idx] = value
                 return
-            child = node._state[z]
-            if not self._is_child(child):
-                child = FieldState()
-                node._state[z] = child
-            node = child
+            if not isinstance(current, FieldState):
+                current = FieldState()
+                state[idx] = current
+            state = current._state

--- a/tests/test_field_state.py
+++ b/tests/test_field_state.py
@@ -279,6 +279,79 @@ class TestFieldStateSetDepth2:
 
 
 # ---------------------------------------------------------------------------
+# Hot-path traversal invariants
+# ---------------------------------------------------------------------------
+
+
+class TestFieldStateTraversal:
+    def test_get_and_set_do_not_dispatch_through_helpers(self, monkeypatch):
+        def fail(*_args):
+            pytest.fail("hot traversal dispatched through a helper")
+
+        monkeypatch.setattr(FieldState, "_has_slot", fail)
+        monkeypatch.setattr(FieldState, "_ensure", fail)
+        monkeypatch.setattr(FieldState, "_is_child", staticmethod(fail))
+
+        fs = FieldState()
+        fp = _make_fp(7, 100)
+        fs.set(fp, "value")
+        assert fs.get(fp) == "value"
+
+    def test_sparse_nested_write_uses_exact_growth_rule(self):
+        fs = FieldState()
+        fs.set(_make_fp(7, 100), "value")
+
+        assert len(fs._state) == 16
+        child = fs._state[7]
+        assert isinstance(child, FieldState)
+        assert len(child._state) == 102
+        assert child._state[100] == "value"
+
+    def test_missing_nested_read_does_not_mutate_state(self):
+        fs = FieldState()
+        child = FieldState()
+        child._state[0] = "existing"
+        fs._state[0] = child
+        root_before = list(fs._state)
+        child_before = list(child._state)
+
+        assert fs.get(_make_fp(0, 100)) is None
+        assert fs._state == root_before
+        assert child._state == child_before
+
+    def test_deeper_write_replaces_intermediate_leaf_with_child(self):
+        fs = FieldState()
+        fs._state[0] = "leaf"
+
+        fs.set(_make_fp(0, 1), "nested")
+
+        assert isinstance(fs._state[0], FieldState)
+        assert fs.get(_make_fp(0, 1)) == "nested"
+
+    def test_leaf_write_preserves_subclass_child(self):
+        class DerivedFieldState(FieldState):
+            pass
+
+        fs = FieldState()
+        child = DerivedFieldState()
+        child._state[0] = "existing"
+        fs._state[0] = child
+
+        fs.set(_make_fp(0), "replacement")
+
+        assert fs._state[0] is child
+        assert fs.get(_make_fp(0, 0)) == "existing"
+
+    def test_maximum_depth_roundtrip(self):
+        fs = FieldState()
+        fp = _make_fp(0, 1, 2, 3, 4, 5, 6)
+
+        fs.set(fp, "deep")
+
+        assert fs.get(fp) == "deep"
+
+
+# ---------------------------------------------------------------------------
 # Multiple paths on the same FieldState
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- bind active path metadata and nested state lists locally in `FieldState.get` and `FieldState.set`
- inline slot existence, growth, and child-node checks while preserving the nested-list state model and Manta-compatible semantics
- add focused coverage for helper-free traversal, sparse growth, missing reads, child preservation, intermediate-leaf replacement, and maximum-depth paths
- document the performance improvement in the changelog

## Performance

Measured in fresh processes on `tests/fixtures/opendota/8822520406.dem`:

| Scenario | Baseline median | Optimized median | Change |
| --- | ---: | ---: | ---: |
| Public `gem.parse` | 76.59 s | 72.73 s | 5.0% faster |
| Core `ReplayParser.parse` | 51.86 s | 49.03 s | 5.5% faster |

Public peak RSS remained effectively flat at about 224 MB. Production traversal counting retained 335,194 reads and 9,962,805 writes while eliminating 15,868,940 `_has_slot`, 15,198,552 `_ensure`, and 15,533,746 `_is_child` dispatches.

The normalized public output matches the preceding baseline exactly: 33,045,771 bytes, SHA-256 `88712b6b104fa937cee13c5589708327a389e02bf70a95a3716fde9b5c2775b2`.

## Validation

- `uv run pytest -q` — 1,800 passed, 3 skipped
- focused FieldState/field-reader/entity suite — 172 passed
- Ruff check and format check — passed
- mypy — passed
- canonical TI2026 integration — 37 passed
- retained interval-axis lock-in — 2 passed
- TI2026 OpenDota parity:
  - canonical: 325 passed, 0 warnings/failures/errors, 1 intentional skip
  - extended: 326 passed, 0 warnings/failures/errors, 1 intentional skip
  - 93-minute stress: 331 passed, 0 warnings/failures/errors, 1 intentional skip

Closes #146