### PR TITLE
perf: share and compile entity field access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   decompressed size and SHA-256 digest.
 
 ### Changed
+- **Shared compiled entity field access.** Entity field-name resolutions now
+  live on parse-scoped serializers, and built-in parser/extractor hot loops
+  reuse compiled field plans instead of allocating per-entity lookup caches.
 - **Faster entity field traversal.** Nested entity field reads and writes now
   inline their slot and child checks, reducing core decoder overhead without
   changing the stored state model or missing-value behavior.

--- a/src/gem/extractors/_snapshots.py
+++ b/src/gem/extractors/_snapshots.py
@@ -12,6 +12,8 @@ import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from gem.schema.sendtable.models import FieldAccessPlan
+
 if TYPE_CHECKING:
     from gem.state.entities import Entity
 
@@ -30,6 +32,42 @@ TEAM_DIRE = 3
 # A coach occupies a row, so the 10 players can span more than 10 indices.
 PLAYER_RESOURCE_SCAN_LIMIT = 30
 
+_POSITION_FIELDS = FieldAccessPlan(
+    (
+        "CBodyComponent.m_cellX",
+        "CBodyComponent.m_cellY",
+        "CBodyComponent.m_vecX",
+        "CBodyComponent.m_vecY",
+    )
+)
+_PLAYER_ID_FIELDS = FieldAccessPlan(("m_nPlayerID", "m_iPlayerID", "m_iPlayerOwnerID"))
+_PLAYER_RESOURCE_FIELDS = FieldAccessPlan(
+    tuple(
+        field_name
+        for resource_idx in range(PLAYER_RESOURCE_SCAN_LIMIT)
+        for field_name in (
+            f"m_vecPlayerData.{resource_idx:04d}.m_iPlayerTeam",
+            f"m_vecPlayerTeamData.{resource_idx:04d}.m_iTeamSlot",
+        )
+    )
+)
+_HERO_SNAPSHOT_FIELDS = FieldAccessPlan(
+    (
+        "m_nPlayerID",
+        "m_iPlayerID",
+        "m_iTeamNum",
+        "m_nCurrentLevel",
+        "m_iCurrentXP",
+        "m_iHealth",
+        "m_iMaxHealth",
+        "m_flMana",
+        "m_flMaxMana",
+        "m_iLastHitCount",
+        "m_iDenies",
+        "m_lifeState",
+    )
+)
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -44,10 +82,11 @@ def _pos(entity: Entity) -> tuple[float, float] | None:
     Returns:
         ``(x, y)`` world coordinates, or ``None`` if any field is missing.
     """
-    cell_x = entity.get_uint32("CBodyComponent.m_cellX")
-    cell_y = entity.get_uint32("CBodyComponent.m_cellY")
-    vec_x = entity.get_float32("CBodyComponent.m_vecX")
-    vec_y = entity.get_float32("CBodyComponent.m_vecY")
+    cell_x_field, cell_y_field, vec_x_field, vec_y_field = entity._resolve_fields(_POSITION_FIELDS)
+    cell_x = entity._get_uint32_resolved(cell_x_field)
+    cell_y = entity._get_uint32_resolved(cell_y_field)
+    vec_x = entity._get_float32_resolved(vec_x_field)
+    vec_y = entity._get_float32_resolved(vec_y_field)
     if cell_x is None or cell_y is None or vec_x is None or vec_y is None:
         return None
     return (cell_x * _CELL_SIZE + vec_x, cell_y * _CELL_SIZE + vec_y)
@@ -81,16 +120,10 @@ def _player_id_from_entity(entity: Entity | None, *, allow_owner: bool = False) 
     """
     if entity is None:
         return None
-    fields = (
-        ("m_nPlayerID", "m_iPlayerID", "m_iPlayerOwnerID")
-        if allow_owner
-        else (
-            "m_nPlayerID",
-            "m_iPlayerID",
-        )
-    )
-    for field_name in fields:
-        val = entity.get_int32(field_name)
+    fields = entity._resolve_fields(_PLAYER_ID_FIELDS)
+    field_count = 3 if allow_owner else 2
+    for field_index in range(field_count):
+        val = entity._get_int32_resolved(fields[field_index])
         if val is not None and val >= 0:
             return val // 2
     return None
@@ -139,9 +172,10 @@ def scan_player_resource(player_resource: Entity) -> PlayerResourceScan:
     team_by_id: dict[int, int] = {}
     team_slot_by_id: dict[int, int] = {}
 
+    fields = player_resource._resolve_fields(_PLAYER_RESOURCE_FIELDS)
     for resource_idx in range(PLAYER_RESOURCE_SCAN_LIMIT):
-        team = player_resource.get_int32(f"m_vecPlayerData.{resource_idx:04d}.m_iPlayerTeam")
-        team_slot = player_resource.get_int32(f"m_vecPlayerTeamData.{resource_idx:04d}.m_iTeamSlot")
+        team = player_resource._get_int32_resolved(fields[resource_idx * 2])
+        team_slot = player_resource._get_int32_resolved(fields[resource_idx * 2 + 1])
         if team not in (TEAM_RADIANT, TEAM_DIRE) or team_slot is None or team_slot < 0:
             continue
         player_id = len(index_by_id)
@@ -205,26 +239,27 @@ def _snapshot_hero(entity: Entity, tick: int) -> PlayerStateSnapshot | None:
     """
     # m_nPlayerID (post-7.31) or m_iPlayerID (pre-7.31) — raw value is doubled;
     # divide by 2 to get player slot 0-9. Reference: opendota/Parse.java getPlayerSlotFromEntity()
-    player_id = entity.get_int32("m_nPlayerID")
+    fields = entity._resolve_fields(_HERO_SNAPSHOT_FIELDS)
+    player_id = entity._get_int32_resolved(fields[0])
     if player_id is None:
-        player_id = entity.get_int32("m_iPlayerID")
+        player_id = entity._get_int32_resolved(fields[1])
     if player_id is None or player_id < 0:
         return None
     player_id //= 2
 
-    team = entity.get_int32("m_iTeamNum") or 0
-    level = entity.get_int32("m_nCurrentLevel") or 0
-    xp = entity.get_int32("m_iCurrentXP") or 0
-    hp = entity.get_int32("m_iHealth") or 0
-    max_hp = entity.get_int32("m_iMaxHealth") or 0
-    mana = entity.get_float32("m_flMana") or 0.0
-    max_mana = entity.get_float32("m_flMaxMana") or 0.0
-    lh = entity.get_int32("m_iLastHitCount") or 0
-    dn = entity.get_int32("m_iDenies") or 0
+    team = entity._get_int32_resolved(fields[2]) or 0
+    level = entity._get_int32_resolved(fields[3]) or 0
+    xp = entity._get_int32_resolved(fields[4]) or 0
+    hp = entity._get_int32_resolved(fields[5]) or 0
+    max_hp = entity._get_int32_resolved(fields[6]) or 0
+    mana = entity._get_float32_resolved(fields[7]) or 0.0
+    max_mana = entity._get_float32_resolved(fields[8]) or 0.0
+    lh = entity._get_int32_resolved(fields[9]) or 0
+    dn = entity._get_int32_resolved(fields[10]) or 0
     # m_lifeState: 0 = alive, 1 = dying, 2 = dead. OpenDota's life_state_dead
     # counts time spent in the non-alive states; we treat any non-zero value as
     # dead for the per-snapshot sample. Defaults to 0 (alive) when absent.
-    life_state = entity.get_int32("m_lifeState") or 0
+    life_state = entity._get_int32_resolved(fields[11]) or 0
 
     pos = _pos(entity)
 

--- a/src/gem/extractors/courier.py
+++ b/src/gem/extractors/courier.py
@@ -12,10 +12,13 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from gem.extractors._snapshots import _pos
+from gem.schema.sendtable.models import FieldAccessPlan
 from gem.state.entities import Entity, EntityOp
 
 if TYPE_CHECKING:
     from gem.parser import ReplayParser
+
+_COURIER_FIELDS = FieldAccessPlan(("m_iTeamNum", "m_iCourierState", "m_bFlyingCourier"))
 
 
 @dataclass
@@ -103,9 +106,10 @@ class CourierExtractor:
 
     def _sample(self, tick: int) -> None:
         for entity in self._couriers.values():
-            team = entity.get_int32("m_iTeamNum") or 0
-            state = entity.get_int32("m_iCourierState") or 0
-            flying = entity.get_bool("m_bFlyingCourier") or False
+            fields = entity._resolve_fields(_COURIER_FIELDS)
+            team = entity._get_int32_resolved(fields[0]) or 0
+            state = entity._get_int32_resolved(fields[1]) or 0
+            flying = entity._get_bool_resolved(fields[2]) or False
             pos = _pos(entity)
             self.snapshots.append(
                 CourierSnapshot(

--- a/src/gem/extractors/draft.py
+++ b/src/gem/extractors/draft.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from gem.catalog import HEROES
+from gem.schema.sendtable.models import FieldAccessPlan
 from gem.state.entities import Entity, EntityOp
 
 if TYPE_CHECKING:
@@ -56,6 +57,23 @@ def _class_to_npc(class_name: str) -> str:
 # Number of ban slots (indices 0-13) and pick slots (indices 0-9) in draft
 _BAN_SLOTS = 14
 _PICK_SLOTS = 10
+_PLAYER_RESOURCE_DRAFT_FIELDS = FieldAccessPlan(
+    tuple(
+        field_name
+        for slot in range(_PICK_SLOTS)
+        for field_name in (
+            f"m_vecPlayerTeamData.{slot:04d}.m_nSelectedHeroID",
+            f"m_vecPlayerTeamData.{slot:04d}.m_hSelectedHero",
+        )
+    )
+)
+_GAMERULES_DRAFT_FIELDS = FieldAccessPlan(
+    (
+        "m_pGameRules.m_iActiveTeam",
+        *(f"m_pGameRules.m_BannedHeroes.{slot:04d}" for slot in range(_BAN_SLOTS)),
+        *(f"m_pGameRules.m_SelectedHeroes.{slot:04d}" for slot in range(_PICK_SLOTS)),
+    )
+)
 
 
 @dataclass
@@ -194,11 +212,13 @@ class DraftExtractor:
         if self._parser is None or self._parser.entity_manager is None:
             return
         em = self._parser.entity_manager
+        fields = pr._resolve_fields(_PLAYER_RESOURCE_DRAFT_FIELDS)
         for i in range(_PICK_SLOTS):
-            hid = pr.get_int32(f"m_vecPlayerTeamData.{i:04d}.m_nSelectedHeroID")
+            offset = i * 2
+            hid = pr._get_int32_resolved(fields[offset])
             if hid is None or hid <= 0 or hid in self._live_id_to_npc:
                 continue
-            handle = pr.get_uint32(f"m_vecPlayerTeamData.{i:04d}.m_hSelectedHero")
+            handle = pr._get_uint32_resolved(fields[offset + 1])
             if handle is None:
                 continue
             hero_entity = em.find_by_handle(handle)
@@ -224,11 +244,12 @@ class DraftExtractor:
 
     def _check_draft(self, entity: Entity) -> None:
         tick = self._parser.tick if self._parser else 0
-        active_team = entity.get_int32("m_pGameRules.m_iActiveTeam") or 0
+        fields = entity._resolve_fields(_GAMERULES_DRAFT_FIELDS)
+        active_team = entity._get_int32_resolved(fields[0]) or 0
 
         # Bans: m_pGameRules.m_BannedHeroes.0000-0013
         for i in range(_BAN_SLOTS):
-            hero_id = entity.get_int32(f"m_pGameRules.m_BannedHeroes.{i:04d}")
+            hero_id = entity._get_int32_resolved(fields[1 + i])
             if hero_id is None or hero_id <= 0:
                 continue
             key = (False, i, hero_id)
@@ -247,8 +268,9 @@ class DraftExtractor:
             )
 
         # Picks: m_pGameRules.m_SelectedHeroes.0000-0009
+        pick_offset = 1 + _BAN_SLOTS
         for i in range(_PICK_SLOTS):
-            hero_id = entity.get_int32(f"m_pGameRules.m_SelectedHeroes.{i:04d}")
+            hero_id = entity._get_int32_resolved(fields[pick_offset + i])
             if hero_id is None or hero_id <= 0:
                 continue
             key = (True, i, hero_id)

--- a/src/gem/extractors/intervals.py
+++ b/src/gem/extractors/intervals.py
@@ -32,6 +32,7 @@ from gem.extractors._snapshots import (
     scan_player_resource,
     team_data_prefix,
 )
+from gem.schema.sendtable.models import FieldAccessPlan
 from gem.state.entities import Entity, EntityOp
 
 if TYPE_CHECKING:
@@ -57,6 +58,32 @@ _TEAM_COUNTER_FIELDS: dict[str, str] = {
     "rune_pickups": "m_iRunePickups",
     "tower_kills": "m_iTowerKills",
 }
+
+_TEAM_DATA_FIELD_NAMES = (
+    "m_iTotalEarnedGold",
+    "m_iTotalEarnedXP",
+    "m_iLastHitCount",
+    "m_iDenyCount",
+    "m_iNetWorth",
+    *_TEAM_COUNTER_FIELDS.values(),
+)
+_TEAM_DATA_FIELDS = FieldAccessPlan(
+    tuple(
+        f"{team_data_prefix(team_slot)}.{field_name}"
+        for team_slot in range(5)
+        for field_name in _TEAM_DATA_FIELD_NAMES
+    )
+)
+_PLAYER_RESOURCE_SCALAR_FIELDS = FieldAccessPlan(
+    tuple(
+        f"m_vecPlayerTeamData.{resource_idx:04d}.{field_name}"
+        for resource_idx in range(30)
+        for field_name in ("m_flTeamFightParticipation", "m_iFirstBloodClaimed")
+    )
+)
+_HERO_NAME_FIELDS = FieldAccessPlan(
+    ("m_pEntity.m_nameStringableIndex", "m_pEntity.m_nameStringTableIndex")
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -511,19 +538,21 @@ class IntervalExtractor:
             prev: Per-team-slot cache of the frame before ``cur``.
         """
         tick = self._parser.tick if self._parser is not None else 0
+        fields = entity._resolve_fields(_TEAM_DATA_FIELDS)
+        width = len(_TEAM_DATA_FIELD_NAMES)
         for team_slot in range(5):
             existing = cur.get(team_slot)
             if existing is not None and existing[0] != tick:
                 prev[team_slot] = existing
-            prefix = team_data_prefix(team_slot)
+            offset = team_slot * width
             cur[team_slot] = (
                 tick,
                 (
-                    _int_or_zero(entity.get_int32(f"{prefix}.m_iTotalEarnedGold")),
-                    _int_or_zero(entity.get_int32(f"{prefix}.m_iTotalEarnedXP")),
-                    _int_or_zero(entity.get_int32(f"{prefix}.m_iLastHitCount")),
-                    _int_or_zero(entity.get_int32(f"{prefix}.m_iDenyCount")),
-                    _int_or_zero(entity.get_int32(f"{prefix}.m_iNetWorth")),
+                    _int_or_zero(entity._get_int32_resolved(fields[offset])),
+                    _int_or_zero(entity._get_int32_resolved(fields[offset + 1])),
+                    _int_or_zero(entity._get_int32_resolved(fields[offset + 2])),
+                    _int_or_zero(entity._get_int32_resolved(fields[offset + 3])),
+                    _int_or_zero(entity._get_int32_resolved(fields[offset + 4])),
                 ),
             )
 
@@ -539,11 +568,14 @@ class IntervalExtractor:
             entity: The just-updated ``CDOTA_DataRadiant``/``CDOTA_DataDire``.
             team: ``TEAM_RADIANT`` or ``TEAM_DIRE``.
         """
+        fields = entity._resolve_fields(_TEAM_DATA_FIELDS)
+        width = len(_TEAM_DATA_FIELD_NAMES)
+        counter_offset = 5
         for team_slot in range(5):
-            prefix = team_data_prefix(team_slot)
+            offset = team_slot * width + counter_offset
             counters = self._team_counters.setdefault((team, team_slot), {})
-            for attr, field_name in _TEAM_COUNTER_FIELDS.items():
-                value = entity.get_int32(f"{prefix}.{field_name}")
+            for field_index, attr in enumerate(_TEAM_COUNTER_FIELDS):
+                value = entity._get_int32_resolved(fields[offset + field_index])
                 if value is not None:
                     counters[attr] = value
 
@@ -592,11 +624,12 @@ class IntervalExtractor:
         resource_idx = self._player_index_by_id.get(player_id)
         if pr is None or resource_idx is None:
             return result
-        prefix = f"m_vecPlayerTeamData.{resource_idx:04d}"
-        tf = pr.get_float32(f"{prefix}.m_flTeamFightParticipation")
+        fields = pr._resolve_fields(_PLAYER_RESOURCE_SCALAR_FIELDS)
+        offset = resource_idx * 2
+        tf = pr._get_float32_resolved(fields[offset])
         if tf is not None and tf != float("inf"):
             result["teamfight_participation"] = tf
-        fb = pr.get_int32(f"{prefix}.m_iFirstBloodClaimed")
+        fb = pr._get_int32_resolved(fields[offset + 1])
         if fb is not None:
             result["firstblood_claimed"] = fb
         return result
@@ -645,13 +678,14 @@ class IntervalExtractor:
             return cur_frame[1]
         if prev_frame is not None and prev_frame[0] < emit_tick:
             return prev_frame[1]
-        prefix = team_data_prefix(team_slot)
+        fields = data_entity._resolve_fields(_TEAM_DATA_FIELDS)
+        offset = team_slot * len(_TEAM_DATA_FIELD_NAMES)
         return (
-            _int_or_zero(data_entity.get_int32(f"{prefix}.m_iTotalEarnedGold")),
-            _int_or_zero(data_entity.get_int32(f"{prefix}.m_iTotalEarnedXP")),
-            _int_or_zero(data_entity.get_int32(f"{prefix}.m_iLastHitCount")),
-            _int_or_zero(data_entity.get_int32(f"{prefix}.m_iDenyCount")),
-            _int_or_zero(data_entity.get_int32(f"{prefix}.m_iNetWorth")),
+            _int_or_zero(data_entity._get_int32_resolved(fields[offset])),
+            _int_or_zero(data_entity._get_int32_resolved(fields[offset + 1])),
+            _int_or_zero(data_entity._get_int32_resolved(fields[offset + 2])),
+            _int_or_zero(data_entity._get_int32_resolved(fields[offset + 3])),
+            _int_or_zero(data_entity._get_int32_resolved(fields[offset + 4])),
         )
 
     def _emit(
@@ -711,9 +745,10 @@ class IntervalExtractor:
             else None
         )
         if entity_names is not None:
-            name_idx = entity.get_int32("m_pEntity.m_nameStringableIndex")
+            fields = entity._resolve_fields(_HERO_NAME_FIELDS)
+            name_idx = entity._get_int32_resolved(fields[0])
             if name_idx is None:
-                name_idx = entity.get_int32("m_pEntity.m_nameStringTableIndex")
+                name_idx = entity._get_int32_resolved(fields[1])
             if name_idx is not None and name_idx >= 0:
                 item = entity_names.items.get(name_idx)
                 if item is not None:

--- a/src/gem/extractors/objectives.py
+++ b/src/gem/extractors/objectives.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 from gem.combat.log import CombatLogEntry
 from gem.extractors._snapshots import _player_id_from_entity, _pos
+from gem.schema.sendtable.models import FieldAccessPlan
 from gem.state.entities import EntityOp
 
 if TYPE_CHECKING:
@@ -48,6 +49,7 @@ _ROSHAN_ITEM_DROPS: dict[str, str] = {
 # unit carries a readable world position via ``CBodyComponent`` (same fields the
 # ward extractor reads), so the plant location is recoverable here.
 _BANNER_UNIT_CLASS = "CDOTA_Unit_Roshans_Banner"
+_BANNER_FIELDS = FieldAccessPlan(("m_lifeState", "m_iTeamNum", "m_hOwnerEntity"))
 
 # Tower NPC name prefix → owning team
 _TOWER_TEAM: dict[str, int] = {
@@ -351,7 +353,8 @@ class ObjectivesExtractor:
             self._banner_lifestate.pop(idx, None)
             return
 
-        life_state = entity.get_int32("m_lifeState")
+        fields = entity._resolve_fields(_BANNER_FIELDS)
+        life_state = entity._get_int32_resolved(fields[0])
         if life_state is None:
             life_state = 0 if op.has(EntityOp.CREATED) else 2
         prev_ls = self._banner_lifestate.get(idx, 2)
@@ -368,13 +371,13 @@ class ObjectivesExtractor:
         self._banner_seen.add(key)
 
         pos = _pos(entity)
-        team = entity.get_int32("m_iTeamNum") or 0
+        team = entity._get_int32_resolved(fields[1]) or 0
 
         # Resolve the planter via m_hOwnerEntity → owner entity → player slot,
         # mirroring ward placer attribution (the owner may be an owned unit, so
         # allow the m_iPlayerOwnerID fallback). -1 = unresolved.
         player_id = -1
-        owner_handle = entity.get_uint32("m_hOwnerEntity")
+        owner_handle = entity._get_uint32_resolved(fields[2])
         if owner_handle is not None and self._parser is not None:
             em = self._parser.entity_manager
             if em is not None:

--- a/src/gem/extractors/players.py
+++ b/src/gem/extractors/players.py
@@ -23,6 +23,7 @@ from gem.extractors._snapshots import (
     scan_player_resource,
     team_data_field,
 )
+from gem.schema.sendtable.models import FieldAccessPlan
 from gem.state.entities import Entity, EntityOp
 
 if TYPE_CHECKING:
@@ -41,6 +42,49 @@ _ITEM_SLOTS = 17  # total slots to scan (0-16) for ongoing inventory snapshots
 _STARTING_ITEM_SLOTS = 8
 _ABILITY_SLOTS = 32  # m_hAbilities.0000-0031 per hero entity
 _NULL_HANDLE = 0xFFFFFF  # empty slot sentinel
+
+_CONTROLLER_FIELDS = FieldAccessPlan(("m_hAssignedHero", "m_iGold", "m_iNetWorth"))
+_ENTITY_NAME_FIELDS = FieldAccessPlan(
+    ("m_pEntity.m_nameStringTableIndex", "m_pEntity.m_nameStringableIndex")
+)
+_ABILITY_ENTITY_FIELDS = FieldAccessPlan(
+    ("m_pEntity.m_nameStringTableIndex", "m_pEntity.m_nameStringableIndex", "m_iLevel")
+)
+_PLAYER_RESOURCE_KDA_FIELDS = FieldAccessPlan(
+    tuple(
+        f"m_vecPlayerTeamData.{resource_idx:04d}.{field_name}"
+        for resource_idx in range(30)
+        for field_name in ("m_iKills", "m_iDeaths", "m_iAssists")
+    )
+)
+_PLAYER_RESOURCE_HERO_FIELDS = FieldAccessPlan(
+    tuple(
+        f"m_vecPlayerTeamData.{resource_idx:04d}.{field_name}"
+        for resource_idx in range(30)
+        for field_name in ("m_hSelectedHero", "m_iLevel")
+    )
+)
+_TEAM_DATA_FIELDS = FieldAccessPlan(
+    tuple(
+        team_data_field(team_slot, field_name)
+        for team_slot in range(5)
+        for field_name in (
+            "m_iNetWorth",
+            "m_iTotalEarnedGold",
+            "m_iTotalEarnedXP",
+            "m_iLastHitCount",
+            "m_iDenyCount",
+        )
+    )
+)
+_ABILITY_HANDLE_FIELDS = FieldAccessPlan(
+    tuple(
+        field_name
+        for slot in range(_ABILITY_SLOTS)
+        for field_name in (f"m_hAbilities.{slot:04d}", f"m_vecAbilities.{slot:04d}")
+    )
+)
+_ITEM_HANDLE_FIELDS = FieldAccessPlan(tuple(f"m_hItems.{slot:04d}" for slot in range(_ITEM_SLOTS)))
 
 __all__ = ["PlayerExtractor", "PlayerStateSnapshot", "PlayerTimeSeries"]
 
@@ -182,14 +226,15 @@ class PlayerExtractor:
         # m_vecPlayerTeamData.%04d.m_iKills/Deaths/Assists on CDOTA_PlayerResource.
         pr = self._player_resource
         if pr is not None:
+            fields = pr._resolve_fields(_PLAYER_RESOURCE_KDA_FIELDS)
             for player_id in range(10):
                 # Read at the resource-array index for this logical slot — a coach
                 # shifts the array so index != slot. Reference: Parse.java
                 # validIndices.
-                prefix = f"m_vecPlayerTeamData.{self._resource_index(player_id):04d}"
-                k = pr.get_int32(f"{prefix}.m_iKills")
-                d = pr.get_int32(f"{prefix}.m_iDeaths")
-                a = pr.get_int32(f"{prefix}.m_iAssists")
+                offset = self._resource_index(player_id) * 3
+                k = pr._get_int32_resolved(fields[offset])
+                d = pr._get_int32_resolved(fields[offset + 1])
+                a = pr._get_int32_resolved(fields[offset + 2])
                 if k is not None or d is not None or a is not None:
                     self.scoreboard[player_id] = (k or 0, d or 0, a or 0)
 
@@ -545,15 +590,16 @@ class PlayerExtractor:
     def _hero_handle_for_player(self, player_id: int) -> int | None:
         ctrl = self._controllers.get(player_id)
         if ctrl is not None:
-            handle = ctrl.get_uint32("m_hAssignedHero")
+            assigned_hero = ctrl._resolve_fields(_CONTROLLER_FIELDS)[0]
+            handle = ctrl._get_uint32_resolved(assigned_hero)
             if handle is not None and handle != _NULL_HANDLE:
                 return handle
         pr = self._player_resource
         if pr is None:
             return None
-        handle = pr.get_uint32(
-            f"m_vecPlayerTeamData.{self._resource_index(player_id):04d}.m_hSelectedHero"
-        )
+        fields = pr._resolve_fields(_PLAYER_RESOURCE_HERO_FIELDS)
+        offset = self._resource_index(player_id) * 2
+        handle = pr._get_uint32_resolved(fields[offset])
         if handle is None or handle == _NULL_HANDLE:
             return None
         return handle
@@ -598,7 +644,8 @@ class PlayerExtractor:
             # The camelCase→snake_case conversion in _snapshot_hero inserts word
             # boundaries at every capital letter, which is wrong for compound names.
             if entity_names is not None:
-                name_idx = entity.get_int32("m_pEntity.m_nameStringableIndex")
+                name_fields = entity._resolve_fields(_ENTITY_NAME_FIELDS)
+                name_idx = entity._get_int32_resolved(name_fields[1])
                 if name_idx is not None and name_idx >= 0:
                     item = entity_names.items.get(name_idx)
                     if item is not None:
@@ -608,8 +655,9 @@ class PlayerExtractor:
             # m_iNetWorth = gold + item value (also on controller for convenience).
             ctrl = self._controllers.get(snap.player_id)
             if ctrl is not None:
-                gold = ctrl.get_int32("m_iGold")
-                nw = ctrl.get_int32("m_iNetWorth")
+                controller_fields = ctrl._resolve_fields(_CONTROLLER_FIELDS)
+                gold = ctrl._get_int32_resolved(controller_fields[1])
+                nw = ctrl._get_int32_resolved(controller_fields[2])
                 if gold is not None:
                     snap.gold = gold
                 if nw is not None:
@@ -632,19 +680,21 @@ class PlayerExtractor:
             if data_entity is not None:
                 # Prefer authoritative team slot; fall back to pid % 5
                 team_slot = self._player_team_slot.get(snap.player_id, snap.player_id % 5)
-                nw = data_entity.get_int32(team_data_field(team_slot, "m_iNetWorth"))
+                data_fields = data_entity._resolve_fields(_TEAM_DATA_FIELDS)
+                offset = team_slot * 5
+                nw = data_entity._get_int32_resolved(data_fields[offset])
                 if nw is not None and nw > 0:
                     snap.net_worth = nw
-                teg = data_entity.get_int32(team_data_field(team_slot, "m_iTotalEarnedGold"))
+                teg = data_entity._get_int32_resolved(data_fields[offset + 1])
                 if teg is not None and teg > 0:
                     snap.total_earned_gold = teg
-                tex = data_entity.get_int32(team_data_field(team_slot, "m_iTotalEarnedXP"))
+                tex = data_entity._get_int32_resolved(data_fields[offset + 2])
                 if tex is not None and tex > 0:
                     snap.total_earned_xp = tex
-                lh = data_entity.get_int32(team_data_field(team_slot, "m_iLastHitCount"))
+                lh = data_entity._get_int32_resolved(data_fields[offset + 3])
                 if lh is not None and lh > 0:
                     snap.lh = lh
-                dn = data_entity.get_int32(team_data_field(team_slot, "m_iDenyCount"))
+                dn = data_entity._get_int32_resolved(data_fields[offset + 4])
                 if dn is not None and dn > 0:
                     snap.dn = dn
             # Overlay authoritative hero level from CDOTA_PlayerResource
@@ -653,9 +703,9 @@ class PlayerExtractor:
             # Parse.java level read. Use the coach-aware resource index.
             pr = self._player_resource
             if pr is not None:
-                lvl = pr.get_int32(
-                    f"m_vecPlayerTeamData.{self._resource_index(snap.player_id):04d}.m_iLevel"
-                )
+                resource_fields = pr._resolve_fields(_PLAYER_RESOURCE_HERO_FIELDS)
+                offset = self._resource_index(snap.player_id) * 2
+                lvl = pr._get_int32_resolved(resource_fields[offset + 1])
                 if lvl is not None and lvl > 0:
                     snap.level = lvl
             snap.ability_levels = self._read_abilities(entity)
@@ -701,18 +751,21 @@ class PlayerExtractor:
             return {}
 
         result: dict[str, int] = {}
+        handle_fields = hero._resolve_fields(_ABILITY_HANDLE_FIELDS)
         for slot in range(_ABILITY_SLOTS):
-            handle = hero.get_uint32(f"m_hAbilities.{slot:04d}")
+            offset = slot * 2
+            handle = hero._get_uint32_resolved(handle_fields[offset])
             if handle is None:
-                handle = hero.get_uint32(f"m_vecAbilities.{slot:04d}")
+                handle = hero._get_uint32_resolved(handle_fields[offset + 1])
             if handle is None or handle == _NULL_HANDLE:
                 continue
             ability_entity = em.find_by_handle(handle)
             if ability_entity is None:
                 continue
-            name_idx = ability_entity.get_int32("m_pEntity.m_nameStringTableIndex")
+            ability_fields = ability_entity._resolve_fields(_ABILITY_ENTITY_FIELDS)
+            name_idx = ability_entity._get_int32_resolved(ability_fields[0])
             if name_idx is None:
-                name_idx = ability_entity.get_int32("m_pEntity.m_nameStringableIndex")
+                name_idx = ability_entity._get_int32_resolved(ability_fields[1])
             if name_idx is None or name_idx < 0:
                 continue
             item = entity_names.items.get(name_idx)
@@ -721,7 +774,7 @@ class PlayerExtractor:
             name = item[0] if isinstance(item, tuple) else str(item)
             if not name:
                 continue
-            level = ability_entity.get_int32("m_iLevel") or 0
+            level = ability_entity._get_int32_resolved(ability_fields[2]) or 0
             if level > 0:
                 result[name] = level
         return result
@@ -749,8 +802,9 @@ class PlayerExtractor:
             return {}
 
         result: dict[int, str] = {}
+        handle_fields = hero._resolve_fields(_ITEM_HANDLE_FIELDS)
         for slot in range(_ITEM_SLOTS):
-            handle = hero.get_uint32(f"m_hItems.{slot:04d}")
+            handle = hero._get_uint32_resolved(handle_fields[slot])
             if handle is None or handle == _NULL_HANDLE:
                 continue
             item_entity = em.find_by_handle(handle)
@@ -758,9 +812,10 @@ class PlayerExtractor:
                 continue
             # Newer replays use m_nameStringTableIndex; older ones use
             # m_nameStringableIndex. Try both, mirroring _read_abilities.
-            name_idx = item_entity.get_int32("m_pEntity.m_nameStringTableIndex")
+            name_fields = item_entity._resolve_fields(_ENTITY_NAME_FIELDS)
+            name_idx = item_entity._get_int32_resolved(name_fields[0])
             if name_idx is None:
-                name_idx = item_entity.get_int32("m_pEntity.m_nameStringableIndex")
+                name_idx = item_entity._get_int32_resolved(name_fields[1])
             if name_idx is None or name_idx < 0:
                 continue
             # EntityNames items are stored as (key_str, value_bytes); key_str is the name

--- a/src/gem/extractors/wards.py
+++ b/src/gem/extractors/wards.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Literal
 
 from gem.combat.log import CombatLogEntry
 from gem.extractors._snapshots import _player_id_from_entity, _pos
+from gem.schema.sendtable.models import FieldAccessPlan
 from gem.state.entities import Entity, EntityOp
 
 if TYPE_CHECKING:
@@ -35,6 +36,7 @@ _WARD_CLASSES: frozenset[str] = frozenset(
         "CDOTA_NPC_Observer_Ward_TrueSight",
     }
 )
+_WARD_FIELDS = FieldAccessPlan(("m_lifeState", "m_iTeamNum", "m_hOwnerEntity"))
 
 # Combat-log target names used in DEATH events for wards (ref Wards.java)
 _WARD_TARGET_NAMES: frozenset[str] = frozenset({"npc_dota_observer_wards", "npc_dota_sentry_wards"})
@@ -241,7 +243,8 @@ class WardsExtractor:
             self._active.pop(idx, None)
             return
 
-        life_state = entity.get_int32("m_lifeState")
+        fields = entity._resolve_fields(_WARD_FIELDS)
+        life_state = entity._get_int32_resolved(fields[0])
         if life_state is None:
             life_state = 0 if op.has(EntityOp.CREATED) else 2
 
@@ -265,12 +268,13 @@ class WardsExtractor:
     ) -> None:
         pos = _pos(entity)
         ward_type: Literal["observer", "sentry"] = "sentry" if "TrueSight" in cls else "observer"
-        team = entity.get_int32("m_iTeamNum") or 0
+        fields = entity._resolve_fields(_WARD_FIELDS)
+        team = entity._get_int32_resolved(fields[1]) or 0
 
         # Resolve placer via m_hOwnerEntity → owner entity → player slot
         player_id = -1
         placer_npc = ""
-        owner_handle = entity.get_uint32("m_hOwnerEntity")
+        owner_handle = entity._get_uint32_resolved(fields[2])
         if owner_handle is not None and self._parser is not None:
             em = self._parser.entity_manager
             if em is not None:

--- a/src/gem/parser.py
+++ b/src/gem/parser.py
@@ -89,11 +89,26 @@ from gem.proto.netmessages_pb2 import (
 from gem.proto.networkbasetypes_pb2 import CNETMsg_Tick
 from gem.results.models import ChatEntry, NeutralItemFoundEvent
 from gem.schema.sendtable import parse_send_tables
+from gem.schema.sendtable.models import FieldAccessPlan
 from gem.state.entities import Entity, EntityManager, EntityOp
 from gem.state.game_events import GameEventHandler, GameEventManager
 from gem.state.string_table import StringTables, handle_create, handle_update
 
 logger = logging.getLogger(__name__)
+
+_GAMERULES_FIELDS = FieldAccessPlan(
+    (
+        "m_pGameRules.m_flGameStartTime",
+        "m_pGameRules.m_fGameTime",
+        "m_pGameRules.m_bGamePaused",
+        "m_pGameRules.m_nPauseStartTick",
+        "m_pGameRules.m_nTotalPausedTicks",
+        "m_pGameRules.m_unMatchID64",
+        "m_pGameRules.m_iGameMode",
+        "m_pGameRules.m_unLeagueID",
+        "m_pGameRules.m_nGameWinner",
+    )
+)
 
 # ---------------------------------------------------------------------------
 # Outer EDemoCommands IDs (stripped of DEM_IsCompressed = 0x40)
@@ -327,7 +342,8 @@ class ReplayParser:
         self._update_game_clock(entity)
         if self._grp_game_start_seen:
             return
-        v = entity.get_float32("m_pGameRules.m_flGameStartTime")
+        game_start = entity._resolve_fields(_GAMERULES_FIELDS)[0]
+        v = entity._get_float32_resolved(game_start)
         if v is None or v == 0.0:
             return
         self._grp_game_start_seen = True
@@ -343,20 +359,21 @@ class ReplayParser:
         output time is then shifted by ``m_flGameStartTime``. Keep this as
         separate metadata so public raw-tick fields remain unchanged.
         """
-        start = entity.get_float32("m_pGameRules.m_flGameStartTime")
+        fields = entity._resolve_fields(_GAMERULES_FIELDS)
+        start = entity._get_float32_resolved(fields[0])
         if start is not None and start != 0.0:
             self._game_start_time_s = _round_positive_seconds(start)
 
         if self._game_start_time_s is None:
             return
 
-        game_time = entity.get_float32("m_pGameRules.m_fGameTime")
+        game_time = entity._get_float32_resolved(fields[1])
         if game_time is not None:
             raw_time_s = _round_positive_seconds(game_time)
         else:
-            paused = entity.get_bool("m_pGameRules.m_bGamePaused") or False
-            pause_start_tick = entity.get_int32("m_pGameRules.m_nPauseStartTick")
-            total_paused_ticks = entity.get_int32("m_pGameRules.m_nTotalPausedTicks") or 0
+            paused = entity._get_bool_resolved(fields[2]) or False
+            pause_start_tick = entity._get_int32_resolved(fields[3])
+            total_paused_ticks = entity._get_int32_resolved(fields[4]) or 0
             parser_tick = self.net_tick if self._net_tick_seen else self.tick
             time_tick = pause_start_tick if paused and pause_start_tick is not None else parser_tick
             raw_time_s = _round_positive_seconds((time_tick - total_paused_ticks) / 30.0)
@@ -501,16 +518,17 @@ class ReplayParser:
         if self.entity_manager is not None:
             grp = self.entity_manager.find_by_class_name("CDOTAGamerulesProxy")
             if grp is not None:
+                fields = grp._resolve_fields(_GAMERULES_FIELDS)
                 if not self.match_id:
-                    v = grp.get_uint32("m_pGameRules.m_unMatchID64")
+                    v = grp._get_uint32_resolved(fields[5])
                     if v:
                         self.match_id = v
                 if not self.game_mode:
-                    v = grp.get_int32("m_pGameRules.m_iGameMode")
+                    v = grp._get_int32_resolved(fields[6])
                     if v:
                         self.game_mode = v
                 if not self.leagueid:
-                    v = grp.get_uint32("m_pGameRules.m_unLeagueID")
+                    v = grp._get_uint32_resolved(fields[7])
                     if v:
                         self.leagueid = v
                 # Fallback for radiant_win when CDemoFileInfo.game_winner == 0
@@ -518,7 +536,7 @@ class ReplayParser:
                 # 2 = RadVictory, 3 = DireVictory.
                 # Reference: refs/manta/dota/dota_shared_enums.proto
                 if self.radiant_win is None:
-                    v = grp.get_int32("m_pGameRules.m_nGameWinner")
+                    v = grp._get_int32_resolved(fields[8])
                     if v == 2:
                         self.radiant_win = True
                     elif v == 3:

--- a/src/gem/schema/sendtable/models.py
+++ b/src/gem/schema/sendtable/models.py
@@ -14,6 +14,7 @@ import re
 from dataclasses import dataclass, field
 
 from gem.schema.field_decoder import FieldDecoder, find_decoder, find_decoder_by_base_type
+from gem.schema.field_path import FieldPath
 
 # Types whose serializer is embedded by pointer (fixed-table model).
 _POINTER_TYPES: frozenset[str] = frozenset(
@@ -172,6 +173,38 @@ class Field:
         }.get(self.model, "unknown")
 
 
+@dataclass(frozen=True, slots=True)
+class ResolvedField:
+    """One serializer-relative entity field lookup result."""
+
+    name: str
+    path: FieldPath | None
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class FieldAccessPlan:
+    """Identity-keyed group of entity fields compiled together by a serializer.
+
+    Plans are module-level constants on hot paths.  Identity equality keeps each
+    serializer lookup O(1) without re-hashing every field name in a large plan.
+    """
+
+    names: tuple[str, ...]
+    unresolved: tuple[ResolvedField, ...] = field(
+        init=False,
+        repr=False,
+        compare=False,
+        hash=False,
+    )
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "unresolved",
+            tuple(ResolvedField(name, None) for name in self.names),
+        )
+
+
 @dataclass
 class Serializer:
     """A named, versioned entity class schema with ordered fields."""
@@ -179,7 +212,87 @@ class Serializer:
     name: str
     version: int
     fields: list[Field] = field(default_factory=list)
+    _resolved_fields: dict[str, ResolvedField] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+        compare=False,
+    )
+    _resolved_plans: dict[FieldAccessPlan, tuple[ResolvedField, ...]] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def _resolve_field(self, name: str) -> ResolvedField:
+        """Return the parse-scoped cached resolution for *name*."""
+        try:
+            return self._resolved_fields[name]
+        except KeyError:
+            resolved = ResolvedField(name, _find_field_path(self, name))
+            self._resolved_fields[name] = resolved
+            return resolved
+
+    def _resolve_plan(self, plan: FieldAccessPlan) -> tuple[ResolvedField, ...]:
+        """Resolve and cache every field in *plan* as one reusable tuple."""
+        try:
+            return self._resolved_plans[plan]
+        except KeyError:
+            resolved = tuple(self._resolve_field(name) for name in plan.names)
+            self._resolved_plans[plan] = resolved
+            return resolved
 
     def __repr__(self) -> str:
         """Return a compact representation for parser/debug output."""
         return f"Serializer({self.name!r}, v{self.version}, {len(self.fields)} fields)"
+
+
+def _find_field_path(serializer: Serializer, name: str) -> FieldPath | None:
+    fp = FieldPath()
+    if _resolve_in_serializer(serializer, fp, name, 0):
+        return fp
+    return None
+
+
+def _resolve_in_serializer(serializer: Serializer, fp: FieldPath, name: str, depth: int) -> bool:
+    for i, f in enumerate(serializer.fields):
+        if name == f.var_name:
+            fp.path[depth] = i
+            fp.last = depth
+            return True
+        if name.startswith(f.var_name + "."):
+            fp.path[depth] = i
+            remainder = name[len(f.var_name) + 1 :]
+            return _resolve_in_field(f, fp, remainder, depth + 1)
+    return False
+
+
+def _resolve_in_field(f: Field, fp: FieldPath, name: str, depth: int) -> bool:
+    model = f.model
+
+    if model in (FIELD_MODEL_FIXED_ARRAY, FIELD_MODEL_VARIABLE_ARRAY):
+        if len(name) == 4:
+            try:
+                fp.path[depth] = int(name)
+                fp.last = depth
+                return True
+            except ValueError:
+                return False
+        return False
+
+    if model == FIELD_MODEL_FIXED_TABLE:
+        if f.serializer is not None:
+            return _resolve_in_serializer(f.serializer, fp, name, depth)
+        return False
+
+    if model == FIELD_MODEL_VARIABLE_TABLE:
+        if f.serializer is not None and len(name) >= 6:
+            try:
+                fp.path[depth] = int(name[:4])
+            except ValueError:
+                return False
+            return _resolve_in_serializer(f.serializer, fp, name[5:], depth + 1)
+        return False
+
+    return False

--- a/src/gem/state/README.md
+++ b/src/gem/state/README.md
@@ -125,11 +125,10 @@ _field_state  the FieldState tree that replay decoding actually writes into,
 
 `get("m_iHealth")` returns `_state["m_iHealth"]` if present, otherwise it
 resolves the name to a `FieldPath` through the serializer and reads
-`_field_state`. Two small caches make the slow path cheap on repeat:
-
-- `_fp_cache` — memoizes `name → FieldPath` so a resolved field isn't re-walked.
-- `_fp_noop` — memoizes names that **don't** resolve, so repeatedly asking for a
-  field a class doesn't have doesn't re-search the serializer tree every time.
+`_field_state`. Positive and negative resolutions are cached on the shared
+serializer, so every entity using that schema reuses the same lookup result.
+Built-in hot loops can resolve immutable field plans once and read those paths
+directly while retaining the same overlay precedence.
 
 Typed accessors (`get_int32`, `get_float32`, `get_string`, …) wrap `get()` and
 coerce. This dual-storage design is why test code can construct an `Entity` and
@@ -179,8 +178,8 @@ missing fields. This is an ordering bug, not a decoder bug.
 ### `_field_state` is sparse; `get()` returns `None` for absent fields
 
 An entity only carries the fields that were actually sent. Reading a field a
-class doesn't have returns `None` (and is cached in `_fp_noop`). Callers must
-tolerate `None` rather than assume every field is present.
+class doesn't have returns `None` (and the miss is cached by its serializer).
+Callers must tolerate `None` rather than assume every field is present.
 
 ### Slot indices are reused — check serials
 

--- a/src/gem/state/entities.py
+++ b/src/gem/state/entities.py
@@ -24,13 +24,9 @@ from gem.schema.field_path import FieldPath
 from gem.schema.field_reader import read_fields
 from gem.schema.field_state import FieldState
 from gem.schema.sendtable import (
-    FIELD_MODEL_FIXED_ARRAY,
-    FIELD_MODEL_FIXED_TABLE,
-    FIELD_MODEL_VARIABLE_ARRAY,
-    FIELD_MODEL_VARIABLE_TABLE,
-    Field,
     Serializer,
 )
+from gem.schema.sendtable.models import FieldAccessPlan, ResolvedField
 from gem.state.string_table import StringTables
 
 # ---------------------------------------------------------------------------
@@ -40,6 +36,8 @@ from gem.state.string_table import StringTables
 _INDEX_BITS: int = 14
 _HANDLE_MASK: int = (1 << _INDEX_BITS) - 1
 _GAME_BUILD_RE = re.compile(r"/dota_v(\d+)/")
+_MISSING = object()
+_ENTITY_NAME_FIELDS = FieldAccessPlan(("m_pEntity.m_nameStringableIndex",))
 
 
 # ---------------------------------------------------------------------------
@@ -121,8 +119,6 @@ class Entity:
         "active",
         "_field_state",
         "_state",
-        "_fp_cache",
-        "_fp_noop",
     )
 
     def __init__(self, index: int, serial: int, cls: Any) -> None:
@@ -133,8 +129,6 @@ class Entity:
         self._field_state = FieldState()
         # Flat dict for direct key-value access (tests may write here directly)
         self._state: dict[str, Any] = {}
-        self._fp_cache: dict[str, FieldPath] = {}
-        self._fp_noop: set[str] = set()
 
     # ------------------------------------------------------------------
     # Field access
@@ -156,22 +150,78 @@ class Entity:
         if name in self._state:
             return self._state[name]
 
-        # Slow path: resolve through serializer field paths
+        # Resolve once per shared serializer, rather than once per entity.
         serializer = getattr(self.cls, "serializer", None)
         if serializer is None:
             return None
-        if name in self._fp_noop:
+        resolved = serializer._resolve_field(name)
+        if resolved.path is None:
             return None
-        if name in self._fp_cache:
-            return self._field_state.get(self._fp_cache[name])
+        return self._field_state.get(resolved.path)
 
-        fp = _find_field_path(serializer, name)
-        if fp is None:
-            self._fp_noop.add(name)
+    def _resolve_fields(self, plan: FieldAccessPlan) -> tuple[ResolvedField, ...]:
+        """Resolve one reusable field plan for this entity's serializer."""
+        serializer = self.cls.serializer
+        if serializer is None:
+            return plan.unresolved
+        return serializer._resolve_plan(plan)
+
+    def _get_resolved(self, field: ResolvedField) -> Any:
+        """Read a pre-resolved field while preserving flat-overlay precedence."""
+        value = self._state.get(field.name, _MISSING)
+        if value is not _MISSING:
+            return value
+        if field.path is None:
             return None
+        return self._field_state.get(field.path)
 
-        self._fp_cache[name] = fp
-        return self._field_state.get(fp)
+    def _get_int32_resolved(self, field: ResolvedField) -> int | None:
+        value = self._state.get(field.name, _MISSING)
+        if value is _MISSING:
+            if field.path is None:
+                return None
+            value = self._field_state.get(field.path)
+        return value if isinstance(value, int) else None
+
+    def _get_uint32_resolved(self, field: ResolvedField) -> int | None:
+        value = self._state.get(field.name, _MISSING)
+        if value is _MISSING:
+            if field.path is None:
+                return None
+            value = self._field_state.get(field.path)
+        return (value & 0xFFFFFFFF) if isinstance(value, int) else None
+
+    def _get_uint64_resolved(self, field: ResolvedField) -> int | None:
+        value = self._state.get(field.name, _MISSING)
+        if value is _MISSING:
+            if field.path is None:
+                return None
+            value = self._field_state.get(field.path)
+        return value if isinstance(value, int) else None
+
+    def _get_float32_resolved(self, field: ResolvedField) -> float | None:
+        value = self._state.get(field.name, _MISSING)
+        if value is _MISSING:
+            if field.path is None:
+                return None
+            value = self._field_state.get(field.path)
+        return float(value) if isinstance(value, (int, float)) else None
+
+    def _get_string_resolved(self, field: ResolvedField) -> str | None:
+        value = self._state.get(field.name, _MISSING)
+        if value is _MISSING:
+            if field.path is None:
+                return None
+            value = self._field_state.get(field.path)
+        return value if isinstance(value, str) else None
+
+    def _get_bool_resolved(self, field: ResolvedField) -> bool | None:
+        value = self._state.get(field.name, _MISSING)
+        if value is _MISSING:
+            if field.path is None:
+                return None
+            value = self._field_state.get(field.path)
+        return bool(value) if isinstance(value, (bool, int)) else None
 
     def exists(self, name: str) -> bool:
         """Return True if *name* has a value in the entity state.
@@ -289,53 +339,7 @@ class Entity:
 
 
 def _find_field_path(serializer: Serializer, name: str) -> FieldPath | None:
-    fp = FieldPath()
-    if _resolve_in_serializer(serializer, fp, name, 0):
-        return fp
-    return None
-
-
-def _resolve_in_serializer(serializer: Serializer, fp: FieldPath, name: str, depth: int) -> bool:
-    for i, f in enumerate(serializer.fields):
-        if name == f.var_name:
-            fp.path[depth] = i
-            fp.last = depth
-            return True
-        if name.startswith(f.var_name + "."):
-            fp.path[depth] = i
-            remainder = name[len(f.var_name) + 1 :]
-            return _resolve_in_field(f, fp, remainder, depth + 1)
-    return False
-
-
-def _resolve_in_field(f: Field, fp: FieldPath, name: str, depth: int) -> bool:
-    model = f.model
-
-    if model in (FIELD_MODEL_FIXED_ARRAY, FIELD_MODEL_VARIABLE_ARRAY):
-        if len(name) == 4:
-            try:
-                fp.path[depth] = int(name)
-                fp.last = depth
-                return True
-            except ValueError:
-                return False
-        return False
-
-    if model == FIELD_MODEL_FIXED_TABLE:
-        if f.serializer is not None:
-            return _resolve_in_serializer(f.serializer, fp, name, depth)
-        return False
-
-    if model == FIELD_MODEL_VARIABLE_TABLE:
-        if f.serializer is not None and len(name) >= 6:
-            try:
-                fp.path[depth] = int(name[:4])
-            except ValueError:
-                return False
-            return _resolve_in_serializer(f.serializer, fp, name[5:], depth + 1)
-        return False
-
-    return False
+    return serializer._resolve_field(name).path
 
 
 # ---------------------------------------------------------------------------
@@ -743,7 +747,8 @@ class EntityManager:
         for e in self.entities:
             if e is None or not e.active:
                 continue
-            idx = e.get_int32("m_pEntity.m_nameStringableIndex")
+            name_field = e._resolve_fields(_ENTITY_NAME_FIELDS)[0]
+            idx = e._get_int32_resolved(name_field)
             if idx is None:
                 continue
             item = names_table.items.get(idx)

--- a/tests/test_combat_aggregator.py
+++ b/tests/test_combat_aggregator.py
@@ -7,9 +7,11 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import fields
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from gem.combat.aggregator import _CombatAggregator, _ParsedPlayerAgg
+from gem.state.entities import Entity
 
 # ---------------------------------------------------------------------------
 # _ParsedPlayerAgg
@@ -65,15 +67,25 @@ class TestParsedPlayerAgg:
 # ---------------------------------------------------------------------------
 
 
-def _make_agg(player_id_raw: int = 0) -> tuple[_CombatAggregator, MagicMock]:
+def _hero_entity(player_id_raw: int) -> Entity:
+    """Return a real entity with a flat player-ID overlay."""
+    entity = Entity(
+        index=0,
+        serial=0,
+        cls=SimpleNamespace(name="CDOTA_Unit_Hero", class_id=0, serializer=None),
+    )
+    entity._state["m_nPlayerID"] = player_id_raw
+    return entity
+
+
+def _make_agg(player_id_raw: int = 0) -> tuple[_CombatAggregator, Entity]:
     """Return a _CombatAggregator wired to a single fake hero entity."""
     player_ext = MagicMock()
     # No entity manager in unit tests -> the summon->owner resolution path no-ops
     # cleanly (it returns None when ``_parser`` is None) instead of dereferencing
     # auto-generated MagicMock attributes.
     player_ext._parser = None
-    hero_entity = MagicMock()
-    hero_entity.get_int32.return_value = player_id_raw
+    hero_entity = _hero_entity(player_id_raw)
     player_ext._heroes_by_npc = {"npc_dota_hero_axe": hero_entity}
     return _CombatAggregator(player_ext), hero_entity
 
@@ -134,10 +146,8 @@ class TestCombatAggregatorDamage:
     def test_damage_taken_on_target(self):
         player_ext = MagicMock()
         # attacker = axe (pid 0), target = mirana (pid 1)
-        axe_entity = MagicMock()
-        axe_entity.get_int32.return_value = 0
-        mirana_entity = MagicMock()
-        mirana_entity.get_int32.return_value = 2  # slot 1
+        axe_entity = _hero_entity(0)
+        mirana_entity = _hero_entity(2)  # slot 1
         player_ext._heroes_by_npc = {
             "npc_dota_hero_axe": axe_entity,
             "npc_dota_hero_mirana": mirana_entity,
@@ -157,10 +167,8 @@ class TestCombatAggregatorDamage:
 
     def test_damage_taken_by_type_accumulates_for_target(self):
         player_ext = MagicMock()
-        axe_entity = MagicMock()
-        axe_entity.get_int32.return_value = 0
-        mirana_entity = MagicMock()
-        mirana_entity.get_int32.return_value = 2  # slot 1
+        axe_entity = _hero_entity(0)
+        mirana_entity = _hero_entity(2)  # slot 1
         player_ext._heroes_by_npc = {
             "npc_dota_hero_axe": axe_entity,
             "npc_dota_hero_mirana": mirana_entity,
@@ -288,10 +296,8 @@ class TestCombatAggregatorSourceAttribution:
     def test_damage_taken_keyed_by_source(self):
         player_ext = MagicMock()
         player_ext._parser = None
-        axe_entity = MagicMock()
-        axe_entity.get_int32.return_value = 0
-        mirana_entity = MagicMock()
-        mirana_entity.get_int32.return_value = 2  # slot 1
+        axe_entity = _hero_entity(0)
+        mirana_entity = _hero_entity(2)  # slot 1
         player_ext._heroes_by_npc = {
             "npc_dota_hero_axe": axe_entity,
             "npc_dota_hero_mirana": mirana_entity,
@@ -429,10 +435,8 @@ class TestDamageTypeConsistency:
 
     def test_damage_taken_by_type_sums_to_total_taken(self):
         player_ext = MagicMock()
-        axe_entity = MagicMock()
-        axe_entity.get_int32.return_value = 0
-        mirana_entity = MagicMock()
-        mirana_entity.get_int32.return_value = 2  # slot 1
+        axe_entity = _hero_entity(0)
+        mirana_entity = _hero_entity(2)  # slot 1
         player_ext._heroes_by_npc = {
             "npc_dota_hero_axe": axe_entity,
             "npc_dota_hero_mirana": mirana_entity,
@@ -472,8 +476,7 @@ class TestSummonKillAttribution:
         em = MagicMock()
         summon_entity = MagicMock()
         summon_entity.get_uint32.return_value = 12345  # owner handle
-        owner_entity = MagicMock()
-        owner_entity.get_int32.return_value = owner_slot_raw
+        owner_entity = _hero_entity(owner_slot_raw)
 
         def _find_by_npc_name(name):
             return summon_entity if name == summon_name else None
@@ -556,10 +559,8 @@ def _two_hero_agg() -> _CombatAggregator:
     """Aggregator with axe (pid 0) and mirana (pid 1) as resolvable heroes."""
     player_ext = MagicMock()
     player_ext._parser = None
-    axe = MagicMock()
-    axe.get_int32.return_value = 0  # raw // 2 -> slot 0
-    mirana = MagicMock()
-    mirana.get_int32.return_value = 2  # raw // 2 -> slot 1
+    axe = _hero_entity(0)  # raw // 2 -> slot 0
+    mirana = _hero_entity(2)  # raw // 2 -> slot 1
     player_ext._heroes_by_npc = {
         "npc_dota_hero_axe": axe,
         "npc_dota_hero_mirana": mirana,

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -379,9 +379,7 @@ class TestEntityGetViaFieldState:
         f.child_decoder = None
         f.serializer = None
 
-        ser = Serializer.__new__(Serializer)
-        ser.name = "TestSer"
-        ser.version = 0
+        ser = Serializer(name="TestSer", version=0)
         ser.fields = [f]
         return ser
 
@@ -397,9 +395,7 @@ class TestEntityGetViaFieldState:
         f.child_decoder = None
         f.serializer = None
 
-        ser = Serializer.__new__(Serializer)
-        ser.name = "ArrSer"
-        ser.version = 0
+        ser = Serializer(name="ArrSer", version=0)
         ser.fields = [f]
         return ser
 
@@ -417,10 +413,10 @@ class TestEntityGetViaFieldState:
         cls = FakeClass("T")
         cls.serializer = ser
         e = Entity(index=0, serial=0, cls=cls)
-        # First call for unknown field adds to _fp_noop
+        # First call records an explicit shared serializer miss.
         assert e.get("nonexistent") is None
-        assert e.get("nonexistent") is None  # hits noop cache
-        assert "nonexistent" in e._fp_noop
+        assert e.get("nonexistent") is None
+        assert ser._resolved_fields["nonexistent"].path is None
 
     def test_get_cache_hit_on_second_call(self):
         ser = self._make_simple_serializer()
@@ -428,9 +424,79 @@ class TestEntityGetViaFieldState:
         cls.serializer = ser
         e = Entity(index=0, serial=0, cls=cls)
         e._field_state.set(_fp(0), 99)
-        e.get("m_iHealth")  # populates _fp_cache
-        assert "m_iHealth" in e._fp_cache
+        e.get("m_iHealth")
+        assert ser._resolved_fields["m_iHealth"].path is not None
         assert e.get("m_iHealth") == 99  # hits cache
+
+    def test_entities_share_positive_and_negative_resolutions(self):
+        ser = self._make_simple_serializer()
+        cls = FakeClass("T")
+        cls.serializer = ser
+        first = Entity(index=0, serial=0, cls=cls)
+        second = Entity(index=1, serial=0, cls=cls)
+        first._field_state.set(_fp(0), 10)
+        second._field_state.set(_fp(0), 20)
+
+        assert first.get("m_iHealth") == 10
+        hit = ser._resolved_fields["m_iHealth"]
+        assert second.get("m_iHealth") == 20
+        assert ser._resolved_fields["m_iHealth"] is hit
+
+        assert first.get("missing") is None
+        miss = ser._resolved_fields["missing"]
+        assert miss.path is None
+        assert second.get("missing") is None
+        assert ser._resolved_fields["missing"] is miss
+
+    def test_distinct_serializers_do_not_share_resolution_state(self):
+        first_ser = self._make_simple_serializer()
+        second_ser = self._make_simple_serializer()
+        second_ser.version = 1
+
+        first_hit = first_ser._resolve_field("m_iHealth")
+        second_hit = second_ser._resolve_field("m_iHealth")
+
+        assert first_hit is not second_hit
+        assert first_ser._resolved_fields is not second_ser._resolved_fields
+
+    def test_resolved_access_preserves_overlay_precedence(self):
+        from gem.schema.sendtable.models import FieldAccessPlan
+
+        ser = self._make_simple_serializer()
+        cls = FakeClass("T")
+        cls.serializer = ser
+        e = Entity(index=0, serial=0, cls=cls)
+        e._field_state.set(_fp(0), 99)
+        plan = FieldAccessPlan(("m_iHealth", "missing"))
+        health, missing = e._resolve_fields(plan)
+
+        assert e._get_int32_resolved(health) == 99
+        e._state["m_iHealth"] = None
+        e._state["missing"] = 42
+        assert e._get_int32_resolved(health) is None
+        assert e._get_int32_resolved(missing) == 42
+
+    def test_field_plan_tuple_is_reused_by_serializer(self):
+        from gem.schema.sendtable.models import FieldAccessPlan
+
+        ser = self._make_simple_serializer()
+        plan = FieldAccessPlan(("m_iHealth", "missing"))
+
+        first = ser._resolve_plan(plan)
+        second = ser._resolve_plan(plan)
+
+        assert second is first
+        assert first[0].path is not None
+        assert first[1].path is None
+
+    def test_entity_does_not_allocate_field_resolution_caches(self):
+        ser = self._make_simple_serializer()
+        cls = FakeClass("T")
+        cls.serializer = ser
+        entity = Entity(index=0, serial=0, cls=cls)
+
+        assert not hasattr(entity, "_fp_cache")
+        assert not hasattr(entity, "_fp_noop")
 
     def test_get_array_field_by_index(self):
         ser = self._make_array_serializer()
@@ -462,9 +528,7 @@ class TestFindFieldPath:
             f.serializer = None
             fields.append(f)
 
-        ser = Serializer.__new__(Serializer)
-        ser.name = "S"
-        ser.version = 0
+        ser = Serializer(name="S", version=0)
         ser.fields = fields
         return ser
 
@@ -498,9 +562,7 @@ class TestFindFieldPath:
         f.child_decoder = None
         f.serializer = inner
 
-        ser = Serializer.__new__(Serializer)
-        ser.name = "S"
-        ser.version = 0
+        ser = Serializer(name="S", version=0)
         ser.fields = [f]
 
         fp = _find_field_path(ser, "m_nested.m_x")
@@ -520,9 +582,7 @@ class TestFindFieldPath:
         f.child_decoder = None
         f.serializer = None
 
-        ser = Serializer.__new__(Serializer)
-        ser.name = "S"
-        ser.version = 0
+        ser = Serializer(name="S", version=0)
         ser.fields = [f]
 
         fp = _find_field_path(ser, "m_Items.0002")
@@ -542,9 +602,7 @@ class TestFindFieldPath:
         f.child_decoder = None
         f.serializer = None
 
-        ser = Serializer.__new__(Serializer)
-        ser.name = "S"
-        ser.version = 0
+        ser = Serializer(name="S", version=0)
         ser.fields = [f]
 
         fp = _find_field_path(ser, "m_Vec.0007")
@@ -564,9 +622,7 @@ class TestFindFieldPath:
         f.child_decoder = None
         f.serializer = inner
 
-        ser = Serializer.__new__(Serializer)
-        ser.name = "S"
-        ser.version = 0
+        ser = Serializer(name="S", version=0)
         ser.fields = [f]
 
         fp = _find_field_path(ser, "m_tbl.0001.m_val")
@@ -788,10 +844,7 @@ class TestEntityManagerClassInfo:
     def test_serializer_linked_when_present(self):
         from gem.schema.sendtable import Serializer
 
-        ser = Serializer.__new__(Serializer)
-        ser.name = "CDOTA_Unit_Hero_Axe"
-        ser.version = 0
-        ser.fields = []
+        ser = Serializer(name="CDOTA_Unit_Hero_Axe", version=0)
 
         em = EntityManager(serializers={"CDOTA_Unit_Hero_Axe": ser}, string_tables=StringTables())
 

--- a/tests/test_objectives_extractor.py
+++ b/tests/test_objectives_extractor.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 from gem.combat.log import CombatLogEntry
+from gem.state.entities import Entity
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -73,7 +74,14 @@ class FakeParser:
             h(entity, op)
 
 
-class _FakeBannerEntity:
+class _FakeClass:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.class_id = 1
+        self.serializer = None
+
+
+class _FakeBannerEntity(Entity):
     """Minimal entity stub for the planted Roshan's Banner unit.
 
     Carries only the fields ``_on_banner_unit`` reads (class name, index,
@@ -82,51 +90,15 @@ class _FakeBannerEntity:
     """
 
     def __init__(self, idx, life_state, team=2) -> None:
-        self._idx = idx
-        self._life_state = life_state
-        self._team = team
-
-    def get_class_name(self):
-        return "CDOTA_Unit_Roshans_Banner"
-
-    def get_index(self):
-        return self._idx
-
-    def get_int32(self, field):
-        if field == "m_lifeState":
-            return self._life_state
-        if field == "m_iTeamNum":
-            return self._team
-        return None
-
-    def get_uint32(self, field):
-        return None
-
-    def get_float32(self, field):
-        return None
+        super().__init__(idx, serial=0, cls=_FakeClass("CDOTA_Unit_Roshans_Banner"))
+        self._state.update({"m_lifeState": life_state, "m_iTeamNum": team})
 
 
-class _FakeItemEntity:
+class _FakeItemEntity(Entity):
     """Minimal entity stub for a Roshan-dropped ``CDOTA_Item_*`` entity."""
 
     def __init__(self, idx, class_name) -> None:
-        self._idx = idx
-        self._class_name = class_name
-
-    def get_class_name(self):
-        return self._class_name
-
-    def get_index(self):
-        return self._idx
-
-    def get_int32(self, field):
-        return None
-
-    def get_uint32(self, field):
-        return None
-
-    def get_float32(self, field):
-        return None
+        super().__init__(idx, serial=0, cls=_FakeClass(class_name))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -21,6 +21,7 @@ Reference: manta/parser.go, manta/demo_packet.go
 from __future__ import annotations
 
 import logging
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -45,6 +46,7 @@ from gem.parser import (
     _read_inner_messages,
 )
 from gem.proto.networkbasetypes_pb2 import CNETMsg_Tick
+from gem.state.entities import Entity
 
 # ---------------------------------------------------------------------------
 # Helpers — build synthetic inner message blobs
@@ -295,12 +297,17 @@ class TestReplayParserGameClock:
     def test_game_rules_proxy_updates_game_time_seconds(self):
         p = ReplayParser(b"")
         p.tick = 6000
-        entity = MagicMock()
-        entity.get_class_name.return_value = "CDOTAGamerulesProxy"
-        entity.get_float32.side_effect = lambda name: {
-            "m_pGameRules.m_flGameStartTime": 100.0,
-            "m_pGameRules.m_fGameTime": 165.2,
-        }.get(name)
+        entity = Entity(
+            index=0,
+            serial=0,
+            cls=SimpleNamespace(name="CDOTAGamerulesProxy", class_id=1, serializer=None),
+        )
+        entity._state.update(
+            {
+                "m_pGameRules.m_flGameStartTime": 100.0,
+                "m_pGameRules.m_fGameTime": 165.2,
+            }
+        )
 
         p._on_entity_game_start(entity, MagicMock())
 
@@ -329,16 +336,20 @@ class TestReplayParserGameClock:
         p.tick = 9999
         p.net_tick = 6000
         p._net_tick_seen = True
-        entity = MagicMock()
-        entity.get_float32.side_effect = lambda name: {
-            "m_pGameRules.m_flGameStartTime": 100.0,
-            "m_pGameRules.m_fGameTime": None,
-        }.get(name)
-        entity.get_bool.return_value = False
-        entity.get_int32.side_effect = lambda name: {
-            "m_pGameRules.m_nPauseStartTick": 0,
-            "m_pGameRules.m_nTotalPausedTicks": 0,
-        }.get(name)
+        entity = Entity(
+            index=0,
+            serial=0,
+            cls=SimpleNamespace(name="CDOTAGamerulesProxy", class_id=1, serializer=None),
+        )
+        entity._state.update(
+            {
+                "m_pGameRules.m_flGameStartTime": 100.0,
+                "m_pGameRules.m_fGameTime": None,
+                "m_pGameRules.m_bGamePaused": False,
+                "m_pGameRules.m_nPauseStartTick": 0,
+                "m_pGameRules.m_nTotalPausedTicks": 0,
+            }
+        )
 
         p._update_game_clock(entity)
 

--- a/tests/test_players_extractor.py
+++ b/tests/test_players_extractor.py
@@ -290,6 +290,19 @@ class TestSnapshotHero:
         assert snap.xp == 1000
         assert snap.hp == 600
 
+    def test_hot_snapshot_path_bypasses_public_entity_get(self, monkeypatch):
+        entity = _hero("Axe", player_id=2)
+
+        def fail(*_args):
+            raise AssertionError("snapshot fell back through Entity.get")
+
+        monkeypatch.setattr(Entity, "get", fail)
+
+        snap = _snapshot_hero(entity, tick=100)
+
+        assert snap is not None
+        assert snap.player_id == 2
+
     def test_player_id_halved(self):
         e = _hero("Pudge", player_id=3)  # m_nPlayerID = 6
         snap = _snapshot_hero(e, tick=0)


### PR DESCRIPTION
## Summary

- move positive and negative dotted-field resolution caches from entities to parse-scoped serializers
- add identity-keyed compiled field plans and optimized internal typed accessors
- migrate parser and built-in extractor hot paths, including bounded player/team/ability/item fields
- preserve public getter, typed conversion, missing-field, and flat-overlay behavior

## Rationale

Entities share serializer schemas, so resolving and retaining the same field names on every entity duplicated work and memory. Compiling those names once per serializer lets hot loops reuse FieldPath objects without leaking schema state between replay parses.

Closes #147

## Performance and parity

- normalized 8822520406 ParsedMatch remains exactly 33,045,771 bytes with SHA-256 88712b6b104fa937cee13c5589708327a389e02bf70a95a3716fde9b5c2775b2
- full-parse elapsed times: 72.219 s, 72.009 s, 84.111 s; median 72.219 s versus 72.734 s previously
- peak RSS: 213,876,736; 223,887,360; 224,428,032 bytes; median 223,887,360 bytes
- profiled public Entity.get calls: 41, down from the documented 26.6 million baseline
- serializer caches retained approximately 604 KB across 2,068 resolutions and 615 compiled plan tuples

## Testing

- [x] uv run ruff check .
- [x] uv run ruff format --check .
- [x] uv run mypy src
- [x] uv run pytest -q — 1,806 passed, 3 skipped
- [x] uv run pytest -q -m "slow or integration" — 62 passed
- [x] exact normalized-output parity on tests/fixtures/opendota/8822520406.dem
- [ ] Docs build — not applicable; only the internal state README changed

## Notes

- [x] Generated protobuf files under src/gem/proto/ were not edited manually.
- [x] Large replay artifacts are not committed.
- [x] Secrets and local credentials are not included.