### PR TITLE
docs: record parser performance improvements for v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-09-04
+
+Improves full-replay parsing speed without changing public APIs or normalized
+parser output, and makes integration fixture selection reproducible across
+development environments.
+
 ### Added
 - **Curated TI2026 replay corpus.** The short, medium, and long TI2026 qualifier
   replays are now named canonical, extended, and stress fixture tiers in the
@@ -36,6 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   replay happens to be found first. The DreamLeague performance baseline and
   feature-specific regression fixtures remain available, while replaced medium
   and long DreamLeague entries are retained as deprecated manifest records.
+- **Documented parser performance profile.** A new maintainer deep dive records
+  the benchmark method, the effect of the five Python optimization passes, output
+  parity checks, measurement limitations, and the remaining CPU and memory work.
 
 ## [0.7.0] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -652,7 +652,8 @@ combat-log layers. The supported top-level API (`gem.parse`, `gem.ParsedMatch`,
 - CLI and example scripts, including HTML match report.
 - Validation, fuzzing, and parser robustness foundations.
 
-[Unreleased]: https://github.com/whanyu1212/gem-dota/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/whanyu1212/gem-dota/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/whanyu1212/gem-dota/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/whanyu1212/gem-dota/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/whanyu1212/gem-dota/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/whanyu1212/gem-dota/compare/v0.5.0...v0.5.1

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -36,6 +36,7 @@ export default defineConfig({
         text: "Internals",
         items: [
           { text: "Parser Internals", link: "/deep-dives/" },
+          { text: "Parser Performance", link: "/deep-dives/parser-performance" },
           { text: "Replay Edge Cases", link: "/deep-dives/replay-edge-cases" },
         ],
       },

--- a/docs/deep-dives/index.md
+++ b/docs/deep-dives/index.md
@@ -8,6 +8,9 @@ If you are new to the binary format, start with
 [Bits & Bytes Primer](../cookbook/bits-and-bytes-primer.md) and
 [How Proto Parsing Works](../cookbook/proto-parsing-pipeline.md).
 
+For benchmark methodology, completed optimization work, and remaining hot paths,
+see [Parser Performance](parser-performance.md).
+
 ## Pipeline
 
 ```text

--- a/docs/deep-dives/parser-performance.md
+++ b/docs/deep-dives/parser-performance.md
@@ -1,0 +1,95 @@
+# Parser Performance
+
+This page records the Python parser optimization work completed after the
+September 2026 baseline profile. It is a maintainer reference, not a performance
+guarantee: replay duration, patch, entity volume, enabled extractors, Python
+version, and hardware all affect parse time.
+
+## Benchmark fixture and method
+
+The common benchmark is
+`tests/fixtures/opendota/8822520406.dem`, a 98,983,300-byte DreamLeague Season 29
+replay lasting 1,397 seconds. The original profile was collected on macOS arm64
+with Python 3.10.4.
+
+Measurements separate three kinds of work:
+
+1. `gem.parse`, including standard extractors and result assembly
+2. `ReplayParser.parse` without standard extractors, isolating core decoding
+3. instrumented profiles and counters, used for rankings and call volume
+
+Elapsed time and peak resident memory come from fresh, uninstrumented processes.
+Instrumented profiles are not used as elapsed-time benchmarks because profiler
+overhead is substantial. Each optimization PR recorded the median of three full
+parses and checked a normalized `ParsedMatch` against its preceding baseline.
+
+## Baseline
+
+The original profile at commit `ed6d7a5` measured:
+
+| Scenario | Elapsed | Peak RSS |
+|---|---:|---:|
+| Public `gem.parse` | 92.976 s | 193.7 MiB |
+| Core `ReplayParser.parse` | 58.280 s | 154.4 MiB |
+
+The dominant repeated work included 36.9 million built-in callback invocations,
+26.6 million `Entity.get` calls, 15.2 million `FieldPath` constructions, 9.96
+million `FieldPath.copy` calls, and approximately 13.9 million recursive decoder
+resolution calls. `FieldState` reads and writes also spent significant time in
+small helper methods invoked once per path component.
+
+See [issue #143](https://github.com/whanyu1212/gem-dota/issues/143) for the full
+historical function table and memory breakdown.
+
+## Optimization sequence
+
+Five deliberately separate changes addressed the measured Python hot paths:
+
+| Change | Main measured effect |
+|---|---|
+| [Class-aware callback routing](https://github.com/whanyu1212/gem-dota/pull/152) | Built-in callback invocations fell from 36,890,700 to 5,381,400 (85.4%). |
+| [Per-entity loop cleanup](https://github.com/whanyu1212/gem-dota/pull/153) | Sampling eligibility checks fell from 2,169,002 to 51,312; interval hero-name resolutions fell from 1,330,198 to 42; unused result tuples were removed from the parser path. |
+| [`FieldState` traversal cleanup](https://github.com/whanyu1212/gem-dota/pull/154) | Production traversal eliminated 15,868,940 `_has_slot`, 15,198,552 `_ensure`, and 15,533,746 `_is_child` dispatches. |
+| [Shared compiled entity fields](https://github.com/whanyu1212/gem-dota/pull/155) | Profiled public `Entity.get` calls fell from 26.6 million to 41; serializer field caches retained about 604 KiB. |
+| [Compact paths and decoder caching](https://github.com/whanyu1212/gem-dota/pull/156) | Production `FieldPath.copy` calls fell from about 9.96 million to zero; recursive decoder resolution fell from about 13.9 million calls to about 80,000. |
+
+The final pass recorded a 64.15-second public median and a 41.40-second core
+median. Those are respectively 11.2% and 15.6% faster than its immediately
+preceding quiet baseline. Compared with the original #143 measurements, they are
+about 31% and 29% lower, but that longer-range comparison spans separate
+measurement sessions and should be treated as directional rather than a
+controlled benchmark.
+
+## Correctness gates
+
+Each pass retained public callback and entity APIs and compared normalized output
+with the preceding implementation. After the final pass, the normalized
+`8822520406` output remained 33,045,771 bytes with SHA-256
+`88712b6b104fa937cee13c5589708327a389e02bf70a95a3716fde9b5c2775b2`.
+
+Focused tests cover callback ordering and lifecycle operations; sparse and nested
+`FieldState` traversal; simple, fixed-array, fixed-table, variable-array, and
+variable-table decoder models; serializer cache isolation; invalid paths; entity
+creation, updates, deletion, and recycled slots. Full replay tests add output and
+OpenDota parity coverage.
+
+## Memory and remaining work
+
+The final pass recorded median peak RSS of 228.2 MB, about 1.9% above its
+immediately preceding public baseline. Its parse-scoped decoder caches were
+estimated at 5.6 MB. The optimization sequence therefore produced a clear CPU
+improvement, but did not establish a memory reduction.
+
+The final profile still identified two measurable Python costs:
+
+- `EntityManager.find_by_npc_name` scans the entity-slot collection.
+- Some extractor paths still repeat indexed field lookup work.
+
+These remain candidates, not committed follow-up work. A new optimization should
+start with a fresh profile and demonstrate enough end-to-end impact to justify
+the added indexes or extractor complexity.
+
+The final PR recorded helper-call elimination for `FieldState`, but not a
+standalone post-change `FieldState` self-time or a complete allocation ranking.
+Do not infer either number from the elapsed-time improvement. Reprofile before
+making claims about the current top memory allocation sites.

--- a/docs/reference/entities.md
+++ b/docs/reference/entities.md
@@ -22,7 +22,7 @@ class EntityOp(enum.IntFlag)
 
 Bitmask indicating what happened to an entity in a packet.
 
-Source: [src/gem/state/entities.py:50](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L50)
+Source: [src/gem/state/entities.py:48](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L48)
 
 #### Methods
 
@@ -32,7 +32,7 @@ Signature: `def EntityOp.has(self, other: EntityOp) -> bool`
 
 Return True if this op includes *other*.
 
-Source: [src/gem/state/entities.py:65](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L65)
+Source: [src/gem/state/entities.py:63](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L63)
 
 ## `gem.state.entities.Entity`
 
@@ -44,7 +44,7 @@ class Entity
 
 A live game entity with decoded field state.
 
-Source: [src/gem/state/entities.py:102](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L102)
+Source: [src/gem/state/entities.py:100](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L100)
 
 #### Methods
 
@@ -54,7 +54,7 @@ Signature: `def Entity.get(self, name: str) -> Any`
 
 Return the current value of *name*, or None if absent.
 
-Source: [src/gem/state/entities.py:143](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L143)
+Source: [src/gem/state/entities.py:137](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L137)
 
 ##### `exists`
 
@@ -62,7 +62,7 @@ Signature: `def Entity.exists(self, name: str) -> bool`
 
 Return True if *name* has a value in the entity state.
 
-Source: [src/gem/state/entities.py:176](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L176)
+Source: [src/gem/state/entities.py:226](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L226)
 
 ##### `get_int32`
 
@@ -70,7 +70,7 @@ Signature: `def Entity.get_int32(self, name: str) -> int | None`
 
 Return the value as int32, or None if absent/wrong type.
 
-Source: [src/gem/state/entities.py:184](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L184)
+Source: [src/gem/state/entities.py:234](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L234)
 
 ##### `get_uint32`
 
@@ -78,7 +78,7 @@ Signature: `def Entity.get_uint32(self, name: str) -> int | None`
 
 Return the value as uint32 (low 32 bits), or None if absent.
 
-Source: [src/gem/state/entities.py:196](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L196)
+Source: [src/gem/state/entities.py:246](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L246)
 
 ##### `get_uint64`
 
@@ -86,7 +86,7 @@ Signature: `def Entity.get_uint64(self, name: str) -> int | None`
 
 Return the value as uint64, or None if absent.
 
-Source: [src/gem/state/entities.py:210](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L210)
+Source: [src/gem/state/entities.py:260](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L260)
 
 ##### `get_float32`
 
@@ -94,7 +94,7 @@ Signature: `def Entity.get_float32(self, name: str) -> float | None`
 
 Return the value as float32, or None if absent.
 
-Source: [src/gem/state/entities.py:222](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L222)
+Source: [src/gem/state/entities.py:272](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L272)
 
 ##### `get_string`
 
@@ -102,7 +102,7 @@ Signature: `def Entity.get_string(self, name: str) -> str | None`
 
 Return the value as str, or None if absent.
 
-Source: [src/gem/state/entities.py:234](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L234)
+Source: [src/gem/state/entities.py:284](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L284)
 
 ##### `get_bool`
 
@@ -110,7 +110,7 @@ Signature: `def Entity.get_bool(self, name: str) -> bool | None`
 
 Return the value as bool, or None if absent.
 
-Source: [src/gem/state/entities.py:246](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L246)
+Source: [src/gem/state/entities.py:296](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L296)
 
 ##### `to_map`
 
@@ -118,7 +118,7 @@ Signature: `def Entity.to_map(self) -> dict[str, Any]`
 
 Return a snapshot of the flat _state dict.
 
-Source: [src/gem/state/entities.py:258](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L258)
+Source: [src/gem/state/entities.py:308](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L308)
 
 ##### `get_class_name`
 
@@ -126,7 +126,7 @@ Signature: `def Entity.get_class_name(self) -> str`
 
 Return the entity class name.
 
-Source: [src/gem/state/entities.py:266](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L266)
+Source: [src/gem/state/entities.py:316](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L316)
 
 ##### `get_class_id`
 
@@ -134,7 +134,7 @@ Signature: `def Entity.get_class_id(self) -> int`
 
 Return the entity class ID.
 
-Source: [src/gem/state/entities.py:270](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L270)
+Source: [src/gem/state/entities.py:320](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L320)
 
 ##### `get_index`
 
@@ -142,7 +142,7 @@ Signature: `def Entity.get_index(self) -> int`
 
 Return the entity slot index.
 
-Source: [src/gem/state/entities.py:274](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L274)
+Source: [src/gem/state/entities.py:324](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L324)
 
 ##### `get_serial`
 
@@ -150,7 +150,7 @@ Signature: `def Entity.get_serial(self) -> int`
 
 Return the entity serial number.
 
-Source: [src/gem/state/entities.py:278](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L278)
+Source: [src/gem/state/entities.py:328](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L328)
 
 ## `gem.state.entities.EntityManager`
 
@@ -162,7 +162,7 @@ class EntityManager
 
 Manages entity lifecycle across a replay stream.
 
-Source: [src/gem/state/entities.py:382](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L382)
+Source: [src/gem/state/entities.py:457](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L457)
 
 #### Methods
 
@@ -172,7 +172,7 @@ Signature: `def EntityManager.on_entity(self, handler: EntityHandler) -> None`
 
 Register an entity event handler.
 
-Source: [src/gem/state/entities.py:413](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L413)
+Source: [src/gem/state/entities.py:488](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L488)
 
 ##### `on_server_info`
 
@@ -180,7 +180,7 @@ Signature: `def EntityManager.on_server_info(self, msg: object) -> None`
 
 Extract classIdSize and game build from CSVCMsg_ServerInfo.
 
-Source: [src/gem/state/entities.py:425](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L425)
+Source: [src/gem/state/entities.py:514](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L514)
 
 ##### `on_class_info`
 
@@ -188,7 +188,7 @@ Signature: `def EntityManager.on_class_info(self, msg: object) -> None`
 
 Build class maps from CDemoClassInfo.
 
-Source: [src/gem/state/entities.py:444](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L444)
+Source: [src/gem/state/entities.py:533](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L533)
 
 ##### `on_baseline_updated`
 
@@ -196,7 +196,7 @@ Signature: `def EntityManager.on_baseline_updated(self) -> None`
 
 Call after instancebaseline string table is created or updated.
 
-Source: [src/gem/state/entities.py:461](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L461)
+Source: [src/gem/state/entities.py:551](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L551)
 
 ##### `on_packet_entities`
 
@@ -204,7 +204,7 @@ Signature: `def EntityManager.on_packet_entities(self, msg: object) -> list[tupl
 
 Decode a CSVCMsg_PacketEntities message.
 
-Source: [src/gem/state/entities.py:465](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L465)
+Source: [src/gem/state/entities.py:555](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L555)
 
 ##### `find`
 
@@ -212,7 +212,7 @@ Signature: `def EntityManager.find(self, index: int) -> Entity | None`
 
 Return the entity at the given slot index, or None.
 
-Source: [src/gem/state/entities.py:580](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L580)
+Source: [src/gem/state/entities.py:682](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L682)
 
 ##### `find_by_handle`
 
@@ -220,7 +220,7 @@ Signature: `def EntityManager.find_by_handle(self, handle: int) -> Entity | None
 
 Return the entity for a Source 2 entity handle, or None.
 
-Source: [src/gem/state/entities.py:590](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L590)
+Source: [src/gem/state/entities.py:692](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L692)
 
 ##### `filter`
 
@@ -228,7 +228,7 @@ Signature: `def EntityManager.filter(self, predicate: Any) -> list[Entity]`
 
 Return all entities matching a predicate.
 
-Source: [src/gem/state/entities.py:603](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L603)
+Source: [src/gem/state/entities.py:705](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L705)
 
 ##### `find_by_class_name`
 
@@ -236,7 +236,7 @@ Signature: `def EntityManager.find_by_class_name(self, class_name: str) -> Entit
 
 Return the first active entity whose class name matches, or None.
 
-Source: [src/gem/state/entities.py:614](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L614)
+Source: [src/gem/state/entities.py:716](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L716)
 
 ##### `find_by_npc_name`
 
@@ -244,7 +244,7 @@ Signature: `def EntityManager.find_by_npc_name(self, npc_name: str) -> Entity | 
 
 Return the first active entity whose NPC name matches, or None.
 
-Source: [src/gem/state/entities.py:625](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L625)
+Source: [src/gem/state/entities.py:727](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L727)
 
 ##### `all_active`
 
@@ -252,4 +252,4 @@ Signature: `def EntityManager.all_active(self) -> list[Entity]`
 
 Return all currently active entities.
 
-Source: [src/gem/state/entities.py:660](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L660)
+Source: [src/gem/state/entities.py:763](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/state/entities.py#L763)

--- a/docs/reference/extractors/courier.md
+++ b/docs/reference/extractors/courier.md
@@ -22,7 +22,7 @@ class CourierSnapshot
 
 A single courier state sample at one tick.
 
-Source: [src/gem/extractors/courier.py:22](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/courier.py#L22)
+Source: [src/gem/extractors/courier.py:25](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/courier.py#L25)
 
 #### Dataclass fields
 
@@ -43,7 +43,7 @@ class CourierExtractor
 
 Polls courier entity state and accumulates snapshots.
 
-Source: [src/gem/extractors/courier.py:42](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/courier.py#L42)
+Source: [src/gem/extractors/courier.py:45](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/courier.py#L45)
 
 #### Methods
 
@@ -53,4 +53,4 @@ Signature: `def CourierExtractor.attach(self, parser: ReplayParser) -> None`
 
 Register callbacks with the parser.
 
-Source: [src/gem/extractors/courier.py:72](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/courier.py#L72)
+Source: [src/gem/extractors/courier.py:75](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/courier.py#L75)

--- a/docs/reference/extractors/draft.md
+++ b/docs/reference/extractors/draft.md
@@ -22,7 +22,7 @@ def resolve_pick_team(event: DraftEvent, players: list[ParsedPlayer]) -> int
 
 Resolve the team (2=Radiant, 3=Dire) for a draft event.
 
-Source: [src/gem/extractors/draft.py:82](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/draft.py#L82)
+Source: [src/gem/extractors/draft.py:100](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/draft.py#L100)
 
 ### Top-level classes
 
@@ -34,7 +34,7 @@ class DraftEvent
 
 A single hero ban or pick in the draft.
 
-Source: [src/gem/extractors/draft.py:62](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/draft.py#L62)
+Source: [src/gem/extractors/draft.py:80](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/draft.py#L80)
 
 #### Dataclass fields
 
@@ -55,7 +55,7 @@ class DraftExtractor
 
 Detects hero picks and bans by polling ``CDOTAGamerulesProxy``.
 
-Source: [src/gem/extractors/draft.py:124](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/draft.py#L124)
+Source: [src/gem/extractors/draft.py:142](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/draft.py#L142)
 
 #### Methods
 
@@ -65,7 +65,7 @@ Signature: `def DraftExtractor.attach(self, parser: ReplayParser) -> None`
 
 Register callbacks with the parser.
 
-Source: [src/gem/extractors/draft.py:162](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/draft.py#L162)
+Source: [src/gem/extractors/draft.py:180](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/draft.py#L180)
 
 ##### `finalize`
 
@@ -73,4 +73,4 @@ Signature: `def DraftExtractor.finalize(self) -> None`
 
 Re-resolve all hero names using the fully-populated live map.
 
-Source: [src/gem/extractors/draft.py:266](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/draft.py#L266)
+Source: [src/gem/extractors/draft.py:291](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/draft.py#L291)

--- a/docs/reference/extractors/objectives.md
+++ b/docs/reference/extractors/objectives.md
@@ -27,7 +27,7 @@ class TowerKill
 
 One tower destruction event.
 
-Source: [src/gem/extractors/objectives.py:87](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/objectives.py#L87)
+Source: [src/gem/extractors/objectives.py:89](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/objectives.py#L89)
 
 #### Dataclass fields
 
@@ -47,7 +47,7 @@ class RoshanKill
 
 One confirmed Roshan death.
 
-Source: [src/gem/extractors/objectives.py:109](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/objectives.py#L109)
+Source: [src/gem/extractors/objectives.py:111](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/objectives.py#L111)
 
 #### Dataclass fields
 
@@ -67,7 +67,7 @@ class BarracksKill
 
 One barracks destruction event.
 
-Source: [src/gem/extractors/objectives.py:131](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/objectives.py#L131)
+Source: [src/gem/extractors/objectives.py:133](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/objectives.py#L133)
 
 #### Dataclass fields
 
@@ -87,7 +87,7 @@ class TormentorKill
 
 One Tormentor (miniboss) kill event.
 
-Source: [src/gem/extractors/objectives.py:151](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/objectives.py#L151)
+Source: [src/gem/extractors/objectives.py:153](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/objectives.py#L153)
 
 #### Dataclass fields
 
@@ -106,7 +106,7 @@ class ShrineKill
 
 One Shrine of Wisdom destruction event.
 
-Source: [src/gem/extractors/objectives.py:170](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/objectives.py#L170)
+Source: [src/gem/extractors/objectives.py:172](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/objectives.py#L172)
 
 #### Dataclass fields
 
@@ -123,7 +123,7 @@ class AegisEvent
 
 An Aegis of the Immortal pickup, steal, or denial event.
 
-Source: [src/gem/extractors/objectives.py:183](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/objectives.py#L183)
+Source: [src/gem/extractors/objectives.py:185](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/objectives.py#L185)
 
 #### Dataclass fields
 
@@ -141,7 +141,7 @@ class BannerPlant
 
 One Roshan's Banner plant event.
 
-Source: [src/gem/extractors/objectives.py:199](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/objectives.py#L199)
+Source: [src/gem/extractors/objectives.py:201](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/objectives.py#L201)
 
 #### Dataclass fields
 
@@ -161,7 +161,7 @@ class CourierDeath
 
 One courier death, detected from the combat log.
 
-Source: [src/gem/extractors/objectives.py:223](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/objectives.py#L223)
+Source: [src/gem/extractors/objectives.py:225](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/objectives.py#L225)
 
 #### Dataclass fields
 
@@ -179,7 +179,7 @@ class ObjectivesExtractor
 
 Extracts tower kills, Roshan kills, barracks kills, tormentor kills, and shrine kills from a replay.
 
-Source: [src/gem/extractors/objectives.py:248](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/objectives.py#L248)
+Source: [src/gem/extractors/objectives.py:250](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/objectives.py#L250)
 
 #### Methods
 
@@ -189,4 +189,4 @@ Signature: `def ObjectivesExtractor.attach(self, parser: ReplayParser) -> None`
 
 Register this extractor's callbacks with a parser.
 
-Source: [src/gem/extractors/objectives.py:306](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/objectives.py#L306)
+Source: [src/gem/extractors/objectives.py:308](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/objectives.py#L308)

--- a/docs/reference/extractors/players.md
+++ b/docs/reference/extractors/players.md
@@ -22,7 +22,7 @@ class PlayerExtractor
 
 Polls hero entity state each tick and accumulates player snapshots.
 
-Source: [src/gem/extractors/players.py:53](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/players.py#L53)
+Source: [src/gem/extractors/players.py:97](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/players.py#L97)
 
 #### Methods
 
@@ -32,7 +32,7 @@ Signature: `def PlayerExtractor.attach(self, parser: ReplayParser) -> None`
 
 Register callbacks with the parser.
 
-Source: [src/gem/extractors/players.py:132](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/players.py#L132)
+Source: [src/gem/extractors/players.py:179](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/players.py#L179)
 
 ##### `hero_pos`
 
@@ -40,7 +40,7 @@ Signature: `def PlayerExtractor.hero_pos(self, npc_name: str) -> tuple[float, fl
 
 Return the current world position of a hero by NPC name.
 
-Source: [src/gem/extractors/players.py:254](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/players.py#L254)
+Source: [src/gem/extractors/players.py:324](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/players.py#L324)
 
 ##### `time_series`
 
@@ -48,7 +48,7 @@ Signature: `def PlayerExtractor.time_series(self, player_id: int) -> PlayerTimeS
 
 Aggregate snapshots for one player into time-series lists.
 
-Source: [src/gem/extractors/players.py:273](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/players.py#L273)
+Source: [src/gem/extractors/players.py:343](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/players.py#L343)
 
 ##### `minute_time_series`
 
@@ -56,4 +56,4 @@ Signature: `def PlayerExtractor.minute_time_series(self, player_id: int) -> Play
 
 Aggregate per-minute snapshots for one player into time-series lists.
 
-Source: [src/gem/extractors/players.py:304](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/players.py#L304)
+Source: [src/gem/extractors/players.py:374](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/players.py#L374)

--- a/docs/reference/extractors/wards.md
+++ b/docs/reference/extractors/wards.md
@@ -22,7 +22,7 @@ class WardEvent
 
 A complete ward placement record with coordinates.
 
-Source: [src/gem/extractors/wards.py:81](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/wards.py#L81)
+Source: [src/gem/extractors/wards.py:83](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/wards.py#L83)
 
 #### Dataclass fields
 
@@ -47,7 +47,7 @@ class WardsExtractor
 
 Extracts ward placement, expiry, and kill events from the entity stream.
 
-Source: [src/gem/extractors/wards.py:115](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/wards.py#L115)
+Source: [src/gem/extractors/wards.py:117](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/wards.py#L117)
 
 #### Properties
 
@@ -57,7 +57,7 @@ Signature: `def WardsExtractor._tick(self) -> int`
 
 No docstring available.
 
-Source: [src/gem/extractors/wards.py:159](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/wards.py#L159)
+Source: [src/gem/extractors/wards.py:165](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/wards.py#L165)
 
 #### Methods
 
@@ -67,7 +67,7 @@ Signature: `def WardsExtractor.attach(self, parser: ReplayParser) -> None`
 
 Register callbacks with the parser.
 
-Source: [src/gem/extractors/wards.py:148](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/wards.py#L148)
+Source: [src/gem/extractors/wards.py:150](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/wards.py#L150)
 
 ##### `finalize`
 
@@ -75,4 +75,4 @@ Signature: `def WardsExtractor.finalize(self) -> list[WardEvent]`
 
 Back-fill placer names and return ward events.
 
-Source: [src/gem/extractors/wards.py:162](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/wards.py#L162)
+Source: [src/gem/extractors/wards.py:168](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/extractors/wards.py#L168)

--- a/docs/reference/field_path.md
+++ b/docs/reference/field_path.md
@@ -20,9 +20,9 @@ See also: [How Proto Parsing Works](../cookbook/proto-parsing-pipeline.md)
 def read_field_paths(r: BitReader) -> list[FieldPath]
 ```
 
-Decode a Huffman-coded sequence of field paths from r.
+Decode field paths into independent mutable compatibility objects.
 
-Source: [src/gem/schema/field_path/path_sequence.py:20](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/field_path/path_sequence.py#L20)
+Source: [src/gem/schema/field_path/path_sequence.py:99](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/field_path/path_sequence.py#L99)
 
 ## `gem.schema.field_path.FieldPath`
 
@@ -34,7 +34,7 @@ class FieldPath
 
 A mutable path of up to 7 integer field indices.
 
-Source: [src/gem/schema/field_path/models.py:8](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/field_path/models.py#L8)
+Source: [src/gem/schema/field_path/models.py:11](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/field_path/models.py#L11)
 
 #### Methods
 
@@ -44,7 +44,7 @@ Signature: `def FieldPath.reset(self) -> None`
 
 Reset to the initial empty state.
 
-Source: [src/gem/schema/field_path/models.py:27](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/field_path/models.py#L27)
+Source: [src/gem/schema/field_path/models.py:30](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/field_path/models.py#L30)
 
 ##### `pop`
 
@@ -52,7 +52,7 @@ Signature: `def FieldPath.pop(self, n: int) -> None`
 
 Pop n levels off the path, zeroing the vacated slots.
 
-Source: [src/gem/schema/field_path/models.py:33](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/field_path/models.py#L33)
+Source: [src/gem/schema/field_path/models.py:36](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/field_path/models.py#L36)
 
 ##### `copy`
 
@@ -60,15 +60,15 @@ Signature: `def FieldPath.copy(self) -> FieldPath`
 
 Return an independent copy of this path.
 
-Source: [src/gem/schema/field_path/models.py:43](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/field_path/models.py#L43)
+Source: [src/gem/schema/field_path/models.py:46](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/field_path/models.py#L46)
 
 ##### `to_tuple`
 
-Signature: `def FieldPath.to_tuple(self) -> tuple[int, ...]`
+Signature: `def FieldPath.to_tuple(self) -> CompactFieldPath`
 
 Return the active indices as an immutable tuple.
 
-Source: [src/gem/schema/field_path/models.py:55](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/field_path/models.py#L55)
+Source: [src/gem/schema/field_path/models.py:58](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/field_path/models.py#L58)
 
 ##### `to_str`
 
@@ -76,7 +76,7 @@ Signature: `def FieldPath.to_str(self) -> str`
 
 Return a slash-separated string of active indices.
 
-Source: [src/gem/schema/field_path/models.py:63](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/field_path/models.py#L63)
+Source: [src/gem/schema/field_path/models.py:91](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/field_path/models.py#L91)
 
 ##### `plus_one`
 
@@ -84,7 +84,7 @@ Signature: `def FieldPath.plus_one(self) -> None`
 
 Increment the deepest index by 1.
 
-Source: [src/gem/schema/field_path/models.py:71](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/field_path/models.py#L71)
+Source: [src/gem/schema/field_path/models.py:99](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/field_path/models.py#L99)
 
 ## `gem.schema.field_path.FieldPathOp`
 

--- a/docs/reference/parser.md
+++ b/docs/reference/parser.md
@@ -18,7 +18,7 @@ class ReplayParser
 
 Drives a full Source 2 replay parse, wiring all subsystems together.
 
-Source: [src/gem/parser.py:168](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L168)
+Source: [src/gem/parser.py:198](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L198)
 
 #### Methods
 
@@ -28,7 +28,7 @@ Signature: `def ReplayParser.on_entity(self, callback: EntityCallback) -> None`
 
 Register a handler called for every entity create/update/delete.
 
-Source: [src/gem/parser.py:249](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L249)
+Source: [src/gem/parser.py:283](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L283)
 
 ##### `on_tick_start`
 
@@ -36,7 +36,7 @@ Signature: `def ReplayParser.on_tick_start(self, callback: TickStartCallback) ->
 
 Register a handler called before the current tick's entity deltas.
 
-Source: [src/gem/parser.py:259](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L259)
+Source: [src/gem/parser.py:326](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L326)
 
 ##### `on_game_event`
 
@@ -44,7 +44,7 @@ Signature: `def ReplayParser.on_game_event(self, name: str, handler: GameEventHa
 
 Register a handler for the named game event.
 
-Source: [src/gem/parser.py:314](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L314)
+Source: [src/gem/parser.py:383](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L383)
 
 ##### `on_combat_log_entry`
 
@@ -52,7 +52,7 @@ Signature: `def ReplayParser.on_combat_log_entry(self, handler: CombatLogHandler
 
 Register a handler for all combat log entries (S1 + S2).
 
-Source: [src/gem/parser.py:323](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L323)
+Source: [src/gem/parser.py:392](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L392)
 
 ##### `on_chat_message`
 
@@ -60,7 +60,7 @@ Signature: `def ReplayParser.on_chat_message(self, handler: ChatCallback) -> Non
 
 Register a handler for all-chat and team-chat messages.
 
-Source: [src/gem/parser.py:331](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L331)
+Source: [src/gem/parser.py:400](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L400)
 
 ##### `on_chat_event`
 
@@ -68,7 +68,7 @@ Signature: `def ReplayParser.on_chat_event(self, handler: ChatEventCallback) -> 
 
 Register a handler for all CDOTAUserMsg_ChatEvent messages.
 
-Source: [src/gem/parser.py:339](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L339)
+Source: [src/gem/parser.py:408](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L408)
 
 ##### `on_neutral_item_found`
 
@@ -76,7 +76,7 @@ Signature: `def ReplayParser.on_neutral_item_found(self, handler: NeutralItemFou
 
 Register a handler for neutral item found messages.
 
-Source: [src/gem/parser.py:347](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L347)
+Source: [src/gem/parser.py:416](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L416)
 
 ##### `on_game_start`
 
@@ -84,7 +84,7 @@ Signature: `def ReplayParser.on_game_start(self, callback: Callable[[int], None]
 
 Register a handler called once when game time reaches zero.
 
-Source: [src/gem/parser.py:355](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L355)
+Source: [src/gem/parser.py:424](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L424)
 
 ##### `on_game_end`
 
@@ -92,7 +92,7 @@ Signature: `def ReplayParser.on_game_end(self, callback: Callable[[int], None]) 
 
 Register a handler called once when the ancient is destroyed.
 
-Source: [src/gem/parser.py:367](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L367)
+Source: [src/gem/parser.py:436](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L436)
 
 ##### `stop_after_tick`
 
@@ -100,7 +100,7 @@ Signature: `def ReplayParser.stop_after_tick(self, tick: int) -> None`
 
 Stop parsing after this tick (inclusive).
 
-Source: [src/gem/parser.py:407](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L407)
+Source: [src/gem/parser.py:476](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L476)
 
 ##### `parse`
 
@@ -108,4 +108,4 @@ Signature: `def ReplayParser.parse(self) -> None`
 
 Parse the replay from start to finish (or until stop_after_tick).
 
-Source: [src/gem/parser.py:419](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L419)
+Source: [src/gem/parser.py:488](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/parser.py#L488)

--- a/docs/reference/sendtable.md
+++ b/docs/reference/sendtable.md
@@ -37,7 +37,7 @@ class Serializer
 
 A named, versioned entity class schema with ordered fields.
 
-Source: [src/gem/schema/sendtable/models.py:176](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/sendtable/models.py#L176)
+Source: [src/gem/schema/sendtable/models.py:210](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/sendtable/models.py#L210)
 
 #### Dataclass fields
 
@@ -57,7 +57,7 @@ class Field
 
 One property of a serializer, including its type model and decoders.
 
-Source: [src/gem/schema/sendtable/models.py:105](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/sendtable/models.py#L105)
+Source: [src/gem/schema/sendtable/models.py:107](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/sendtable/models.py#L107)
 
 #### Dataclass fields
 
@@ -89,7 +89,7 @@ Signature: `def Field.set_model(self, model: int) -> None`
 
 Assign the field model and wire up the appropriate decoders.
 
-Source: [src/gem/schema/sendtable/models.py:131](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/sendtable/models.py#L131)
+Source: [src/gem/schema/sendtable/models.py:133](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/sendtable/models.py#L133)
 
 ##### `model_name`
 
@@ -97,7 +97,7 @@ Signature: `def Field.model_name(self) -> str`
 
 Return a human-readable model name for debugging.
 
-Source: [src/gem/schema/sendtable/models.py:164](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/sendtable/models.py#L164)
+Source: [src/gem/schema/sendtable/models.py:166](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/sendtable/models.py#L166)
 
 ## `gem.schema.sendtable.FieldType`
 
@@ -109,7 +109,7 @@ class FieldType
 
 Parsed representation of a C++ field type string.
 
-Source: [src/gem/schema/sendtable/models.py:53](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/sendtable/models.py#L53)
+Source: [src/gem/schema/sendtable/models.py:55](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/schema/sendtable/models.py#L55)
 
 #### Dataclass fields
 


### PR DESCRIPTION
## Summary

- add a durable parser-performance deep dive covering the #143 baseline and optimization PRs #152-#156
- document measured wins, output-parity gates, measurement caveats, and remaining CPU/memory work
- refresh generated API-reference source links after the entity-path changes
- prepare the accumulated changelog entries as v0.7.1

## Rationale

The five scoped Python optimization passes are merged and form a coherent patch release. Moving the benchmark results into the documentation preserves the evidence after closing the historical tracking issue and avoids implying that the remaining lookup and memory costs were eliminated.

Closes #143

## Testing

- [x] npm run docs:build
- [x] git diff --check
- [x] repository Python checks already passed on the merged source: 1,833 passed, 3 skipped; Ruff, formatting, and mypy clean
- [x] replay-backed suite: 61 passed; one OpenDota-dependent draft setup errored on unavailable DNS/network access

## Release plan

After merge, run `scripts/release.sh 0.7.1` from updated `main`, review the generated release commit/tag, then push `v0.7.1` to trigger PyPI publishing.