### PR TITLE
Use binary search for nearest teamfight snapshots.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Faster teamfight snapshot lookup.** Reuse binary-search tick indexes for
+  chronological position and XP queries, preserving ties and unordered-input
+  compatibility.
 - **Fewer summon ownership scans.** Skip redundant entity lookups for damage
   events with a source name and no positive stun duration, preserving damage,
   stun, ability/item usage, and kill attribution.

--- a/src/gem/extractors/teamfights.py
+++ b/src/gem/extractors/teamfights.py
@@ -29,7 +29,10 @@ Reference: refs/parser/src/main/java/opendota/CreateParsedDataBlob.java
 from __future__ import annotations
 
 import math
+from bisect import bisect_left
+from collections.abc import Mapping
 from dataclasses import dataclass, field
+from itertools import pairwise
 from typing import TYPE_CHECKING
 
 from gem.combat.log import CombatLogEntry, opendota_translate
@@ -200,6 +203,7 @@ def detect_teamfights(
     """
     h2s: dict[str, int] = hero_to_slot or {}
     entries = sorted(combat_log, key=lambda e: e.tick)
+    snapshot_lookups = _prepare_snapshot_lookups(player_snapshots)
 
     # --- Pass 1: detect fight windows from hero deaths ----------------------
     # ``active`` holds fights still within their cooldown window.
@@ -235,11 +239,12 @@ def detect_teamfights(
 
         # Resolve the dying hero's position from the nearest snapshot.
         death_pos: tuple[float, float] | None = None
-        if player_snapshots:
+        if snapshot_lookups:
             tgt_slot = h2s.get(entry.target_name)
             if tgt_slot is not None:
-                snaps = player_snapshots.get(tgt_slot, [])
-                death_pos = _nearest_pos(snaps, entry.tick)
+                snaps = snapshot_lookups.get(tgt_slot)
+                if snaps is not None:
+                    death_pos = _nearest_pos(snaps, entry.tick)
 
         # Find the best active fight to absorb this death into.
         target_fight: Teamfight | None = None
@@ -354,11 +359,11 @@ def detect_teamfights(
             if entry.log_type == "DAMAGE":
                 if entry.target_is_hero and not entry.target_is_illusion and entry.attacker_is_hero:
                     if atk_slot is not None and _near_fight(
-                        atk_slot, entry.tick, fight, player_snapshots
+                        atk_slot, entry.tick, fight, snapshot_lookups
                     ):
                         fight.players[atk_slot].damage_dealt += entry.value
                     if tgt_slot is not None and _near_fight(
-                        tgt_slot, entry.tick, fight, player_snapshots
+                        tgt_slot, entry.tick, fight, snapshot_lookups
                     ):
                         fight.players[tgt_slot].damage_taken += entry.value
 
@@ -370,7 +375,7 @@ def detect_teamfights(
                     and entry.attacker_is_hero
                     and entry.attacker_name != entry.target_name
                     and atk_slot is not None
-                    and _near_fight(atk_slot, entry.tick, fight, player_snapshots)
+                    and _near_fight(atk_slot, entry.tick, fight, snapshot_lookups)
                 ):
                     fight.players[atk_slot].healing += entry.value
 
@@ -379,7 +384,7 @@ def detect_teamfights(
                 # stores in target_name (not the attacker). Matches OpenDota and
                 # gem's own combat aggregator (see combat/aggregator.py GOLD).
                 if tgt_slot is not None and _near_fight(
-                    tgt_slot, entry.tick, fight, player_snapshots
+                    tgt_slot, entry.tick, fight, snapshot_lookups
                 ):
                     fight.players[tgt_slot].gold_delta += entry.value
 
@@ -388,7 +393,7 @@ def detect_teamfights(
                 and not entry.attacker_is_illusion
                 and atk_slot is not None
                 and entry.inflictor_name
-                and _near_fight(atk_slot, entry.tick, fight, player_snapshots)
+                and _near_fight(atk_slot, entry.tick, fight, snapshot_lookups)
             ):
                 uses = (
                     fight.players[atk_slot].ability_uses
@@ -398,10 +403,10 @@ def detect_teamfights(
                 uses[entry.inflictor_name] = uses.get(entry.inflictor_name, 0) + 1
 
     # --- Pass 3: XP deltas from snapshots -----------------------------------
-    if player_snapshots:
+    if snapshot_lookups:
         for fight in fights:
-            for pid, snaps in player_snapshots.items():
-                if not snaps or pid >= 10:
+            for pid, snaps in snapshot_lookups.items():
+                if not snaps.snapshots or pid >= 10:
                     continue
                 xp_start = _nearest_xp(snaps, fight.start_tick)
                 xp_end = _nearest_xp(snaps, fight.end_tick)
@@ -475,10 +480,11 @@ def detect_opendota_teamfights(
     if not fights:
         return []
 
+    snapshot_lookups = _prepare_snapshot_lookups(player_snapshots)
     for fight in fights:
         _populate_opendota_xp_bounds(
             fight,
-            player_snapshots,
+            snapshot_lookups,
             game_start_tick=game_start_tick,
         )
 
@@ -493,7 +499,7 @@ def detect_opendota_teamfights(
                 fight,
                 entry,
                 h2s,
-                player_snapshots,
+                snapshot_lookups,
             )
 
     return fights
@@ -537,7 +543,7 @@ def _is_counted_opendota_death(entry: CombatLogEntry) -> bool:
 
 def _populate_opendota_xp_bounds(
     fight: OpenDotaTeamfight,
-    player_snapshots: dict[int, list[PlayerStateSnapshot]] | None,
+    player_snapshots: Mapping[int, list[PlayerStateSnapshot] | _SnapshotLookup] | None,
     *,
     game_start_tick: int | None,
 ) -> None:
@@ -560,7 +566,7 @@ def _populate_opendota_teamfight_event(
     fight: OpenDotaTeamfight,
     entry: CombatLogEntry,
     hero_to_slot: dict[str, int],
-    player_snapshots: dict[int, list[PlayerStateSnapshot]] | None,
+    player_snapshots: Mapping[int, list[PlayerStateSnapshot] | _SnapshotLookup] | None,
 ) -> None:
     if entry.log_type == "DEATH":
         _populate_opendota_death(fight, entry, hero_to_slot, player_snapshots)
@@ -604,7 +610,7 @@ def _populate_opendota_death(
     fight: OpenDotaTeamfight,
     entry: CombatLogEntry,
     hero_to_slot: dict[str, int],
-    player_snapshots: dict[int, list[PlayerStateSnapshot]] | None,
+    player_snapshots: Mapping[int, list[PlayerStateSnapshot] | _SnapshotLookup] | None,
 ) -> None:
     if not _is_counted_opendota_death(entry):
         return
@@ -646,7 +652,7 @@ def _near_fight(
     slot: int,
     tick: int,
     fight: Teamfight,
-    player_snapshots: dict | None,
+    player_snapshots: Mapping[int, list[PlayerStateSnapshot] | _SnapshotLookup] | None,
 ) -> bool:
     """Return True if the player was spatially close to the fight at the given tick.
 
@@ -676,7 +682,49 @@ def _near_fight(
     return math.dist(pos, (fight.centroid_x, fight.centroid_y)) <= _FIGHT_RADIUS
 
 
-def _nearest_xp(snaps: list, tick: int) -> int | None:
+@dataclass(slots=True)
+class _SnapshotLookup:
+    """Per-detector tick index; unordered inputs retain linear selection."""
+
+    snapshots: list[PlayerStateSnapshot]
+    ticks: tuple[int, ...] | None = field(init=False)
+
+    def __post_init__(self) -> None:
+        ticks = tuple(snap.tick for snap in self.snapshots)
+        self.ticks = None if any(a > b for a, b in pairwise(ticks)) else ticks
+
+
+def _prepare_snapshot_lookups(
+    player_snapshots: dict[int, list[PlayerStateSnapshot]] | None,
+) -> dict[int, _SnapshotLookup] | None:
+    if player_snapshots is None:
+        return None
+    return {pid: _SnapshotLookup(snaps) for pid, snaps in player_snapshots.items()}
+
+
+def _nearest_snapshot(
+    snaps: list[PlayerStateSnapshot] | _SnapshotLookup, tick: int
+) -> PlayerStateSnapshot | None:
+    if isinstance(snaps, _SnapshotLookup):
+        snapshots, ticks = snaps.snapshots, snaps.ticks
+    else:
+        snapshots, ticks = snaps, None
+    if not snapshots:
+        return None
+    if ticks is None:
+        return min(snapshots, key=lambda snap: abs(snap.tick - tick))
+
+    right = bisect_left(ticks, tick)
+    if right == 0:
+        return snapshots[0]
+    if right == len(ticks) or tick - ticks[right - 1] <= ticks[right] - tick:
+        # The predecessor may be the last of many equal ticks. Match min()'s
+        # first-in-list tie behavior without walking backward through the run.
+        return snapshots[bisect_left(ticks, ticks[right - 1], 0, right)]
+    return snapshots[right]
+
+
+def _nearest_xp(snaps: list[PlayerStateSnapshot] | _SnapshotLookup, tick: int) -> int | None:
     """Return cumulative earned XP from the snapshot nearest to the given tick.
 
     Uses ``total_earned_xp`` (``m_iTotalEarnedXP``, monotonically increasing),
@@ -684,17 +732,16 @@ def _nearest_xp(snaps: list, tick: int) -> int | None:
     ``m_iCurrentXP`` across a fight window would erase the XP gain of any hero
     who levels up mid-fight once the ``max(0, ...)`` clamp is applied.
     """
-    if not snaps:
-        return None
-    return min(snaps, key=lambda s: abs(s.tick - tick)).total_earned_xp
+    snap = _nearest_snapshot(snaps, tick)
+    return None if snap is None else snap.total_earned_xp
 
 
-def _nearest_pos(snaps: list, tick: int) -> tuple[float, float] | None:
+def _nearest_pos(
+    snaps: list[PlayerStateSnapshot] | _SnapshotLookup, tick: int
+) -> tuple[float, float] | None:
     """Return world (x, y) from the snapshot nearest to the given tick."""
-    if not snaps:
-        return None
-    snap = min(snaps, key=lambda s: abs(s.tick - tick))
-    if snap.x is None or snap.y is None:
+    snap = _nearest_snapshot(snaps, tick)
+    if snap is None or snap.x is None or snap.y is None:
         return None
     return snap.x, snap.y
 

--- a/tests/test_teamfights.py
+++ b/tests/test_teamfights.py
@@ -6,6 +6,10 @@ Integration tests parse a real .dem fixture and verify plausible output.
 
 from __future__ import annotations
 
+import math
+from itertools import combinations_with_replacement
+from types import SimpleNamespace
+
 import pytest
 
 from gem.combat.log import CombatLogEntry
@@ -13,7 +17,9 @@ from gem.extractors.teamfights import (
     Teamfight,
     _near_fight,
     _nearest_pos,
+    _nearest_snapshot,
     _nearest_xp,
+    _SnapshotLookup,
     _update_centroid,
     detect_opendota_teamfights,
     detect_teamfights,
@@ -960,3 +966,179 @@ class TestTeamfightsIntegration:
         for tf in match.teamfights:
             for p in tf.players:
                 assert p.xp_delta >= 0
+
+
+def _lookup_snap(tick, marker=0, **overrides):
+    values = {
+        "tick": tick,
+        "x": float(marker),
+        "y": float(-marker),
+        "total_earned_xp": 1000 + marker,
+        "xp": marker,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _linear_snapshot(snaps, tick):
+    if isinstance(snaps, _SnapshotLookup):
+        snaps = snaps.snapshots
+    return min(snaps, key=lambda snap: abs(snap.tick - tick), default=None)
+
+
+class TestSnapshotLookup:
+    def test_generated_chronological_lists_match_by_identity(self):
+        for size in range(6):
+            for ticks in combinations_with_replacement(range(-2, 3), size):
+                snaps = [_lookup_snap(tick, i) for i, tick in enumerate(ticks)]
+                lookup = _SnapshotLookup(snaps)
+                assert lookup.snapshots is snaps
+                assert lookup.ticks == ticks
+                for query in range(-3, 4):
+                    assert _nearest_snapshot(lookup, query) is _linear_snapshot(snaps, query)
+
+    @pytest.mark.parametrize(
+        "ticks,query,index",
+        [
+            ([], 10, None),
+            ([10], -1, 0),
+            ([10], 99, 0),
+            ([10, 10, 20, 20], 0, 0),
+            ([10, 10, 20, 20], 10, 0),
+            ([10, 10, 20, 20], 14, 0),
+            ([10, 10, 20, 20], 15, 0),
+            ([10, 10, 20, 20], 16, 2),
+            ([10, 10, 20, 20], 20, 2),
+            ([10, 10, 20, 20], 99, 2),
+            ([10, 10, 10], 99, 0),
+            ([20, 10, 20, 10], 15, 0),
+            ([30, 10, 10], 11, 1),
+        ],
+    )
+    def test_boundaries_duplicates_and_unordered_ties(self, ticks, query, index):
+        snaps = [_lookup_snap(tick, i) for i, tick in enumerate(ticks)]
+        original = snaps.copy()
+        lookup = _SnapshotLookup(snaps)
+        expected = None if index is None else snaps[index]
+        for value in (snaps, lookup):
+            assert _nearest_snapshot(value, query) is expected
+            assert _nearest_xp(value, query) == (
+                None if expected is None else expected.total_earned_xp
+            )
+            assert _nearest_pos(value, query) == (
+                None if expected is None else (expected.x, expected.y)
+            )
+        assert all(a is b for a, b in zip(snaps, original, strict=True))
+        if ticks != sorted(ticks):
+            assert lookup.ticks is None
+
+    @pytest.mark.parametrize("x,y", [(None, 0.0), (0.0, None), (None, None), (0.0, 0.0)])
+    def test_selected_missing_coordinates_do_not_seek_another_snapshot(self, x, y):
+        snaps = [_lookup_snap(10, x=x, y=y), _lookup_snap(10, 1), _lookup_snap(20, 2)]
+        lookup = _SnapshotLookup(snaps)
+        assert _nearest_snapshot(lookup, 15) is snaps[0]
+        assert _nearest_pos(lookup, 15) == (None if x is None or y is None else (x, y))
+        assert _nearest_xp(lookup, 15) == 1000
+
+    @pytest.mark.parametrize("duplicate", [False, True])
+    def test_query_tick_probes_are_logarithmic(self, duplicate):
+        ticks = [0] * 4096 + [10] * 4096 if duplicate else list(range(8192))
+        snaps = [_lookup_snap(tick, i) for i, tick in enumerate(ticks)]
+        lookup = _SnapshotLookup(snaps)
+
+        class CountedTicks:
+            probes = 0
+
+            def __len__(self):
+                return len(ticks)
+
+            def __getitem__(self, index):
+                self.probes += 1
+                return ticks[index]
+
+        counted = CountedTicks()
+        lookup.ticks = counted
+
+        class IndexedSnapshots(list):
+            def __iter__(self):
+                pytest.fail("A prepared lookup must not iterate over snapshots")
+
+        lookup.snapshots = IndexedSnapshots(snaps)
+        for query in (-1, 0, 5, 10, 4096, 8193):
+            counted.probes = 0
+            assert _nearest_snapshot(lookup, query) is _linear_snapshot(snaps, query)
+            assert counted.probes > 0
+            assert counted.probes <= 2 * math.ceil(math.log2(len(ticks) + 1)) + 6
+
+    @pytest.mark.parametrize("detector", [detect_teamfights, detect_opendota_teamfights])
+    @pytest.mark.parametrize("unordered", [False, True])
+    def test_detectors_reuse_preparation_and_match_linear_results(
+        self, monkeypatch, detector, unordered
+    ):
+        import gem.extractors.teamfights as tf
+
+        heroes = ["npc_dota_hero_axe", "npc_dota_hero_pudge", "npc_dota_hero_lina"]
+        snaps = {
+            pid: [
+                _lookup_snap(tick, i, x=pid * 10000.0 + i, y=0.0)
+                for i, tick in enumerate((2400, 2700, 2700, 3000, 3300, 3600))
+            ]
+            for pid in range(3)
+        }
+        snaps[0][3].x = None
+        if unordered:
+            snaps = {pid: list(reversed(values)) for pid, values in snaps.items()}
+        original_lists = {pid: values.copy() for pid, values in snaps.items()}
+        original_values = [[vars(s).copy() for s in values] for values in snaps.values()]
+        entries = [
+            _death(3000, heroes[0], game_time_s=100),
+            _death(3030, heroes[1], game_time_s=101),
+            _death(3060, heroes[2], game_time_s=102),
+            _damage(3045, heroes[0], heroes[1]),
+            _ability(3045, heroes[0], "axe_berserkers_call"),
+        ]
+        for entry in entries:
+            entry.game_time_s = entry.tick // 30
+        kwargs = {
+            "hero_to_slot": dict(zip(heroes, range(3), strict=True)),
+            "player_snapshots": snaps,
+        }
+        if detector is detect_opendota_teamfights:
+            kwargs["game_start_tick"] = 0
+        prepared = []
+        used = []
+        original_init = _SnapshotLookup.__init__
+        original_nearest = tf._nearest_snapshot
+
+        def prepare(self, snapshots):
+            original_init(self, snapshots)
+            prepared.append(self)
+
+        def nearest(lookup, tick):
+            assert isinstance(lookup, _SnapshotLookup)
+            used.append(lookup)
+            return original_nearest(lookup, tick)
+
+        with monkeypatch.context() as patch:
+            patch.setattr(_SnapshotLookup, "__init__", prepare)
+            patch.setattr(tf, "_nearest_snapshot", nearest)
+            actual = detector(entries, **kwargs)
+        assert len(prepared) == len(snaps)
+        assert {id(v.snapshots) for v in prepared} == {id(v) for v in snaps.values()}
+        assert {id(v) for v in used} == {id(v) for v in prepared}
+        assert len(used) > len(prepared)
+        with monkeypatch.context() as patch:
+            patch.setattr(tf, "_nearest_snapshot", _linear_snapshot)
+            expected = detector(entries, **kwargs)
+        assert actual == expected
+        assert actual
+        assert [[vars(s) for s in values] for values in snaps.values()] == original_values
+        for pid, values in snaps.items():
+            assert all(a is b for a, b in zip(values, original_lists[pid], strict=True))
+
+    def test_no_opendota_fights_does_not_prepare(self, monkeypatch):
+        def unexpected(*args):
+            pytest.fail("No-fights return should precede snapshot preparation")
+
+        monkeypatch.setattr(_SnapshotLookup, "__init__", unexpected)
+        assert detect_opendota_teamfights([], player_snapshots={0: [_lookup_snap(0)]}) == []


### PR DESCRIPTION
## Summary

Closes #166.

Replace repeated nearest-snapshot scans with per-player tick indexes reused throughout each teamfight detector. Both position and cumulative-XP lookup share the same selection helper. Ordered inputs use binary search; unordered inputs and direct private-helper list calls retain linear selection in original list order.

A second lower-bound search when choosing the predecessor preserves the first duplicate even after the final tick or at a midpoint. Missing coordinates on the selected snapshot still return no position. Public signatures, clustering, attribution, fight windows, result types, and caller data remain unchanged. Indexes are local to detection and discarded afterward. Includes an Unreleased changelog entry.

## References and compatibility

Read OpenDota `refs/parser/processors/processTeamfights.mjs` for position/XP output use, Manta `parser.go` for tick dispatch, and Clarity `InputSourceProcessor.java` for tick/reset handling. Gem's existing `min(..., key=distance)` selection is the compatibility oracle. PlayerExtractor documents chronological snapshots; direct detector callers have no ordering requirement, so unordered lists keep the old fallback without sorting or mutation.

Regression coverage compares snapshot object identity across generated ordered lists, distinct duplicate records, exact/midpoint/boundary queries, missing coordinates, and unordered ties. Both complete detectors are compared with the linear oracle. Lookup preparation is counted once per player per invocation; a logarithmic-probe test rejects iteration over prepared snapshot lists, including 8,192-element duplicate cases. OpenDota's no-fights early return avoids preparation.

## Validation

- Focused teamfight/assembly suite: **198 passed**.
- Strengthened lookup-only suite: **25 passed**.
- `ruff check .`, `ruff format --check .`, `mypy src`, and `git diff --check`: passed (175 formatted files, 88 source files checked).
- Commit hooks passed.
- GitHub CI passed (53 s); distribution build passed (15 s). PyPI publication is intentionally skipped for the PR.

Full unit/slow/integration result:

```
..............................                                           [100%]
=========================== short test summary info ============================
SKIPPED [1] tests/test_bulk.py:250: pyarrow not installed
SKIPPED [1] tests/test_field_decoder.py:208: Flag optimised away for this range too
SKIPPED [1] tests/test_parquet_export.py:56: No parquet engine installed
3699 passed, 3 skipped in 872.39s (0:14:32)
```

Offline OpenDota full-mode parity, thresholds unchanged:

| Replay | Passed | Warnings | Failures | Skips |
|---|---:|---:|---:|---:|
| 8868259993 | 325 | 0 | 0 | 1 |
| 8860187335 | 326 | 0 | 0 | 1 |
| 8856501050 | 331 | 0 | 0 | 1 |

Each parity skip is the existing informational `teamfights/total_count` comparison. No required fixture or attribution check was skipped. Optional parquet coverage remains unavailable without a parquet engine; full-suite skip reasons are disclosed above.

## Instrumentation

Separate instrumented parses; timings are not performance evidence. Query counts and public output are unchanged. All replay inputs were chronological, so every query used the binary path.

| Replay | Position queries | XP queries | Baseline linear visits | Candidate binary probes | Preparations | Indexed snapshot references |
|---|---:|---:|---:|---:|---:|---:|
| 8822520406 | 6499 | 540 | 11121620 | 108802 | 20 | 31600 |
| 8856501050 | 16251 | 920 | 100192785 | 312381 | 20 | 116700 |

Preparation includes one tick extraction and one adjacent-order check per list. Binary probes count accesses inside `bisect_left`; constant-time neighbor/selection accesses are additional. Prepared snapshot references count both detectors separately. No persistent cache or copied snapshot records are introduced.

## Focused benchmarks

Three fresh processes; five repetitions of 6,500 deterministic queries per case and function. Reported values are medians of the three process medians, in nanoseconds/query. Prepared indexes are built outside steady-state timing. The batch column includes one preparation plus all 6,500 queries. Preparation is also timed independently (five batches of 100 preparations). Queries include exact ticks, midpoints, before/after bounds, and deterministic interior ticks.

| Case | Function | Linear ns/query | Indexed ns/query | Prepare + queries ns/query | Preparation µs |
|---|---|---:|---:|---:|---:|
| empty | position | 58.3 | 143.4 | 144.2 | 0.63 |
| empty | xp | 58.4 | 144.2 | 144.0 | 0.63 |
| singleton | position | 380.1 | 292.1 | 293.8 | 0.68 |
| singleton | xp | 323.7 | 241.8 | 243.5 | 0.68 |
| small | position | 898.9 | 380.8 | 381.5 | 1.20 |
| small | xp | 836.0 | 329.9 | 331.1 | 1.20 |
| dense1800 | position | 136938.2 | 513.4 | 554.8 | 138.94 |
| dense1800 | xp | 134825.5 | 460.6 | 499.4 | 138.94 |
| dense7200 | position | 538371.1 | 568.9 | 654.1 | 544.64 |
| dense7200 | xp | 544038.8 | 515.9 | 601.1 | 544.64 |
| duplicates7200 | position | 536979.7 | 561.0 | 662.5 | 544.02 |
| duplicates7200 | xp | 541085.7 | 519.8 | 609.3 | 544.02 |

Indexed position/XP queries on the 1,800-snapshot synthetic lists are about 267× / 293× faster in steady state; the preparation-plus-query batch also shows a large improvement. These are synthetic SimpleNamespace records with the explicit boundary/interior query mix in the script, not predictions of end-to-end replay speedup. Preparation remains O(N), and unordered input retains O(N) lookup for compatibility.

The empty-list path is slower by roughly 85 ns/query because it goes through the shared helper and lookup dispatch. Singleton and larger measured inputs improve. This small empty-input tradeoff is disclosed rather than hidden; full replay benchmarks below include all preparation and dispatch costs.

## Public replay benchmarks

Baseline `e721334a13e5e38b56c97c530aed5e9493618783` (merged #171) was archived before implementation. Candidate `e9666c48dbe04261649463c573296d0bea3775da`. Both use the same existing interpreter/dependencies and absolute fixture files. Three sequential fresh-process pairs per replay, ordered B/C, C/B, B/C. No tests or microbenchmarks ran concurrently with public timing. Preparation is included in parse time. Imports, serialization, and hashing are excluded; peak RSS is captured before serialization. Core parsing does not execute teamfight detection.

Environment and fixture SHA-256:

```json
{
  "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]",
  "platform": "macOS-26.6.2-arm64-arm-64bit",
  "cpu": "Apple M2",
  "ram_gib": 16,
  "packages": {
    "numpy": "2.2.6",
    "pandas": "2.3.3",
    "protobuf": "7.34.0",
    "python-snappy": "0.7.3",
    "pytest": "9.0.2",
    "ruff": "0.15.5",
    "mypy": "1.19.1"
  },
  "fixture_sha256": {
    "8822520406": "5f976ab73b2efb0e4eca9f7f14d5980f3aae5f63e7952e16a8497eeded57d39d",
    "8856501050": "0f7577525b995347ed9df0c793cc8661c2a9db4ee176bf35cb5dd940e5af17e2"
  }
}
```

Medians (negative change means lower):

| Replay | Metric | Baseline | Candidate | Change |
|---|---|---:|---:|---:|
| 8822520406 | Elapsed s | 57.955 | 57.541 | -0.71% |
| 8822520406 | User CPU s | 57.826 | 57.248 | -1.00% |
| 8822520406 | Peak RSS MiB | 218.188 | 200.484 | -8.11% |
| 8856501050 | Elapsed s | 195.515 | 184.672 | -5.55% |
| 8856501050 | User CPU s | 193.386 | 182.525 | -5.62% |
| 8856501050 | Peak RSS MiB | 640.500 | 638.047 | -0.38% |

Individual measurements in execution order:

| Replay | Pair | Revision | Elapsed s | User CPU s | Peak RSS MiB |
|---|---:|---|---:|---:|---:|
| 8822520406 | 1 | baseline | 60.069 | 58.824 | 207.000 |
| 8822520406 | 1 | candidate | 57.405 | 57.248 | 202.266 |
| 8822520406 | 2 | candidate | 57.541 | 57.192 | 200.359 |
| 8822520406 | 2 | baseline | 57.827 | 57.671 | 218.250 |
| 8822520406 | 3 | baseline | 57.955 | 57.826 | 218.188 |
| 8822520406 | 3 | candidate | 58.409 | 57.931 | 200.484 |
| 8856501050 | 1 | baseline | 195.515 | 193.386 | 619.250 |
| 8856501050 | 1 | candidate | 186.719 | 184.036 | 638.047 |
| 8856501050 | 2 | candidate | 184.672 | 182.525 | 643.141 |
| 8856501050 | 2 | baseline | 195.402 | 193.272 | 640.500 |
| 8856501050 | 3 | baseline | 199.796 | 197.155 | 649.562 |
| 8856501050 | 3 | candidate | 182.721 | 180.534 | 631.125 |

The short-replay median elapsed improvement is only 0.71%, with the third pair slightly slower (58.409 vs 57.955 s); this does not establish a reliable user-visible speedup for that fixture. The long candidate was faster in all three pairs, with median elapsed/user CPU lower by 5.55% / 5.62%. Treat these as fixture-specific observations on this host, not guaranteed percentages.

Host load was recorded for every run (see raw records). Short elapsed ranges overlap: baseline 57.827–60.069 s and candidate 57.405–58.409 s. Long ranges are baseline 195.402–199.796 s and candidate 182.721–186.719 s. No systematic CPU regression was observed.

Peak RSS is lower in the reported medians. Short baseline/candidate ranges are 207.000–218.250 / 200.359–202.266 MiB. Long ranges overlap at 619.250–649.562 / 631.125–643.141 MiB, with changes in both directions across pairs. This supports no systematic memory regression; it is not a guarantee of a fixed memory saving. The temporary tick indexes add about one pointer per indexed snapshot and are discarded at detector return. Core-only diagnostics were unnecessary because no unexplained systematic regression appeared.

## Output equivalence

Sorted-key compact public JSON with `PYTHONHASHSEED=0` is compared byte-for-byte against baseline after every parse.

| Replay | JSON bytes | SHA-256 (both revisions) |
|---|---:|---|
| 8822520406 | 30401205 | `3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427` |
| 8856501050 | 187363261 | `1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e` |

## Reproduction

Run from the candidate checkout. Save the scripts below at the stated temporary paths and adjust `ROOT` if needed. Install the same environment and provision the local replay/OpenDota fixtures before timing.

```bash
mkdir -p /private/tmp/gem-166-baseline /private/tmp/gem-166-results
git archive e721334a13e5e38b56c97c530aed5e9493618783 | tar -x -C /private/tmp/gem-166-baseline
export PYTHONHASHSEED=0
export UV_CACHE_DIR=/private/tmp/gem-166-uv-cache
uv run --no-sync pytest -q -o addopts='' tests/test_teamfights.py tests/test_match_builder.py
uv run --no-sync pytest -m '' -q -o addopts='' -ra
uv run --no-sync ruff check .
uv run --no-sync ruff format --check .
uv run --no-sync mypy src
.venv/bin/python /private/tmp/gem-166-parity.py 8868259993
.venv/bin/python /private/tmp/gem-166-parity.py 8860187335
.venv/bin/python /private/tmp/gem-166-parity.py 8856501050
.venv/bin/python /private/tmp/gem-166-bench.py instrument baseline 8822520406
.venv/bin/python /private/tmp/gem-166-bench.py instrument candidate 8822520406
.venv/bin/python /private/tmp/gem-166-bench.py instrument baseline 8856501050
.venv/bin/python /private/tmp/gem-166-bench.py instrument candidate 8856501050
# Finish other validation processes before either timing command:
.venv/bin/python /private/tmp/gem-166-micro.py
.venv/bin/python /private/tmp/gem-166-bench.py pairs
```

<details>
<summary>Temporary reproduction script: gem-166-bench.py</summary>

```python
import collections
import hashlib
import json
import os
from pathlib import Path
import platform
import resource
import subprocess
import sys
import time

ROOT = Path('/Users/hanyuwu/Study/gem')
BASE = Path('/private/tmp/gem-166-baseline')
OUT = Path('/private/tmp/gem-166-results')
OUT.mkdir(exist_ok=True)

def run(revision, match_id, repetition, instrument=False):
    source = BASE if revision == 'baseline' else ROOT
    sys.path.insert(0, str(source / 'src'))
    import gem
    import gem.extractors.teamfights as tf
    assert Path(gem.__file__).is_relative_to(source)
    counts = collections.Counter()
    if instrument:
        if revision == 'candidate':
            original_init = tf._SnapshotLookup.__init__
            def init(self, snapshots):
                original_init(self, snapshots)
                counts['preparations'] += 1
                counts['prepared_snapshots'] += len(snapshots)
                counts['unordered_preparations'] += self.ticks is None
            tf._SnapshotLookup.__init__ = init
            original_bisect = tf.bisect_left
            class Probes:
                def __init__(self, values): self.values = values
                def __len__(self): return len(self.values)
                def __getitem__(self, i):
                    counts['bisect_tick_probes'] += 1
                    return self.values[i]
            def bisect(values, *args, **kwargs):
                counts['binary_searches'] += 1
                return original_bisect(Probes(values), *args, **kwargs)
            tf.bisect_left = bisect
        def wrap(original, kind):
            def lookup(snaps, tick):
                counts[kind + '_queries'] += 1
                if revision == 'baseline' or isinstance(snaps, list):
                    counts['linear_queries'] += 1
                    counts['linear_snapshot_visits'] += len(snaps)
                elif snaps.ticks is None:
                    counts['linear_queries'] += 1
                    counts['linear_snapshot_visits'] += len(snaps.snapshots)
                else:
                    counts['indexed_queries'] += 1
                return original(snaps, tick)
            return lookup
        tf._nearest_pos = wrap(tf._nearest_pos, 'position')
        tf._nearest_xp = wrap(tf._nearest_xp, 'xp')
    path = ROOT / 'tests/fixtures/opendota' / f'{match_id}.dem'
    before = resource.getrusage(resource.RUSAGE_SELF)
    load_before = os.getloadavg()
    start = time.perf_counter()
    match = gem.parse(path)
    elapsed = time.perf_counter() - start
    after = resource.getrusage(resource.RUSAGE_SELF)
    record = dict(revision=revision, match_id=match_id, repetition=repetition,
                  instrumented=instrument, elapsed_s=elapsed, user_s=after.ru_utime-before.ru_utime,
                  peak_rss_bytes=after.ru_maxrss if sys.platform == 'darwin' else after.ru_maxrss*1024,
                  load_before=load_before, load_after=os.getloadavg(), python=sys.version,
                  platform=platform.platform(), fixture_bytes=path.stat().st_size,
                  players=len(match.players), combat_entries=len(match.combat_log))
    payload = json.dumps(gem.to_dict(match), sort_keys=True, separators=(',', ':')).encode()
    record.update(output_bytes=len(payload), output_sha256=hashlib.sha256(payload).hexdigest())
    output = OUT / f'{revision}-{match_id}.json'
    if output.exists(): assert output.read_bytes() == payload
    else: output.write_bytes(payload)
    other = OUT / f'{"candidate" if revision == "baseline" else "baseline"}-{match_id}.json'
    if other.exists(): assert other.read_bytes() == payload, 'Changed public output'
    if instrument:
        record['counts'] = dict(counts)
        if revision == 'candidate':
            baseline = json.loads((OUT/f'baseline-{match_id}-instrument.json').read_text())['counts']
            for key in ('position_queries', 'xp_queries'):
                assert counts[key] == baseline[key]
            assert counts['linear_snapshot_visits'] == 0
            assert counts['unordered_preparations'] == 0
        (OUT/f'{revision}-{match_id}-instrument.json').write_text(json.dumps(record, indent=2))
    else:
        with (OUT/'benchmarks.jsonl').open('a') as f: f.write(json.dumps(record)+'\n')
    print(json.dumps(record), flush=True)

if sys.argv[1] == 'pairs':
    for match_id in ('8822520406','8856501050'):
        for repetition in range(1,4):
            revisions = ('baseline','candidate') if repetition % 2 else ('candidate','baseline')
            for revision in revisions:
                print(f'START {revision} {match_id} pair {repetition}', flush=True)
                subprocess.run([sys.executable,__file__,'run',revision,match_id,str(repetition)], check=True)
elif sys.argv[1] == 'instrument':
    run(sys.argv[2],sys.argv[3],'instrument',True)
else:
    run(*sys.argv[2:])

```
</details>

<details>
<summary>Temporary reproduction script: gem-166-micro.py</summary>

```python
import json
from pathlib import Path
import statistics
import subprocess
import sys
import time
from types import SimpleNamespace
ROOT = Path('/Users/hanyuwu/Study/gem')
OUT = Path('/private/tmp/gem-166-results')
if len(sys.argv) == 1:
    for process in range(1,4):
        subprocess.run([sys.executable, __file__, str(process)], check=True)
    raise SystemExit
sys.path.insert(0, str(ROOT/'src'))
from gem.extractors.teamfights import _SnapshotLookup, _nearest_pos, _nearest_xp

def old_pos(snaps, tick):
    if not snaps: return None
    snap = min(snaps, key=lambda s: abs(s.tick-tick))
    if snap.x is None or snap.y is None: return None
    return snap.x, snap.y

def old_xp(snaps, tick):
    if not snaps: return None
    return min(snaps, key=lambda s: abs(s.tick-tick)).total_earned_xp

def workload(fn, data, queries):
    for query in queries: fn(data, query)

for case,n,duplicate in [('empty',0,False),('singleton',1,False),('small',8,False),
                         ('dense1800',1800,False),('dense7200',7200,False),('duplicates7200',7200,True)]:
    snaps = [SimpleNamespace(tick=(i//100 if duplicate else i)*30, x=float(i), y=0.0,
                             total_earned_xp=i*10, xp=i%100) for i in range(n)]
    end = snaps[-1].tick if snaps else 0
    # Repeated exact, midpoint, before/after-range and deterministic interior queries.
    queries = [(-1,0,end,end+30,15,(i*7919)%(end+1))[i%6] for i in range(6500)]
    indexed = _SnapshotLookup(snaps)
    prep=[]
    for _ in range(5):
        t=time.perf_counter_ns()
        for _ in range(100): _SnapshotLookup(snaps)
        prep.append((time.perf_counter_ns()-t)/100)
    for kind,old,new in [('position',old_pos,_nearest_pos),('xp',old_xp,_nearest_xp)]:
        assert all(old(snaps,q)==new(indexed,q) for q in queries[:100])
        values={'baseline':[], 'candidate':[], 'prepare_plus_queries':[]}
        for repetition in range(5):
            order=('baseline','candidate') if repetition%2==0 else ('candidate','baseline')
            for revision in order:
                fn,data=(old,snaps) if revision=='baseline' else (new,indexed)
                t=time.perf_counter_ns(); workload(fn,data,queries)
                values[revision].append((time.perf_counter_ns()-t)/len(queries))
            t=time.perf_counter_ns(); data=_SnapshotLookup(snaps); workload(new,data,queries)
            values['prepare_plus_queries'].append((time.perf_counter_ns()-t)/len(queries))
        record=dict(process=int(sys.argv[1]),case=case,snapshots=n,kind=kind,queries=6500,
                    repetitions=5,ns_per_query=values, preparation_ns=prep,
                    medians_ns={k:statistics.median(v) for k,v in values.items()},
                    median_preparation_ns=statistics.median(prep))
        with (OUT/'micro.jsonl').open('a') as f: f.write(json.dumps(record)+'\n')
        print(json.dumps({k:v for k,v in record.items() if k not in ('ns_per_query','preparation_ns')}),flush=True)

```
</details>

<details>
<summary>Temporary reproduction script: gem-166-parity.py</summary>

```python
from dataclasses import asdict
import json
from pathlib import Path
import sys
ROOT = Path('/Users/hanyuwu/Study/gem')
sys.path.insert(0, str(ROOT))
from scripts.validate_opendota import validate_match
m = int(sys.argv[1])
p = ROOT/'tests/fixtures/opendota'
r = validate_match(m, p/f'{m}.dem', od=json.loads((p/f'{m}.opendota.json').read_text()), mode='full')
s = dict(match_id=m, passed=r.passed, warned=r.warned, failed=r.failed, skipped=r.skipped,
         errors=r.errors, nonpassing=[dict(name=f.name,status=f.status,note=f.note)
                                    for f in r.all_fields if f.status!='PASS'])
(Path('/private/tmp/gem-166-results')/f'parity-{m}.json').write_text(json.dumps(dict(summary=s,result=asdict(r)),default=str,indent=2))
print(json.dumps(s), flush=True)
assert not r.failed and not r.errors

```
</details>

<details>
<summary>Raw replay measurements including host load</summary>

```jsonl
{"revision": "baseline", "match_id": "8822520406", "repetition": "1", "instrumented": false, "elapsed_s": 60.06898425007239, "user_s": 58.824324, "peak_rss_bytes": 217055232, "load_before": [2.12255859375, 3.02880859375, 3.17236328125], "load_after": [2.08251953125, 2.86572265625, 3.1005859375], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "fixture_bytes": 98983300, "players": 10, "combat_entries": 44686, "output_bytes": 30401205, "output_sha256": "3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427"}
{"revision": "candidate", "match_id": "8822520406", "repetition": "1", "instrumented": false, "elapsed_s": 57.40535099990666, "user_s": 57.248224, "peak_rss_bytes": 212090880, "load_before": [2.07568359375, 2.85107421875, 3.09375], "load_after": [4.21484375, 3.30712890625, 3.24462890625], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "fixture_bytes": 98983300, "players": 10, "combat_entries": 44686, "output_bytes": 30401205, "output_sha256": "3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427"}
{"revision": "candidate", "match_id": "8822520406", "repetition": "2", "instrumented": false, "elapsed_s": 57.54138841596432, "user_s": 57.191718, "peak_rss_bytes": 210092032, "load_before": [4.197265625, 3.318359375, 3.2490234375], "load_after": [3.07861328125, 3.14208984375, 3.18603515625], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "fixture_bytes": 98983300, "players": 10, "combat_entries": 44686, "output_bytes": 30401205, "output_sha256": "3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427"}
{"revision": "baseline", "match_id": "8822520406", "repetition": "2", "instrumented": false, "elapsed_s": 57.826587832998484, "user_s": 57.670567999999996, "peak_rss_bytes": 228851712, "load_before": [3.07861328125, 3.14208984375, 3.18603515625], "load_after": [3.0712890625, 3.1396484375, 3.18017578125], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "fixture_bytes": 98983300, "players": 10, "combat_entries": 44686, "output_bytes": 30401205, "output_sha256": "3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427"}
{"revision": "baseline", "match_id": "8822520406", "repetition": "3", "instrumented": false, "elapsed_s": 57.954963041935116, "user_s": 57.825503999999995, "peak_rss_bytes": 228786176, "load_before": [3.0712890625, 3.1396484375, 3.18017578125], "load_after": [2.74169921875, 3.04638671875, 3.14111328125], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "fixture_bytes": 98983300, "players": 10, "combat_entries": 44686, "output_bytes": 30401205, "output_sha256": "3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427"}
{"revision": "candidate", "match_id": "8822520406", "repetition": "3", "instrumented": false, "elapsed_s": 58.4093487909995, "user_s": 57.930902, "peak_rss_bytes": 210223104, "load_before": [2.74169921875, 3.04638671875, 3.14111328125], "load_after": [2.8388671875, 3.04296875, 3.13427734375], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "fixture_bytes": 98983300, "players": 10, "combat_entries": 44686, "output_bytes": 30401205, "output_sha256": "3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427"}
{"revision": "baseline", "match_id": "8856501050", "repetition": "1", "instrumented": false, "elapsed_s": 195.51469312503468, "user_s": 193.38562100000001, "peak_rss_bytes": 649330688, "load_before": [2.8388671875, 3.04296875, 3.13427734375], "load_after": [2.68505859375, 2.87060546875, 3.0361328125], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "fixture_bytes": 385487555, "players": 10, "combat_entries": 272400, "output_bytes": 187363261, "output_sha256": "1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e"}
{"revision": "candidate", "match_id": "8856501050", "repetition": "1", "instrumented": false, "elapsed_s": 186.7194702080451, "user_s": 184.03583600000002, "peak_rss_bytes": 669040640, "load_before": [2.8193359375, 2.89111328125, 3.041015625], "load_after": [3.03173828125, 3.0849609375, 3.09619140625], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "fixture_bytes": 385487555, "players": 10, "combat_entries": 272400, "output_bytes": 187363261, "output_sha256": "1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e"}
{"revision": "candidate", "match_id": "8856501050", "repetition": "2", "instrumented": false, "elapsed_s": 184.67173729196656, "user_s": 182.525171, "peak_rss_bytes": 674381824, "load_before": [2.87255859375, 3.048828125, 3.08251953125], "load_after": [3.2900390625, 3.09033203125, 3.0869140625], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "fixture_bytes": 385487555, "players": 10, "combat_entries": 272400, "output_bytes": 187363261, "output_sha256": "1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e"}
{"revision": "baseline", "match_id": "8856501050", "repetition": "2", "instrumented": false, "elapsed_s": 195.40179804107174, "user_s": 193.272126, "peak_rss_bytes": 671612928, "load_before": [3.17138671875, 3.0703125, 3.07958984375], "load_after": [2.6875, 3.068359375, 3.08251953125], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "fixture_bytes": 385487555, "players": 10, "combat_entries": 272400, "output_bytes": 187363261, "output_sha256": "1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e"}
{"revision": "baseline", "match_id": "8856501050", "repetition": "3", "instrumented": false, "elapsed_s": 199.7955407499103, "user_s": 197.15497, "peak_rss_bytes": 681115648, "load_before": [2.8154296875, 3.08203125, 3.08740234375], "load_after": [3.55029296875, 3.1708984375, 3.111328125], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "fixture_bytes": 385487555, "players": 10, "combat_entries": 272400, "output_bytes": 187363261, "output_sha256": "1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e"}
{"revision": "candidate", "match_id": "8856501050", "repetition": "3", "instrumented": false, "elapsed_s": 182.7213075000327, "user_s": 180.534436, "peak_rss_bytes": 661782528, "load_before": [3.38525390625, 3.1484375, 3.103515625], "load_after": [3.4169921875, 3.06591796875, 3.060546875], "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]", "platform": "macOS-26.6.2-arm64-arm-64bit", "fixture_bytes": 385487555, "players": 10, "combat_entries": 272400, "output_bytes": 187363261, "output_sha256": "1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e"}

```
</details>

<details>
<summary>Individual microbenchmark repetitions (ns, rounded to 0.1)</summary>

```jsonl
{"process": 1, "case": "empty", "kind": "position", "baseline": [55.2, 54.4, 54.6, 54.6, 54.9], "candidate": [139.2, 133.4, 133.7, 133.8, 133.7], "prepare_plus_queries": [133.5, 133.7, 133.4, 133.3, 133.6], "preparation_ns": [607.9, 590.0, 591.2, 591.7, 589.6]}
{"process": 1, "case": "empty", "kind": "xp", "baseline": [55.1, 58.1, 54.7, 54.8, 54.8], "candidate": [157.6, 139.7, 133.8, 133.9, 133.5], "prepare_plus_queries": [142.3, 138.8, 133.3, 133.5, 134.0], "preparation_ns": [607.9, 590.0, 591.2, 591.7, 589.6]}
{"process": 1, "case": "singleton", "kind": "position", "baseline": [356.4, 351.4, 354.0, 371.3, 370.7], "candidate": [269.3, 271.8, 289.5, 288.8, 284.6], "prepare_plus_queries": [272.2, 273.1, 286.8, 286.9, 285.0], "preparation_ns": [650.4, 636.2, 1162.1, 634.6, 630.4]}
{"process": 1, "case": "singleton", "kind": "xp", "baseline": [319.3, 300.4, 315.4, 315.4, 317.8], "candidate": [224.0, 226.1, 237.6, 236.1, 235.1], "prepare_plus_queries": [226.5, 225.1, 240.5, 239.5, 238.6], "preparation_ns": [650.4, 636.2, 1162.1, 634.6, 630.4]}
{"process": 1, "case": "small", "kind": "position", "baseline": [840.7, 886.2, 884.4, 885.2, 885.9], "candidate": [355.1, 376.6, 373.2, 374.4, 374.9], "prepare_plus_queries": [367.0, 371.9, 375.3, 374.1, 375.7], "preparation_ns": [1191.2, 1184.2, 1169.2, 1327.9, 1191.2]}
{"process": 1, "case": "small", "kind": "xp", "baseline": [809.8, 824.7, 821.4, 818.2, 821.5], "candidate": [306.0, 324.3, 326.1, 323.2, 323.7], "prepare_plus_queries": [313.7, 322.9, 328.0, 324.1, 326.6], "preparation_ns": [1191.2, 1184.2, 1169.2, 1327.9, 1191.2]}
{"process": 1, "case": "dense1800", "kind": "position", "baseline": [128125.0, 128555.3, 128608.3, 130685.5, 132264.0], "candidate": [498.2, 498.5, 500.4, 496.2, 512.5], "prepare_plus_queries": [524.4, 523.7, 523.1, 536.0, 544.1], "preparation_ns": [130754.2, 132395.4, 133134.6, 133419.2, 133409.2]}
{"process": 1, "case": "dense1800", "kind": "xp", "baseline": [131821.0, 127200.5, 124192.6, 125290.7, 126403.3], "candidate": [448.9, 448.8, 440.8, 442.2, 444.6], "prepare_plus_queries": [476.2, 458.9, 463.7, 462.6, 463.7], "preparation_ns": [130754.2, 132395.4, 133134.6, 133419.2, 133409.2]}
{"process": 1, "case": "dense7200", "kind": "position", "baseline": [566732.9, 542670.1, 548707.2, 545540.0, 532253.2], "candidate": [546.5, 551.7, 570.0, 568.5, 550.7], "prepare_plus_queries": [632.7, 627.8, 656.4, 672.1, 627.5], "preparation_ns": [516391.2, 515412.1, 514877.9, 514709.2, 514781.2]}
{"process": 1, "case": "dense7200", "kind": "xp", "baseline": [552704.7, 532743.8, 530259.8, 533391.6, 530474.8], "candidate": [514.7, 514.6, 515.4, 513.8, 495.3], "prepare_plus_queries": [601.1, 577.4, 603.4, 602.6, 575.9], "preparation_ns": [516391.2, 515412.1, 514877.9, 514709.2, 514781.2]}
{"process": 1, "case": "duplicates7200", "kind": "position", "baseline": [535286.5, 536979.7, 534269.4, 584541.8, 565335.0], "candidate": [559.0, 554.7, 583.5, 580.8, 806.1], "prepare_plus_queries": [641.3, 666.8, 668.0, 666.1, 788.1], "preparation_ns": [545122.1, 543192.5, 529570.8, 543546.7, 531767.9]}
{"process": 1, "case": "duplicates7200", "kind": "xp", "baseline": [557304.4, 551277.5, 583016.6, 558600.7, 549129.6], "candidate": [526.8, 525.1, 528.1, 524.7, 559.3], "prepare_plus_queries": [613.3, 883.9, 614.8, 612.3, 646.3], "preparation_ns": [545122.1, 543192.5, 529570.8, 543546.7, 531767.9]}
{"process": 2, "case": "empty", "kind": "position", "baseline": [64.7, 64.9, 65.8, 64.1, 65.8], "candidate": [164.5, 159.4, 158.9, 156.3, 158.0], "prepare_plus_queries": [159.6, 159.1, 160.0, 157.8, 158.5], "preparation_ns": [726.2, 710.0, 699.2, 696.7, 713.3]}
{"process": 2, "case": "empty", "kind": "xp", "baseline": [72.0, 66.0, 64.4, 63.7, 64.1], "candidate": [168.8, 157.9, 166.0, 156.4, 157.4], "prepare_plus_queries": [160.8, 160.3, 160.3, 158.2, 157.6], "preparation_ns": [726.2, 710.0, 699.2, 696.7, 713.3]}
{"process": 2, "case": "singleton", "kind": "position", "baseline": [419.3, 415.6, 414.5, 415.8, 413.8], "candidate": [321.9, 321.0, 324.1, 318.8, 319.7], "prepare_plus_queries": [322.2, 323.6, 321.1, 320.3, 320.1], "preparation_ns": [762.1, 746.7, 1431.2, 737.9, 734.2]}
{"process": 2, "case": "singleton", "kind": "xp", "baseline": [375.8, 351.9, 350.5, 350.1, 352.2], "candidate": [281.0, 272.3, 264.4, 267.5, 268.2], "prepare_plus_queries": [269.8, 268.0, 269.1, 269.0, 278.2], "preparation_ns": [762.1, 746.7, 1431.2, 737.9, 734.2]}
{"process": 2, "case": "small", "kind": "position", "baseline": [1042.9, 983.4, 982.6, 983.6, 984.6], "candidate": [440.9, 417.9, 415.5, 418.2, 416.9], "prepare_plus_queries": [418.8, 417.4, 417.3, 417.6, 416.6], "preparation_ns": [1408.8, 1404.2, 1378.3, 1621.2, 1457.5]}
{"process": 2, "case": "small", "kind": "xp", "baseline": [917.3, 915.8, 915.1, 914.8, 915.4], "candidate": [359.8, 360.4, 364.5, 362.6, 359.7], "prepare_plus_queries": [361.6, 362.1, 361.8, 364.2, 387.3], "preparation_ns": [1408.8, 1404.2, 1378.3, 1621.2, 1457.5]}
{"process": 2, "case": "dense1800", "kind": "position", "baseline": [144425.2, 137489.3, 137408.8, 137133.4, 135370.3], "candidate": [532.1, 529.5, 532.2, 531.2, 532.6], "prepare_plus_queries": [556.7, 577.8, 554.4, 557.8, 553.2], "preparation_ns": [147721.7, 148362.1, 148193.8, 148661.2, 148221.2]}
{"process": 2, "case": "dense1800", "kind": "xp", "baseline": [133766.9, 134825.5, 135102.7, 135010.5, 134368.9], "candidate": [460.6, 456.1, 476.2, 474.4, 455.7], "prepare_plus_queries": [478.3, 501.3, 499.4, 499.5, 481.6], "preparation_ns": [147721.7, 148362.1, 148193.8, 148661.2, 148221.2]}
{"process": 2, "case": "dense7200", "kind": "position", "baseline": [555739.6, 534878.3, 536787.9, 546186.7, 537801.7], "candidate": [571.3, 566.6, 573.9, 568.9, 549.2], "prepare_plus_queries": [655.1, 627.8, 654.1, 661.3, 628.8], "preparation_ns": [535846.7, 545634.2, 544635.8, 554805.8, 542348.3]}
{"process": 2, "case": "dense7200", "kind": "xp", "baseline": [578222.0, 554027.8, 550171.2, 548510.3, 536388.8], "candidate": [575.6, 574.3, 517.9, 512.5, 496.1], "prepare_plus_queries": [669.8, 604.2, 601.2, 602.1, 573.3], "preparation_ns": [535846.7, 545634.2, 544635.8, 554805.8, 542348.3]}
{"process": 2, "case": "duplicates7200", "kind": "position", "baseline": [535080.4, 542468.3, 549017.3, 544280.8, 538543.0], "candidate": [561.0, 552.5, 578.5, 575.7, 560.0], "prepare_plus_queries": [634.6, 666.5, 662.5, 702.1, 634.1], "preparation_ns": [550170.4, 550370.4, 549271.7, 549438.3, 551928.3]}
{"process": 2, "case": "duplicates7200", "kind": "xp", "baseline": [597601.5, 533039.0, 534026.6, 542957.3, 541085.7], "candidate": [525.2, 519.8, 504.0, 500.6, 528.5], "prepare_plus_queries": [607.7, 610.9, 585.5, 614.0, 609.3], "preparation_ns": [550170.4, 550370.4, 549271.7, 549438.3, 551928.3]}
{"process": 3, "case": "empty", "kind": "position", "baseline": [58.3, 58.0, 58.0, 58.3, 58.4], "candidate": [149.5, 143.4, 143.4, 143.5, 142.5], "prepare_plus_queries": [143.9, 143.3, 144.2, 145.0, 144.2], "preparation_ns": [650.0, 633.8, 632.9, 629.6, 633.3]}
{"process": 3, "case": "empty", "kind": "xp", "baseline": [59.1, 58.6, 58.4, 58.3, 58.3], "candidate": [145.2, 144.3, 143.4, 144.0, 144.2], "prepare_plus_queries": [144.8, 142.6, 143.8, 144.0, 144.2], "preparation_ns": [650.0, 633.8, 632.9, 629.6, 633.3]}
{"process": 3, "case": "singleton", "kind": "position", "baseline": [380.1, 379.6, 381.9, 378.3, 381.7], "candidate": [290.6, 291.4, 293.9, 292.1, 293.8], "prepare_plus_queries": [290.2, 296.2, 293.8, 293.8, 295.3], "preparation_ns": [689.6, 677.5, 1206.2, 662.1, 661.2]}
{"process": 3, "case": "singleton", "kind": "xp", "baseline": [330.7, 323.7, 325.0, 323.5, 322.8], "candidate": [241.7, 241.8, 242.1, 298.3, 239.8], "prepare_plus_queries": [243.5, 241.4, 245.5, 242.7, 244.2], "preparation_ns": [689.6, 677.5, 1206.2, 662.1, 661.2]}
{"process": 3, "case": "small", "kind": "position", "baseline": [896.0, 899.7, 899.1, 898.9, 898.8], "candidate": [379.9, 380.8, 380.8, 382.2, 381.2], "prepare_plus_queries": [380.4, 381.6, 381.5, 389.6, 381.4], "preparation_ns": [1197.5, 1173.3, 1191.7, 1380.0, 1196.2]}
{"process": 3, "case": "small", "kind": "xp", "baseline": [832.6, 835.5, 836.7, 836.0, 836.4], "candidate": [329.9, 330.5, 331.3, 329.9, 329.4], "prepare_plus_queries": [330.4, 331.1, 330.0, 331.1, 331.1], "preparation_ns": [1197.5, 1173.3, 1191.7, 1380.0, 1196.2]}
{"process": 3, "case": "dense1800", "kind": "position", "baseline": [136938.2, 137384.1, 134677.7, 140238.0, 135664.3], "candidate": [534.0, 532.5, 511.3, 508.8, 513.4], "prepare_plus_queries": [562.9, 554.8, 531.8, 556.4, 532.2], "preparation_ns": [138982.1, 139214.6, 138942.5, 138611.7, 138900.8]}
{"process": 3, "case": "dense1800", "kind": "xp", "baseline": [136008.5, 135739.9, 134757.4, 133708.9, 137386.6], "candidate": [460.4, 475.9, 478.0, 475.9, 487.1], "prepare_plus_queries": [500.1, 503.9, 500.2, 480.1, 516.1], "preparation_ns": [138982.1, 139214.6, 138942.5, 138611.7, 138900.8]}
{"process": 3, "case": "dense7200", "kind": "position", "baseline": [547169.6, 541068.1, 532820.7, 538371.1, 536161.3], "candidate": [609.2, 605.1, 547.4, 543.2, 573.3], "prepare_plus_queries": [698.3, 659.1, 628.8, 663.9, 662.6], "preparation_ns": [570382.5, 572558.8, 567874.6, 568294.6, 565609.6]}
{"process": 3, "case": "dense7200", "kind": "xp", "baseline": [544038.8, 555466.0, 546619.2, 536884.8, 534817.1], "candidate": [496.1, 514.0, 600.4, 566.6, 515.9], "prepare_plus_queries": [594.7, 602.0, 657.7, 578.5, 598.9], "preparation_ns": [570382.5, 572558.8, 567874.6, 568294.6, 565609.6]}
{"process": 3, "case": "duplicates7200", "kind": "position", "baseline": [559834.3, 536840.0, 534575.8, 539705.4, 529279.7], "candidate": [557.2, 576.6, 556.7, 552.0, 557.0], "prepare_plus_queries": [657.0, 665.1, 637.6, 668.6, 637.7], "preparation_ns": [541874.2, 544017.5, 554203.3, 546329.2, 536300.0]}
{"process": 3, "case": "duplicates7200", "kind": "xp", "baseline": [540665.8, 542051.7, 528023.8, 530815.2, 536408.5], "candidate": [533.4, 523.1, 504.2, 501.3, 504.7], "prepare_plus_queries": [614.5, 590.0, 584.0, 594.7, 586.1], "preparation_ns": [541874.2, 544017.5, 554203.3, 546329.2, 536300.0]}
```
</details>

## Release hygiene

- [x] Unreleased changelog updated.
- [x] No public API, dependency, or Python-version changes.
- [x] Generated protobufs untouched; no replay artifacts or investigation scripts committed.
- [x] Docs build not applicable.

Temporary scripts, baseline archive, and generated outputs are removed after preserving these reproduction notes.
