### PR TITLE
Optimize EntityOp membership checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Lower entity-operation check overhead.** `EntityOp.has()` checks flag values
+  directly, avoiding `IntFlag` operation overhead in extractor callbacks while
+  preserving overlap semantics and integer-mask compatibility.
+
 ## [0.7.1] - 2026-09-04
 
 Improves full-replay parsing speed without changing public APIs or normalized

--- a/src/gem/state/entities.py
+++ b/src/gem/state/entities.py
@@ -61,14 +61,16 @@ class EntityOp(enum.IntFlag):
     DELETED_LEFT = 0x04 | 0x10
 
     def has(self, other: EntityOp) -> bool:
-        """Return True if this op includes *other*.
+        """Return True if this op overlaps any bit in *other*.
 
         Args:
             other: The flag to test for.
 
         Returns:
-            True if the flag is set.
+            True if any queried bit is set. Querying ``NONE`` returns False.
         """
+        if isinstance(other, EntityOp):
+            return bool(self._value_ & other._value_)
         return bool(self & other)
 
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -36,6 +36,44 @@ def entity_op():
 
 
 class TestEntityOp:
+    @pytest.mark.parametrize("op", [EntityOp(mask) for mask in range(32)])
+    @pytest.mark.parametrize("query", [EntityOp(mask) for mask in range(32)])
+    def test_all_defined_masks_match_intflag_overlap(self, op, query):
+        expected = bool(op & query)
+        assert op.has(query) is expected
+
+    @pytest.mark.parametrize("op", EntityOp.__members__.values(), ids=EntityOp.__members__)
+    @pytest.mark.parametrize("query", list(EntityOp))
+    def test_named_operations_match_intflag_overlap(self, op, query):
+        assert op.has(query) is bool(op & query)
+
+    def test_composite_query_requires_any_overlap(self):
+        assert EntityOp.CREATED.has(EntityOp.CREATED_ENTERED) is True
+        assert EntityOp.ENTERED.has(EntityOp.CREATED_ENTERED) is True
+        assert EntityOp.UPDATED.has(EntityOp.CREATED_ENTERED) is False
+
+    @pytest.mark.parametrize("op", EntityOp.__members__.values(), ids=EntityOp.__members__)
+    def test_zero_masks_never_overlap(self, op):
+        assert op.has(EntityOp.NONE) is False
+        assert EntityOp.NONE.has(op) is False
+
+    @pytest.mark.parametrize("op", [EntityOp(mask) for mask in range(32)])
+    @pytest.mark.parametrize("query", [0, 1, 2, 9, 10, 20, 31, 32, 33, -1, -2, False, True])
+    def test_integer_masks_preserve_operator_behavior(self, op, query):
+        assert op.has(query) is bool(op & query)
+
+    @pytest.mark.parametrize("op", [EntityOp(32), EntityOp(33), EntityOp(-1)])
+    @pytest.mark.parametrize("query", [EntityOp.NONE, EntityOp.CREATED, EntityOp(32), EntityOp(-1)])
+    def test_unknown_and_negative_flag_masks_preserve_operator_behavior(self, op, query):
+        assert op.has(query) is bool(op & query)
+
+    @pytest.mark.parametrize("query", [None, "CREATED", 1.5, object()])
+    def test_invalid_operands_preserve_type_error(self, query):
+        with pytest.raises(TypeError):
+            EntityOp.CREATED & query
+        with pytest.raises(TypeError):
+            EntityOp.CREATED.has(query)
+
     def test_flag_check(self, entity_op):
         op = entity_op.CREATED | entity_op.ENTERED
         assert op.has(entity_op.CREATED)


### PR DESCRIPTION
## Summary

`EntityOp.has()` runs in extractor callbacks and currently invokes `IntFlag.__and__` for every check. Use the underlying integer masks for `EntityOp` arguments, retaining the original operator expression as a fallback for integer masks and other operands. The public type/signature and all extractor call sites remain unchanged.

Clarify that composite queries use **any-bit overlap**, and that zero masks never overlap. Add exhaustive mask, named-operation, integer/boolean, unknown/negative-bit, and invalid-operand regression tests, plus an Unreleased changelog entry.

Closes #160.

## Rationale

Manta's `refs/manta/entity.go::EntityOp.Flag` uses `o&p != 0`, matching the preserved semantics. Cross-checked Clarity's entity lifecycle dispatch and OpenDota's ward creation/update/deletion handlers; this change does not alter lifecycle dispatch or attribution.

## Testing

- Full suite (including slow and integration): **3442 passed, 3 skipped, 0 failures, 0 errors**.
- New flag tests also passed against the original implementation: **1,550 passed**. Candidate focused entity/extractor suite: **1,901 passed**.
- `ruff check .`, `ruff format --check .`, `mypy src/gem/`, and `git diff --check`: passed.
- No generated protobufs, dependencies, Python requirements, or replay artifacts changed.
- Suite skip: `tests.test_bulk.TestParseManyToParquet::test_writes_subdir_per_replay` — pyarrow not installed
- Suite skip: `tests.test_field_decoder.TestQuantizedFloatDecoder::test_rounddown_flag_active` — Flag optimised away for this range too
- Suite skip: `tests.test_parquet_export.TestParquetExport::test_to_parquet_writes_files` — No parquet engine installed

TI2026 offline OpenDota validation (`mode="full"`, existing 0.25% gold/XP curve gates):

| Replay | Passed | Warnings | Failures | Informational skips |
|---|---:|---:|---:|---:|
| 8868259993 | 325 | 0 | 0 | 1 |
| 8860187335 | 326 | 0 | 0 | 1 |
| 8856501050 | 331 | 0 | 0 | 1 |

The parity validator deliberately skips `teamfights/total_count` as informational because OpenDota uses a different expanded death-event pipeline. No required TI2026 fixture or comparison was missing.

## Performance

Environment: macOS 26.6.2 arm64, CPython 3.10.4 (Clang 14.0.3), NumPy 2.2.6, pandas 2.3.3, protobuf 7.34.0, python-snappy 0.7.3. Same existing `.venv` and dependencies throughout. Baseline commit: `823bd61b7906cbfe5d33b30eed98215dd3a24dc3`.

### Method microbenchmark

Three fresh processes, five repetitions of one million calls per case in each process, preconstructed flags. Values below are medians of the three process medians, including method-call and compatibility-branch overhead; the candidate is the actual `EntityOp.has` method.

| Case | Original ns/call | Candidate ns/call | Local speedup |
|---|---:|---:|---:|
| hit | 778.21 | 145.44 | 5.35x |
| miss | 776.31 | 145.85 | 5.32x |
| composite | 778.50 | 142.10 | 5.48x |
| zero_query | 782.52 | 146.39 | 5.35x |
| zero_op | 771.35 | 146.52 | 5.26x |

Separate cProfile checks in each process recorded 10,000 enum `__and__` calls beneath 10,000 original-method calls and **zero** beneath 10,000 candidate `has()` calls. Profiling is separate from elapsed-time benchmarks.

### Full replay measurements and host-load limitation

Each revision/scenario/replay used three fresh, sequential processes. Timing excludes imports, output serialization, and hashing. RSS is captured before serialization; the reported RSS statistic is the median of per-process peak RSS. Core parsing uses `ReplayParser` without standard extractors.

**The initial before/after timing series is confounded by host load and is not evidence of a whole-parser speedup or a code-caused slowdown.** Heavy macOS Spotlight indexing was observed during candidate runs (load average 10.16; `mds_stores` approximately 92% CPU plus multiple busy `mdworker_shared` processes). The unchanged short-replay core control also slowed. All measurements are retained below; none were dropped as outliers.

| Replay / mode | Baseline elapsed s | Candidate elapsed s | Baseline user CPU s | Candidate user CPU s | Baseline peak RSS MiB | Candidate peak RSS MiB |
|---|---:|---:|---:|---:|---:|---:|
| 8822520406 / public | 64.664 | 77.990 | 64.137 | 77.185 | 218.922 | 200.375 |
| 8822520406 / core | 42.922 | 49.406 | 42.022 | 49.070 | 161.609 | 153.797 |
| 8856501050 / public | 205.753 | 216.331 | 203.174 | 210.828 | 631.641 | 639.906 |
| 8856501050 / core | 145.385 | 142.935 | 143.044 | 141.711 | 433.859 | 434.578 |

To investigate the drift, ran three additional fresh-process old/new public-parse pairs on `8822520406`, reversing order for pair two. The old-method process temporarily restores the exact original `bool(self & other)` method at runtime; all other candidate code stays identical. Paired medians were **67.621 s original vs 66.788 s candidate** (1.23% lower), with user CPU **65.903 s vs 64.847 s** and peak RSS **191.344 vs 192.016 MiB**. Individual timing ranges overlap, so this PR claims the measured method-level gain, not a statistically established whole-parser percentage. No material regression appears in the paired check; public stress RSS stayed within the observed baseline range apart from one lower candidate measurement.

<details>
<summary>Every replay benchmark run</summary>

| Revision | Replay | Mode | Run | Elapsed s | User CPU s | Peak RSS bytes |
|---|---|---|---:|---:|---:|---:|
| baseline | 8822520406 | public | 1 | 64.664457 | 64.136896 | 229556224 |
| baseline | 8822520406 | public | 2 | 63.984026 | 63.813069 | 229752832 |
| baseline | 8822520406 | public | 3 | 66.618256 | 65.610816 | 214269952 |
| baseline | 8822520406 | core | 1 | 43.364808 | 42.022193 | 168214528 |
| baseline | 8822520406 | core | 2 | 42.921505 | 42.394914 | 169459712 |
| baseline | 8822520406 | core | 3 | 42.158279 | 41.920262 | 182190080 |
| baseline | 8856501050 | public | 1 | 217.318113 | 214.268143 | 662323200 |
| baseline | 8856501050 | public | 2 | 205.752748 | 203.173679 | 686342144 |
| baseline | 8856501050 | public | 3 | 205.371636 | 202.715113 | 657293312 |
| baseline | 8856501050 | core | 1 | 145.385392 | 143.044087 | 456736768 |
| baseline | 8856501050 | core | 2 | 142.657201 | 142.242895 | 454574080 |
| baseline | 8856501050 | core | 3 | 149.734706 | 148.412503 | 454934528 |
| candidate | 8822520406 | public | 1 | 66.766159 | 65.198270 | 206176256 |
| candidate | 8822520406 | public | 2 | 81.128510 | 80.336882 | 211501056 |
| candidate | 8822520406 | public | 3 | 77.989930 | 77.184614 | 210108416 |
| candidate | 8822520406 | core | 1 | 49.406084 | 49.070276 | 162283520 |
| candidate | 8822520406 | core | 2 | 51.045238 | 50.705571 | 147816448 |
| candidate | 8822520406 | core | 3 | 47.891669 | 47.643522 | 161267712 |
| candidate | 8856501050 | public | 1 | 242.851423 | 235.340529 | 595902464 |
| candidate | 8856501050 | public | 2 | 216.331407 | 210.827529 | 670990336 |
| candidate | 8856501050 | public | 3 | 193.885757 | 191.676473 | 674004992 |
| candidate | 8856501050 | core | 1 | 141.980388 | 139.772646 | 469745664 |
| candidate | 8856501050 | core | 2 | 142.934827 | 141.710744 | 455688192 |
| candidate | 8856501050 | core | 3 | 152.744544 | 148.057009 | 453804032 |
| paired-baseline | 8822520406 | public | 1 | 64.633744 | 63.839415 | 207159296 |
| paired-candidate | 8822520406 | public | 1 | 66.287309 | 64.308141 | 204111872 |
| paired-candidate | 8822520406 | public | 2 | 68.670379 | 66.532908 | 197820416 |
| paired-baseline | 8822520406 | public | 2 | 67.924572 | 65.903422 | 198819840 |
| paired-baseline | 8822520406 | public | 3 | 67.620703 | 65.978598 | 200638464 |
| paired-candidate | 8822520406 | public | 3 | 66.788471 | 64.847401 | 201342976 |

</details>

### Exact output equivalence

All baseline/candidate public runs and all paired runs compare the full sorted-key JSON bytes, using fixed separators and `PYTHONHASHSEED=0`. The short fixture returns 10 players / 44,686 combat entries; the stress fixture returns 10 players / 272,400 entries. Every core run completed without a parse error.

| Replay | Output bytes | SHA-256 (both revisions) |
|---|---:|---|
| 8822520406 | 30401205 | `3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427` |
| 8856501050 | 187363261 | `1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e` |

## Reproduction

Tests used the installed environment without dependency changes. `UV_CACHE_DIR` avoids the desktop sandbox's restriction on the default uv cache.

```sh
UV_CACHE_DIR=/private/tmp/gem-160-uv-cache uv run --no-sync ruff check .
UV_CACHE_DIR=/private/tmp/gem-160-uv-cache uv run --no-sync ruff format --check .
UV_CACHE_DIR=/private/tmp/gem-160-uv-cache uv run --no-sync mypy src/gem/
UV_CACHE_DIR=/private/tmp/gem-160-uv-cache PYTHONHASHSEED=0 uv run --no-sync pytest tests/ -q -o addopts='' -m '' -ra --junitxml=/private/tmp/gem-160-results/pytest.xml
```

Use an empty `/private/tmp/gem-160-results` directory for a new measurement series. Save the benchmark harness below to `/private/tmp/gem-160-bench.py` and run from the repository root. The baseline suite was run before the implementation edit, at `823bd61`; the candidate, micro, and paired commands were run after the edit. Reproduction uses the same environment for both checkouts. The portable copy below resolves `ROOT` from the working directory rather than the original absolute checkout path.

```sh
PYTHONHASHSEED=0 .venv/bin/python /private/tmp/gem-160-bench.py suite baseline
# Apply this PR, keeping the same Python environment and replay files.
for run in 1 2 3; do PYTHONHASHSEED=0 .venv/bin/python /private/tmp/gem-160-bench.py micro "$run" || exit; done
PYTHONHASHSEED=0 .venv/bin/python /private/tmp/gem-160-bench.py suite candidate
PYTHONHASHSEED=0 .venv/bin/python /private/tmp/gem-160-bench.py paired
```

<details>
<summary>Temporary benchmark harness</summary>

```python
import cProfile
import hashlib
import json
import os
from pathlib import Path
import platform
import resource
import statistics
import subprocess
import sys
import time
import timeit

import gem
from gem.parser import ReplayParser
from gem.state.entities import EntityOp

ROOT = Path.cwd()
OUT = Path('/private/tmp/gem-160-results')
OUT.mkdir(exist_ok=True)

def replay(revision, mode, match_id, run):
    if revision == 'paired-baseline':
        def original(self, other):
            return bool(self & other)
        EntityOp.has = original
    path = ROOT / 'tests/fixtures/opendota' / f'{match_id}.dem'
    parser = ReplayParser(path) if mode == 'core' else None
    before = resource.getrusage(resource.RUSAGE_SELF)
    start = time.perf_counter()
    if parser is None:
        result = gem.parse(path)
    else:
        parser.parse()
    elapsed = time.perf_counter() - start
    after = resource.getrusage(resource.RUSAGE_SELF)
    record = dict(revision=revision, mode=mode, match_id=match_id, run=run,
                  elapsed_s=elapsed, user_s=after.ru_utime-before.ru_utime,
                  peak_rss_bytes=after.ru_maxrss if sys.platform == 'darwin' else after.ru_maxrss*1024,
                  python=sys.version, platform=platform.platform(), executable=sys.executable,
                  fixture_bytes=path.stat().st_size)
    if parser is not None:
        record.update(parse_error=str(parser.parse_error) if parser.parse_error else None,
                      tick=parser.tick, match_id_parsed=parser.match_id)
        if parser.parse_error:
            raise RuntimeError(record)
    else:
        record.update(players=len(result.players), combat_entries=len(result.combat_log))
        encoded = json.dumps(gem.to_dict(result), sort_keys=True, separators=(',', ':')).encode()
        record.update(output_bytes=len(encoded), output_sha256=hashlib.sha256(encoded).hexdigest())
        output = OUT / f'{revision}-{match_id}.json'
        if output.exists():
            assert output.read_bytes() == encoded, 'Within-revision output changed'
        else:
            output.write_bytes(encoded)
        if revision != 'baseline':
            assert (OUT / f'baseline-{match_id}.json').read_bytes() == encoded, 'Replay output changed'
    print(json.dumps(record), flush=True)
    with (OUT / 'replays.jsonl').open('a') as f:
        f.write(json.dumps(record)+'\n')

def micro(run):
    def original(self, other):
        return bool(self & other)
    candidate = EntityOp.has
    cases = {'hit': (EntityOp.CREATED_ENTERED, EntityOp.CREATED),
             'miss': (EntityOp.UPDATED, EntityOp.DELETED),
             'composite': (EntityOp.CREATED, EntityOp.CREATED_ENTERED),
             'zero_query': (EntityOp.CREATED, EntityOp.NONE),
             'zero_op': (EntityOp.NONE, EntityOp.DELETED)}
    records=[]
    for name, (op, query) in cases.items():
        for label, method in [('original', original), ('candidate', candidate)]:
            times = timeit.repeat('method(op, query)', globals=dict(method=method,op=op,query=query),
                                  repeat=5, number=1_000_000)
            records.append(dict(run=run, case=name, method=label,
                                repetitions_ns_per_call=[v*1000 for v in times],
                                median_ns_per_call=statistics.median(times)*1000))
    for label, method in [('original',original), ('candidate',candidate)]:
        profile=cProfile.Profile()
        profile.enable()
        for _ in range(10000):
            method(EntityOp.CREATED_ENTERED,EntityOp.CREATED)
        profile.disable()
        enum_and=sum(stat.callcount for stat in profile.getstats()
                     if hasattr(stat.code,'co_name') and stat.code.co_name=='__and__'
                     and 'enum.py' in stat.code.co_filename)
        assert enum_and == (10000 if label=='original' else 0), (label,enum_and)
        records.append(dict(run=run,method=label,instrumented_calls=10000,enum_and_calls=enum_and))
    for record in records:
        print(json.dumps(record),flush=True)
    with (OUT / 'micro.jsonl').open('a') as f:
        for record in records:
            f.write(json.dumps(record)+'\n')

if sys.argv[1]=='paired':
    for run in range(1,4):
        revisions = ('paired-baseline','paired-candidate') if run % 2 else ('paired-candidate','paired-baseline')
        for revision in revisions:
            print(f'START {revision} public 8822520406 run {run}',flush=True)
            subprocess.run([sys.executable,__file__,'replay',revision,'public','8822520406',str(run)],check=True)
elif sys.argv[1]=='suite':
    revision=sys.argv[2]
    for match_id in ('8822520406','8856501050'):
        for mode in ('public','core'):
            for run in range(1,4):
                print(f'START {revision} {mode} {match_id} run {run}',flush=True)
                subprocess.run([sys.executable,__file__,'replay',revision,mode,match_id,str(run)],check=True)
elif sys.argv[1]=='replay':
    replay(*sys.argv[2:])
elif sys.argv[1]=='micro':
    micro(sys.argv[2])
```

</details>

Offline parity command, using the temporary runner below:

```sh
for match in 8868259993 8860187335 8856501050; do PYTHONHASHSEED=0 .venv/bin/python /private/tmp/gem-160-parity.py "$match" || exit; done
```

<details>
<summary>Temporary offline parity runner</summary>

```python
from dataclasses import asdict
import json
from pathlib import Path
import sys

ROOT = Path.cwd()
sys.path.insert(0, str(ROOT))
from scripts.validate_opendota import validate_match

match_id = int(sys.argv[1])
fixture_dir = ROOT / 'tests/fixtures/opendota'
od = json.loads((fixture_dir / f'{match_id}.opendota.json').read_text())
result = validate_match(match_id, fixture_dir / f'{match_id}.dem', od=od, mode='full')
summary = dict(match_id=match_id, passed=result.passed, warned=result.warned,
               failed=result.failed, skipped=result.skipped, errors=result.errors,
               nonpassing=[dict(name=f.name, status=f.status, gem=f.gem_value,
                                reference=f.ref_value, note=f.note)
                           for f in result.all_fields if f.status != 'PASS'])
Path(f'/private/tmp/gem-160-results/parity-{match_id}.json').write_text(
    json.dumps(dict(summary=summary, result=asdict(result)), default=str, indent=2))
print(json.dumps(summary),flush=True)
assert result.failed == 0 and not result.errors, summary
```

</details>

Benchmark scripts and large outputs are temporary and are not included in the commit. Their complete reproduction source is retained here before cleanup.
