### PR TITLE
Cache player IDs and prefilter hero snapshots.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Lower player sampling overhead.** Reuse guarded player-ID resolutions and
+  select hero candidates before constructing full snapshots, preserving attribution
+  and sampling behavior.
 - **Faster teamfight snapshot lookup.** Reuse binary-search tick indexes for
   chronological position and XP queries, preserving ties and unordered-input
   compatibility.

--- a/src/gem/extractors/_snapshots.py
+++ b/src/gem/extractors/_snapshots.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from functools import lru_cache
+from typing import TYPE_CHECKING, Any
 
 from gem.schema.sendtable.models import FieldAccessPlan
 
@@ -120,12 +121,85 @@ def _player_id_from_entity(entity: Entity | None, *, allow_owner: bool = False) 
     """
     if entity is None:
         return None
+    return _resolve_player_id(entity, 1 if allow_owner else 0)
+
+
+@dataclass(slots=True)
+class _PlayerIdCacheEntry:
+    index: int
+    serial: int
+    cls: Any
+    serializer: Any
+    field_state: Any
+    dependencies: tuple[tuple[int, Any], ...]
+    player_id: int
+
+
+def _snapshot_player_id(entity: Entity) -> int | None:
+    return _resolve_player_id(entity, 2)
+
+
+def _resolve_player_id(entity: Entity, mode: int) -> int | None:
+    # Modes: direct, owner fallback, snapshot. Unlike general attribution,
+    # snapshots reject a negative primary ID instead of trying the secondary.
+    cache = entity._player_id_cache
+    if entity._state:
+        entity._player_id_cache = cache = None
+    elif cache is not None:
+        entry = cache.get(mode)
+        if entry is not None:
+            if (
+                entry.index == entity.index
+                and entry.serial == entity.serial
+                and entry.cls is entity.cls
+                and entry.serializer is entity.cls.serializer
+                and entry.field_state is entity._field_state
+            ):
+                # Read current storage: FieldState can grow or replace its list.
+                state = entity._field_state._state
+                for index, previous in entry.dependencies:
+                    # Match FieldState._get_compact's extra-slot bound exactly.
+                    raw = state[index] if len(state) >= index + 2 else None
+                    if raw is not previous:
+                        break
+                else:
+                    return entry.player_id
+            del cache[mode]
+
     fields = entity._resolve_fields(_PLAYER_ID_FIELDS)
-    field_count = 3 if allow_owner else 2
+    field_count = 3 if mode == 1 else 2
     for field_index in range(field_count):
         val = entity._get_int32_resolved(fields[field_index])
-        if val is not None and val >= 0:
-            return val // 2
+        if val is None:
+            continue
+        if val < 0:
+            if mode == 2:
+                return None
+            continue
+        player_id = val // 2
+        if not entity._state and all(
+            field.path is None or len(field.path) == 1 for field in fields[:field_count]
+        ):
+            state = entity._field_state._state
+            dependencies = tuple(
+                (field.path[0], state[field.path[0]] if len(state) >= field.path[0] + 2 else None)
+                for field in fields[: field_index + 1]
+                if field.path is not None
+            )
+            entry = _PlayerIdCacheEntry(
+                entity.index,
+                entity.serial,
+                entity.cls,
+                entity.cls.serializer,
+                entity._field_state,
+                dependencies,
+                player_id,
+            )
+            if cache is None:
+                entity._player_id_cache = {mode: entry}
+            else:
+                cache[mode] = entry
+        return player_id
     return None
 
 
@@ -237,16 +311,21 @@ def _snapshot_hero(entity: Entity, tick: int) -> PlayerStateSnapshot | None:
     Returns:
         A snapshot, or ``None`` if the player ID could not be resolved.
     """
-    # m_nPlayerID (post-7.31) or m_iPlayerID (pre-7.31) — raw value is doubled;
-    # divide by 2 to get player slot 0-9. Reference: opendota/Parse.java getPlayerSlotFromEntity()
-    fields = entity._resolve_fields(_HERO_SNAPSHOT_FIELDS)
-    player_id = entity._get_int32_resolved(fields[0])
+    player_id = _snapshot_player_id(entity)
     if player_id is None:
-        player_id = entity._get_int32_resolved(fields[1])
-    if player_id is None or player_id < 0:
         return None
-    player_id //= 2
+    return _build_hero_snapshot(entity, tick, player_id)
 
+
+@lru_cache(maxsize=256)
+def _fallback_npc_name(class_name: str) -> str:
+    # Preserve the existing conversion; EntityNames can override it later.
+    ending = class_name[len(_HERO_CLASS_PREFIX) :].replace("_", "")
+    return "npc_dota_hero" + re.sub(r"([A-Z])", r"_\1", ending).lower()
+
+
+def _build_hero_snapshot(entity: Entity, tick: int, player_id: int) -> PlayerStateSnapshot:
+    fields = entity._resolve_fields(_HERO_SNAPSHOT_FIELDS)
     team = entity._get_int32_resolved(fields[2]) or 0
     level = entity._get_int32_resolved(fields[3]) or 0
     xp = entity._get_int32_resolved(fields[4]) or 0
@@ -263,17 +342,10 @@ def _snapshot_hero(entity: Entity, tick: int) -> PlayerStateSnapshot | None:
 
     pos = _pos(entity)
 
-    # Convert entity class name to the canonical NPC name (camelCase → snake_case).
-    # "CDOTA_Unit_Hero_TemplarAssassin" → "npc_dota_hero_templar_assassin"
-    # "CDOTA_Unit_Hero_Nyx_Assassin"   → "npc_dota_hero_nyx_assassin" (already underscored)
-    # This matches dotaconstants keys and the combat log string table.
-    # Reference: refs/parser/Parse.java combatLogName2
-    _ending = entity.get_class_name()[len(_HERO_CLASS_PREFIX) :].replace("_", "")
-    _npc_name = "npc_dota_hero" + re.sub(r"([A-Z])", r"_\1", _ending).lower()
     return PlayerStateSnapshot(
         tick=tick,
         player_id=player_id,
-        npc_name=_npc_name,
+        npc_name=_fallback_npc_name(entity.get_class_name()),
         team=team,
         level=level,
         xp=xp,

--- a/src/gem/extractors/players.py
+++ b/src/gem/extractors/players.py
@@ -17,9 +17,11 @@ from gem.extractors._snapshots import (
     TEAM_RADIANT,
     PlayerStateSnapshot,
     PlayerTimeSeries,
+    _build_hero_snapshot,
     _player_id_from_entity,
     _pos,
-    _snapshot_hero,
+    _snapshot_hero,  # noqa: F401 — retained private compatibility import
+    _snapshot_player_id,
     scan_player_resource,
     team_data_field,
 )
@@ -621,21 +623,26 @@ class PlayerExtractor:
             if self._parser is not None and self._parser.string_tables is not None
             else None
         )
-        snaps_by_player: dict[int, tuple[Entity, PlayerStateSnapshot]] = {}
+        selected: dict[int, Entity] = {}
         for player_id in range(10):
             entity = self._canonical_hero_entity(player_id)
             if entity is None:
                 continue
-            snap = _snapshot_hero(entity, tick)
-            if snap is not None:
-                snap.game_time_s = getattr(self._parser, "game_time_s", None)
-                snaps_by_player[snap.player_id] = (entity, snap)
+            resolved_id = _snapshot_player_id(entity)
+            if resolved_id is not None:
+                selected[resolved_id] = entity
         for _, entity in sorted(self._heroes.items()):
-            snap = _snapshot_hero(entity, tick)
-            if snap is None or snap.player_id in snaps_by_player:
-                continue
+            resolved_id = _snapshot_player_id(entity)
+            if resolved_id is not None and resolved_id not in selected:
+                selected[resolved_id] = entity
+
+        # Finish selection before constructing full snapshots, preserving the
+        # last canonical / first fallback winner and staging before overlays.
+        snaps_by_player: dict[int, tuple[Entity, PlayerStateSnapshot]] = {}
+        for player_id, entity in selected.items():
+            snap = _build_hero_snapshot(entity, tick, player_id)
             snap.game_time_s = getattr(self._parser, "game_time_s", None)
-            snaps_by_player[snap.player_id] = (entity, snap)
+            snaps_by_player[player_id] = (entity, snap)
         for player_id in sorted(snaps_by_player):
             entity, snap = snaps_by_player[player_id]
             # Resolve canonical NPC name from the EntityNames string table so that

--- a/src/gem/state/entities.py
+++ b/src/gem/state/entities.py
@@ -120,6 +120,7 @@ class Entity:
         "cls",
         "active",
         "_field_state",
+        "_player_id_cache",
         "_state",
     )
 
@@ -129,6 +130,7 @@ class Entity:
         self.cls = cls
         self.active = True
         self._field_state = FieldState()
+        self._player_id_cache: Any = None
         # Flat dict for direct key-value access (tests may write here directly)
         self._state: dict[str, Any] = {}
 

--- a/tests/test_players_extractor.py
+++ b/tests/test_players_extractor.py
@@ -8,6 +8,8 @@ All tests use fake entities and a fake parser — no real .dem files.
 
 from __future__ import annotations
 
+import pytest
+
 from gem.extractors._snapshots import (
     TEAM_DIRE,
     TEAM_RADIANT,
@@ -1531,3 +1533,329 @@ class TestDeathCountReincarnation:
             )
         )
         assert ext._total_deaths.get(0) == 1
+
+
+def _decoded_id_entity(values=(None, None, None), *, nested=False, index=1, serial=1):
+    from gem.schema.sendtable.models import Field, ResolvedField, Serializer
+    from gem.state.entities import ClassInfo
+
+    names = ("m_nPlayerID", "m_iPlayerID", "m_iPlayerOwnerID")
+    serializer = Serializer("Hero", 0)
+    serializer.fields = [Field(n, "int32", "", "", 0, "", None, None, None, None) for n in names]
+    entity = Entity(index, serial, ClassInfo(1, "CDOTA_Unit_Hero_Axe", serializer))
+    for i, (name, value) in enumerate(zip(names, values, strict=True)):
+        path = (i, 0) if nested else (i,)
+        if nested:
+            serializer._resolved_fields[name] = ResolvedField(name, path)
+        entity._field_state._set_compact(path, value)
+    return entity
+
+
+def _linear_player_id(entity, mode):
+    from gem.extractors._snapshots import _PLAYER_ID_FIELDS
+
+    fields = entity._resolve_fields(_PLAYER_ID_FIELDS)
+    for field in fields[: 3 if mode == 1 else 2]:
+        value = entity._get_int32_resolved(field)
+        if value is None:
+            continue
+        if value >= 0:
+            return value // 2
+        if mode == 2:
+            return None
+    return None
+
+
+def _resolve_id_mode(entity, mode):
+    from gem.extractors._snapshots import _snapshot_player_id
+
+    if mode == 2:
+        return _snapshot_player_id(entity)
+    return _player_id_from_entity(entity, allow_owner=mode == 1)
+
+
+class TestGuardedPlayerIds:
+    @pytest.mark.parametrize("mode", range(3))
+    @pytest.mark.parametrize(
+        "values",
+        [
+            (0, 8, 10),
+            (6, 8, 10),
+            (None, 8, 10),
+            (-1, 8, 10),
+            (None, None, 10),
+            (-1, -2, 10),
+            (None, None, None),
+            (6.0, 8, 10),
+            ("6", False, 10),
+            (True, 8, 10),
+            (20, None, None),
+        ],
+    )
+    def test_decoded_modes_match_original(self, values, mode):
+        entity = _decoded_id_entity(values)
+        assert entity._player_id_cache is None
+        expected = _linear_player_id(entity, mode)
+        assert _resolve_id_mode(entity, mode) == expected
+        assert _resolve_id_mode(entity, mode) == expected
+        if expected is None:
+            assert entity._player_id_cache is None
+        else:
+            assert entity._player_id_cache[mode].player_id == expected
+
+    def test_hits_skip_resolved_readers_and_unrelated_updates(self, monkeypatch):
+        entity = _decoded_id_entity((0, None, None))
+        for mode in range(3):
+            assert _resolve_id_mode(entity, mode) == 0
+        entries = dict(entity._player_id_cache)
+
+        def unexpected(*args):
+            pytest.fail("cache hit resolved fields again")
+
+        monkeypatch.setattr(Entity, "_resolve_fields", unexpected)
+        monkeypatch.setattr(Entity, "_get_int32_resolved", unexpected)
+        entity._field_state._set_compact((100,), 99)
+        entity.active = False
+        for mode in range(3):
+            assert _resolve_id_mode(entity, mode) == 0
+            assert entity._player_id_cache[mode] is entries[mode]
+        entity.active = True
+        assert _resolve_id_mode(entity, 2) == 0
+
+    @pytest.mark.parametrize("mode", range(3))
+    def test_late_population_priority_and_replacement(self, mode):
+        entity = _decoded_id_entity()
+        for values in [
+            (None, None, None),
+            (None, 8, 10),
+            (0, 8, 10),
+            (6, 8, 10),
+            (6.0, 8, 10),
+            (-1, 8, 10),
+            (None, None, 12),
+            (None, None, None),
+            (False, 8, 10),
+        ]:
+            for i, value in enumerate(values):
+                entity._field_state._state[i] = value
+            assert _resolve_id_mode(entity, mode) == _linear_player_id(entity, mode)
+            assert _resolve_id_mode(entity, mode) == _linear_player_id(entity, mode)
+            if _linear_player_id(entity, mode) is None:
+                assert not entity._player_id_cache or mode not in entity._player_id_cache
+
+    @pytest.mark.parametrize("change", ["index", "serial", "class", "serializer", "field_state"])
+    def test_identity_changes_discard_entry(self, change):
+        from copy import copy
+
+        from gem.schema.field_state import FieldState
+
+        entity = _decoded_id_entity((6, None, None))
+        assert _resolve_id_mode(entity, 0) == 3
+        old = entity._player_id_cache[0]
+        if change == "index":
+            entity.index += 1
+        elif change == "serial":
+            entity.serial += 1
+        elif change == "class":
+            entity.cls = copy(entity.cls)
+        elif change == "serializer":
+            entity.cls.serializer = copy(entity.cls.serializer)
+        else:
+            entity._field_state = FieldState()
+            entity._field_state._set_compact((0,), 6)
+        assert _resolve_id_mode(entity, 0) == 3
+        assert entity._player_id_cache[0] is not old
+
+    def test_current_root_storage_and_extra_slot_bound(self):
+        entity = _decoded_id_entity((None, 8, None))
+        assert _resolve_id_mode(entity, 0) == 4
+        entity._field_state._state = [None, 8]
+        assert _resolve_id_mode(entity, 0) is None  # index 1 requires length >= 3
+        entity._field_state._state.append(None)
+        assert _resolve_id_mode(entity, 0) == 4
+        entity._field_state._state = [0, 8, None]
+        assert _resolve_id_mode(entity, 0) == 0
+
+    def test_raw_identity_does_not_confuse_equal_float_and_int(self):
+        entity = _decoded_id_entity((6, 8, None))
+        assert _resolve_id_mode(entity, 0) == 3
+        entity._field_state._state[0] = 6.0
+        assert _resolve_id_mode(entity, 0) == 4
+        entity._field_state._state[0] = int("1000")
+        assert _resolve_id_mode(entity, 0) == 500
+        entry = entity._player_id_cache[0]
+        entity._field_state._state[0] = int("1000")
+        assert _resolve_id_mode(entity, 0) == 500
+        assert entity._player_id_cache[0] is not entry
+
+    def test_overlay_added_changed_cleared(self):
+        entity = _decoded_id_entity((6, 8, 10))
+        for mode in range(3):
+            _resolve_id_mode(entity, mode)
+        for value in [0, None, -1, "invalid"]:
+            entity._state["m_nPlayerID"] = value
+            for mode in range(3):
+                assert _resolve_id_mode(entity, mode) == _linear_player_id(entity, mode)
+                assert entity._player_id_cache is None
+        entity._state.clear()
+        assert _resolve_id_mode(entity, 0) == 3
+        assert entity._player_id_cache is not None
+
+    @pytest.mark.parametrize("mode", range(3))
+    def test_nested_paths_are_uncached(self, mode):
+        entity = _decoded_id_entity((None, 8, 10), nested=True)
+        assert _resolve_id_mode(entity, mode) == 4
+        assert entity._player_id_cache is None
+        entity._field_state._set_compact((0, 0), 0)
+        assert _resolve_id_mode(entity, mode) == 0
+        assert entity._player_id_cache is None
+
+    def test_entries_are_entity_local_with_recycled_indices(self):
+        first = _decoded_id_entity((6, None, None))
+        second = _decoded_id_entity((8, None, None), serial=2)
+        third = _decoded_id_entity((0, None, None))
+        for e, expected in [(first, 3), (second, 4), (third, 0)]:
+            assert e._player_id_cache is None
+            assert _resolve_id_mode(e, 0) == expected
+        assert first._player_id_cache is not second._player_id_cache
+        assert first._player_id_cache is not third._player_id_cache
+
+    def test_absent_primary_schema_and_owner_mode_are_independent(self):
+        entity = _decoded_id_entity((None, None, 8))
+        entity.cls.serializer.fields = entity.cls.serializer.fields[2:]
+        entity._field_state._state = [8, None]
+        assert _resolve_id_mode(entity, 1) == 4
+        assert _resolve_id_mode(entity, 0) is None
+        assert _resolve_id_mode(entity, 2) is None
+        assert set(entity._player_id_cache) == {1}
+        entity._field_state._state[0] = 10
+        assert _resolve_id_mode(entity, 1) == 5
+
+
+@pytest.mark.parametrize("minute", [False, True])
+def test_prefilter_matches_original_selection_and_complete_snapshots(monkeypatch, minute):
+    from gem.extractors import players as module
+
+    heroes = [
+        _hero("Axe", index=i, m_nPlayerID=raw, m_iHealth=100 + i)
+        for i, raw in [(40, 0), (5, 0), (30, 2), (2, 2), (50, 4)]
+    ]
+    illusion = _ent("CDOTA_Unit_Hero_Axe", m_iPlayerOwnerID=6)
+    invalid = _ent("CDOTA_Unit_Hero_Axe", m_nPlayerID=-1, m_iPlayerID=6)
+    canonical = [heroes[0], heroes[1], heroes[0], None, illusion, invalid]
+    fallback = {
+        50: heroes[4],
+        30: heroes[2],
+        2: heroes[3],
+        40: heroes[0],
+        60: illusion,
+        70: invalid,
+    }
+    # Original algorithm: construct first, last canonical wins, sorted fallback first wins.
+    expected = {}
+    for entity in canonical:
+        if entity is not None:
+            snap = _snapshot_hero(entity, 123)
+            if snap is not None:
+                expected[snap.player_id] = (entity, snap)
+    for _, entity in sorted(fallback.items()):
+        snap = _snapshot_hero(entity, 123)
+        if snap is not None and snap.player_id not in expected:
+            expected[snap.player_id] = (entity, snap)
+    ext = PlayerExtractor()
+    ext.attach(FakeParser())
+    ext._parser.game_time_s = 17
+    ext._heroes = fallback
+    monkeypatch.setattr(
+        ext, "_canonical_hero_entity", lambda p: canonical[p] if p < len(canonical) else None
+    )
+    monkeypatch.setattr(ext, "_read_abilities", lambda e: {"ability": e.index})
+    monkeypatch.setattr(ext, "_read_inventory", lambda e: {0: "item_blink"})
+    diffs = []
+    monkeypatch.setattr(ext, "_diff_inventory", lambda *args: diffs.append(args))
+    built = []
+    original = module._build_hero_snapshot
+
+    def build(entity, tick, player_id):
+        built.append((player_id, entity))
+        return original(entity, tick, player_id)
+
+    monkeypatch.setattr(module, "_build_hero_snapshot", build)
+    ext._sample(123, minute=minute)
+    assert len(built) == len(expected) == 3
+    assert all(entity is expected[pid][0] for pid, entity in built)
+    expected_snaps = []
+    for pid in sorted(expected):
+        entity, snap = expected[pid]
+        snap.game_time_s = 17
+        snap.ability_levels = {"ability": entity.index}
+        if not minute:
+            snap.items = {0: "item_blink"}
+        expected_snaps.append(snap)
+    assert (ext._minute_snaps if minute else ext.snapshots) == expected_snaps
+    assert len(diffs) == (0 if minute else 3)
+
+
+def test_fallback_npc_name_cache_is_bounded_and_reused():
+    from gem.extractors._snapshots import _fallback_npc_name
+
+    _fallback_npc_name.cache_clear()
+    assert _fallback_npc_name("CDOTA_Unit_Hero_TemplarAssassin") == "npc_dota_hero_templar_assassin"
+    assert _fallback_npc_name("CDOTA_Unit_Hero_Nyx_Assassin") == "npc_dota_hero_nyx_assassin"
+    _fallback_npc_name("CDOTA_Unit_Hero_TemplarAssassin")
+    assert _fallback_npc_name.cache_info().hits == 1
+    for i in range(300):
+        _fallback_npc_name(f"CDOTA_Unit_Hero_Test{i}")
+    assert _fallback_npc_name.cache_info().currsize == 256
+    _fallback_npc_name.cache_clear()
+
+
+def test_cached_fallback_does_not_freeze_entity_names():
+    from gem.state.string_table import StringTable, StringTables
+
+    table = StringTable(0, "EntityNames")
+    tables = StringTables()
+    tables.add(table)
+    parser = FakeParser()
+    parser.string_tables = tables
+    ext = PlayerExtractor()
+    ext.attach(parser)
+    entity = _hero("QueenOfPain", **{"m_pEntity.m_nameStringableIndex": 7})
+    ext._heroes[0] = entity
+    ext._sample(1)
+    table.items[7] = ("npc_dota_hero_queenofpain", b"")
+    ext._sample(2)
+    table.items[7] = ("updated_name", b"")
+    ext._sample(3)
+    assert [s.npc_name for s in ext.snapshots] == [
+        "npc_dota_hero_queen_of_pain",
+        "npc_dota_hero_queenofpain",
+        "updated_name",
+    ]
+
+
+def test_decoded_cache_and_canonical_handles_remain_parser_local():
+    from gem.state.string_table import StringTables
+
+    extractors = []
+    for raw in [0, 8]:
+        parser = FakeParser()
+        parser.string_tables = StringTables()
+        entity = _decoded_id_entity((raw, None, None))
+        replacement = _decoded_id_entity((raw, None, None), serial=2)
+        parser.entity_manager = FakeEntityManager({100: entity, 200: replacement})
+        ext = PlayerExtractor()
+        ext.attach(parser)
+        controller = _ent("CDOTAPlayerController", m_hAssignedHero=100)
+        ext._controllers[0] = controller
+        ext._sample(1)
+        assert entity._player_id_cache[2].player_id == raw // 2
+        assert replacement._player_id_cache is None
+        controller._state["m_hAssignedHero"] = 200
+        ext._sample(2)
+        assert replacement._player_id_cache[2].player_id == raw // 2
+        controller._state["m_hAssignedHero"] = 999
+        ext._sample(3)
+        assert [s.player_id for s in ext.snapshots] == [raw // 2, raw // 2]
+        extractors.append(ext)
+    assert extractors[0].snapshots[0].player_id != extractors[1].snapshots[0].player_id


### PR DESCRIPTION
Closes #162.

## Summary and compatibility

Cache successful root-level player IDs behind entity index/serial, class/serializer, FieldState identity, and current raw-value guards. Prefilter hero candidates before constructing one snapshot per selected player. Cache only the deterministic fallback NPC conversion (256 entries).

Preserve general direct/owner precedence, snapshot rejection of negative primary IDs, ID zero, integer/boolean behavior, late population and replacement, nested/overlay fallback, canonical last-wins/fallback first-wins selection, staging before overlays, sampling cadence, and live EntityNames overrides. No decoder hooks, dependencies, persistent entity registry, or public result-model changes.

Reference rationale: OpenDota `refs/parser/src/main/java/opendota/Parse.java:getPlayerSlotFromEntity` establishes field precedence and doubled IDs. Manta `refs/manta/entity.go` and Clarity `refs/clarity/src/main/java/skadistats/clarity/model/Entity.java` establish entity identity and mutable state. Gem's pre-change resolver and sampling behavior remain the compatibility oracle, including its negative-ID distinction.

Baseline: `24a776856fe713eb5b82867883ee59b7ca5bf661`; candidate: `6a124931be10bd7bcfa6f84bd4a041a9d362723c`.

## Validation

- Full unit/slow/integration suite: **3754 passed, 3 skipped**, 749.40 s.
- Focused player/ward/combat/interval/running-total tests: **519 passed, 3 deselected**. Focused match assembly: **117 passed**. Includes **55 new regression cases**.
- Repository-wide Ruff lint and format check pass; mypy passes for all 88 source files.
- Full-suite skips: `tests/test_bulk.py:250` — optional pyarrow unavailable; `tests/test_parquet_export.py:56` — optional Parquet engine unavailable; `tests/test_field_decoder.py:208` — flag optimized away for that range. None is a required parity fixture.

Commands (same existing `.venv`; `uv run --no-sync` is equivalent with the configured UV cache):
```sh
.venv/bin/python -m pytest -q -o addopts='' tests/test_players_extractor.py tests/test_wards_extractor.py tests/test_ml_running_totals.py tests/test_intervals_extractor.py tests/test_combat_aggregator.py -m 'not slow and not integration'
.venv/bin/python -m pytest -q -o addopts='' tests/test_match_builder.py -m 'not slow and not integration'
UV_CACHE_DIR=/private/tmp/gem-162/uv-cache uv run --no-sync pytest -m '' -q -o addopts='' -ra
.venv/bin/python -m ruff check .
.venv/bin/python -m ruff format --check .
.venv/bin/python -m mypy src/gem/
```


### Offline OpenDota parity

Full offline validation with unchanged thresholds; complete summaries and every non-passing field below.

```json
[
  {
    "match_id": 8868259993,
    "passed": 325,
    "warned": 0,
    "failed": 0,
    "skipped": 1,
    "errors": [],
    "nonpassing": [
      {
        "name": "teamfights/total_count",
        "status": "SKIP",
        "note": "OpenDota applies deaths>=3 filtering over its expanded event pipeline. Count comparison is informational only."
      }
    ]
  },
  {
    "match_id": 8860187335,
    "passed": 326,
    "warned": 0,
    "failed": 0,
    "skipped": 1,
    "errors": [],
    "nonpassing": [
      {
        "name": "teamfights/total_count",
        "status": "SKIP",
        "note": "OpenDota applies deaths>=3 filtering over its expanded event pipeline. Count comparison is informational only."
      }
    ]
  },
  {
    "match_id": 8856501050,
    "passed": 331,
    "warned": 0,
    "failed": 0,
    "skipped": 1,
    "errors": [],
    "nonpassing": [
      {
        "name": "teamfights/total_count",
        "status": "SKIP",
        "note": "OpenDota applies deaths>=3 filtering over its expanded event pipeline. Count comparison is informational only."
      }
    ]
  }
]
```

<details><summary>Host memory-pressure diagnostics during the noisy interval</summary>

Read-only `date -u`, `vm_stat`, and `memory_pressure` snapshots. Host-wide counters showed substantial compression/decompression activity, so small RSS differences should not be interpreted as precise allocation savings.

```text
memory-pressure-1.txt
Sun Sep  6 04:59:54 UTC 2026
Mach Virtual Memory Statistics: (page size of 16384 bytes)
Pages free:                                     4229.
Pages active:                                 186123.
Pages inactive:                               184925.
Pages speculative:                               681.
Pages throttled:                                   0.
Pages wired down:                             198107.
Pages purgeable:                                  24.
"Translation faults":                     6085905557.
Pages copy-on-write:                       391952527.
Pages zero filled:                        2318477816.
Pages reactivated:                        1417078090.
Pages purged:                               61860720.
File-backed pages:                            133056.
Anonymous pages:                              238673.
Pages stored in compressor:                  1736474.
Pages occupied by compressor:                 436782.
Decompressions:                            950112330.
Compressions:                             1066060384.
Pageins:                                    86971767.
Pageouts:                                    1809283.
Swapins:                                     4693446.
Swapouts:                                    6168528.
The system has 17179869184 (1048576 pages with a page size of 16384).

Stats: 
Pages free: 4292 
Pages purgeable: 24 
Pages purged: 61860720 

Swap I/O:
Swapins: 4693446 
Swapouts: 6168528 

Page Q counts:
Pages active: 186039 
Pages inactive: 184927 
Pages speculative: 684 
Pages throttled: 0 
Pages wired down: 198092 

Compressor Stats:
Pages used by compressor: 436782 
Pages decompressed: 950112330 
Pages compressed: 1066060384 

File I/O:
Pageins: 86971771 
Pageouts: 1809283 

System-wide memory free percentage: 37%

memory-pressure-2.txt
Sun Sep  6 05:01:18 UTC 2026
Mach Virtual Memory Statistics: (page size of 16384 bytes)
Pages free:                                     3976.
Pages active:                                 199162.
Pages inactive:                               197479.
Pages speculative:                              1364.
Pages throttled:                                   0.
Pages wired down:                             198242.
Pages purgeable:                                 401.
"Translation faults":                     6087051665.
Pages copy-on-write:                       392003700.
Pages zero filled:                        2318854246.
Pages reactivated:                        1417382802.
Pages purged:                               61876585.
File-backed pages:                            108455.
Anonymous pages:                              289550.
Pages stored in compressor:                  1677623.
Pages occupied by compressor:                 410526.
Decompressions:                            950482981.
Compressions:                             1066382342.
Pageins:                                    87009861.
Pageouts:                                    1809918.
Swapins:                                     4693450.
Swapouts:                                    6168528.
The system has 17179869184 (1048576 pages with a page size of 16384).

Stats: 
Pages free: 4061 
Pages purgeable: 401 
Pages purged: 61876585 

Swap I/O:
Swapins: 4693450 
Swapouts: 6168528 

Page Q counts:
Pages active: 199078 
Pages inactive: 197479 
Pages speculative: 1367 
Pages throttled: 0 
Pages wired down: 198227 

Compressor Stats:
Pages used by compressor: 410526 
Pages decompressed: 950482981 
Pages compressed: 1066382342 

File I/O:
Pageins: 87009865 
Pageouts: 1809918 

System-wide memory free percentage: 39%

```

</details>

Timing launches were paused after the second-block short cache-only run while the host was overloaded. The active child finished normally; offline parity and operation-count checks ran during the pause. No timings were discarded because of host load; the fixed variant order then resumed. Pause/resume UTC timestamps:
```text
Sun Sep  6 05:05:28 UTC 2026
Sun Sep  6 05:35:49 UTC 2026

```

Power-status spot check (read-only `pmset -g batt` / `pmset -g therm`):
```text
Sun Sep  6 05:45:53 UTC 2026
Now drawing from 'AC Power'
 -InternalBattery-0 (id=36044899)	80%; AC attached; not charging present: true
Note: No thermal warning level has been recorded
Note: No performance warning level has been recorded
Note: No CPU power status has been recorded

```

## Environment

```json
{
  "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]",
  "platform": "macOS-26.6.2-arm64-arm-64bit",
  "hardware": "Apple M2, 16 GiB",
  "packages": {
    "numpy": "2.2.6",
    "pandas": "2.3.3",
    "protobuf": "7.34.0",
    "python-snappy": "0.7.3",
    "pytest": "9.0.2",
    "ruff": "0.15.5",
    "mypy": "1.19.1"
  },
  "fixtures": {
    "8822520406": "5f976ab73b2efb0e4eca9f7f14d5980f3aae5f63e7952e16a8497eeded57d39d",
    "8856501050": "0f7577525b995347ed9df0c793cc8661c2a9db4ee176bf35cb5dd940e5af17e2"
  }
}
```

## Performance interpretation

Both optimizations have direct evidence: stable root-ID hits take roughly 0.36–0.47 µs versus 0.80–1.24 µs for the original resolver, and the duplicate-candidate sampling microbenchmarks improve by 58–87%. Replay instrumentation reduces full snapshot construction from 76,731 to 16,040 and from 120,032 to 59,280, preserving accepted snapshots. Decoded ID field-tree reads fall from 3,556,127 / 4,796,854 to 122 / 162; the raw guards still perform 3,556,007 / 4,796,696 reads.

**The pooled replay improvements below are observations, not reliable estimates of a code-only end-to-end speedup.** Within-block CPU differences change sign. Core-only controls also change sign (candidate user CPU -9.2% then +28.5%), despite bypassing these helpers. Shared-host load and memory compression changed materially; all corrected measurements are retained. These runs do not establish a repeatable CPU regression, but cannot bound small regressions or justify a fixed throughput claim.

The allocation tradeoff is explicit: +8 bytes per Entity and approximately 424 bytes for its first successful cache entry, with about 384 bytes for two additional modes. Public median peak RSS changes +1.36% on the short replay and -5.47% on the long replay; individual RSS ranges are broad, and core controls show +1.1% / +6.4%. Treat RSS as noisy process measurements, not evidence that caching saves memory or that its allocation cost is zero. Repeated invalidation and uncached layouts are slower in the resolver microbenchmark; stable root fields dominate these two replay workloads.

## Public replay benchmarks

Three fresh processes per replay/variant, sequentially, with block orders B/cache/selection/combined; combined/selection/cache/B; cache/B/combined/selection. A fresh baseline was captured before implementation. An initial timing matrix was superseded after finding three lazy pipeline imports inside the timer; all timing results below are from the corrected fully preloaded harness. No test suite ran alongside timed parsing. Imports, serialization, and hashing are outside elapsed/user timing; peak RSS is captured before serialization. Peak RSS includes interpreter/import costs and is in MiB below.

| Replay | Variant | Median elapsed s | Median user CPU s | Median peak RSS MiB |
|---|---|---|---|---|
| 8822520406 | baseline | 81.079 | 78.741 | 197.031 |
| 8822520406 | cache-only | 70.505 | 67.612 | 204.859 |
| 8822520406 | selection-only | 60.140 | 59.435 | 205.781 |
| 8822520406 | combined | 63.637 | 62.805 | 199.703 |
| 8856501050 | baseline | 284.991 | 270.257 | 637.047 |
| 8856501050 | cache-only | 251.499 | 243.240 | 572.516 |
| 8856501050 | selection-only | 217.692 | 213.739 | 576.312 |
| 8856501050 | combined | 201.798 | 198.341 | 602.172 |

- `8822520406` combined versus baseline: elapsed -21.51%, user CPU -20.24%, peak RSS +1.36%.
- `8856501050` combined versus baseline: elapsed -29.19%, user CPU -26.61%, peak RSS -5.47%.

<details><summary>Every individual replay measurement and host load (1/5/15 min)</summary>

| Replay | Block | Variant | Elapsed s | User s | RSS MiB | Load before | Load after |
|---|---|---|---|---|---|---|---|
| 8822520406 | 1 | baseline | 57.809 | 57.304 | 202.078 | 3.59/3.68/3.81 | 3.89/3.73/3.82 |
| 8822520406 | 1 | cache-only | 53.697 | 53.265 | 204.859 | 3.98/3.75/3.82 | 4.04/3.81/3.84 |
| 8822520406 | 1 | selection-only | 54.292 | 54.130 | 216.688 | 4.04/3.81/3.84 | 2.81/3.51/3.73 |
| 8822520406 | 1 | combined | 54.096 | 53.930 | 216.188 | 2.81/3.51/3.73 | 2.88/3.39/3.66 |
| 8822520406 | 2 | baseline | 81.079 | 78.741 | 197.031 | 3.90/3.96/5.73 | 4.71/4.32/5.71 |
| 8822520406 | 2 | cache-only | 105.090 | 97.955 | 184.469 | 10.98/10.28/6.92 | 6.98/9.31/6.94 |
| 8822520406 | 2 | selection-only | 121.484 | 107.699 | 185.031 | 26.23/11.41/6.75 | 11.15/10.30/6.90 |
| 8822520406 | 2 | combined | 109.900 | 83.605 | 186.500 | 3.08/4.05/3.93 | 27.20/11.35/6.70 |
| 8822520406 | 3 | baseline | 122.159 | 103.486 | 185.594 | 4.67/5.40/5.23 | 8.54/6.65/5.75 |
| 8822520406 | 3 | cache-only | 70.505 | 67.612 | 214.703 | 5.12/5.71/5.32 | 4.56/5.39/5.23 |
| 8822520406 | 3 | selection-only | 60.140 | 59.435 | 205.781 | 5.23/6.12/5.62 | 3.36/5.41/5.39 |
| 8822520406 | 3 | combined | 63.637 | 62.805 | 199.703 | 8.73/6.73/5.78 | 5.51/6.19/5.64 |
| 8856501050 | 1 | baseline | 179.522 | 177.125 | 648.109 | 2.88/3.39/3.66 | 2.50/3.12/3.50 |
| 8856501050 | 1 | cache-only | 176.697 | 174.656 | 673.625 | 2.58/3.11/3.50 | 3.33/3.34/3.53 |
| 8856501050 | 1 | selection-only | 211.278 | 202.503 | 504.297 | 3.72/3.43/3.55 | 8.47/5.21/4.20 |
| 8856501050 | 1 | combined | 195.549 | 192.642 | 616.281 | 7.47/5.15/4.20 | 3.10/4.11/3.95 |
| 8856501050 | 2 | baseline | 284.991 | 270.257 | 637.047 | 5.73/4.26/4.73 | 5.41/5.79/5.34 |
| 8856501050 | 2 | cache-only | 251.499 | 243.240 | 572.516 | 3.04/3.78/4.86 | 4.97/4.03/4.67 |
| 8856501050 | 2 | selection-only | 217.692 | 213.739 | 576.312 | 3.71/3.92/5.22 | 3.43/3.89/4.92 |
| 8856501050 | 2 | combined | 201.798 | 198.341 | 602.172 | 4.66/4.31/5.70 | 3.76/3.94/5.24 |
| 8856501050 | 3 | baseline | 289.600 | 276.849 | 490.422 | 9.59/6.74/5.89 | 5.44/6.07/5.78 |
| 8856501050 | 3 | cache-only | 295.595 | 264.939 | 381.094 | 3.36/5.41/5.39 | 8.25/6.31/5.73 |
| 8856501050 | 3 | selection-only | 293.402 | 276.178 | 582.484 | 5.26/6.12/5.88 | 5.04/5.23/5.50 |
| 8856501050 | 3 | combined | 309.728 | 287.818 | 416.672 | 5.05/5.95/5.75 | 5.41/6.20/5.90 |

</details>

### Within-block combined/baseline changes

Negative values indicate lower candidate measurements. Host conditions changed both within and between blocks; these paired deltas and the pooled medians should be read together.

| Replay | Block | Elapsed | User CPU | Peak RSS |
|---|---|---|---|---|
| 8822520406 | 1 | -6.42% | -5.89% | +6.98% |
| 8822520406 | 2 | +35.55% | +6.18% | -5.34% |
| 8822520406 | 3 | -47.91% | -39.31% | +7.60% |
| 8856501050 | 1 | +8.93% | +8.76% | -4.91% |
| 8856501050 | 2 | -29.19% | -26.61% | -5.47% |
| 8856501050 | 3 | +6.95% | +3.96% | -15.04% |

### Core-only diagnostic controls

Two fresh-process pairs on the long replay, B/C then C/B, to investigate disagreement between paired public CPU changes and pooled medians. `ReplayParser.parse()` bypasses the optimized extractor helpers but still pays the new Entity-slot cost. Imports and parser construction precede timing; no serialization follows. These controls are reported separately from the public measurements.

| Pair | Variant | Elapsed s | User s | RSS MiB | Load before | Load after |
|---|---|---|---|---|---|---|
| 1 | baseline | 216.735 | 206.509 | 426.531 | 4.74/5.14/5.46 | 4.44/4.63/5.15 |
| 1 | combined | 191.190 | 187.603 | 431.281 | 4.44/4.63/5.15 | 5.08/4.57/5.00 |
| 2 | combined | 221.532 | 205.617 | 432.047 | 5.08/4.57/5.00 | 5.48/7.00/6.13 |
| 2 | baseline | 162.407 | 159.967 | 405.938 | 5.20/6.91/6.11 | 3.30/5.34/5.59 |

### Output equality

All three processes of all four variants produced byte-identical sorted-key compact public JSON with `PYTHONHASHSEED=0`. Hashes:

| Replay | Bytes | SHA-256 |
|---|---|---|
| 8822520406 | 30401205 | 3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427 |
| 8856501050 | 187363261 | 1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e |

## Resolver microbenchmarks

Preconstructed decoded fixtures; three fresh processes, five repetitions of 200,000 calls per case. Each process column gives its five-repetition median; aggregate columns take the median of those three process medians. Includes wrapper/dispatch/guard overhead. Replacement includes a raw ID change on every call. The baseline snapshot case isolates the original ID-resolution expression, excluding full construction.

| Case | Baseline process medians ns | Combined process medians ns | Baseline ns | Combined ns | Change |
|---|---|---|---|---|---|
| direct-hit | 953.7, 975.3, 975.1 | 402.0, 418.9, 398.0 | 975.1 | 402.0 | -58.8% |
| zero-hit | 826.2, 827.7, 798.9 | 401.5, 383.4, 396.3 | 826.2 | 396.3 | -52.0% |
| owner-hit | 1088.4, 1073.2, 1069.7 | 406.4, 403.9, 414.2 | 1073.2 | 406.4 | -62.1% |
| snapshot-hit | 795.5, 803.7, 807.9 | 356.1, 356.5, 366.6 | 803.7 | 356.5 | -55.6% |
| missing | 1240.0, 1251.9, 1245.4 | 1344.1, 1384.9, 1370.1 | 1245.4 | 1370.1 | +10.0% |
| replacement | 893.4, 929.5, 918.7 | 2354.4, 2343.9, 2332.7 | 918.7 | 2343.9 | +155.1% |
| overlay | 508.5, 519.9, 514.6 | 647.0, 636.6, 632.6 | 514.6 | 636.6 | +23.7% |
| nested | 935.2, 931.5, 907.2 | 1346.9, 1337.2, 1378.6 | 931.5 | 1346.9 | +44.6% |
| higher-priority-invalid | 1247.6, 1242.6, 1236.9 | 474.7, 484.2, 462.1 | 1242.6 | 474.7 | -61.8% |

Stable root-field hits improve; repeated invalidation, unresolved, overlay, and nested cases have additional dispatch/eligibility overhead. This optimization targets the observed stable root-field layout, not all possible workloads.

## Sampling microbenchmarks

Added because shared-host replay timings were noisy. Three fresh processes per variant; five repetitions of 300 actual `_sample()` calls per case. Preconstructed flat-overlay entities use the compatibility resolver, with supplied canonical candidates and empty inventory/ability work. Accepted output is byte-compared outside timing and cleared after each sample. This isolates prefiltering and NPC conversion; these are not whole-replay timings.

| Case | Baseline process medians µs | Selection process medians µs | Baseline µs/sample | Selection µs/sample | Change |
|---|---|---|---|---|---|
| canonical+10-duplicates | 167.15, 161.05, 169.94 | 69.45, 68.29, 70.54 | 167.15 | 69.45 | -58.5% |
| canonical+100-duplicates | 819.71, 804.28, 828.91 | 103.12, 102.71, 102.95 | 819.71 | 102.95 | -87.4% |
| fallback-100 | 735.73, 734.90, 745.23 | 101.72, 99.20, 99.54 | 735.73 | 99.54 | -86.5% |
| owner-only-rejected | 48.37, 47.93, 48.21 | 46.01, 46.34, 45.94 | 48.21 | 46.01 | -4.6% |

## Allocation measurement

Controlled `tracemalloc` measurement over 10,000 entities with shared class/schema, after warming schema resolution. Includes list/storage allocation equally in both variants; no entity registry. New slot is paid for every entity, cache allocations only for successful resolutions.

```json
[
  {
    "variant": "baseline",
    "entity_getsizeof": 80,
    "empty_allocation_bytes_per_entity": 312.5845,
    "one_mode_cache_bytes_per_entity": 0.1049,
    "two_additional_modes_bytes_per_entity": 0.0
  },
  {
    "variant": "combined",
    "entity_getsizeof": 88,
    "empty_allocation_bytes_per_entity": 320.5848,
    "one_mode_cache_bytes_per_entity": 424.2229,
    "two_additional_modes_bytes_per_entity": 384.0317
  }
]
```

## Separate instrumentation

These runs are operation-count evidence only; their timings are not used. Raw guard reads are counted explicitly and are not zero-read cache hits. `id_field_tree_reads` counts typed ID reads that reach decoded FieldState; `id_plan_resolutions` counts calls to the compiled ID plan. Baseline snapshot ID reads share its hero plan.

```json
[
  {
    "variant": "baseline",
    "replay": "8822520406",
    "counts": {
      "resolver_calls_mode_0": 3497915,
      "id_plan_resolutions": 3479396,
      "typed_id_reads": 6372000,
      "id_field_tree_reads": 3556127,
      "accepted_snapshots": 16040,
      "sampling_calls": 2521,
      "snapshot_candidates": 76731,
      "resolver_calls_mode_2": 76731,
      "hero_plan_resolutions": 76731,
      "full_snapshots": 76731,
      "unresolved": 18579,
      "resolver_calls_mode_1": 60,
      "npc_conversion_misses": 76731
    },
    "sha256": "3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427"
  },
  {
    "variant": "combined",
    "replay": "8822520406",
    "counts": {
      "resolver_calls_mode_0": 3497915,
      "id_plan_resolutions": 122,
      "typed_id_reads": 211,
      "id_field_tree_reads": 122,
      "cache_misses": 122,
      "cache_entries_created": 122,
      "dependency_slots_prepared": 122,
      "accepted_snapshots": 16040,
      "sampling_calls": 2521,
      "raw_guard_reads": 3556007,
      "cache_hits": 3556005,
      "snapshot_candidates": 76731,
      "resolver_calls_mode_2": 76731,
      "full_snapshots": 16040,
      "hero_plan_resolutions": 16040,
      "none_entity_bypasses": 18579,
      "unresolved": 18579,
      "resolver_calls_mode_1": 60,
      "invalidations": 2,
      "npc_conversion_misses": 10
    },
    "sha256": "3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427"
  },
  {
    "variant": "baseline",
    "replay": "8856501050",
    "counts": {
      "resolver_calls_mode_0": 4720594,
      "id_plan_resolutions": 4676822,
      "typed_id_reads": 7312549,
      "id_field_tree_reads": 4796854,
      "accepted_snapshots": 59280,
      "sampling_calls": 6647,
      "unresolved": 43998,
      "snapshot_candidates": 120032,
      "resolver_calls_mode_2": 120032,
      "hero_plan_resolutions": 120032,
      "full_snapshots": 120032,
      "resolver_calls_mode_1": 226,
      "npc_conversion_misses": 120032
    },
    "sha256": "1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e"
  },
  {
    "variant": "combined",
    "replay": "8856501050",
    "counts": {
      "resolver_calls_mode_0": 4720594,
      "id_plan_resolutions": 162,
      "typed_id_reads": 285,
      "id_field_tree_reads": 162,
      "cache_misses": 162,
      "cache_entries_created": 162,
      "dependency_slots_prepared": 162,
      "accepted_snapshots": 59280,
      "sampling_calls": 6647,
      "raw_guard_reads": 4796696,
      "cache_hits": 4796692,
      "none_entity_bypasses": 43998,
      "unresolved": 43998,
      "snapshot_candidates": 120032,
      "resolver_calls_mode_2": 120032,
      "full_snapshots": 59280,
      "hero_plan_resolutions": 59280,
      "resolver_calls_mode_1": 226,
      "invalidations": 4,
      "npc_conversion_misses": 10
    },
    "sha256": "1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e"
  }
]
```

<details><summary>Superseded timings: lazy imports were still inside timer</summary>

These preliminary records are retained for transparency and are excluded from all reported medians. The timing matrix was restarted uniformly after explicitly preloading intervals, smoke/vision, and the core parser. Output equality checks from these runs also passed.

| Replay | Variant | Block | Elapsed s | User s | RSS MiB |
|---|---|---|---|---|---|
| 8822520406 | baseline | 1 | 61.000 | 58.447 | 199.516 |
| 8822520406 | baseline | 2 | 57.175 | 55.987 | 192.859 |
| 8856501050 | baseline | 1 | 189.077 | 181.906 | 594.531 |
| 8856501050 | baseline | 2 | 181.283 | 177.664 | 586.812 |
| 8822520406 | cache-only | 1 | 55.254 | 54.154 | 195.891 |
| 8822520406 | cache-only | 2 | 54.909 | 54.189 | 200.844 |
| 8822520406 | cache-only | 3 | 53.566 | 52.963 | 218.328 |
| 8856501050 | cache-only | 1 | 207.677 | 198.913 | 605.234 |
| 8856501050 | cache-only | 2 | 179.616 | 174.572 | 620.016 |
| 8822520406 | combined | 1 | 59.091 | 56.084 | 188.422 |
| 8822520406 | combined | 2 | 53.768 | 52.758 | 196.047 |
| 8856501050 | combined | 1 | 178.404 | 173.628 | 612.547 |
| 8856501050 | combined | 2 | 176.862 | 173.345 | 615.141 |
| 8822520406 | selection-only | 1 | 58.064 | 56.711 | 194.062 |
| 8822520406 | selection-only | 2 | 55.197 | 54.838 | 216.859 |
| 8856501050 | selection-only | 1 | 171.621 | 169.278 | 632.859 |
| 8856501050 | selection-only | 2 | 195.996 | 187.056 | 630.641 |

</details>

## Reproduction

Save the scripts and patches in the following details into `/private/tmp/gem-162/` under their displayed filenames. Run from this repository with the same existing `.venv`. The scripts use this checkout for combined and archived main plus the patches for isolated variants. Replace the absolute repository path in scripts when running elsewhere.

```sh
mkdir -p /private/tmp/gem-162/{baseline,cache-only,selection-only,results}
for variant in baseline cache-only selection-only; do
  git archive 24a776856fe713eb5b82867883ee59b7ca5bf661 | tar -x -C /private/tmp/gem-162/$variant
done
(cd /private/tmp/gem-162/cache-only && git apply /private/tmp/gem-162/cache-only.patch)
(cd /private/tmp/gem-162/selection-only && git apply /private/tmp/gem-162/selection-only.patch)
PYTHONHASHSEED=0 .venv/bin/python /private/tmp/gem-162/run_bench.py
for process in 1 2 3; do
  for variant in baseline combined; do
    .venv/bin/python /private/tmp/gem-162/micro.py "$variant" "$process"
  done
done
for process in 1 2 3; do
  for variant in baseline selection-only; do
    .venv/bin/python /private/tmp/gem-162/selection_micro.py "$variant" "$process"
  done
done
for variant in baseline combined; do
  .venv/bin/python /private/tmp/gem-162/allocation.py "$variant"
  for replay in 8822520406 8856501050; do
    PYTHONHASHSEED=0 .venv/bin/python /private/tmp/gem-162/instrument.py "$variant" "$replay"
  done
done
PYTHONHASHSEED=0 .venv/bin/python /private/tmp/gem-162/parity.py
for variant in baseline combined; do
  PYTHONHASHSEED=0 .venv/bin/python /private/tmp/gem-162/core.py "$variant" 8856501050 1
done
for variant in combined baseline; do
  PYTHONHASHSEED=0 .venv/bin/python /private/tmp/gem-162/core.py "$variant" 8856501050 2
done
```

<details><summary>bench.py</summary>

```python
import sys, os, time, resource, json, hashlib
from pathlib import Path
variant, replay, run = sys.argv[1:]
root=Path('/private/tmp/gem-162')
source=root/variant if variant!='combined' else Path('/Users/hanyuwu/Study/gem')
sys.path.insert(0,str(source/'src'))
import gem
import gem.extractors.intervals
import gem.extractors.smoke_vision
import gem.parser
assert Path(gem.__file__).is_relative_to(source), gem.__file__
fixture=Path('/Users/hanyuwu/Study/gem/tests/fixtures/opendota')/(replay+'.dem')
load=os.getloadavg(); cpu=resource.getrusage(resource.RUSAGE_SELF).ru_utime; start=time.perf_counter()
match=gem.parse(fixture)
elapsed=time.perf_counter()-start; usage=resource.getrusage(resource.RUSAGE_SELF)
r=dict(variant=variant,replay=replay,run=run,elapsed=elapsed,user=usage.ru_utime-cpu,rss=usage.ru_maxrss,load_before=load,load_after=os.getloadavg())
payload=json.dumps(gem.to_dict(match),sort_keys=True,separators=(',',':')).encode()
r.update(bytes=len(payload),sha256=hashlib.sha256(payload).hexdigest())
reference=root/'results'/f'{replay}.json'
if reference.exists(): assert payload==reference.read_bytes(), 'output mismatch'
else: reference.write_bytes(payload)
(root/'results'/f'{variant}-{replay}-{run}.json').write_text(json.dumps(r))
print(json.dumps(r),flush=True)

```

</details>

<details><summary>run_bench.py</summary>

```python
import os, sys, subprocess
from pathlib import Path
root=Path('/private/tmp/gem-162')
orders=[['baseline','cache-only','selection-only','combined'],['combined','selection-only','cache-only','baseline'],['cache-only','baseline','combined','selection-only']]
for block, order in enumerate(orders,1):
    for replay in ['8822520406','8856501050']:
        for variant in order:
            if (root/'results'/f'{variant}-{replay}-{block}.json').exists():continue
            subprocess.run([sys.executable,str(root/'bench.py'),variant,replay,str(block)],env={**os.environ,'PYTHONHASHSEED':'0'},check=True)

```

</details>

<details><summary>micro.py</summary>

```python
import sys, timeit, json, statistics
from pathlib import Path
variant, process=sys.argv[1:]
root=Path('/private/tmp/gem-162')
source=Path('/Users/hanyuwu/Study/gem') if variant=='combined' else root/variant
sys.path.insert(0,str(source/'src'))
from types import SimpleNamespace
from gem.state.entities import Entity
from gem.schema.sendtable.models import Serializer, ResolvedField
from gem.extractors import _snapshots as s

def make(paths,values,overlay=False):
    ser=Serializer('Test',0)
    ser._resolved_fields.update({n:ResolvedField(n,p) for n,p in zip(s._PLAYER_ID_FIELDS.names,paths)})
    e=Entity(1,2,SimpleNamespace(name='CDOTA_Unit_Hero_Axe',serializer=ser))
    for name,path,value in zip(s._PLAYER_ID_FIELDS.names,paths,values):
        if overlay:e._state[name]=value
        elif path is not None:e._field_state._set_compact(path,value)
    return e

def original_snapshot(e):
    fields=e._resolve_fields(s._HERO_SNAPSHOT_FIELDS)
    raw=e._get_int32_resolved(fields[0])
    if raw is None:raw=e._get_int32_resolved(fields[1])
    return raw//2 if raw is not None and raw>=0 else None

snapshot=getattr(s,'_snapshot_player_id',original_snapshot)
rows=[]
for case,paths,values,overlay,mode,mutate in [
    ('direct-hit',(None,(1,),None),(None,6,None),False,'direct',False),
    ('zero-hit',((0,),None,None),(0,None,None),False,'direct',False),
    ('owner-hit',(None,None,(2,)),(None,None,8),False,'owner',False),
    ('snapshot-hit',(None,(1,),None),(None,6,None),False,'snapshot',False),
    ('missing',((0,),(1,),(2,)),(None,None,None),False,'direct',False),
    ('replacement',((0,),None,None),(6,None,None),False,'direct',True),
    ('overlay',((0,),(1,),(2,)),(6,None,None),True,'direct',False),
    ('nested',((0,0),None,None),(6,None,None),False,'direct',False),
    ('higher-priority-invalid',((0,),(1,),None),(-1,6,None),False,'direct',False),
]:
    e=make(paths,values,overlay)
    if mode=='snapshot':fn=lambda:snapshot(e)
    elif mode=='owner':fn=lambda:s._player_id_from_entity(e,allow_owner=True)
    else:fn=lambda:s._player_id_from_entity(e)
    if mutate:
        def call():
            e._field_state._state[0]=8 if e._field_state._state[0]==6 else 6
            return fn()
    else:call=fn
    call()
    samples=timeit.repeat(call,number=200000,repeat=5)
    rows.append(dict(case=case,ns=[x*1e9/200000 for x in samples],median_ns=statistics.median(samples)*1e9/200000))
result=dict(variant=variant,process=process,rows=rows)
(root/'results'/f'micro-{variant}-{process}.json').write_text(json.dumps(result))
print(json.dumps(result),flush=True)

```

</details>

<details><summary>selection_micro.py</summary>

```python
import sys,json,timeit,statistics,hashlib
from pathlib import Path
from types import SimpleNamespace
from dataclasses import asdict
variant,process=sys.argv[1:]
root=Path('/private/tmp/gem-162')
sys.path.insert(0,str(root/variant/'src'))
from gem.extractors.players import PlayerExtractor
from gem.state.entities import Entity
names=['Axe','Sven','Pudge','CrystalMaiden','Lina','Lion','Slark','DrowRanger','Luna','Juggernaut']
def entity(i,owner_only=False):
    e=Entity(i,1,SimpleNamespace(name='CDOTA_Unit_Hero_'+names[i%10],serializer=None))
    e._state.update({'m_iPlayerOwnerID' if owner_only else 'm_nPlayerID':(i%10)*2,
        'm_iTeamNum':2,'m_nCurrentLevel':10,'m_iCurrentXP':1000,'m_iHealth':1000+i,
        'm_iMaxHealth':1500,'m_flMana':300.0,'m_flMaxMana':500.0,
        'CBodyComponent.m_cellX':10,'CBodyComponent.m_cellY':20,
        'CBodyComponent.m_vecX':1.0,'CBodyComponent.m_vecY':2.0})
    return e
rows=[]
for case,canonical_count,fallback_count,owner_only in [
    ('canonical+10-duplicates',10,10,False),
    ('canonical+100-duplicates',10,100,False),
    ('fallback-100',0,100,False),
    ('owner-only-rejected',0,100,True),
]:
    ext=PlayerExtractor()
    canonical=[entity(i) for i in range(canonical_count)]
    ext._canonical_hero_entity=lambda pid:canonical[pid] if pid<len(canonical) else None
    ext._heroes={i:entity(i,owner_only) for i in reversed(range(fallback_count))}
    ext._sample(100)
    payload=json.dumps([asdict(s) for s in ext.snapshots],sort_keys=True,separators=(',',':')).encode()
    reference=root/'results'/f'selection-output-{case}.json'
    if reference.exists():assert payload==reference.read_bytes()
    else:reference.write_bytes(payload)
    accepted=len(ext.snapshots)
    ext.snapshots.clear()
    def sample():
        ext._sample(100)
        ext.snapshots.clear()
    samples=timeit.repeat(sample,number=300,repeat=5)
    rows.append(dict(case=case,accepted=accepted,us=[x*1e6/300 for x in samples],median_us=statistics.median(samples)*1e6/300,sha256=hashlib.sha256(payload).hexdigest()))
r=dict(variant=variant,process=process,rows=rows)
(root/'results'/f'selection-micro-{variant}-{process}.json').write_text(json.dumps(r))
print(json.dumps(r),flush=True)

```

</details>

<details><summary>allocation.py</summary>

```python
import sys,gc,json,tracemalloc
from pathlib import Path
from types import SimpleNamespace
variant=sys.argv[1]
root=Path('/private/tmp/gem-162')
source=Path('/Users/hanyuwu/Study/gem') if variant=='combined' else root/variant
sys.path.insert(0,str(source/'src'))
from gem.state.entities import Entity
from gem.schema.sendtable.models import Serializer,ResolvedField
from gem.extractors import _snapshots as s
ser=Serializer('Test',0)
ser._resolved_fields['m_nPlayerID']=ResolvedField('m_nPlayerID',(0,))
cls=SimpleNamespace(serializer=ser,name='CDOTA_Unit_Hero_Axe')
e=Entity(0,0,cls)
e._field_state._set_compact((0,),0)
s._player_id_from_entity(e)
N=10000
gc.collect();tracemalloc.start();before=tracemalloc.get_traced_memory()[0]
entities=[Entity(0,0,cls) for _ in range(N)]
after=tracemalloc.get_traced_memory()[0]
result={'variant':variant,'entity_getsizeof':sys.getsizeof(entities[0]),'empty_allocation_bytes_per_entity':(after-before)/N}
for e in entities:e._field_state._set_compact((0,),0)
before=tracemalloc.get_traced_memory()[0]
for e in entities:s._player_id_from_entity(e)
after=tracemalloc.get_traced_memory()[0]
result['one_mode_cache_bytes_per_entity']=(after-before)/N
before=tracemalloc.get_traced_memory()[0]
if hasattr(s,'_snapshot_player_id'):
    for e in entities:
        s._player_id_from_entity(e,allow_owner=True)
        s._snapshot_player_id(e)
after=tracemalloc.get_traced_memory()[0]
result['two_additional_modes_bytes_per_entity']=(after-before)/N
(root/'results'/f'allocation-{variant}.json').write_text(json.dumps(result))
print(json.dumps(result))

```

</details>

<details><summary>core.py</summary>

```python
import sys,os,time,resource,json
from pathlib import Path
variant,replay,run=sys.argv[1:]
root=Path('/private/tmp/gem-162')
source=Path('/Users/hanyuwu/Study/gem') if variant=='combined' else root/variant
sys.path.insert(0,str(source/'src'))
import gem
from gem.parser import ReplayParser
assert Path(gem.__file__).is_relative_to(source)
parser=ReplayParser(str(Path('/Users/hanyuwu/Study/gem/tests/fixtures/opendota')/(replay+'.dem')))
load=os.getloadavg();cpu=resource.getrusage(resource.RUSAGE_SELF).ru_utime;start=time.perf_counter()
parser.parse()
elapsed=time.perf_counter()-start;usage=resource.getrusage(resource.RUSAGE_SELF)
assert getattr(parser,'parse_error',None) is None
r=dict(variant=variant,replay=replay,run=run,elapsed=elapsed,user=usage.ru_utime-cpu,rss=usage.ru_maxrss,load_before=load,load_after=os.getloadavg())
(root/'results'/f'core-{variant}-{replay}-{run}.json').write_text(json.dumps(r))
print(json.dumps(r),flush=True)

```

</details>

<details><summary>instrument.py</summary>

```python
import ast, inspect, sys, json, collections, hashlib
from pathlib import Path
variant,replay=sys.argv[1:]
root=Path('/private/tmp/gem-162')
source=Path('/Users/hanyuwu/Study/gem') if variant=='combined' else root/variant
sys.path.insert(0,str(source/'src'))
import gem
from gem.extractors import _snapshots as s, players as p
from gem.state.entities import Entity
counts=collections.Counter()
def replace(old,new):
    for mod in list(sys.modules.values()):
        if mod is not None and getattr(mod,'__name__','').startswith('gem'):
            for name,value in list(vars(mod).items()):
                if value is old:setattr(mod,name,new)
original_fields=Entity._resolve_fields
original_int=Entity._get_int32_resolved
def fields(e,plan):
    if plan is s._PLAYER_ID_FIELDS:counts['id_plan_resolutions']+=1
    elif plan is s._HERO_SNAPSHOT_FIELDS:counts['hero_plan_resolutions']+=1
    return original_fields(e,plan)
def integer(e,f):
    if f.name in s._PLAYER_ID_FIELDS.names:
        counts['typed_id_reads']+=1
        if f.name not in e._state and f.path is not None:counts['id_field_tree_reads']+=1
    return original_int(e,f)
Entity._resolve_fields=fields
Entity._get_int32_resolved=integer
if hasattr(s,'_resolve_player_id'):
    tree=ast.parse('from __future__ import annotations\n'+inspect.getsource(s._resolve_player_id))
    for node in ast.walk(tree):
        if isinstance(node,ast.For) and isinstance(node.target,ast.Tuple):
            node.body.insert(0,ast.parse("_instrument['raw_guard_reads'] += 1").body[0])
    s._instrument=counts
    exec(compile(ast.fix_missing_locations(tree),'<instrumented resolver>','exec'),s.__dict__)
    resolve=s._resolve_player_id
    def resolver(e,mode):
        counts[f'resolver_calls_mode_{mode}']+=1
        before=(e._player_id_cache or {}).get(mode)
        result=resolve(e,mode)
        after=(e._player_id_cache or {}).get(mode)
        if before is not None and before is after:counts['cache_hits']+=1
        else:counts['cache_misses']+=1
        if before is not None and before is not after:counts['invalidations']+=1
        if after is not None and before is not after:
            counts['cache_entries_created']+=1
            counts['dependency_slots_prepared']+=len(after.dependencies)
        if result is None:counts['unresolved']+=1
        return result
    s._resolve_player_id=resolver
    general=s._player_id_from_entity
    def general_with_none(e,*,allow_owner=False):
        if e is None:
            counts[f'resolver_calls_mode_{int(allow_owner)}']+=1
            counts['none_entity_bypasses']+=1
            counts['unresolved']+=1
        return general(e,allow_owner=allow_owner)
    replace(general,general_with_none)
    snapid=s._snapshot_player_id
    def candidate(e):
        counts['snapshot_candidates']+=1
        return snapid(e)
    replace(snapid,candidate)
    builder=s._build_hero_snapshot
    def build(e,t,pid):
        counts['full_snapshots']+=1
        return builder(e,t,pid)
    replace(builder,build)
else:
    resolve=s._player_id_from_entity
    def resolver(e,*,allow_owner=False):
        counts[f'resolver_calls_mode_{int(allow_owner)}']+=1
        result=resolve(e,allow_owner=allow_owner)
        if result is None:counts['unresolved']+=1
        return result
    replace(resolve,resolver)
    snapshot=s._snapshot_hero
    def build(e,t):
        counts['snapshot_candidates']+=1
        counts['resolver_calls_mode_2']+=1
        result=snapshot(e,t)
        if result is not None:counts['full_snapshots']+=1
        else:counts['unresolved']+=1
        return result
    replace(snapshot,build)
sample=p.PlayerExtractor._sample
def sampling(e,tick,minute=False):
    before=len(e.snapshots)+len(e._minute_snaps)
    sample(e,tick,minute=minute)
    counts['accepted_snapshots']+=len(e.snapshots)+len(e._minute_snaps)-before
    counts['sampling_calls']+=1
p.PlayerExtractor._sample=sampling
match=gem.parse(Path('/Users/hanyuwu/Study/gem/tests/fixtures/opendota')/(replay+'.dem'))
if variant=='combined':
    assert sum(counts[f'resolver_calls_mode_{i}'] for i in range(3)) == counts['cache_hits']+counts['cache_misses']+counts['none_entity_bypasses']
    assert counts['full_snapshots']==counts['accepted_snapshots']
    baseline=json.loads((root/'results'/f'instrument-baseline-{replay}.json').read_text())['counts']
    for key in ['resolver_calls_mode_0','resolver_calls_mode_1','resolver_calls_mode_2','snapshot_candidates','accepted_snapshots','sampling_calls']:
        assert counts[key]==baseline[key], (key,counts[key],baseline[key])
counts['npc_conversion_misses']=s._fallback_npc_name.cache_info().misses if hasattr(s,'_fallback_npc_name') else counts['full_snapshots']
payload=json.dumps(gem.to_dict(match),sort_keys=True,separators=(',',':')).encode()
assert payload==(root/'results'/f'{replay}.json').read_bytes()
result=dict(variant=variant,replay=replay,counts=dict(counts),sha256=hashlib.sha256(payload).hexdigest())
(root/'results'/f'instrument-{variant}-{replay}.json').write_text(json.dumps(result))
print(json.dumps(result),flush=True)

```

</details>

<details><summary>parity.py</summary>

```python
import sys,json
from dataclasses import asdict
from pathlib import Path
root=Path('/Users/hanyuwu/Study/gem')
sys.path.insert(0,str(root))
sys.path.insert(0,str(root/'src'))
from scripts.validate_opendota import validate_match
p=root/'tests/fixtures/opendota'
for m in ['8868259993','8860187335','8856501050']:
    od=json.loads((p/f'{m}.opendota.json').read_text())
    r=validate_match(int(m),p/f'{m}.dem',od=od,mode='full')
    data=asdict(r)
    Path(f'/private/tmp/gem-162/results/parity-{m}.json').write_text(json.dumps(data,default=str))
    summary=dict(match_id=r.match_id,passed=r.passed,warned=r.warned,failed=r.failed,skipped=r.skipped,errors=r.errors,nonpassing=[dict(name=f.name,status=f.status,note=f.note) for f in r.all_fields if f.status!='PASS'])
    Path(f'/private/tmp/gem-162/results/parity-summary-{m}.json').write_text(json.dumps(summary))
    print(json.dumps(summary),flush=True)
    assert not r.failed and not r.errors

```

</details>

<details><summary>cache-only.patch</summary>

```diff
--- a/src/gem/state/entities.py
+++ b/src/gem/state/entities.py
@@ -120,6 +120,7 @@
         "cls",
         "active",
         "_field_state",
+        "_player_id_cache",
         "_state",
     )
 
@@ -129,6 +130,7 @@
         self.cls = cls
         self.active = True
         self._field_state = FieldState()
+        self._player_id_cache: Any = None
         # Flat dict for direct key-value access (tests may write here directly)
         self._state: dict[str, Any] = {}
 
--- a/src/gem/extractors/_snapshots.py
+++ b/src/gem/extractors/_snapshots.py
@@ -10,7 +10,8 @@
 
 import re
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from functools import lru_cache
+from typing import TYPE_CHECKING, Any
 
 from gem.schema.sendtable.models import FieldAccessPlan
 
@@ -120,12 +121,80 @@
     """
     if entity is None:
         return None
+    return _resolve_player_id(entity, 1 if allow_owner else 0)
+
+
+@dataclass(slots=True)
+class _PlayerIdCacheEntry:
+    index: int
+    serial: int
+    cls: Any
+    serializer: Any
+    field_state: Any
+    dependencies: tuple[tuple[int, Any], ...]
+    player_id: int
+
+
+def _snapshot_player_id(entity: Entity) -> int | None:
+    return _resolve_player_id(entity, 2)
+
+
+def _resolve_player_id(entity: Entity, mode: int) -> int | None:
+    # Modes: direct, owner fallback, snapshot. Unlike general attribution,
+    # snapshots reject a negative primary ID instead of trying the secondary.
+    cache = entity._player_id_cache
+    if entity._state:
+        entity._player_id_cache = cache = None
+    elif cache is not None:
+        entry = cache.get(mode)
+        if entry is not None:
+            if (
+                entry.index == entity.index
+                and entry.serial == entity.serial
+                and entry.cls is entity.cls
+                and entry.serializer is entity.cls.serializer
+                and entry.field_state is entity._field_state
+            ):
+                # Read current storage: FieldState can grow or replace its list.
+                state = entity._field_state._state
+                for index, previous in entry.dependencies:
+                    # Match FieldState._get_compact's extra-slot bound exactly.
+                    raw = state[index] if len(state) >= index + 2 else None
+                    if raw is not previous:
+                        break
+                else:
+                    return entry.player_id
+            del cache[mode]
+
     fields = entity._resolve_fields(_PLAYER_ID_FIELDS)
-    field_count = 3 if allow_owner else 2
+    field_count = 3 if mode == 1 else 2
     for field_index in range(field_count):
         val = entity._get_int32_resolved(fields[field_index])
-        if val is not None and val >= 0:
-            return val // 2
+        if val is None:
+            continue
+        if val < 0:
+            if mode == 2:
+                return None
+            continue
+        player_id = val // 2
+        if not entity._state and all(
+            field.path is None or len(field.path) == 1 for field in fields[:field_count]
+        ):
+            state = entity._field_state._state
+            dependencies = tuple(
+                (field.path[0], state[field.path[0]] if len(state) >= field.path[0] + 2 else None)
+                for field in fields[: field_index + 1]
+                if field.path is not None
+            )
+            entry = _PlayerIdCacheEntry(
+                entity.index, entity.serial, entity.cls, entity.cls.serializer,
+                entity._field_state, dependencies, player_id,
+            )
+            if cache is None:
+                entity._player_id_cache = {mode: entry}
+            else:
+                cache[mode] = entry
+        return player_id
     return None
 
 
@@ -237,15 +306,10 @@
     Returns:
         A snapshot, or ``None`` if the player ID could not be resolved.
     """
-    # m_nPlayerID (post-7.31) or m_iPlayerID (pre-7.31) — raw value is doubled;
-    # divide by 2 to get player slot 0-9. Reference: opendota/Parse.java getPlayerSlotFromEntity()
+    player_id = _snapshot_player_id(entity)
+    if player_id is None:
+        return None
     fields = entity._resolve_fields(_HERO_SNAPSHOT_FIELDS)
-    player_id = entity._get_int32_resolved(fields[0])
-    if player_id is None:
-        player_id = entity._get_int32_resolved(fields[1])
-    if player_id is None or player_id < 0:
-        return None
-    player_id //= 2
 
     team = entity._get_int32_resolved(fields[2]) or 0
     level = entity._get_int32_resolved(fields[3]) or 0

```

</details>

<details><summary>selection-only.patch</summary>

```diff
--- a/src/gem/extractors/_snapshots.py
+++ b/src/gem/extractors/_snapshots.py
@@ -10,6 +10,7 @@
 
 import re
 from dataclasses import dataclass, field
+from functools import lru_cache
 from typing import TYPE_CHECKING
 
 from gem.schema.sendtable.models import FieldAccessPlan
@@ -227,6 +228,14 @@
     return f"{team_data_prefix(team_slot)}.{field_name}"
 
 
+def _snapshot_player_id(entity: Entity) -> int | None:
+    fields = entity._resolve_fields(_HERO_SNAPSHOT_FIELDS)
+    val = entity._get_int32_resolved(fields[0])
+    if val is None:
+        val = entity._get_int32_resolved(fields[1])
+    return val // 2 if val is not None and val >= 0 else None
+
+
 def _snapshot_hero(entity: Entity, tick: int) -> PlayerStateSnapshot | None:
     """Build a ``PlayerStateSnapshot`` from a hero entity.
 
@@ -237,16 +246,21 @@
     Returns:
         A snapshot, or ``None`` if the player ID could not be resolved.
     """
-    # m_nPlayerID (post-7.31) or m_iPlayerID (pre-7.31) — raw value is doubled;
-    # divide by 2 to get player slot 0-9. Reference: opendota/Parse.java getPlayerSlotFromEntity()
+    player_id = _snapshot_player_id(entity)
+    if player_id is None:
+        return None
+    return _build_hero_snapshot(entity, tick, player_id)
+
+
+@lru_cache(maxsize=256)
+def _fallback_npc_name(class_name: str) -> str:
+    # Preserve the existing conversion; EntityNames can override it later.
+    ending = class_name[len(_HERO_CLASS_PREFIX) :].replace("_", "")
+    return "npc_dota_hero" + re.sub(r"([A-Z])", r"_\1", ending).lower()
+
+
+def _build_hero_snapshot(entity: Entity, tick: int, player_id: int) -> PlayerStateSnapshot:
     fields = entity._resolve_fields(_HERO_SNAPSHOT_FIELDS)
-    player_id = entity._get_int32_resolved(fields[0])
-    if player_id is None:
-        player_id = entity._get_int32_resolved(fields[1])
-    if player_id is None or player_id < 0:
-        return None
-    player_id //= 2
-
     team = entity._get_int32_resolved(fields[2]) or 0
     level = entity._get_int32_resolved(fields[3]) or 0
     xp = entity._get_int32_resolved(fields[4]) or 0
@@ -263,17 +277,10 @@
 
     pos = _pos(entity)
 
-    # Convert entity class name to the canonical NPC name (camelCase → snake_case).
-    # "CDOTA_Unit_Hero_TemplarAssassin" → "npc_dota_hero_templar_assassin"
-    # "CDOTA_Unit_Hero_Nyx_Assassin"   → "npc_dota_hero_nyx_assassin" (already underscored)
-    # This matches dotaconstants keys and the combat log string table.
-    # Reference: refs/parser/Parse.java combatLogName2
-    _ending = entity.get_class_name()[len(_HERO_CLASS_PREFIX) :].replace("_", "")
-    _npc_name = "npc_dota_hero" + re.sub(r"([A-Z])", r"_\1", _ending).lower()
     return PlayerStateSnapshot(
         tick=tick,
         player_id=player_id,
-        npc_name=_npc_name,
+        npc_name=_fallback_npc_name(entity.get_class_name()),
         team=team,
         level=level,
         xp=xp,
--- a/src/gem/extractors/players.py
+++ b/src/gem/extractors/players.py
@@ -17,9 +17,11 @@
     TEAM_RADIANT,
     PlayerStateSnapshot,
     PlayerTimeSeries,
+    _build_hero_snapshot,
     _player_id_from_entity,
     _pos,
-    _snapshot_hero,
+    _snapshot_hero,  # noqa: F401 — retained private compatibility import
+    _snapshot_player_id,
     scan_player_resource,
     team_data_field,
 )
@@ -621,21 +623,26 @@
             if self._parser is not None and self._parser.string_tables is not None
             else None
         )
-        snaps_by_player: dict[int, tuple[Entity, PlayerStateSnapshot]] = {}
+        selected: dict[int, Entity] = {}
         for player_id in range(10):
             entity = self._canonical_hero_entity(player_id)
             if entity is None:
                 continue
-            snap = _snapshot_hero(entity, tick)
-            if snap is not None:
-                snap.game_time_s = getattr(self._parser, "game_time_s", None)
-                snaps_by_player[snap.player_id] = (entity, snap)
+            resolved_id = _snapshot_player_id(entity)
+            if resolved_id is not None:
+                selected[resolved_id] = entity
         for _, entity in sorted(self._heroes.items()):
-            snap = _snapshot_hero(entity, tick)
-            if snap is None or snap.player_id in snaps_by_player:
-                continue
+            resolved_id = _snapshot_player_id(entity)
+            if resolved_id is not None and resolved_id not in selected:
+                selected[resolved_id] = entity
+
+        # Finish selection before constructing full snapshots, preserving the
+        # last canonical / first fallback winner and staging before overlays.
+        snaps_by_player: dict[int, tuple[Entity, PlayerStateSnapshot]] = {}
+        for player_id, entity in selected.items():
+            snap = _build_hero_snapshot(entity, tick, player_id)
             snap.game_time_s = getattr(self._parser, "game_time_s", None)
-            snaps_by_player[snap.player_id] = (entity, snap)
+            snaps_by_player[player_id] = (entity, snap)
         for player_id in sorted(snaps_by_player):
             entity, snap = snaps_by_player[player_id]
             # Resolve canonical NPC name from the EntityNames string table so that

```

</details>

## Release hygiene

Changelog updated. No generated protobuf edits, dependencies, replay artifacts, or credentials in this PR. CI and distribution builds passed on the candidate commit; publishing to PyPI is intentionally skipped for pull requests. Temporary sources/scripts/results will be removed after verifying these reproduction notes on GitHub.
