### PR TITLE
Skip redundant summon ownership scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Fewer summon ownership scans.** Skip redundant entity lookups for damage
+  events with a source name and no positive stun duration, preserving damage,
+  stun, ability/item usage, and kill attribution.
 - **Lower entity-operation check overhead.** `EntityOp.has()` checks flag values
   directly, avoiding `IntFlag` operation overhead in extractor callbacks while
   preserving overlap semantics and integer-mask compatibility.

--- a/src/gem/combat/aggregator.py
+++ b/src/gem/combat/aggregator.py
@@ -326,16 +326,19 @@ class _CombatAggregator:
             entry: A ``CombatLogEntry`` instance.
         """
         attacker_pid = self._hero_to_pid(entry.attacker_name) if entry.attacker_is_hero else None
-        # Credit summoned unit damage/stuns/uses to the owning hero when the
-        # attacker is not a hero itself (Warlock Golem, LD bear, Chen creeps,
-        # Pugna ward, Beastmaster boars, etc.). DEATH is handled separately
-        # below because OpenDota credits kills to the combat-log sourcename, not
-        # the attacker name.
+        source_name = getattr(entry, "damage_source_name", "") or ""
+        # Resolve summon ownership for ability/item uses, positive stuns, and
+        # damage without a source name. Sourced damage does not otherwise use
+        # the owner slot, even when the source is not a hero. DEATH has separate
+        # source-first attribution below.
         if (
             attacker_pid is None
             and not entry.attacker_is_hero
             and entry.attacker_name
             and entry.log_type in ("DAMAGE", "ABILITY", "ITEM")
+            and (
+                entry.log_type != CombatLogType.DAMAGE or not source_name or entry.stun_duration > 0
+            )
         ):
             attacker_pid = self._summon_to_pid(entry.attacker_name)
 
@@ -352,7 +355,6 @@ class _CombatAggregator:
         # transient units such as Beastmaster boars and Brewmaster split units.
         # When the source name is empty (auto-attack: source == attacker), fall
         # back to the attacker slot.
-        source_name = getattr(entry, "damage_source_name", "") or ""
         if source_name:
             source_pid = self._hero_to_pid(source_name)
             source_unit = source_name

--- a/tests/test_combat_aggregator.py
+++ b/tests/test_combat_aggregator.py
@@ -10,7 +10,10 @@ from dataclasses import fields
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 from gem.combat.aggregator import _CombatAggregator, _ParsedPlayerAgg
+from gem.combat.log import CombatLogEntry, CombatLogType
 from gem.state.entities import Entity
 
 # ---------------------------------------------------------------------------
@@ -682,3 +685,182 @@ class TestInflictorDicts:
         p = agg.players[0]
         assert p.ability_uses["axe_battle_hunger"] == 1
         assert p.ability_targets["axe_battle_hunger"]["npc_dota_hero_mirana"] == 1
+
+
+_OWNER = "npc_dota_hero_warlock"
+_SOURCE = "npc_dota_hero_axe"
+_TARGET = "npc_dota_hero_mirana"
+_SUMMONS = (
+    "npc_dota_warlock_golem_1",
+    "npc_dota_lone_druid_bear1",
+    "npc_dota_neutral_centaur_khan",  # Chen-controlled creep
+    "npc_dota_pugna_nether_ward_1",
+    "npc_dota_beastmaster_boar_1",
+    "npc_dota_brewmaster_earth_1",
+    "npc_dota_brewmaster_storm_1",
+    "npc_dota_brewmaster_fire_1",
+)
+
+
+@pytest.fixture(params=_SUMMONS)
+def owned_unit(request):
+    owner = _hero_entity(0)
+    unit = MagicMock(spec=Entity)
+    unit.get_uint32.return_value = 12345
+    em = MagicMock()
+    em.find_by_npc_name.side_effect = lambda name: unit if name == request.param else None
+    em.find_by_handle.return_value = owner
+    player_ext = SimpleNamespace(
+        _parser=SimpleNamespace(entity_manager=em),
+        _heroes_by_npc={_OWNER: owner, _SOURCE: _hero_entity(2), _TARGET: _hero_entity(4)},
+    )
+    return _CombatAggregator(player_ext), em, request.param
+
+
+def _summon_entry(attacker, **overrides):
+    values = {
+        "tick": 300,
+        "log_type": CombatLogType.DAMAGE,
+        "attacker_name": attacker,
+        "damage_source_name": _SOURCE,
+        "target_name": _TARGET,
+        "target_is_hero": True,
+        "value": 100,
+        "damage_type": "magical",
+        "inflictor_name": "item_radiance",
+        "game_time_s": 10,
+    }
+    values.update(overrides)
+    return CombatLogEntry(**values)
+
+
+def _expected_summon_damage(source, credited_pid):
+    victim = _ParsedPlayerAgg(damage_taken={source: 100}, damage_taken_by_type={"magical": 100})
+    expected = {2: victim}
+    if credited_pid is not None:
+        expected[credited_pid] = _ParsedPlayerAgg(
+            damage={_TARGET: 100},
+            damage_by_type={"magical": 100},
+            damage_targets={"radiance": {_TARGET: 100}},
+            hero_hits={"radiance": 1},
+            damage_inflictor={"radiance": 100},
+            hero_damage=100,
+            max_hero_hit={
+                "type": "max_hero_hit",
+                "time": 10,
+                "max": True,
+                "inflictor": "radiance",
+                "unit": source,
+                "key": _TARGET,
+                "value": 100,
+            },
+        )
+        if source == _SOURCE:
+            victim.damage_inflictor_received["radiance"] = 100
+    return expected
+
+
+class TestSummonOwnershipScans:
+    @pytest.mark.parametrize("source_kind", ["hero", "summon", "unresolved"])
+    @pytest.mark.parametrize("stun_duration", [0.0, 1.5])
+    def test_sourced_damage(self, owned_unit, source_kind, stun_duration):
+        agg, em, attacker = owned_unit
+        source = {"hero": _SOURCE, "summon": attacker, "unresolved": "unknown_source"}[source_kind]
+        entry = _summon_entry(attacker, damage_source_name=source, stun_duration=stun_duration)
+        agg.on_entry(entry)
+        expected = _expected_summon_damage(source, 1 if source_kind == "hero" else None)
+        if stun_duration:
+            expected[0] = _ParsedPlayerAgg(stuns_dealt=stun_duration)
+            em.find_by_npc_name.assert_called_once_with(attacker)
+            em.find_by_handle.assert_called_once_with(12345)
+        else:
+            em.find_by_npc_name.assert_not_called()
+            em.find_by_handle.assert_not_called()
+        assert agg.players == expected
+
+    @pytest.mark.parametrize("source", ["", None, "missing"])
+    def test_missing_source_damage_uses_owner(self, owned_unit, source):
+        agg, em, attacker = owned_unit
+        entry = _summon_entry(attacker, damage_source_name=source)
+        if source == "missing":
+            values = vars(entry).copy()
+            del values["damage_source_name"]
+            entry = SimpleNamespace(**values)
+        agg.on_entry(entry)
+        em.find_by_npc_name.assert_called_once_with(attacker)
+        em.find_by_handle.assert_called_once_with(12345)
+        assert agg.players == _expected_summon_damage(attacker, 0)
+
+    @pytest.mark.parametrize("source", ["", _SOURCE, "unknown_source"])
+    @pytest.mark.parametrize("kind", [CombatLogType.ABILITY, CombatLogType.ITEM])
+    def test_uses_remain_credited_to_owner(self, owned_unit, source, kind):
+        agg, em, attacker = owned_unit
+        entry = _summon_entry(attacker, log_type=kind, damage_source_name=source)
+        agg.on_entry(entry)
+        em.find_by_npc_name.assert_called_once_with(attacker)
+        em.find_by_handle.assert_called_once_with(12345)
+        expected = _ParsedPlayerAgg()
+        if kind == CombatLogType.ABILITY:
+            expected.ability_uses["item_radiance"] = 1
+            expected.ability_targets["radiance"][_TARGET] = 1
+        else:
+            expected.item_uses["item_radiance"] = 1
+        assert agg.players == {0: expected}
+
+    @pytest.mark.parametrize("source", [_SOURCE, "", "unknown_source"])
+    def test_death_source_first_then_owner(self, owned_unit, source):
+        agg, em, attacker = owned_unit
+        entry = _summon_entry(attacker, log_type=CombatLogType.DEATH, damage_source_name=source)
+        agg.on_entry(entry)
+        if source == _SOURCE:
+            em.find_by_npc_name.assert_not_called()
+            em.find_by_handle.assert_not_called()
+            pid = 1
+        else:
+            em.find_by_npc_name.assert_called_once_with(attacker)
+            em.find_by_handle.assert_called_once_with(12345)
+            pid = 0
+        assert agg.players == {pid: _ParsedPlayerAgg(kills_log=[entry])}
+
+    def test_self_death_does_not_resolve_owner(self, owned_unit):
+        agg, em, attacker = owned_unit
+        agg.on_entry(_summon_entry(attacker, log_type=CombatLogType.DEATH, target_name=attacker))
+        em.find_by_npc_name.assert_not_called()
+        em.find_by_handle.assert_not_called()
+        assert agg.players == {}
+
+    @pytest.mark.parametrize("attacker,is_hero", [(_SOURCE, True), ("unknown", True), ("", False)])
+    def test_ineligible_attackers_do_not_scan(self, owned_unit, attacker, is_hero):
+        agg, em, _ = owned_unit
+        agg.on_entry(_summon_entry(attacker, attacker_is_hero=is_hero, stun_duration=1.5))
+        expected = _expected_summon_damage(_SOURCE, 1)
+        if attacker == _SOURCE:
+            expected[1].stuns_dealt = 1.5
+        em.find_by_npc_name.assert_not_called()
+        em.find_by_handle.assert_not_called()
+        assert agg.players == expected
+
+    @pytest.mark.parametrize(
+        "attacker",
+        ["npc_dota_creep_goodguys_melee", "npc_dota_neutral_kobold", "npc_dota_badguys_tower1_mid"],
+    )
+    @pytest.mark.parametrize("source", ["", _SOURCE])
+    def test_unowned_units(self, owned_unit, attacker, source):
+        agg, em, _ = owned_unit
+        em.find_by_npc_name.side_effect = None
+        em.find_by_npc_name.return_value = None
+        agg.on_entry(_summon_entry(attacker, damage_source_name=source))
+        if source:
+            em.find_by_npc_name.assert_not_called()
+        else:
+            em.find_by_npc_name.assert_called_once_with(attacker)
+        em.find_by_handle.assert_not_called()
+        assert agg.players == _expected_summon_damage(source or attacker, 1 if source else None)
+
+    def test_unresolved_owner_preserves_source_damage(self, owned_unit):
+        agg, em, attacker = owned_unit
+        em.find_by_handle.return_value = None
+        agg.on_entry(_summon_entry(attacker, stun_duration=1.5))
+        em.find_by_npc_name.assert_called_once_with(attacker)
+        em.find_by_handle.assert_called_once_with(12345)
+        assert agg.players == _expected_summon_damage(_SOURCE, 1)


### PR DESCRIPTION
## Summary

Closes #163.

Skip summon-owner resolution for non-stunning `DAMAGE` entries with a non-empty `damage_source_name`. For example, a Warlock golem's own named damage still stays under the golem, while a positive stun still credits its owner. Source presence is sufficient; the source need not resolve to a hero.

Keep the existing eligibility predicates, empty/None/missing-source fallback, ability/item usage attribution, and separate source-first death handling. No ownership cache, NPC whitelist, entity-scan changes, dependencies, or public API changes. Includes focused regression tests and an Unreleased changelog entry.

## Rationale and references

The early owner slot is unused by sourced damage unless the event contributes a positive stun. OpenDota `refs/parser/src/main/java/opendota/CreateParsedDataBlob.java::handleDamageCombat` attributes damage to `e.sourcename`; its death handler separately excludes self-deaths. Cross-checked Clarity's S1/S2 `getDamageSourceName` and `getStunDuration` accessors and Manta's `dota_shared_enums.proto` source/stun fields before implementing.

The tests use real `CombatLogEntry` records (plus a missing-attribute compatibility object), lookup spies, distinct owner/source/target players, and full accumulator equality. They cover successful ownership for golems, bears, Chen-controlled creeps, wards, boars, and Brewmaster split units, as well as unowned creeps/towers, unresolved owners, hero attackers, and self-deaths.

## Validation

- Focused aggregation, stun, kill, and match assembly suite: **453 passed**.
- `uv run --no-sync ruff check .`: passed.
- `uv run --no-sync ruff format --check .`: 175 files already formatted.
- `uv run --no-sync mypy src`: passed, 88 source files.
- `git diff --check`: passed.
- GitHub CI: passed (52 s); distribution build: passed (17 s). PyPI publication is intentionally skipped for this PR.

Full unit/slow/integration result:

```
.....                                                                    [100%]
=========================== short test summary info ============================
SKIPPED [1] tests/test_bulk.py:250: pyarrow not installed
SKIPPED [1] tests/test_field_decoder.py:208: Flag optimised away for this range too
SKIPPED [1] tests/test_parquet_export.py:56: No parquet engine installed
3674 passed, 3 skipped in 880.55s (0:14:40)
```

Offline OpenDota `mode="full"` validation, with existing thresholds unchanged:

| Replay | Passed | Warnings | Failures | Skips |
|---|---:|---:|---:|---:|
| 8868259993 | 325 | 0 | 0 | 1 |
| 8860187335 | 326 | 0 | 0 | 1 |
| 8856501050 | 331 | 0 | 0 | 1 |

Each parity skip is the existing informational `teamfights/total_count` comparison (expanded OpenDota event-pipeline filtering). No required fixture or attribution parity check was skipped. Optional parquet coverage remains unavailable without a parquet engine; the full-suite skip reasons above are disclosed.

## Scan-count instrumentation

These are call counts from separate instrumented runs, not performance timings. All observed lookups returned `None`; synthetic tests cover successful ownership resolution.

| Replay | Category | Baseline | Candidate |
|---|---|---:|---:|
| 8822520406 | `ABILITY\|source=False\|stun=False` | 213 | 213 |
| 8822520406 | `DAMAGE\|source=True\|stun=False` | 3349 | 0 |
| 8822520406 | `DEATH\|source=True\|stun=False` | 407 | 407 |
| 8822520406 | `outside_on_entry` | 1 | 1 |
| 8822520406 | **Total** | **3970** | **621** |
| 8856501050 | `ABILITY\|source=False\|stun=False` | 329 | 329 |
| 8856501050 | `DAMAGE\|source=True\|stun=False` | 10520 | 0 |
| 8856501050 | `DEATH\|source=True\|stun=False` | 3837 | 3837 |
| 8856501050 | `outside_on_entry` | 9 | 9 |
| 8856501050 | **Total** | **14695** | **4175** |

No lookups for positive-stun damage, empty-source damage, or item use occurred in these two replay samples; their preservation is covered by the regression tests.

## Public parse benchmarks

Baseline: `f7e6b94bce8ebe40f77bea030c386ecd4762e523` (main including #170), isolated via `git archive`. Candidate: `4b4cefb52472ab4c617e538ab0cd839471789b3f`. Both use the same existing interpreter/dependencies and absolute replay paths. Three alternating fresh-process pairs per replay; order B/C, C/B, B/C. Runs were sequential after all tests/instrumentation completed. Imports, JSON serialization, and hashing are outside parse timing. Peak RSS is captured before serialization. No profiler timings are used as speed evidence.

Environment: Apple M2, 16 GiB RAM, macOS 26.6.2 arm64, CPython 3.10.4. The host was not idle: a diagnostic process snapshot during the long runs showed macOS `duetexpertd` at 96.7% CPU and Spotlight updater at 22.8%. Load averages are retained in the raw records; the timing variation limits general speedup claims.

```json
{
  "platform": "macOS-26.6.2-arm64-arm-64bit",
  "machine": "arm64",
  "processor": "arm",
  "packages": {
    "numpy": "2.2.6",
    "pandas": "2.3.3",
    "protobuf": "7.34.0",
    "python-snappy": "0.7.3",
    "pytest": "9.0.2",
    "ruff": "0.15.5",
    "mypy": "1.19.1"
  },
  "fixture_sha256": {
    "8822520406": "5f976ab73b2efb0e4eca9f7f14d5980f3aae5f63e7952e16a8497eeded57d39d",
    "8856501050": "0f7577525b995347ed9df0c793cc8661c2a9db4ee176bf35cb5dd940e5af17e2"
  }
}
```

Medians (RSS in MiB; negative change means lower):

| Replay | Metric | Baseline | Candidate | Change |
|---|---|---:|---:|---:|
| 8822520406 | Elapsed seconds | 63.995 | 57.615 | -9.97% |
| 8822520406 | User CPU seconds | 62.701 | 57.374 | -8.50% |
| 8822520406 | Peak RSS MiB | 211.062 | 213.859 | +1.33% |
| 8856501050 | Elapsed seconds | 250.738 | 234.461 | -6.49% |
| 8856501050 | User CPU seconds | 245.223 | 230.309 | -6.08% |
| 8856501050 | Peak RSS MiB | 635.750 | 637.844 | +0.33% |

Individual measurements, in execution order:

| Replay | Pair | Revision | Elapsed s | User CPU s | Peak RSS MiB |
|---|---:|---|---:|---:|---:|
| 8822520406 | 1 | baseline | 60.784 | 60.194 | 218.172 |
| 8822520406 | 1 | candidate | 57.545 | 57.374 | 218.609 |
| 8822520406 | 2 | candidate | 57.615 | 57.346 | 213.859 |
| 8822520406 | 2 | baseline | 63.995 | 62.701 | 200.312 |
| 8822520406 | 3 | baseline | 69.803 | 69.360 | 211.062 |
| 8822520406 | 3 | candidate | 69.336 | 68.536 | 203.062 |
| 8856501050 | 1 | baseline | 250.738 | 245.223 | 602.875 |
| 8856501050 | 1 | candidate | 223.113 | 219.624 | 642.891 |
| 8856501050 | 2 | candidate | 243.927 | 238.623 | 611.734 |
| 8856501050 | 2 | baseline | 254.482 | 249.978 | 643.828 |
| 8856501050 | 3 | baseline | 211.463 | 207.985 | 635.750 |
| 8856501050 | 3 | candidate | 234.461 | 230.309 | 637.844 |

The observed medians favor the candidate, but the host drift is large enough that these are not a guaranteed speedup or a statistically established fixed percentage. All short-replay pairs and the first two long-replay pairs had lower candidate elapsed/user CPU time; the third long pair was slower (234.461 vs 211.463 elapsed seconds, 230.309 vs 207.985 user CPU seconds). The candidate long CPU range (219.624–238.623 s) lies within the baseline range (207.985–249.978 s), so that pair does not establish a systematic CPU regression.

Peak RSS also varies in both directions by pair. Short baseline/candidate ranges are 200.312–218.172 / 203.062–218.609 MiB; long ranges are 602.875–643.828 / 611.734–642.891 MiB. The small median increases (2.797 / 2.094 MiB) are within that process-to-process variation, with no consistent memory regression observed. This change adds no retained state. The firm performance result is the removal of 3,349 / 10,520 full entity scans; output equivalence and retained attribution are independently verified.

## Output equivalence

Public output is sorted-key JSON with fixed compact separators and `PYTHONHASHSEED=0`. Baseline/candidate bytes are compared directly (not only hashes), including every timed parse. Internal combat accumulators are compared separately before postgame scalar overlays can mask attribution differences.

| Replay | Public JSON bytes | Public SHA-256 (both revisions) | Internal aggregate SHA-256 (both revisions) |
|---|---:|---|---|
| 8822520406 | 30401205 | `3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427` | `9bf31755c256a99781f45926e07cf3011867bac201250365a749a8583ad0c89a` |
| 8856501050 | 187363261 | `1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e` | `56d0b00ad5cdd7ba461948b171663899231b60c2bb70b11ea618a16ceaf66a60` |

## Reproduction

Run from the repository root with the same environment and local fixtures. Save the two scripts below at the shown temporary paths, adjusting `ROOT` if needed. The baseline archive must be created from the recorded baseline commit before applying candidate changes.

```bash
mkdir -p /private/tmp/gem-163-baseline /private/tmp/gem-163-results
git archive f7e6b94bce8ebe40f77bea030c386ecd4762e523 | tar -x -C /private/tmp/gem-163-baseline
export PYTHONHASHSEED=0
export UV_CACHE_DIR=/private/tmp/gem-163-uv-cache
uv run --no-sync pytest -q -o addopts='' tests/test_combat_aggregator.py tests/test_ability_courier_draft_stuns.py tests/test_derived_kills.py tests/test_match_builder.py
uv run --no-sync pytest -m '' -q -o addopts='' -ra
uv run --no-sync ruff check .
uv run --no-sync ruff format --check .
uv run --no-sync mypy src
.venv/bin/python /private/tmp/gem-163-parity.py 8868259993
.venv/bin/python /private/tmp/gem-163-parity.py 8860187335
.venv/bin/python /private/tmp/gem-163-parity.py 8856501050
.venv/bin/python /private/tmp/gem-163-bench.py instrument baseline 8822520406
.venv/bin/python /private/tmp/gem-163-bench.py instrument candidate 8822520406
.venv/bin/python /private/tmp/gem-163-bench.py instrument baseline 8856501050
.venv/bin/python /private/tmp/gem-163-bench.py instrument candidate 8856501050
# Wait for all other validation processes to finish before timing:
.venv/bin/python /private/tmp/gem-163-bench.py pairs
```

<details>
<summary>Temporary reproduction script: gem-163-bench.py</summary>

```python
import collections
import hashlib
import json
import os
from pathlib import Path
import platform
import resource
import subprocess
import sys
import time

ROOT = Path('/Users/hanyuwu/Study/gem')
BASE = Path('/private/tmp/gem-163-baseline')
OUT = Path('/private/tmp/gem-163-results')
OUT.mkdir(exist_ok=True)

def run(revision, match_id, repetition, instrument=False):
    source = BASE if revision == 'baseline' else ROOT
    sys.path.insert(0, str(source / 'src'))
    import gem
    from gem.api import _to_json_compatible
    from gem.combat.aggregator import _CombatAggregator
    from gem.state.entities import EntityManager
    assert Path(gem.__file__).is_relative_to(source), gem.__file__
    counts = collections.Counter()
    found = collections.Counter()
    context = 'outside_on_entry'
    aggregate = None
    if instrument:
        original_entry = _CombatAggregator.on_entry
        original_find = EntityManager.find_by_npc_name
        def on_entry(self, entry):
            nonlocal context, aggregate
            previous = context
            kind = getattr(entry.log_type, 'value', entry.log_type)
            context = f'{kind}|source={bool(getattr(entry,"damage_source_name","") or "")}|stun={entry.stun_duration > 0}'
            aggregate = self
            try:
                return original_entry(self, entry)
            finally:
                context = previous
        def find(self, name):
            counts[context] += 1
            value = original_find(self, name)
            found[context] += value is not None
            return value
        _CombatAggregator.on_entry = on_entry
        EntityManager.find_by_npc_name = find
    path = ROOT / 'tests/fixtures/opendota' / f'{match_id}.dem'
    before = resource.getrusage(resource.RUSAGE_SELF)
    load_before = os.getloadavg()
    start = time.perf_counter()
    match = gem.parse(path)
    elapsed = time.perf_counter()-start
    after = resource.getrusage(resource.RUSAGE_SELF)
    record = dict(revision=revision, match_id=match_id, repetition=repetition,
                  instrumented=instrument, elapsed_s=elapsed, user_s=after.ru_utime-before.ru_utime,
                  peak_rss_bytes=after.ru_maxrss if sys.platform=='darwin' else after.ru_maxrss*1024,
                  load_before=load_before, load_after=os.getloadavg(),
                  python=sys.version, platform=platform.platform(), source=str(source),
                  fixture_bytes=path.stat().st_size, players=len(match.players),
                  combat_entries=len(match.combat_log))
    payload = json.dumps(gem.to_dict(match),sort_keys=True,separators=(',',':')).encode()
    record.update(output_bytes=len(payload),output_sha256=hashlib.sha256(payload).hexdigest())
    output = OUT / f'{revision}-{match_id}.json'
    if output.exists():
        assert output.read_bytes()==payload, 'Inconsistent output within revision'
    else:
        output.write_bytes(payload)
    other = OUT / f'{"candidate" if revision=="baseline" else "baseline"}-{match_id}.json'
    if other.exists():
        assert other.read_bytes()==payload, 'Changed public output'
    if instrument:
        record.update(scans=dict(counts),found=dict(found),total_scans=sum(counts.values()))
        internal = json.dumps(_to_json_compatible(aggregate.players),sort_keys=True,separators=(',',':')).encode()
        record['aggregate_sha256'] = hashlib.sha256(internal).hexdigest()
        internal_path = OUT/f'{revision}-{match_id}-aggregates.json'
        internal_path.write_bytes(internal)
        other_internal = OUT/f'{"candidate" if revision=="baseline" else "baseline"}-{match_id}-aggregates.json'
        if other_internal.exists():
            assert other_internal.read_bytes()==internal, 'Changed internal aggregates'
        if revision=='candidate':
            assert counts['DAMAGE|source=True|stun=False']==0, counts
            baseline=json.loads((OUT/f'baseline-{match_id}-instrument.json').read_text())
            expected={k:v for k,v in baseline['scans'].items() if k!='DAMAGE|source=True|stun=False'}
            assert dict(counts)==expected, (counts,expected)
        (OUT/f'{revision}-{match_id}-instrument.json').write_text(json.dumps(record,indent=2))
    else:
        with (OUT/'benchmarks.jsonl').open('a') as f:
            f.write(json.dumps(record)+'\n')
    print(json.dumps(record),flush=True)

if sys.argv[1]=='pairs':
    for match_id in ('8822520406','8856501050'):
        for repetition in range(1,4):
            revisions=('baseline','candidate') if repetition%2 else ('candidate','baseline')
            for revision in revisions:
                print(f'START {revision} {match_id} pair {repetition}',flush=True)
                subprocess.run([sys.executable,__file__,'run',revision,match_id,str(repetition)],check=True)
elif sys.argv[1]=='instrument':
    run(sys.argv[2],sys.argv[3],'instrument',True)
else:
    run(*sys.argv[2:])

```
</details>

<details>
<summary>Temporary reproduction script: gem-163-parity.py</summary>

```python
from dataclasses import asdict
import json
import sys
from pathlib import Path
ROOT = Path('/Users/hanyuwu/Study/gem')
sys.path.insert(0, str(ROOT))
from scripts.validate_opendota import validate_match
match_id = int(sys.argv[1])
p = ROOT / 'tests/fixtures/opendota'
od = json.loads((p / f'{match_id}.opendota.json').read_text())
result = validate_match(match_id, p / f'{match_id}.dem', od=od, mode='full')
summary = dict(match_id=match_id, passed=result.passed, warned=result.warned,
               failed=result.failed, skipped=result.skipped, errors=result.errors,
               nonpassing=[dict(name=f.name, status=f.status, gem=f.gem_value,
                                reference=f.ref_value, note=f.note)
                           for f in result.all_fields if f.status != 'PASS'])
(Path('/private/tmp/gem-163-results') / f'parity-{match_id}.json').write_text(
    json.dumps(dict(summary=summary, result=asdict(result)), default=str, indent=2))
print(json.dumps(summary), flush=True)
assert result.failed == 0 and not result.errors

```
</details>

<details>
<summary>Raw benchmark records including load averages</summary>

```jsonl
{"revision": "baseline", "match_id": "8822520406", "repetition": "1", "instrumented": false, "elapsed_s": 60.78437929099891, "user_s": 60.193955, "peak_rss_bytes": 228769792, "load_before": [2.50927734375, 3.33349609375, 3.67626953125], "load_after": [2.458984375, 3.17724609375, 3.59375], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "source": "/private/tmp/gem-163-baseline", "fixture_bytes": 98983300, "players": 10, "combat_entries": 44686, "output_bytes": 30401205, "output_sha256": "3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427"}
{"revision": "candidate", "match_id": "8822520406", "repetition": "1", "instrumented": false, "elapsed_s": 57.54476049996447, "user_s": 57.374234, "peak_rss_bytes": 229228544, "load_before": [2.458984375, 3.17724609375, 3.59375], "load_after": [3.1005859375, 3.24365234375, 3.587890625], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "source": "/Users/hanyuwu/Study/gem", "fixture_bytes": 98983300, "players": 10, "combat_entries": 44686, "output_bytes": 30401205, "output_sha256": "3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427"}
{"revision": "candidate", "match_id": "8822520406", "repetition": "2", "instrumented": false, "elapsed_s": 57.61474766698666, "user_s": 57.346213, "peak_rss_bytes": 224247808, "load_before": [3.1005859375, 3.24365234375, 3.587890625], "load_after": [3.35595703125, 3.26318359375, 3.56982421875], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "source": "/Users/hanyuwu/Study/gem", "fixture_bytes": 98983300, "players": 10, "combat_entries": 44686, "output_bytes": 30401205, "output_sha256": "3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427"}
{"revision": "baseline", "match_id": "8822520406", "repetition": "2", "instrumented": false, "elapsed_s": 63.99499849998392, "user_s": 62.701012, "peak_rss_bytes": 210042880, "load_before": [3.35595703125, 3.26318359375, 3.56982421875], "load_after": [3.4326171875, 3.34716796875, 3.57958984375], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "source": "/private/tmp/gem-163-baseline", "fixture_bytes": 98983300, "players": 10, "combat_entries": 44686, "output_bytes": 30401205, "output_sha256": "3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427"}
{"revision": "baseline", "match_id": "8822520406", "repetition": "3", "instrumented": false, "elapsed_s": 69.80288466706406, "user_s": 69.359746, "peak_rss_bytes": 221315072, "load_before": [3.4326171875, 3.34716796875, 3.57958984375], "load_after": [3.11474609375, 3.306640625, 3.54541015625], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "source": "/private/tmp/gem-163-baseline", "fixture_bytes": 98983300, "players": 10, "combat_entries": 44686, "output_bytes": 30401205, "output_sha256": "3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427"}
{"revision": "candidate", "match_id": "8822520406", "repetition": "3", "instrumented": false, "elapsed_s": 69.33623512496706, "user_s": 68.536017, "peak_rss_bytes": 212926464, "load_before": [3.025390625, 3.28466796875, 3.5361328125], "load_after": [3.91796875, 3.44384765625, 3.5703125], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "source": "/Users/hanyuwu/Study/gem", "fixture_bytes": 98983300, "players": 10, "combat_entries": 44686, "output_bytes": 30401205, "output_sha256": "3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427"}
{"revision": "baseline", "match_id": "8856501050", "repetition": "1", "instrumented": false, "elapsed_s": 250.73821058298927, "user_s": 245.222566, "peak_rss_bytes": 632160256, "load_before": [3.91796875, 3.44384765625, 3.5703125], "load_after": [7.0224609375, 4.541015625, 3.9658203125], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "source": "/private/tmp/gem-163-baseline", "fixture_bytes": 385487555, "players": 10, "combat_entries": 272400, "output_bytes": 187363261, "output_sha256": "1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e"}
{"revision": "candidate", "match_id": "8856501050", "repetition": "1", "instrumented": false, "elapsed_s": 223.1129823749652, "user_s": 219.62387, "peak_rss_bytes": 674119680, "load_before": [10.13037109375, 5.38623046875, 4.27880859375], "load_after": [3.2099609375, 4.40771484375, 4.130859375], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "source": "/Users/hanyuwu/Study/gem", "fixture_bytes": 385487555, "players": 10, "combat_entries": 272400, "output_bytes": 187363261, "output_sha256": "1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e"}
{"revision": "candidate", "match_id": "8856501050", "repetition": "2", "instrumented": false, "elapsed_s": 243.92673475004267, "user_s": 238.622885, "peak_rss_bytes": 641449984, "load_before": [3.5712890625, 4.44384765625, 4.146484375], "load_after": [4.60546875, 4.48583984375, 4.21044921875], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "source": "/Users/hanyuwu/Study/gem", "fixture_bytes": 385487555, "players": 10, "combat_entries": 272400, "output_bytes": 187363261, "output_sha256": "1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e"}
{"revision": "baseline", "match_id": "8856501050", "repetition": "2", "instrumented": false, "elapsed_s": 254.48171629197896, "user_s": 249.978005, "peak_rss_bytes": 675102720, "load_before": [4.19384765625, 4.396484375, 4.1826171875], "load_after": [3.1806640625, 3.8740234375, 4.01708984375], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "source": "/private/tmp/gem-163-baseline", "fixture_bytes": 385487555, "players": 10, "combat_entries": 272400, "output_bytes": 187363261, "output_sha256": "1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e"}
{"revision": "baseline", "match_id": "8856501050", "repetition": "3", "instrumented": false, "elapsed_s": 211.46322804188821, "user_s": 207.984682, "peak_rss_bytes": 666632192, "load_before": [3.23876953125, 3.86181640625, 4.01025390625], "load_after": [4.091796875, 4.046875, 4.04345703125], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "source": "/private/tmp/gem-163-baseline", "fixture_bytes": 385487555, "players": 10, "combat_entries": 272400, "output_bytes": 187363261, "output_sha256": "1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e"}
{"revision": "candidate", "match_id": "8856501050", "repetition": "3", "instrumented": false, "elapsed_s": 234.46115258301143, "user_s": 230.30896099999998, "peak_rss_bytes": 668827648, "load_before": [4.31103515625, 4.09423828125, 4.06005859375], "load_after": [3.52392578125, 4.1484375, 4.12548828125], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "source": "/Users/hanyuwu/Study/gem", "fixture_bytes": 385487555, "players": 10, "combat_entries": 272400, "output_bytes": 187363261, "output_sha256": "1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e"}

```
</details>

## Release hygiene

- [x] Unreleased changelog updated.
- [x] Generated protobufs untouched; no dependency or Python-version changes.
- [x] No replay artifacts, benchmark scripts, or credentials committed.
- [x] Docs build not applicable (no docs changes).

Temporary investigation scripts, baseline archive, and generated outputs are removed after preserving these reproduction notes.
