### PR TITLE
perf: compact field paths and cache decoder resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   decompressed size and SHA-256 digest.
 
 ### Changed
+- **Compact cached field decoding.** Entity deltas now retain compact immutable
+  field paths and reuse parse-scoped serializer decoder resolutions, reducing
+  path allocation and repeated schema traversal without changing decoded state.
 - **Shared compiled entity field access.** Entity field-name resolutions now
   live on parse-scoped serializers, and built-in parser/extractor hot loops
   reuse compiled field plans instead of allocating per-entity lookup caches.

--- a/src/gem/schema/field_path/models.py
+++ b/src/gem/schema/field_path/models.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from typing import TypeAlias
+
 _RESET = [-1, 0, 0, 0, 0, 0, 0]
+CompactFieldPath: TypeAlias = tuple[int, ...]
 
 
 class FieldPath:
@@ -52,13 +55,38 @@ class FieldPath:
         fp.done = self.done
         return fp
 
-    def to_tuple(self) -> tuple[int, ...]:
+    def to_tuple(self) -> CompactFieldPath:
         """Return the active indices as an immutable tuple.
 
         Returns:
             Tuple of active integer indices, e.g. ``(2, 0, 5)``.
         """
-        return tuple(self.path[: self.last + 1])
+        path = self.path
+        last = self.last
+        if last < 0:
+            return ()
+        if last == 0:
+            return (path[0],)
+        if last == 1:
+            return (path[0], path[1])
+        if last == 2:
+            return (path[0], path[1], path[2])
+        if last == 3:
+            return (path[0], path[1], path[2], path[3])
+        if last == 4:
+            return (path[0], path[1], path[2], path[3], path[4])
+        if last == 5:
+            return (path[0], path[1], path[2], path[3], path[4], path[5])
+        return (path[0], path[1], path[2], path[3], path[4], path[5], path[6])
+
+    @classmethod
+    def _from_tuple(cls, path: CompactFieldPath) -> FieldPath:
+        """Materialize a mutable compatibility path from compact indices."""
+        fp = cls()
+        for index, value in enumerate(path):
+            fp.path[index] = value
+        fp.last = len(path) - 1
+        return fp
 
     def to_str(self) -> str:
         """Return a slash-separated string of active indices.

--- a/src/gem/schema/field_path/path_sequence.py
+++ b/src/gem/schema/field_path/path_sequence.py
@@ -10,15 +10,15 @@ from gem.schema.field_path.huffman import (
     _HUFF_TABLE_BITS,
     HUFF_TREE,
 )
-from gem.schema.field_path.models import FieldPath
+from gem.schema.field_path.models import CompactFieldPath, FieldPath
 from gem.schema.field_path.operations import FIELD_PATH_OPS
 
 if TYPE_CHECKING:
     from gem.binary.reader import BitReader
 
 
-def read_field_paths(r: BitReader) -> list[FieldPath]:
-    """Decode a Huffman-coded sequence of field paths from r.
+def _read_compact_field_paths(r: BitReader) -> list[CompactFieldPath]:
+    """Decode a Huffman-coded sequence into compact immutable paths.
 
     Uses a flat O(1) decode table to resolve each Huffman op in a single
     peek + skip rather than a per-bit tree walk. The peek/skip/rem_bits
@@ -32,11 +32,11 @@ def read_field_paths(r: BitReader) -> list[FieldPath]:
         r: BitReader positioned at the start of the field path sequence.
 
     Returns:
-        List of FieldPath objects, one per updated field (not including the
+        Compact active-index tuples, one per updated field (not including the
         finish sentinel).
     """
     fp = FieldPath()
-    paths: list[FieldPath] = []
+    paths: list[CompactFieldPath] = []
     ops = FIELD_PATH_OPS
     table = _HUFF_DECODE_TABLE
     table_bits = _HUFF_TABLE_BITS
@@ -76,6 +76,38 @@ def read_field_paths(r: BitReader) -> list[FieldPath]:
 
         ops[op_idx].fn(r, fp)
         if not fp.done:
-            paths.append(fp.copy())
+            path = fp.path
+            last = fp.last
+            if last == 0:
+                paths.append((path[0],))
+            elif last == 1:
+                paths.append((path[0], path[1]))
+            elif last == 2:
+                paths.append((path[0], path[1], path[2]))
+            elif last == 3:
+                paths.append((path[0], path[1], path[2], path[3]))
+            elif last == 4:
+                paths.append((path[0], path[1], path[2], path[3], path[4]))
+            elif last == 5:
+                paths.append((path[0], path[1], path[2], path[3], path[4], path[5]))
+            else:
+                paths.append((path[0], path[1], path[2], path[3], path[4], path[5], path[6]))
 
     return paths
+
+
+def read_field_paths(r: BitReader) -> list[FieldPath]:
+    """Decode field paths into independent mutable compatibility objects.
+
+    Production entity decoding consumes :func:`_read_compact_field_paths`
+    directly.  This public wrapper preserves the established ``FieldPath``
+    return type for schema callers and tests.
+
+    Args:
+        r: BitReader positioned at the start of the field path sequence.
+
+    Returns:
+        List of FieldPath objects, one per updated field (not including the
+        finish sentinel).
+    """
+    return [FieldPath._from_tuple(path) for path in _read_compact_field_paths(r)]

--- a/src/gem/schema/field_reader.py
+++ b/src/gem/schema/field_reader.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 
 from gem.binary.reader import BitReader
 from gem.schema.field_decoder import FieldDecoder
-from gem.schema.field_path import FieldPath, read_field_paths
+from gem.schema.field_path import FieldPath
+from gem.schema.field_path.models import CompactFieldPath
+from gem.schema.field_path.path_sequence import _read_compact_field_paths
 from gem.schema.field_state import FieldState
 from gem.schema.sendtable import (
     FIELD_MODEL_FIXED_ARRAY,
@@ -22,14 +24,33 @@ from gem.schema.sendtable import (
 
 
 def _resolve_decoder(serializer: Serializer, fp: FieldPath, pos: int) -> FieldDecoder | None:
-    """Resolve the decoder for ``fp`` starting at ``serializer.fields[pos]``."""
-    f: Field = serializer.fields[fp.path[pos]]
-    return _resolve_field_decoder(f, fp, pos + 1)
+    """Compatibility resolver for a mutable ``FieldPath``."""
+    return _resolve_compact_decoder(serializer, fp.to_tuple(), pos)
 
 
 def _resolve_field_decoder(f: Field, fp: FieldPath, pos: int) -> FieldDecoder | None:
-    """Resolve the decoder for a field-path step within one send-table field."""
+    """Compatibility field resolver for a mutable ``FieldPath``."""
+    return _resolve_compact_field_decoder(f, fp.to_tuple(), pos)
+
+
+def _resolve_compact_decoder(
+    serializer: Serializer,
+    path: CompactFieldPath,
+    pos: int,
+) -> FieldDecoder | None:
+    """Resolve the decoder for a compact path from one serializer level."""
+    f: Field = serializer.fields[path[pos]]
+    return _resolve_compact_field_decoder(f, path, pos + 1)
+
+
+def _resolve_compact_field_decoder(
+    f: Field,
+    path: CompactFieldPath,
+    pos: int,
+) -> FieldDecoder | None:
+    """Resolve one compact field-path step using Source 2 field models."""
     model = f.model
+    last = len(path) - 1
 
     if model in (FIELD_MODEL_SIMPLE, FIELD_MODEL_FIXED_ARRAY):
         return f.decoder
@@ -38,35 +59,48 @@ def _resolve_field_decoder(f: Field, fp: FieldPath, pos: int) -> FieldDecoder | 
         # A path ending on the table field decodes the table presence bit.
         # Deeper paths continue inside the referenced serializer at the same
         # path position, matching manta/field.go:getDecoderForFieldPath.
-        if fp.last == pos - 1:
+        if last == pos - 1:
             return f.base_decoder
-        return _resolve_decoder(_require_serializer(f, fp, pos), fp, pos)
+        return _resolve_compact_decoder(_require_serializer(f, path, pos), path, pos)
 
     if model == FIELD_MODEL_VARIABLE_ARRAY:
         # Variable arrays use the base decoder for length metadata and the
         # child decoder for element slots.
-        if fp.last == pos:
+        if last == pos:
             return f.child_decoder
         return f.base_decoder
 
     if model == FIELD_MODEL_VARIABLE_TABLE:
         # Variable tables encode a length/index layer before nested fields, so
         # recursion skips one extra path component.
-        if fp.last >= pos + 1:
-            return _resolve_decoder(_require_serializer(f, fp, pos), fp, pos + 1)
+        if last >= pos + 1:
+            return _resolve_compact_decoder(_require_serializer(f, path, pos), path, pos + 1)
         return f.base_decoder
 
     return f.decoder
 
 
-def _require_serializer(f: Field, fp: FieldPath, pos: int) -> Serializer:
+def _require_serializer(f: Field, path: CompactFieldPath, pos: int) -> Serializer:
     if f.serializer is None:
-        path = fp.to_str()
+        path_string = "/".join(str(index) for index in path)
         raise ValueError(
             f"{f.model_name()} field {f.var_name!r} needs a serializer "
-            f"to resolve field path {path!r} at position {pos}"
+            f"to resolve field path {path_string!r} at position {pos}"
         )
     return f.serializer
+
+
+def _resolve_cached_decoder(
+    serializer: Serializer,
+    path: CompactFieldPath,
+) -> FieldDecoder | None:
+    """Return a parse-scoped cached decoder, including explicit None results."""
+    try:
+        return serializer._resolved_decoders[path]
+    except KeyError:
+        decoder = _resolve_compact_decoder(serializer, path, 0)
+        serializer._resolved_decoders[path] = decoder
+        return decoder
 
 
 # Backwards-compatible private aliases for older internal tests/imports.
@@ -82,9 +116,14 @@ def read_fields(r: BitReader, serializer: Serializer, state: FieldState) -> None
         serializer: The Serializer schema for this entity class.
         state: The FieldState tree to update.
     """
-    fps = read_field_paths(r)
-    for fp in fps:
-        decoder = _resolve_decoder(serializer, fp, 0)
+    paths = _read_compact_field_paths(r)
+    decoder_cache = serializer._resolved_decoders
+    for path in paths:
+        try:
+            decoder = decoder_cache[path]
+        except KeyError:
+            decoder = _resolve_compact_decoder(serializer, path, 0)
+            decoder_cache[path] = decoder
         if decoder is not None:
             value = decoder(r)
-            state.set(fp, value)
+            state._set_compact(path, value)

--- a/src/gem/schema/field_state.py
+++ b/src/gem/schema/field_state.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import TypeAlias, TypeGuard
 
 from gem.schema.field_path import FieldPath
+from gem.schema.field_path.models import CompactFieldPath
 
 FieldValue: TypeAlias = object | None
 
@@ -62,6 +63,21 @@ class FieldState:
             state = child._state
         return None
 
+    def _get_compact(self, path: CompactFieldPath) -> FieldValue:
+        """Read an internal compact path without materializing a FieldPath."""
+        state = self._state
+        last = len(path) - 1
+        for i, idx in enumerate(path):
+            if len(state) < idx + 2:
+                return None
+            if i == last:
+                return state[idx]
+            child = state[idx]
+            if not isinstance(child, FieldState):
+                return None
+            state = child._state
+        return None
+
     def set(self, fp: FieldPath, value: FieldValue) -> None:
         """Write a value at the given field path, growing the tree as needed.
 
@@ -78,6 +94,26 @@ class FieldState:
         state = self._state
         for i in range(last + 1):
             idx = path[i]
+            current_len = len(state)
+            if current_len < idx + 2:
+                new_len = max(idx + 2, current_len * 2)
+                state.extend([None] * (new_len - current_len))
+
+            current = state[idx]
+            if i == last:
+                if not isinstance(current, FieldState):
+                    state[idx] = value
+                return
+            if not isinstance(current, FieldState):
+                current = FieldState()
+                state[idx] = current
+            state = current._state
+
+    def _set_compact(self, path: CompactFieldPath, value: FieldValue) -> None:
+        """Write an internal compact path without materializing a FieldPath."""
+        state = self._state
+        last = len(path) - 1
+        for i, idx in enumerate(path):
             current_len = len(state)
             if current_len < idx + 2:
                 new_len = max(idx + 2, current_len * 2)

--- a/src/gem/schema/sendtable/models.py
+++ b/src/gem/schema/sendtable/models.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 
 from gem.schema.field_decoder import FieldDecoder, find_decoder, find_decoder_by_base_type
 from gem.schema.field_path import FieldPath
+from gem.schema.field_path.models import CompactFieldPath
 
 # Types whose serializer is embedded by pointer (fixed-table model).
 _POINTER_TYPES: frozenset[str] = frozenset(
@@ -178,7 +179,7 @@ class ResolvedField:
     """One serializer-relative entity field lookup result."""
 
     name: str
-    path: FieldPath | None
+    path: CompactFieldPath | None
 
 
 @dataclass(frozen=True, slots=True, eq=False)
@@ -224,6 +225,12 @@ class Serializer:
         repr=False,
         compare=False,
     )
+    _resolved_decoders: dict[CompactFieldPath, FieldDecoder | None] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+        compare=False,
+    )
 
     def _resolve_field(self, name: str) -> ResolvedField:
         """Return the parse-scoped cached resolution for *name*."""
@@ -248,10 +255,10 @@ class Serializer:
         return f"Serializer({self.name!r}, v{self.version}, {len(self.fields)} fields)"
 
 
-def _find_field_path(serializer: Serializer, name: str) -> FieldPath | None:
+def _find_field_path(serializer: Serializer, name: str) -> CompactFieldPath | None:
     fp = FieldPath()
     if _resolve_in_serializer(serializer, fp, name, 0):
-        return fp
+        return fp.to_tuple()
     return None
 
 

--- a/src/gem/state/README.md
+++ b/src/gem/state/README.md
@@ -120,15 +120,18 @@ them in order:
 _state        a plain dict overlay. Checked FIRST. Tests (and any flat lookup)
               can write here directly to bypass schema resolution.
 _field_state  the FieldState tree that replay decoding actually writes into,
-              addressed by FieldPath. The real source of decoded values.
+              addressed internally by compact active-index tuples. The real
+              source of decoded values.
 ```
 
 `get("m_iHealth")` returns `_state["m_iHealth"]` if present, otherwise it
-resolves the name to a `FieldPath` through the serializer and reads
+resolves the name to a compact field path through the serializer and reads
 `_field_state`. Positive and negative resolutions are cached on the shared
 serializer, so every entity using that schema reuses the same lookup result.
+Entity-delta decoder selection is cached on that same parse-scoped serializer.
 Built-in hot loops can resolve immutable field plans once and read those paths
-directly while retaining the same overlay precedence.
+directly while retaining the same overlay precedence. The public mutable
+`FieldPath` model remains available for schema-level callers and diagnostics.
 
 Typed accessors (`get_int32`, `get_float32`, `get_string`, …) wrap `get()` and
 coerce. This dual-storage design is why test code can construct an `Entity` and

--- a/src/gem/state/entities.py
+++ b/src/gem/state/entities.py
@@ -157,7 +157,7 @@ class Entity:
         resolved = serializer._resolve_field(name)
         if resolved.path is None:
             return None
-        return self._field_state.get(resolved.path)
+        return self._field_state._get_compact(resolved.path)
 
     def _resolve_fields(self, plan: FieldAccessPlan) -> tuple[ResolvedField, ...]:
         """Resolve one reusable field plan for this entity's serializer."""
@@ -173,14 +173,14 @@ class Entity:
             return value
         if field.path is None:
             return None
-        return self._field_state.get(field.path)
+        return self._field_state._get_compact(field.path)
 
     def _get_int32_resolved(self, field: ResolvedField) -> int | None:
         value = self._state.get(field.name, _MISSING)
         if value is _MISSING:
             if field.path is None:
                 return None
-            value = self._field_state.get(field.path)
+            value = self._field_state._get_compact(field.path)
         return value if isinstance(value, int) else None
 
     def _get_uint32_resolved(self, field: ResolvedField) -> int | None:
@@ -188,7 +188,7 @@ class Entity:
         if value is _MISSING:
             if field.path is None:
                 return None
-            value = self._field_state.get(field.path)
+            value = self._field_state._get_compact(field.path)
         return (value & 0xFFFFFFFF) if isinstance(value, int) else None
 
     def _get_uint64_resolved(self, field: ResolvedField) -> int | None:
@@ -196,7 +196,7 @@ class Entity:
         if value is _MISSING:
             if field.path is None:
                 return None
-            value = self._field_state.get(field.path)
+            value = self._field_state._get_compact(field.path)
         return value if isinstance(value, int) else None
 
     def _get_float32_resolved(self, field: ResolvedField) -> float | None:
@@ -204,7 +204,7 @@ class Entity:
         if value is _MISSING:
             if field.path is None:
                 return None
-            value = self._field_state.get(field.path)
+            value = self._field_state._get_compact(field.path)
         return float(value) if isinstance(value, (int, float)) else None
 
     def _get_string_resolved(self, field: ResolvedField) -> str | None:
@@ -212,7 +212,7 @@ class Entity:
         if value is _MISSING:
             if field.path is None:
                 return None
-            value = self._field_state.get(field.path)
+            value = self._field_state._get_compact(field.path)
         return value if isinstance(value, str) else None
 
     def _get_bool_resolved(self, field: ResolvedField) -> bool | None:
@@ -220,7 +220,7 @@ class Entity:
         if value is _MISSING:
             if field.path is None:
                 return None
-            value = self._field_state.get(field.path)
+            value = self._field_state._get_compact(field.path)
         return bool(value) if isinstance(value, (bool, int)) else None
 
     def exists(self, name: str) -> bool:
@@ -339,7 +339,8 @@ class Entity:
 
 
 def _find_field_path(serializer: Serializer, name: str) -> FieldPath | None:
-    return serializer._resolve_field(name).path
+    path = serializer._resolve_field(name).path
+    return FieldPath._from_tuple(path) if path is not None else None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -425,7 +425,7 @@ class TestEntityGetViaFieldState:
         e = Entity(index=0, serial=0, cls=cls)
         e._field_state.set(_fp(0), 99)
         e.get("m_iHealth")
-        assert ser._resolved_fields["m_iHealth"].path is not None
+        assert ser._resolved_fields["m_iHealth"].path == (0,)
         assert e.get("m_iHealth") == 99  # hits cache
 
     def test_entities_share_positive_and_negative_resolutions(self):

--- a/tests/test_field_path.py
+++ b/tests/test_field_path.py
@@ -123,6 +123,18 @@ class TestFieldPath:
         fp.last = 1
         assert fp.to_str() == "1/2"
 
+    @pytest.mark.parametrize(
+        "indices",
+        [(), (0,), (1, 2), (1, 2, 3), (1, 2, 3, 4, 5, 6, 7)],
+    )
+    def test_tuple_roundtrip_uses_only_active_indices(self, indices):
+        from gem.schema.field_path import FieldPath
+
+        fp = FieldPath._from_tuple(indices)
+
+        assert fp.to_tuple() == indices
+        assert fp.last == len(indices) - 1
+
 
 class TestReadFieldPaths:
     def test_returns_list(self, read_field_paths, reader_cls):
@@ -138,6 +150,27 @@ class TestReadFieldPaths:
         result = read_field_paths(r)
         assert isinstance(result, list)
         assert len(result) == 1
+        assert result[0].to_tuple() == (0,)
+
+    def test_public_results_remain_independent_mutable_paths(self, read_field_paths, reader_cls):
+        data = _bits_to_bytes("0010")  # PlusOne, PlusOne, Finish
+
+        first, second = read_field_paths(reader_cls(data))
+        first.path[0] = 99
+
+        assert first.to_tuple() == (99,)
+        assert second.to_tuple() == (1,)
+
+    def test_compact_reader_does_not_copy_mutable_paths(self, monkeypatch, reader_cls):
+        from gem.schema.field_path import FieldPath
+        from gem.schema.field_path.path_sequence import _read_compact_field_paths
+
+        def fail_copy(_self):
+            pytest.fail("compact decoding must not call FieldPath.copy")
+
+        monkeypatch.setattr(FieldPath, "copy", fail_copy)
+
+        assert _read_compact_field_paths(reader_cls(_bits_to_bytes("0010"))) == [(0,), (1,)]
 
     def test_empty_result_on_immediate_finish(self, read_field_paths, reader_cls):
         """If the first op decoded is FinishEncoding, result should be empty.

--- a/tests/test_field_reader.py
+++ b/tests/test_field_reader.py
@@ -8,7 +8,13 @@ from __future__ import annotations
 import pytest
 
 from gem.schema.field_path import FieldPath
-from gem.schema.field_reader import _resolve_decoder, _resolve_field_decoder, read_fields
+from gem.schema.field_reader import (
+    _resolve_cached_decoder,
+    _resolve_compact_decoder,
+    _resolve_decoder,
+    _resolve_field_decoder,
+    read_fields,
+)
 from gem.schema.field_state import FieldState
 from gem.schema.sendtable import (
     FIELD_MODEL_FIXED_ARRAY,
@@ -66,6 +72,13 @@ def _make_serializer(*fields: Field, name: str = "TestSerializer") -> Serializer
     s = Serializer(name=name, version=0)
     s.fields = list(fields)
     return s
+
+
+def _constant_decoder(value):
+    def decode(_reader):
+        return value
+
+    return decode
 
 
 # ---------------------------------------------------------------------------
@@ -297,6 +310,156 @@ class TestGetDecoder:
 
 
 # ---------------------------------------------------------------------------
+# compact decoder resolution and serializer cache
+# ---------------------------------------------------------------------------
+
+
+class TestCompactDecoderResolution:
+    def test_simple_and_fixed_array_match_mutable_resolution(self):
+        for model, path in (
+            (FIELD_MODEL_SIMPLE, (0,)),
+            (FIELD_MODEL_FIXED_ARRAY, (0, 3)),
+        ):
+            decoder = _constant_decoder(5)
+            serializer = _make_serializer(_make_field(model, decoder=decoder))
+
+            assert _resolve_compact_decoder(serializer, path, 0) is decoder
+            assert _resolve_decoder(serializer, _make_fp(*path), 0) is decoder
+
+    def test_fixed_table_base_and_deep_paths_match_mutable_resolution(self):
+        base_decoder = _constant_decoder(True)
+        child_decoder = _constant_decoder(7)
+        child = _make_serializer(
+            _make_field(FIELD_MODEL_SIMPLE, decoder=child_decoder),
+            name="Inner",
+        )
+        serializer = _make_serializer(
+            _make_field(
+                FIELD_MODEL_FIXED_TABLE,
+                base_decoder=base_decoder,
+                serializer=child,
+            )
+        )
+
+        for path, expected in (((0,), base_decoder), ((0, 0), child_decoder)):
+            assert _resolve_compact_decoder(serializer, path, 0) is expected
+            assert _resolve_decoder(serializer, _make_fp(*path), 0) is expected
+
+    def test_variable_array_base_and_child_paths_match_mutable_resolution(self):
+        base_decoder = _constant_decoder(3)
+        child_decoder = _constant_decoder("element")
+        serializer = _make_serializer(
+            _make_field(
+                FIELD_MODEL_VARIABLE_ARRAY,
+                base_decoder=base_decoder,
+                child_decoder=child_decoder,
+            )
+        )
+
+        for path, expected in (((0,), base_decoder), ((0, 4), child_decoder)):
+            assert _resolve_compact_decoder(serializer, path, 0) is expected
+            assert _resolve_decoder(serializer, _make_fp(*path), 0) is expected
+
+    def test_variable_table_boundaries_and_deep_path_match_mutable_resolution(self):
+        base_decoder = _constant_decoder(2)
+        child_decoder = _constant_decoder("deep")
+        child = _make_serializer(
+            _make_field(FIELD_MODEL_SIMPLE, decoder=child_decoder),
+            name="Inner",
+        )
+        serializer = _make_serializer(
+            _make_field(
+                FIELD_MODEL_VARIABLE_TABLE,
+                base_decoder=base_decoder,
+                serializer=child,
+            )
+        )
+
+        for path, expected in (
+            ((0,), base_decoder),
+            ((0, 3), base_decoder),
+            ((0, 3, 0), child_decoder),
+        ):
+            assert _resolve_compact_decoder(serializer, path, 0) is expected
+            assert _resolve_decoder(serializer, _make_fp(*path), 0) is expected
+
+    def test_missing_nested_serializer_preserves_error(self):
+        serializer = _make_serializer(
+            _make_field(FIELD_MODEL_FIXED_TABLE, base_decoder=lambda r: True)
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="fixed-table field 'test' needs a serializer.*'0/0'.*position 1",
+        ):
+            _resolve_compact_decoder(serializer, (0, 0), 0)
+
+    def test_invalid_top_level_index_preserves_index_error(self):
+        serializer = _make_serializer(_make_field(FIELD_MODEL_SIMPLE, decoder=lambda r: 0))
+
+        with pytest.raises(IndexError):
+            _resolve_compact_decoder(serializer, (5,), 0)
+
+
+class TestDecoderCache:
+    def test_reuses_resolution_for_repeated_path(self, monkeypatch):
+        import gem.schema.field_reader as field_reader
+
+        decoder = _constant_decoder(5)
+        serializer = _make_serializer(_make_field(FIELD_MODEL_SIMPLE, decoder=decoder))
+        original = field_reader._resolve_compact_decoder
+        calls = 0
+
+        def counting_resolver(serializer, path, pos):
+            nonlocal calls
+            calls += 1
+            return original(serializer, path, pos)
+
+        monkeypatch.setattr(field_reader, "_resolve_compact_decoder", counting_resolver)
+
+        assert _resolve_cached_decoder(serializer, (0,)) is decoder
+        assert _resolve_cached_decoder(serializer, (0,)) is decoder
+        assert calls == 1
+
+    def test_caches_explicit_none(self, monkeypatch):
+        import gem.schema.field_reader as field_reader
+
+        serializer = _make_serializer(_make_field(FIELD_MODEL_SIMPLE, decoder=None))
+        original = field_reader._resolve_compact_decoder
+        calls = 0
+
+        def counting_resolver(serializer, path, pos):
+            nonlocal calls
+            calls += 1
+            return original(serializer, path, pos)
+
+        monkeypatch.setattr(field_reader, "_resolve_compact_decoder", counting_resolver)
+
+        assert _resolve_cached_decoder(serializer, (0,)) is None
+        assert _resolve_cached_decoder(serializer, (0,)) is None
+        assert serializer._resolved_decoders == {(0,): None}
+        assert calls == 1
+
+    def test_same_name_and_version_serializers_are_isolated(self):
+        first_decoder = _constant_decoder(1)
+        second_decoder = _constant_decoder(2)
+        first = _make_serializer(_make_field(FIELD_MODEL_SIMPLE, decoder=first_decoder))
+        second = _make_serializer(_make_field(FIELD_MODEL_SIMPLE, decoder=second_decoder))
+
+        assert _resolve_cached_decoder(first, (0,)) is first_decoder
+        assert _resolve_cached_decoder(second, (0,)) is second_decoder
+        assert first._resolved_decoders is not second._resolved_decoders
+
+    def test_failed_resolution_is_not_cached(self):
+        serializer = _make_serializer(_make_field(FIELD_MODEL_FIXED_TABLE))
+
+        with pytest.raises(ValueError):
+            _resolve_cached_decoder(serializer, (0, 0))
+
+        assert serializer._resolved_decoders == {}
+
+
+# ---------------------------------------------------------------------------
 # read_fields — integration with BitReader
 # ---------------------------------------------------------------------------
 
@@ -431,3 +594,37 @@ class TestReadFields:
         state = FieldState()
         r = BitReader(data)
         assert read_fields(r, ser, state) is None
+
+    def test_read_fields_uses_compact_paths_and_reuses_decoder_cache(self, monkeypatch):
+        """The production path bypasses mutable copies and public state traversal."""
+        from gem.binary.reader import BitReader
+        from gem.schema.field_path import FieldPath
+
+        def fail(*_args):
+            pytest.fail("read_fields dispatched through a mutable compatibility path")
+
+        monkeypatch.setattr(FieldPath, "copy", fail)
+        monkeypatch.setattr(FieldState, "set", fail)
+        decoder = _constant_decoder(42)
+        ser = _make_serializer(_make_field(FIELD_MODEL_SIMPLE, decoder=decoder))
+        state = FieldState()
+        data = self._bits_to_bytes("010")
+
+        read_fields(BitReader(data), ser, state)
+        read_fields(BitReader(data), ser, state)
+
+        assert state._get_compact((0,)) == 42
+        assert ser._resolved_decoders == {(0,): decoder}
+
+    def test_read_fields_caches_none_decoder(self):
+        from gem.binary.reader import BitReader
+
+        ser = _make_serializer(_make_field(FIELD_MODEL_SIMPLE, decoder=None))
+        state = FieldState()
+        data = self._bits_to_bytes("010")
+
+        read_fields(BitReader(data), ser, state)
+        read_fields(BitReader(data), ser, state)
+
+        assert ser._resolved_decoders == {(0,): None}
+        assert state._get_compact((0,)) is None

--- a/tests/test_field_state.py
+++ b/tests/test_field_state.py
@@ -22,6 +22,13 @@ def _make_fp(*indices: int) -> FieldPath:
     return fp
 
 
+def _state_tree(state: FieldState):
+    """Return nested list contents without comparing node identities."""
+    return [
+        _state_tree(value) if isinstance(value, FieldState) else value for value in state._state
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Construction
 # ---------------------------------------------------------------------------
@@ -349,6 +356,74 @@ class TestFieldStateTraversal:
         fs.set(fp, "deep")
 
         assert fs.get(fp) == "deep"
+
+
+# ---------------------------------------------------------------------------
+# compact-path traversal
+# ---------------------------------------------------------------------------
+
+
+class TestFieldStateCompactTraversal:
+    @pytest.mark.parametrize(
+        "path",
+        [(0,), (7,), (7, 100), (0, 1, 2, 3, 4, 5, 6)],
+    )
+    def test_roundtrip_matches_mutable_path(self, path):
+        compact_state = FieldState()
+        mutable_state = FieldState()
+
+        compact_state._set_compact(path, "value")
+        mutable_state.set(_make_fp(*path), "value")
+
+        assert _state_tree(compact_state) == _state_tree(mutable_state)
+        assert compact_state._get_compact(path) == "value"
+
+    def test_write_sequence_preserves_tree_semantics(self):
+        compact_state = FieldState()
+        mutable_state = FieldState()
+        writes = [((0,), "leaf"), ((0, 2), "nested"), ((0,), "ignored"), ((1,), None)]
+
+        for path, value in writes:
+            compact_state._set_compact(path, value)
+            mutable_state.set(_make_fp(*path), value)
+
+        assert _state_tree(compact_state) == _state_tree(mutable_state)
+        assert compact_state._get_compact((0, 2)) == "nested"
+        assert compact_state._get_compact((0,)) is compact_state._state[0]
+        assert compact_state._get_compact((1,)) is None
+
+    def test_missing_read_does_not_mutate_state(self):
+        state = FieldState()
+        state._set_compact((0, 1), "existing")
+        root_before = list(state._state)
+        child = state._state[0]
+        assert isinstance(child, FieldState)
+        child_before = list(child._state)
+
+        assert state._get_compact((0, 100)) is None
+        assert state._state == root_before
+        assert child._state == child_before
+
+    def test_empty_compact_path_is_a_noop(self):
+        state = FieldState()
+        before = list(state._state)
+
+        state._set_compact((), "ignored")
+
+        assert state._get_compact(()) is None
+        assert state._state == before
+
+    def test_compact_traversal_bypasses_public_methods(self, monkeypatch):
+        def fail(*_args):
+            pytest.fail("compact traversal dispatched through a public method")
+
+        monkeypatch.setattr(FieldState, "get", fail)
+        monkeypatch.setattr(FieldState, "set", fail)
+        state = FieldState()
+
+        state._set_compact((2, 3), "value")
+
+        assert state._get_compact((2, 3)) == "value"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- use compact immutable tuple paths in the production field-path decode pipeline while preserving the public mutable FieldPath API
- cache resolved field decoders per serializer and traverse FieldState directly with compact paths
- add compatibility, boundary, cache-lifecycle, state-parity, and production-path regression coverage
- update the changelog and entity-state internals documentation

## Rationale

Entity decoding copied roughly 10 million FieldPath objects and repeatedly performed recursive decoder resolution on the TI2026 stress fixture. Keeping Huffman mutation local, storing compact active-index tuples, and caching decoder resolution removes that allocation and dispatch overhead without changing parser output or public APIs.

Closes #148

## Testing

- [x] uv run ruff check src/ tests/
- [x] uv run ruff format --check src/ tests/
- [x] uv run mypy src/gem/
- [x] uv run pytest -m "not slow and not integration" — 1,833 passed, 3 skipped
- [x] slow/integration parser assertions — 61 passed; one draft-integration setup remained blocked by a confirmed OpenDota HTTP 522 response
- [x] offline TI2026 OpenDota parity for matches 8868259993, 8860187335, and 8856501050 — zero mismatches
- [x] normalized output checksum unchanged: 88712b6b104fa937cee13c5589708327a389e02bf70a95a3716fde9b5c2775b2
- [x] git diff --check
- [ ] Docs build — not required; no VitePress documentation changed

## Performance

TI2026 fixture, three fresh-process runs:

- public parse median: 64.15 s, 11.2% faster than the previous quiet baseline
- core parse median: 41.40 s, 15.6% faster than the previous quiet baseline
- production FieldPath.copy calls: approximately 9.96 million to zero
- recursive decoder-resolution calls: approximately 13.9 million to approximately 80 thousand
- median peak RSS: 228.2 MB, approximately 1.9% above the prior public baseline
- estimated parse-scoped decoder-cache ownership: approximately 5.6 MB

The remaining measurable Python hot paths include EntityManager.find_by_npc_name and repeated extractor field lookup. Those are intentionally outside this PR.

## Notes

- [x] Generated protobuf files under src/gem/proto/ were not edited manually.
- [x] Large replay artifacts are not committed.
- [x] Secrets and local credentials are not included.
- public parser, entity, result, and mutable FieldPath behavior remains compatible
- no Huffman operation, entity-state model, or Rust-extension changes are included
