### PR TITLE
Reuse replay fixtures and clarify test tiers.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: uv run mypy src/gem/
 
       - name: Test with coverage
-        run: uv run pytest tests/ -m "not integration" -q --cov=gem --cov-report=xml --cov-report=term
+        run: uv run pytest tests/ -m "not slow and not integration and not network" -q --cov=gem --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Less repeated test setup.** Share read-only replay results across integration
+  checks and separate fast, offline, and live-network test commands.
 - **Lower player sampling overhead.** Reuse guarded player-ID resolutions and
   select hero candidates before constructing full snapshots, preserving attribution
   and sampling behavior.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,10 +12,10 @@ fuller contributor workflow; the list below is the day-to-day short version.)
 # Install project + dev dependencies
 uv sync --group dev
 
-# Run default test suite (skips slow/integration markers via pyproject.toml)
+# Run default test suite (skips slow/integration/network markers via pyproject.toml)
 uv run pytest
 
-# Run all tests, including slow/integration markers
+# Run all tests, including slow/integration/network markers
 uv run pytest -m ""
 
 # Run a single test file
@@ -28,10 +28,16 @@ uv run pytest tests/binary/test_reader.py::TestReadBits::test_read_8_bits
 uv run pytest --cov=gem --cov-report=term-missing
 
 # Explicit fast loop — equivalent to the default marker filter
-uv run pytest -m "not slow and not integration"
+uv run pytest -m "not slow and not integration and not network"
 
-# Integration suite (requires replay fixtures)
-uv run pytest -m integration
+# Offline integration suite (requires local replay fixtures)
+uv run pytest -m "integration and not network"
+
+# All offline tests
+uv run pytest -m "not network"
+
+# Live network smoke
+uv run pytest -m network
 
 # Broader remote draft integration sample (downloads/parses 5 pro replays)
 GEM_DRAFT_INTEGRATION_FULL=1 uv run pytest tests/test_draft_integration.py -m integration
@@ -432,15 +438,22 @@ scripts (`test_audit_camp_annotations.py`, `test_audit_opendota_fixture_constant
   for fixture lifecycle, capabilities, integrity metadata, and replacements.
   Map/reference images for examples, reports, and camp-zone tooling live under
   `assets/maps/`, not `tests/fixtures/`.
-- `uv run pytest` skips `slow` and `integration` markers by default so local
+- `uv run pytest` skips `slow`, `integration`, and `network` markers by default so local
   checks do not fetch or parse large replay files accidentally. Use `-m ""` to
   include every marker category in a full local run.
-- Real `.dem` files are needed only for tests marked `@pytest.mark.integration`
-  and/or `@pytest.mark.slow` — skip them in the fast loop with
-  `-m "not slow and not integration"`.
+- Full `.dem` files belong in tests marked `integration` and `slow`. Small
+  committed truncated replays remain permissible in the fast suite. Live external
+  services require the `network` marker; mocked network unit tests do not.
 - `tests/test_draft_integration.py` is intentionally a one-replay remote smoke
   test by default; set `GEM_DRAFT_INTEGRATION_FULL=1` when you need the broader
   five-replay OpenDota sample.
+- Run touched tests during iteration and the fast suite plus lint/type checks for
+  every PR. Run relevant offline integration for parser changes. Use broader
+  parity matrices and performance benchmarks for releases or changes that warrant
+  them; they are not required for every small edit.
+- Shared parsed-match fixtures in `tests/conftest.py` are lazy and read-only by
+  convention. Tests that mutate output or configure different extractors must use
+  isolated setup. Reference JSON is a separate dependency from replay parsing.
 - Markers are declared in `pyproject.toml` under `[tool.pytest.ini_options]`.
 
 ## Examples

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,7 @@ uv run mypy src/gem/
 ### Running tests
 
 ```bash
-# Full suite
+# Fast developer/PR suite
 uv run pytest
 
 # Single file
@@ -191,15 +191,33 @@ uv run pytest tests/binary/test_reader.py::TestReadVarUint32::test_two_bytes
 uv run pytest --cov=gem --cov-report=html
 ```
 
-### Test markers
+### Test tiers
 
-- `@pytest.mark.slow` — tests that require a real `.dem` file (not run in CI by default)
-- `@pytest.mark.integration` — full-replay integration tests
+| Purpose | Command |
+|---|---|
+| Developer/PR fast suite | `uv run pytest` |
+| Offline integration | `uv run pytest -m "integration and not network"` |
+| All offline tests | `uv run pytest -m "not network"` |
+| Live network smoke | `uv run pytest -m network` |
+| Everything, including network | `uv run pytest -m ""` |
 
-Skip slow tests during development:
-```bash
-uv run pytest -m "not slow and not integration"
-```
+The default suite and PR CI exclude `slow`, `integration`, and `network`.
+`slow` covers expensive full-replay tests; `integration` covers full-replay
+integration checks; `network` identifies live external services. Mocked network
+tests remain in the fast suite, as do small committed truncated replay checks.
+Offline commands do not download missing fixtures; missing assets are reported as
+skips. Synchronize fixtures explicitly before required integration validation.
+
+Run focused tests during iteration and fast tests plus lint/type checks for every
+PR. Parser changes also need relevant offline integration. Broader parity matrices
+and performance benchmarks belong to releases or changes that warrant them.
+The live draft smoke still supports `GEM_DRAFT_INTEGRATION_FULL=1` for its broader
+five-replay sample.
+
+Shared parsed matches are lazy session fixtures and must be treated as read-only.
+Reuse them when parsing configuration is identical; tests that mutate results or
+configure different extractors need isolated setup. OpenDota JSON is a separate
+fixture so replay-only assertions do not require reference data.
 
 ### Writing tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,11 +71,12 @@ addopts = [
     "-v",
     "--tb=short",
     "-m",
-    "not slow and not integration",
+    "not slow and not integration and not network",
 ]
 markers = [
-    "slow: marks tests that require real replay files",
+    "slow: marks expensive tests requiring full replay files",
     "integration: marks integration tests against full replays",
+    "network: marks tests that contact live external services",
 ]
 
 [tool.coverage.run]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,11 @@
+import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from gem.results.models import ParsedMatch
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 OPENDOTA_FIXTURES_DIR = FIXTURES_DIR / "opendota"
@@ -8,6 +13,7 @@ TI2026_SHORT_MATCH_ID = 8868259993
 TI2026_MEDIUM_MATCH_ID = 8860187335
 TI2026_LONG_MATCH_ID = 8856501050
 PERFORMANCE_BASELINE_MATCH_ID = 8822520406
+FEATURE_PARITY_MATCH_ID = 8855188139
 DEPRECATED_OPENDOTA_REPLAY_IDS = frozenset({8821954344, 8822593932})
 DEPRECATED_OPENDOTA_REPLAY_NAMES = frozenset(
     f"{match_id}.dem" for match_id in DEPRECATED_OPENDOTA_REPLAY_IDS
@@ -21,8 +27,9 @@ PREFERRED_OPENDOTA_REPLAY_IDS = (
 
 
 def pytest_configure(config):
-    config.addinivalue_line("markers", "slow: marks tests that require real replay files")
+    config.addinivalue_line("markers", "slow: marks expensive tests requiring full replay files")
     config.addinivalue_line("markers", "integration: marks integration tests against full replays")
+    config.addinivalue_line("markers", "network: marks tests that contact live external services")
 
 
 def available_opendota_replay_paths() -> list[Path]:
@@ -79,3 +86,30 @@ def performance_baseline_replay_path() -> Path:
 def full_replay_path(ti2026_short_replay_path: Path) -> Path:
     """Compatibility alias for the canonical TI2026 integration replay."""
     return ti2026_short_replay_path
+
+
+@pytest.fixture(scope="session")
+def canonical_parsed_match(full_replay_path: Path) -> "ParsedMatch":
+    """Parse the canonical replay once; consumers must treat the result as read-only."""
+    import gem
+
+    return gem.parse(str(full_replay_path))
+
+
+@pytest.fixture(scope="session")
+def feature_parity_match() -> "ParsedMatch":
+    """Share read-only feature parity output independently of the reference JSON."""
+    import gem
+
+    path = _required_replay_path(FEATURE_PARITY_MATCH_ID, "feature parity")
+    return gem.parse(str(path))
+
+
+@pytest.fixture(scope="session")
+def feature_parity_reference() -> dict:
+    """Load the read-only OpenDota reference once, only for tests that need it."""
+    path = OPENDOTA_FIXTURES_DIR / f"{FEATURE_PARITY_MATCH_ID}.opendota.json"
+    if not path.exists():
+        pytest.skip(f"OpenDota reference {path.name} not available")
+    with path.open() as stream:
+        return json.load(stream)

--- a/tests/test_ability_courier_draft_stuns.py
+++ b/tests/test_ability_courier_draft_stuns.py
@@ -388,12 +388,10 @@ class TestStunDuration:
 @pytest.mark.integration
 class TestPhase8Integration:
     @pytest.fixture(scope="class")
-    def match(self, full_replay_path):
-        import gem
+    def match(self, canonical_parsed_match):
+        return canonical_parsed_match
 
-        return gem.parse(str(full_replay_path))
-
-    def test_ability_levels_populated(self, match, full_replay_path):
+    def test_ability_levels_populated(self, full_replay_path):
         from gem.extractors.players import PlayerExtractor
 
         # Re-parse to access snapshots directly

--- a/tests/test_derived_kills_integration.py
+++ b/tests/test_derived_kills_integration.py
@@ -10,16 +10,9 @@ Marked ``slow`` + ``integration`` — needs a real ``.dem`` plus its
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
-
 import pytest
 
-import gem
 from gem.catalog.heroes import HEROES
-
-FIXTURES_DIR = Path(__file__).parent / "fixtures" / "opendota"
-_MATCH_ID = 8855188139
 
 _NAME_TO_HERO_ID = {name: meta["id"] for name, meta in HEROES.items()}
 
@@ -38,20 +31,14 @@ _SCALARS = [
 @pytest.mark.integration
 class TestDerivedKillsMatchOpenDota:
     @pytest.fixture(scope="class")
-    def rows(self):
-        """Parse once; pair each player with OpenDota by hero.
+    def rows(self, feature_parity_reference, feature_parity_match):
+        """Pair each player in the shared match with OpenDota by hero.
 
         Returns:
             List of ``(hero_name, {scalar: (gem, od)})`` tuples.
         """
-        dem = FIXTURES_DIR / f"{_MATCH_ID}.dem"
-        od_path = FIXTURES_DIR / f"{_MATCH_ID}.opendota.json"
-        if not dem.exists() or not od_path.exists():
-            pytest.skip(f"OpenDota fixture {_MATCH_ID} (.dem + .opendota.json) not available")
-
-        match = gem.parse(str(dem))
-        with open(od_path) as fh:
-            od = json.load(fh)
+        match = feature_parity_match
+        od = feature_parity_reference
         od_by_hero = {p["hero_id"]: p for p in od.get("players") or []}
 
         out = []

--- a/tests/test_draft_integration.py
+++ b/tests/test_draft_integration.py
@@ -111,6 +111,7 @@ def od_hero_id_map() -> dict[int, str]:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.network
 @pytest.mark.integration
 @pytest.mark.slow
 @pytest.mark.parametrize("match_id", MATCH_IDS)

--- a/tests/test_final_inventory_integration.py
+++ b/tests/test_final_inventory_integration.py
@@ -13,17 +13,11 @@ Marked ``slow`` + ``integration`` — needs a real ``.dem`` plus its
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
-
 import pytest
 
 import gem
 from gem.catalog.heroes import HEROES
 from gem.catalog.items import item_key_by_id
-
-FIXTURES_DIR = Path(__file__).parent / "fixtures" / "opendota"
-_MATCH_ID = 8855188139
 
 _NAME_TO_HERO_ID = {name: meta["id"] for name, meta in HEROES.items()}
 
@@ -50,20 +44,14 @@ def _gem_main_inventory_keys(player: gem.ParsedPlayer) -> list[str | None]:
 @pytest.mark.integration
 class TestFinalInventoryMatchesOpenDota:
     @pytest.fixture(scope="class")
-    def comparison(self):
-        """Parse the fixture once and pair each player with OpenDota by hero.
+    def comparison(self, feature_parity_reference, feature_parity_match):
+        """Pair the shared parsed match with OpenDota by hero.
 
         Returns:
             List of ``(hero_name, gem_keys, od_keys)`` tuples for slots 0-5.
         """
-        dem = FIXTURES_DIR / f"{_MATCH_ID}.dem"
-        od_path = FIXTURES_DIR / f"{_MATCH_ID}.opendota.json"
-        if not dem.exists() or not od_path.exists():
-            pytest.skip(f"OpenDota fixture {_MATCH_ID} (.dem + .opendota.json) not available")
-
-        match = gem.parse(str(dem))
-        with open(od_path) as fh:
-            od = json.load(fh)
+        match = feature_parity_match
+        od = feature_parity_reference
         od_by_hero = {p["hero_id"]: p for p in od.get("players") or []}
 
         rows: list[tuple[str, list[str | None], list[str | None]]] = []

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -27,6 +27,17 @@ FIXTURE_TRUNCATED = (
     Path(__file__).parent / "fixtures" / "ti14_finals_g3_xg_vs_falcons_truncated.dem"
 )
 
+
+@pytest.fixture(scope="module")
+def truncated_parsed_match():
+    """Share the read-only truncated result between the public parse checks."""
+    import gem
+
+    if not FIXTURE_TRUNCATED.exists():
+        pytest.skip("Truncated fixture not found")
+    return gem.parse(str(FIXTURE_TRUNCATED))
+
+
 _MAGIC_S2 = b"PBDEMS2\x00"
 
 
@@ -180,27 +191,18 @@ class TestParseFuzz:
         result = gem.parse(str(f))
         assert isinstance(result, ParsedMatch)
 
-    def test_truncated_fixture(self) -> None:
+    def test_truncated_fixture(self, truncated_parsed_match) -> None:
         """Pre-built truncated fixture parses without hanging."""
-        import gem
         from gem.results.models import ParsedMatch
 
-        if not FIXTURE_TRUNCATED.exists():
-            pytest.skip("Truncated fixture not found")
-
-        result = gem.parse(str(FIXTURE_TRUNCATED))
+        result = truncated_parsed_match
         assert isinstance(result, ParsedMatch)
         # Truncated replay should still extract some partial data
         assert result.match_id >= 0
 
-    def test_truncated_fixture_has_partial_data(self) -> None:
+    def test_truncated_fixture_has_partial_data(self, truncated_parsed_match) -> None:
         """Truncated fixture returns partial (non-empty) data, not a completely blank match."""
-        import gem
-
-        if not FIXTURE_TRUNCATED.exists():
-            pytest.skip("Truncated fixture not found")
-
-        result = gem.parse(str(FIXTURE_TRUNCATED))
+        result = truncated_parsed_match
         # At minimum the sendtables/entitymanager must have initialised
         # (truncation happens after the header, so some data is available).
         assert result.match_id != 0 or len(result.combat_log) > 0 or len(result.players) == 10

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -434,10 +434,8 @@ class TestLaneAdvantage:
 @pytest.mark.integration
 class TestLaneIntegration:
     @pytest.fixture(scope="class")
-    def match(self, full_replay_path):
-        import gem
-
-        return gem.parse(str(full_replay_path))
+    def match(self, canonical_parsed_match):
+        return canonical_parsed_match
 
     def test_all_players_have_valid_lane_role(self, match):
         for pp in match.players:

--- a/tests/test_purchase_parity_integration.py
+++ b/tests/test_purchase_parity_integration.py
@@ -21,16 +21,9 @@ Marked ``slow`` + ``integration`` — needs a real ``.dem`` plus its
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
-
 import pytest
 
-import gem
 from gem.catalog.heroes import HEROES
-
-FIXTURES_DIR = Path(__file__).parent / "fixtures" / "opendota"
-_MATCH_ID = 8855188139
 
 _NAME_TO_HERO_ID = {name: meta["id"] for name, meta in HEROES.items()}
 
@@ -61,20 +54,14 @@ _EXPECTED_COUNTS = {
 @pytest.mark.integration
 class TestPurchaseParityMatchesOpenDota:
     @pytest.fixture(scope="class")
-    def paired(self):
-        """Parse the fixture once and pair each player with its OpenDota blob.
+    def paired(self, feature_parity_reference, feature_parity_match):
+        """Pair the shared parsed match with each player's OpenDota blob.
 
         Returns:
             Dict of ``hero_id -> (ParsedPlayer, opendota_player_dict)``.
         """
-        dem = FIXTURES_DIR / f"{_MATCH_ID}.dem"
-        od_path = FIXTURES_DIR / f"{_MATCH_ID}.opendota.json"
-        if not dem.exists() or not od_path.exists():
-            pytest.skip(f"OpenDota fixture {_MATCH_ID} (.dem + .opendota.json) not available")
-
-        match = gem.parse(str(dem))
-        with open(od_path) as fh:
-            od = json.load(fh)
+        match = feature_parity_match
+        od = feature_parity_reference
         od_by_hero = {p["hero_id"]: p for p in od.get("players") or []}
 
         pairs = {}

--- a/tests/test_replay_fixtures.py
+++ b/tests/test_replay_fixtures.py
@@ -1,0 +1,49 @@
+"""Missing optional assets must skip only the fixture consumers that need them."""
+
+import json
+from unittest.mock import Mock
+
+import pytest
+
+import gem
+from tests import conftest as replay_fixtures
+
+
+@pytest.mark.parametrize("match_id", [8868259993, 8855188139])
+def test_missing_replay_skips_before_parsing(tmp_path, monkeypatch, match_id):
+    monkeypatch.setattr(replay_fixtures, "OPENDOTA_FIXTURES_DIR", tmp_path)
+    parse = Mock()
+    monkeypatch.setattr(gem, "parse", parse)
+    with pytest.raises(pytest.skip.Exception, match=str(match_id)):
+        if match_id == 8855188139:
+            replay_fixtures.feature_parity_match.__wrapped__()
+        else:
+            replay_fixtures.ti2026_short_replay_path.__wrapped__()
+    parse.assert_not_called()
+
+
+def test_feature_match_does_not_require_reference_json(tmp_path, monkeypatch):
+    monkeypatch.setattr(replay_fixtures, "OPENDOTA_FIXTURES_DIR", tmp_path)
+    replay = tmp_path / "8855188139.dem"
+    replay.touch()
+    parse = Mock(return_value=object())
+    monkeypatch.setattr(gem, "parse", parse)
+    assert replay_fixtures.feature_parity_match.__wrapped__() is parse.return_value
+    parse.assert_called_once_with(str(replay))
+
+
+def test_missing_reference_skips_without_parsing(tmp_path, monkeypatch):
+    monkeypatch.setattr(replay_fixtures, "OPENDOTA_FIXTURES_DIR", tmp_path)
+    (tmp_path / "8855188139.dem").touch()
+    parse = Mock()
+    monkeypatch.setattr(gem, "parse", parse)
+    with pytest.raises(pytest.skip.Exception, match="8855188139.opendota.json"):
+        replay_fixtures.feature_parity_reference.__wrapped__()
+    parse.assert_not_called()
+
+
+def test_reference_does_not_require_replay(tmp_path, monkeypatch):
+    monkeypatch.setattr(replay_fixtures, "OPENDOTA_FIXTURES_DIR", tmp_path)
+    reference = {"players": [{"hero_id": 1}]}
+    (tmp_path / "8855188139.opendota.json").write_text(json.dumps(reference))
+    assert replay_fixtures.feature_parity_reference.__wrapped__() == reference

--- a/tests/test_roshan_drops_integration.py
+++ b/tests/test_roshan_drops_integration.py
@@ -15,27 +15,17 @@ Marked ``slow`` + ``integration`` — needs a real ``.dem``.
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
-import gem
 from gem.analysis.roshan import _HIGH_VALUE_DROPS, build_rosh_conversions
-
-FIXTURES_DIR = Path(__file__).parent / "fixtures" / "opendota"
-_MATCH_ID = 8855188139
 
 
 @pytest.mark.slow
 @pytest.mark.integration
 class TestRoshanDropsPopulate:
     @pytest.fixture(scope="class")
-    def match(self):
-        """Parse the fixture once for the whole class."""
-        dem = FIXTURES_DIR / f"{_MATCH_ID}.dem"
-        if not dem.exists():
-            pytest.skip(f"OpenDota fixture {_MATCH_ID}.dem not available")
-        return gem.parse(str(dem))
+    def match(self, feature_parity_match):
+        return feature_parity_match
 
     def test_has_roshan_kills(self, match):
         assert match.roshans, "fixture expected to contain at least one Roshan kill"
@@ -93,11 +83,8 @@ class TestRoshanDropsPopulate:
 @pytest.mark.integration
 class TestRoshConversionDrops:
     @pytest.fixture(scope="class")
-    def conversions(self):
-        dem = FIXTURES_DIR / f"{_MATCH_ID}.dem"
-        if not dem.exists():
-            pytest.skip(f"OpenDota fixture {_MATCH_ID}.dem not available")
-        return build_rosh_conversions(gem.parse(str(dem)))
+    def conversions(self, feature_parity_match):
+        return build_rosh_conversions(feature_parity_match)
 
     def test_conversions_built(self, conversions):
         assert conversions

--- a/tests/test_teamfights.py
+++ b/tests/test_teamfights.py
@@ -931,10 +931,8 @@ class TestSpatialSplit:
 @pytest.mark.integration
 class TestTeamfightsIntegration:
     @pytest.fixture(scope="class")
-    def match(self, full_replay_path):
-        import gem
-
-        return gem.parse(str(full_replay_path))
+    def match(self, canonical_parsed_match):
+        return canonical_parsed_match
 
     def test_teamfights_detected(self, match):
         assert len(match.teamfights) > 0, "Expected at least one teamfight in replay fixture"


### PR DESCRIPTION
## Summary

Share lazy, read-only parsed matches across integration checks: three identical canonical public parses become one, and five feature-parity public parses become one. Keep OpenDota JSON separate so replay-only consumers do not gain a JSON requirement. Share the truncated fuzz result and remove an unused public-match dependency from the separately configured ability extractor test.

Preserve every existing regression assertion and test ID. Add five lightweight missing-asset checks. Distinct extractor configurations retain independent parses. Add a `network` marker only to the live draft test; align default/CI filters and document fast, offline, and live test tiers. No production code, dependencies, replay files, scheduled jobs, or test deletions.

Baseline: `f6a579dcc294983881cefc657b5b7222634ae88c`; candidate: `26db1a73f2681d5614ced82395ed7d3fadf025e9`.

## Validation and measurements

Timed suites use the same CPython environment, local fixtures, `PYTHONHASHSEED=0`, and no coverage. Baseline ran from a git archive, with local ignored `.dem` files symlinked in; candidate ran afterward. Before the network marker existed, offline baseline selection used `-m "" --ignore=tests/test_draft_integration.py`; candidate used `-m "not network"`. The baseline/candidate fast expressions are identical. Timings below include pytest startup and fixture setup. Peak RSS is the macOS child-process high-water mark in MiB; only one timed test process ran at a time. One measurement per tier/revision: these are observations, not a universal speedup guarantee.


| Tier | Revision | Wall s | User CPU s | Peak RSS MiB | Exit | Load after (1/5/15m) |
|---|---|---|---|---|---|---|
| fast | baseline | 6.61 | 5.56 | 151.23 | 0 | 2.59/3.13/3.88 |
| fast | candidate | 6.44 | 5.43 | 149.52 | 0 | 6.61/4.95/4.28 |
| offline | baseline | 724.61 | 707.18 | 438.59 | 0 | 6.12/4.69/4.17 |
| offline | candidate | 347.99 | 339.56 | 412.41 | 0 | 5.56/4.21/4.07 |

Offline observed wall-time change: -52.0%; peak RSS change: -6.0%. Session fixtures retain the two shared outputs until session teardown; memory is measured explicitly rather than assumed to improve.

<details><summary>baseline fast: results, durations, and every skip</summary>

```text
........................................................................ [ 89%]
........................................................................ [ 91%]
........................................................................ [ 93%]
........................................................................ [ 95%]
........................................................................ [ 97%]
........................................................................ [ 99%]
.......................                                                  [100%]
============================= slowest 25 durations =============================
0.73s call     tests/test_fuzz.py::TestParseFuzz::test_truncated_fixture_has_partial_data
0.59s setup    tests/test_field_path.py::TestDecodeTableCrossValidation::test_captured_buffers_nonempty
0.59s call     tests/test_fuzz.py::TestParseFuzz::test_truncated_fixture
0.40s call     tests/test_bulk.py::TestParseManyToDataframe::test_returns_dict_with_match_path_column
0.18s call     tests/test_field_path.py::TestDecodeTableCrossValidation::test_table_matches_tree_walk_on_real_data
0.11s call     tests/test_sendtable.py::TestParseSendTables::test_fields_have_decoders
0.10s call     tests/test_sendtable.py::TestParseSendTables::test_variable_arrays_have_generic_type_and_child_decoder
0.08s call     tests/binary/test_reader.py::TestReadBytesUnaligned::test_read_bytes_matches_slow_fallback_across_offsets_sizes_and_data
0.07s call     tests/test_sendtable.py::TestParseSendTables::test_field_types_parsed
0.07s call     tests/test_sendtable.py::TestParseSendTables::test_serializer_references_are_resolved
0.06s call     tests/test_sendtable.py::TestParseSendTables::test_returns_nonempty_dict
0.06s call     tests/test_sendtable.py::TestParseSendTables::test_known_entity_classes_present
0.06s call     tests/test_sendtable.py::TestParseSendTables::test_real_fixture_resolves_cworld_body_component_version_zero
0.06s call     tests/test_sendtable.py::TestParseSendTables::test_serializer_repr
0.04s call     tests/test_match_builder.py::TestBuildParsedMatchExtractorOutputs::test_courier_snapshots_stored
0.04s call     tests/test_audit_opendota_fixture_constants.py::test_saved_opendota_fixtures_resolve_against_bundled_item_constants
0.03s call     tests/test_bulk.py::TestParseManyToDataframe::test_rows_concatenated_across_replays
0.03s call     tests/test_players_extractor.py::TestHeroClassPrefix::test_value
0.03s setup    tests/test_entities.py::TestEntityOp::test_integer_masks_preserve_operator_behavior[31-EntityOp.CREATED]
0.03s call     tests/test_render_camp_zones_overlay.py::test_render_overlay_draws_top_right_legend
0.02s call     tests/test_render_camp_zones_overlay.py::test_render_overlay_draws_camp_marker
0.02s call     tests/test_fetch_icons.py::test_item_icon_check_returns_nonzero_for_missing_non_recipe_icons
0.01s setup    tests/test_entities.py::TestEntityGetViaFieldState::test_field_plan_tuple_is_reused_by_serializer
0.01s call     tests/test_teamfights.py::TestSnapshotLookup::test_query_tick_probes_are_logarithmic[False]
0.01s call     tests/test_fetch_opendota_fixture.py::test_main_returns_nonzero_on_fetch_error
=========================== short test summary info ============================
SKIPPED [1] tests/test_bulk.py:250: pyarrow not installed
SKIPPED [1] tests/test_field_decoder.py:208: Flag optimised away for this range too
SKIPPED [1] tests/test_parquet_export.py:56: No parquet engine installed
3692 passed, 3 skipped, 62 deselected in 6.00s
```

</details>

<details><summary>baseline offline: results, durations, and every skip</summary>

```text
........................................................................ [ 90%]
........................................................................ [ 92%]
........................................................................ [ 93%]
........................................................................ [ 95%]
........................................................................ [ 97%]
........................................................................ [ 99%]
............                                                             [100%]
============================= slowest 25 durations =============================
117.56s setup    tests/test_roshan_drops_integration.py::TestRoshConversionDrops::test_conversions_built
100.96s setup    tests/test_roshan_drops_integration.py::TestRoshanDropsPopulate::test_has_roshan_kills
80.00s setup    tests/test_final_inventory_integration.py::TestFinalInventoryMatchesOpenDota::test_all_players_paired
79.85s setup    tests/test_purchase_parity_integration.py::TestPurchaseParityMatchesOpenDota::test_all_players_paired
79.26s setup    tests/test_derived_kills_integration.py::TestDerivedKillsMatchOpenDota::test_all_players_paired
45.75s setup    tests/test_intervals_axis_integration.py::TestIntervalAxisLockIn::test_tick_start_xp_lh_and_denies_are_exact
42.79s setup    tests/test_teamfights.py::TestTeamfightsIntegration::test_teamfights_detected
37.40s setup    tests/test_lane.py::TestLaneIntegration::test_all_players_have_valid_lane_role
37.31s setup    tests/test_ability_courier_draft_stuns.py::TestPhase8Integration::test_ability_levels_populated
32.80s call     tests/test_ability_courier_draft_stuns.py::TestPhase8Integration::test_ability_levels_populated
32.20s setup    tests/test_ml_running_totals.py::TestMLTotalsIntegration::test_running_totals_populated
31.95s setup    tests/test_extractors.py::TestExtractorsIntegration::test_objectives_tower_kills_positive
0.68s call     tests/test_fuzz.py::TestParseFuzz::test_truncated_fixture
0.61s setup    tests/test_field_path.py::TestDecodeTableCrossValidation::test_captured_buffers_nonempty
0.56s call     tests/test_fuzz.py::TestParseFuzz::test_truncated_fixture_has_partial_data
0.44s call     tests/test_bulk.py::TestParseManyToDataframe::test_returns_dict_with_match_path_column
0.28s call     tests/test_sendtable.py::TestParseSendTables::test_serializer_references_are_resolved
0.16s call     tests/test_field_path.py::TestDecodeTableCrossValidation::test_table_matches_tree_walk_on_real_data
0.12s call     tests/test_sendtable.py::TestParseSendTables::test_returns_nonempty_dict
0.11s call     tests/test_sendtable.py::TestParseSendTables::test_fields_have_decoders
0.11s call     tests/test_sendtable.py::TestParseSendTables::test_serializer_repr
0.11s call     tests/test_sendtable.py::TestParseSendTables::test_field_types_parsed
0.10s call     tests/test_sendtable.py::TestParseSendTables::test_known_entity_classes_present
0.08s call     tests/test_sendtable.py::TestParseSendTables::test_variable_arrays_have_generic_type_and_child_decoder
0.08s call     tests/test_sendtable.py::TestParseSendTables::test_real_fixture_resolves_cworld_body_component_version_zero
=========================== short test summary info ============================
SKIPPED [1] tests/test_bulk.py:250: pyarrow not installed
SKIPPED [1] tests/test_field_decoder.py:208: Flag optimised away for this range too
SKIPPED [1] tests/test_parquet_export.py:56: No parquet engine installed
3753 passed, 3 skipped in 724.02s (0:12:04)
```

</details>

<details><summary>candidate fast: results, durations, and every skip</summary>

```text
........................................................................ [ 89%]
........................................................................ [ 91%]
........................................................................ [ 93%]
........................................................................ [ 95%]
........................................................................ [ 97%]
........................................................................ [ 99%]
............................                                             [100%]
============================= slowest 25 durations =============================
0.89s setup    tests/test_field_path.py::TestDecodeTableCrossValidation::test_captured_buffers_nonempty
0.56s setup    tests/test_fuzz.py::TestParseFuzz::test_truncated_fixture
0.44s call     tests/test_bulk.py::TestParseManyToDataframe::test_returns_dict_with_match_path_column
0.20s call     tests/test_field_path.py::TestDecodeTableCrossValidation::test_table_matches_tree_walk_on_real_data
0.11s call     tests/test_sendtable.py::TestParseSendTables::test_fields_have_decoders
0.10s call     tests/test_sendtable.py::TestParseSendTables::test_variable_arrays_have_generic_type_and_child_decoder
0.08s call     tests/test_sendtable.py::TestParseSendTables::test_returns_nonempty_dict
0.08s call     tests/test_sendtable.py::TestParseSendTables::test_field_types_parsed
0.07s call     tests/binary/test_reader.py::TestReadBytesUnaligned::test_read_bytes_matches_slow_fallback_across_offsets_sizes_and_data
0.07s call     tests/test_sendtable.py::TestParseSendTables::test_serializer_references_are_resolved
0.07s call     tests/test_sendtable.py::TestParseSendTables::test_real_fixture_resolves_cworld_body_component_version_zero
0.07s call     tests/test_sendtable.py::TestParseSendTables::test_known_entity_classes_present
0.06s call     tests/test_sendtable.py::TestParseSendTables::test_serializer_repr
0.05s call     tests/test_bulk.py::TestParseManyToDataframe::test_rows_concatenated_across_replays
0.05s call     tests/test_audit_opendota_fixture_constants.py::test_saved_opendota_fixtures_resolve_against_bundled_item_constants
0.04s setup    tests/test_entities.py::TestEntityOp::test_integer_masks_preserve_operator_behavior[-1-EntityOp.CREATED_ENTERED|ENTERED|DELETED|CREATED]
0.04s call     tests/test_match_builder.py::TestBuildParsedMatchSmoke::test_has_ten_players
0.03s call     tests/test_match_builder.py::TestBuildParsedMatchPlayerNames::test_no_entity_manager_no_names_set
0.03s call     tests/test_vision.py::TestEstimateVisionWard::test_ward_not_yet_placed
0.03s call     tests/test_render_camp_zones_overlay.py::test_render_overlay_draws_camp_marker
0.03s call     tests/test_render_camp_zones_overlay.py::test_render_overlay_draws_top_right_legend
0.01s setup    tests/test_entities.py::TestEntityOp::test_integer_masks_preserve_operator_behavior[32-EntityOp.NONE]
0.01s call     tests/binary/test_stream.py::TestOuterMessages::test_path_source_context_manager_closes_resources
0.01s call     tests/test_fuzz.py::TestParseFuzz::test_empty_file
0.01s setup    tests/test_sendtable.py::TestParseSendTables::test_returns_nonempty_dict
=========================== short test summary info ============================
SKIPPED [1] tests/test_bulk.py:250: pyarrow not installed
SKIPPED [1] tests/test_field_decoder.py:208: Flag optimised away for this range too
SKIPPED [1] tests/test_parquet_export.py:56: No parquet engine installed
3697 passed, 3 skipped, 62 deselected in 6.05s
```

</details>

<details><summary>candidate offline: results, durations, and every skip</summary>

```text
........................................................................ [ 89%]
........................................................................ [ 91%]
........................................................................ [ 93%]
........................................................................ [ 95%]
........................................................................ [ 97%]
........................................................................ [ 99%]
.................                                                        [100%]
============================= slowest 25 durations =============================
103.40s setup    tests/test_derived_kills_integration.py::TestDerivedKillsMatchOpenDota::test_all_players_paired
61.41s setup    tests/test_intervals_axis_integration.py::TestIntervalAxisLockIn::test_tick_start_xp_lh_and_denies_are_exact
48.12s setup    tests/test_ability_courier_draft_stuns.py::TestPhase8Integration::test_ability_upgrades_arr_matches_opendota
46.76s setup    tests/test_ml_running_totals.py::TestMLTotalsIntegration::test_running_totals_populated
42.89s setup    tests/test_extractors.py::TestExtractorsIntegration::test_objectives_tower_kills_positive
37.80s call     tests/test_ability_courier_draft_stuns.py::TestPhase8Integration::test_ability_levels_populated
0.69s setup    tests/test_fuzz.py::TestParseFuzz::test_truncated_fixture
0.69s setup    tests/test_field_path.py::TestDecodeTableCrossValidation::test_captured_buffers_nonempty
0.49s call     tests/test_bulk.py::TestParseManyToDataframe::test_returns_dict_with_match_path_column
0.34s call     tests/test_field_path.py::TestDecodeTableCrossValidation::test_table_matches_tree_walk_on_real_data
0.29s call     tests/test_sendtable.py::TestParseSendTables::test_serializer_repr
0.15s call     tests/test_sendtable.py::TestParseSendTables::test_variable_arrays_have_generic_type_and_child_decoder
0.14s call     tests/test_sendtable.py::TestParseSendTables::test_fields_have_decoders
0.13s call     tests/test_sendtable.py::TestParseSendTables::test_field_types_parsed
0.13s call     tests/test_sendtable.py::TestParseSendTables::test_serializer_references_are_resolved
0.12s call     tests/test_sendtable.py::TestParseSendTables::test_returns_nonempty_dict
0.12s call     tests/test_sendtable.py::TestParseSendTables::test_known_entity_classes_present
0.11s call     tests/test_sendtable.py::TestParseSendTables::test_real_fixture_resolves_cworld_body_component_version_zero
0.09s setup    tests/test_combat_aggregator.py::TestSummonOwnershipScans::test_ineligible_attackers_do_not_scan[npc_dota_brewmaster_storm_1-npc_dota_hero_axe-True]
0.08s call     tests/binary/test_reader.py::TestReadBytesUnaligned::test_read_bytes_matches_slow_fallback_across_offsets_sizes_and_data
0.06s setup    tests/test_roshan_drops_integration.py::TestRoshConversionDrops::test_conversions_built
0.05s call     tests/test_render_camp_zones_overlay.py::test_render_overlay_draws_top_right_legend
0.05s teardown tests/test_wards_extractor.py::TestSameTickOrderingFix::test_same_tick_natural_expiry_via_combat_log
0.04s call     tests/test_render_camp_zones_overlay.py::test_render_overlay_draws_camp_marker
0.03s call     tests/test_audit_opendota_fixture_constants.py::test_saved_opendota_fixtures_resolve_against_bundled_item_constants
=========================== short test summary info ============================
SKIPPED [1] tests/test_bulk.py:250: pyarrow not installed
SKIPPED [1] tests/test_field_decoder.py:208: Flag optimised away for this range too
SKIPPED [1] tests/test_parquet_export.py:56: No parquet engine installed
3758 passed, 3 skipped, 1 deselected in 347.46s (0:05:47)
```

</details>

Collection preserves all 3,757 original node IDs and adds five fixture tests. The actual default command collects 3,700 tests (62 deselected); `-m network` selects only `test_draft_matches_opendota[8735903160]`. All original assertion ASTs are unchanged. No required local replay or reference fixture was missing. The three offline skips are optional pyarrow/Parquet coverage and the existing optimized-away decoder flag case. An independent read-only review found no actionable fixture-isolation or coverage issues. Repository-wide Ruff lint/format checks and mypy (88 source files) passed. CI and distribution builds passed; PyPI publishing is intentionally skipped for PRs.

### Separate operation counts and mutation checks

The instrumented runs are excluded from timing. The all-offline candidate run includes independently configured extractor tests; the reversed-module run checks ordering. Hashes compare shared results immediately after setup and after all consumers. Shared fixture fingerprints also match across the normal and reversed fresh processes. The candidate still executes the four separately configured ability, combined-extractor, interval-boundary, and running-total parses. Its two truncated public parses are the shared fuzz result and the intentionally isolated field-path instrumentation parse.


| Replay | Baseline public parses | Candidate public parses |
|---|---|---|
| 8868259993.dem | 3 | 1 |
| 8855188139.dem | 5 | 1 |

<details><summary>baseline normal: operation counts and fingerprints</summary>

```json
{
  "variant": "baseline",
  "mode": "normal",
  "public": {
    "8868259993.dem": 3,
    "8855188139.dem": 5
  },
  "core": [
    [
      "test_teamfights.py:match"
    ],
    [
      "test_lane.py:match"
    ],
    [
      "test_ability_courier_draft_stuns.py:match"
    ],
    [
      "test_ability_courier_draft_stuns.py:test_ability_levels_populated"
    ],
    [
      "test_final_inventory_integration.py:comparison"
    ],
    [
      "test_purchase_parity_integration.py:paired"
    ],
    [
      "test_derived_kills_integration.py:rows"
    ],
    [
      "test_roshan_drops_integration.py:match"
    ],
    [
      "test_roshan_drops_integration.py:conversions"
    ]
  ],
  "fingerprints": [],
  "exitstatus": 0
}
```

</details>

<details><summary>candidate all: operation counts and fingerprints</summary>

```json
{
  "variant": "candidate",
  "mode": "all",
  "public": {
    "8868259993.dem": 1,
    "8855188139.dem": 1,
    "ti14_finals_g3_xg_vs_falcons_truncated.dem": 2,
    "empty.dem": 1,
    "bad_magic.dem": 1,
    "does_not_exist.dem": 1,
    "header_only.dem": 1,
    "garbage.dem": 1,
    "dummy.dem": 1
  },
  "core": [
    [
      "test_ability_courier_draft_stuns.py:test_ability_levels_populated"
    ],
    [
      "conftest.py:canonical_parsed_match"
    ],
    [
      "conftest.py:feature_parity_match"
    ],
    [
      "test_extractors.py:extractors"
    ],
    [
      "test_field_path.py:captured_buffers"
    ],
    [
      "test_fuzz.py:test_empty_file"
    ],
    [
      "test_fuzz.py:test_wrong_magic_file"
    ],
    [
      "test_fuzz.py:test_nonexistent_file"
    ],
    [
      "test_fuzz.py:test_header_only_file"
    ],
    [
      "test_fuzz.py:test_garbage_content_file"
    ],
    [
      "test_fuzz.py:truncated_parsed_match"
    ],
    [
      "test_intervals_axis_integration.py:residuals"
    ],
    [
      "test_ml_running_totals.py:player_ext"
    ],
    [
      "test_parser.py:test_missing_magic_is_recorded_not_raised"
    ],
    [
      "test_parser.py:test_stream_exception_is_recorded_not_raised"
    ],
    [
      "test_parser.py:test_parse_breaks_when_tick_exceeds_stop_tick"
    ]
  ],
  "fingerprints": [
    {
      "fixture": "canonical_parsed_match",
      "before": "7894826d0b99fd162e754fd028104a53f151a8e47c452938fbe60104977bcf33",
      "after": "7894826d0b99fd162e754fd028104a53f151a8e47c452938fbe60104977bcf33",
      "equal": true
    },
    {
      "fixture": "feature_parity_reference",
      "before": "4ede8ac3a5a02b61d9bf1d2c2a7712001ba5f8de658c77d41e25e903a62bca8c",
      "after": "4ede8ac3a5a02b61d9bf1d2c2a7712001ba5f8de658c77d41e25e903a62bca8c",
      "equal": true
    },
    {
      "fixture": "feature_parity_match",
      "before": "217fb0b2c637d21b126e6f19f17edaf7f0aa04264f99509b35f85daeb3331fa8",
      "after": "217fb0b2c637d21b126e6f19f17edaf7f0aa04264f99509b35f85daeb3331fa8",
      "equal": true
    },
    {
      "fixture": "truncated_parsed_match",
      "before": "6683bc230dedd6596b93d2858a87e7aa07dac8b299d8adc427f4d09e4aa49883",
      "after": "6683bc230dedd6596b93d2858a87e7aa07dac8b299d8adc427f4d09e4aa49883",
      "equal": true
    }
  ],
  "exitstatus": 0
}
```

</details>

<details><summary>candidate reverse: operation counts and fingerprints</summary>

```json
{
  "variant": "candidate",
  "mode": "reverse",
  "public": {
    "8855188139.dem": 1,
    "8868259993.dem": 1
  },
  "core": [
    [
      "conftest.py:feature_parity_match"
    ],
    [
      "test_ability_courier_draft_stuns.py:test_ability_levels_populated"
    ],
    [
      "conftest.py:canonical_parsed_match"
    ]
  ],
  "fingerprints": [
    {
      "fixture": "feature_parity_match",
      "before": "217fb0b2c637d21b126e6f19f17edaf7f0aa04264f99509b35f85daeb3331fa8",
      "after": "217fb0b2c637d21b126e6f19f17edaf7f0aa04264f99509b35f85daeb3331fa8",
      "equal": true
    },
    {
      "fixture": "feature_parity_reference",
      "before": "4ede8ac3a5a02b61d9bf1d2c2a7712001ba5f8de658c77d41e25e903a62bca8c",
      "after": "4ede8ac3a5a02b61d9bf1d2c2a7712001ba5f8de658c77d41e25e903a62bca8c",
      "equal": true
    },
    {
      "fixture": "canonical_parsed_match",
      "before": "7894826d0b99fd162e754fd028104a53f151a8e47c452938fbe60104977bcf33",
      "after": "7894826d0b99fd162e754fd028104a53f151a8e47c452938fbe60104977bcf33",
      "equal": true
    }
  ],
  "exitstatus": 0
}
```

</details>

### Individual integration modules

Each migrated integration module also passed in its own pytest process:

- individual-test_ability_courier_draft_stuns.py.log: 10 passed, 20 deselected in 124.69s (0:02:04)
- individual-test_derived_kills_integration.py.log: 3 passed in 113.34s (0:01:53)
- individual-test_final_inventory_integration.py.log: 3 passed in 128.75s (0:02:08)
- individual-test_lane.py.log: 10 passed, 42 deselected in 66.95s (0:01:06)
- individual-test_purchase_parity_integration.py.log: 7 passed in 101.77s (0:01:41)
- individual-test_roshan_drops_integration.py.log: 9 passed in 204.52s (0:03:24)
- individual-test_teamfights.py.log: 7 passed, 74 deselected in 64.29s (0:01:04)

### Environment

```json
{
  "python": "3.10.4 (main, Sep 12 2023, 14:13:09) [Clang 14.0.3 (clang-1403.0.22.14.1)]",
  "platform": "macOS-26.6.2-arm64-arm-64bit",
  "packages": {
    "pytest": "9.0.2",
    "pytest-cov": "7.0.0",
    "protobuf": "7.34.0",
    "numpy": "2.2.6",
    "pandas": "2.3.3"
  },
  "hash_seed": 0,
  "coverage": "disabled for both timed suites",
  "load": [
    3.5908203125,
    3.30908203125,
    3.74853515625
  ]
}
```

## Reproduction

Use the existing `.venv` from the repository. Save the scripts below in `/private/tmp/gem-test-tiers/`; replace the absolute repository path if needed. Create a baseline archive and link the same ignored replay files before running. Run each command sequentially. `run.py` captures collection, fast, and offline results. `inspect_run.py` counts parsing and fingerprints shared outputs separately from timing.

```sh
mkdir -p /private/tmp/gem-test-tiers/baseline
git archive f6a579dcc294983881cefc657b5b7222634ae88c | tar -x -C /private/tmp/gem-test-tiers/baseline
for replay in "$PWD"/tests/fixtures/opendota/*.dem; do
  ln -s "$replay" /private/tmp/gem-test-tiers/baseline/tests/fixtures/opendota/
done
.venv/bin/python /private/tmp/gem-test-tiers/run.py baseline
.venv/bin/python /private/tmp/gem-test-tiers/run.py candidate
PYTHONHASHSEED=0 .venv/bin/python /private/tmp/gem-test-tiers/inspect_run.py candidate all
PYTHONHASHSEED=0 .venv/bin/python /private/tmp/gem-test-tiers/inspect_run.py candidate reverse
PYTHONHASHSEED=0 .venv/bin/python /private/tmp/gem-test-tiers/inspect_run.py baseline normal
for module in test_teamfights test_lane test_ability_courier_draft_stuns test_final_inventory_integration test_purchase_parity_integration test_derived_kills_integration test_roshan_drops_integration; do
  .venv/bin/python -m pytest tests/$module.py -m integration -q -o addopts='' -ra
done
.venv/bin/python -m pytest --collect-only -q -o addopts='' -m network
.venv/bin/python -m pytest --collect-only -q -o addopts='' -m network > /private/tmp/gem-test-tiers/network-collect.log
.venv/bin/python /private/tmp/gem-test-tiers/check_structure.py
.venv/bin/python -m ruff check .
.venv/bin/python -m ruff format --check .
.venv/bin/python -m mypy src/gem/
```

The live network test is validated by collection, not a fresh remote download. Missing local assets are skips during development and must be disclosed when reporting required integration validation.


<details><summary>run.py</summary>

```python
import subprocess,sys,time,resource,json,os
from pathlib import Path
variant=sys.argv[1];root=Path('/private/tmp/gem-test-tiers');repo=Path('/Users/hanyuwu/Study/gem');cwd=root/'baseline' if variant=='baseline' else repo
env={**os.environ,'PYTHONPATH':str(cwd/'src'),'PYTHONHASHSEED':'0'}
python=str(repo/'.venv/bin/python')
for tier,args in [('collect',['--collect-only','-m','']),('fast',['-m','not slow and not integration and not network']),('offline',['-m','not network'] if variant!='baseline' else ['-m','','--ignore=tests/test_draft_integration.py'])]:
    start=time.perf_counter();before=resource.getrusage(resource.RUSAGE_CHILDREN)
    with (root/f'{variant}-{tier}.log').open('w') as log:
        result=subprocess.run([python,'-m','pytest','-q','-o','addopts=','--durations=25','-ra',*args],cwd=cwd,env=env,stdout=log,stderr=subprocess.STDOUT)
    usage=resource.getrusage(resource.RUSAGE_CHILDREN)
    record=dict(variant=variant,tier=tier,elapsed=time.perf_counter()-start,user=usage.ru_utime-before.ru_utime,peak_rss=usage.ru_maxrss,returncode=result.returncode,load=os.getloadavg())
    (root/f'{variant}-{tier}.json').write_text(json.dumps(record));print(json.dumps(record),flush=True)
    if result.returncode:sys.exit(result.returncode)

```

</details>

<details><summary>inspect_run.py</summary>

```python
import sys,os,json,hashlib,inspect
from pathlib import Path
import pytest
root=Path('/private/tmp/gem-test-tiers');variant,mode=sys.argv[1:]
repo=Path('/Users/hanyuwu/Study/gem');source=root/'baseline' if variant=='baseline' else repo
os.chdir(source);sys.path.insert(0,str(source/'src'));sys.path.insert(0,str(source/'tests'))
import gem
from gem.parser import ReplayParser
public=[];core=[];shared={};checks=[]
def digest(value):
    return hashlib.sha256(json.dumps(value if isinstance(value,dict) else gem.to_dict(value),sort_keys=True,separators=(',',':')).encode()).hexdigest()
class Plugin:
    def pytest_sessionstart(self,session):
        original=gem.parse;original_core=ReplayParser.parse
        def parse(path,*a,**kw):
            public.append(str(path));return original(path,*a,**kw)
        def core_parse(parser,*a,**kw):
            callers=[f'{Path(f.filename).name}:{f.function}' for f in inspect.stack()[1:] if '/tests/' in f.filename]
            core.append(callers[:2]);return original_core(parser,*a,**kw)
        gem.parse=parse;ReplayParser.parse=core_parse
    @pytest.hookimpl(hookwrapper=True)
    def pytest_fixture_setup(self,fixturedef,request):
        result=yield
        if fixturedef.argname in ('canonical_parsed_match','feature_parity_match','feature_parity_reference','truncated_parsed_match') and result.excinfo is None:
            value=result.get_result();shared[fixturedef.argname]=(value,digest(value))
    def pytest_sessionfinish(self,session,exitstatus):
        for name,(value,before) in shared.items():
            after=digest(value);checks.append(dict(fixture=name,before=before,after=after,equal=before==after))
        record=dict(variant=variant,mode=mode,public=public,core=core,fingerprints=checks,exitstatus=int(exitstatus))
        (root/f'inspect-{variant}-{mode}.json').write_text(json.dumps(record,indent=2))
        if any(not c['equal'] for c in checks):session.exitstatus=1
files=['test_teamfights.py','test_lane.py','test_ability_courier_draft_stuns.py','test_final_inventory_integration.py','test_purchase_parity_integration.py','test_derived_kills_integration.py','test_roshan_drops_integration.py']
if mode=='reverse':files.reverse()
if mode=='all':args=['tests','-m','not network']
else:args=['tests/'+p for p in files]+['-m','integration']
raise SystemExit(pytest.main(['-q','-o','addopts=','-ra',*args],plugins=[Plugin()]))

```

</details>

<details><summary>check_structure.py</summary>

```python
from pathlib import Path
import ast,json
root=Path('/private/tmp/gem-test-tiers')
def ids(name):
    return {s for s in (root/name).read_text().splitlines() if s.startswith('tests/') and '::' in s}
b=ids('baseline-collect.log');c=ids('candidate-collect.log');network=ids('network-collect.log')
assert b<=c
assert network=={'tests/test_draft_integration.py::test_draft_matches_opendota[8735903160]'}
for old in (root/'baseline/tests').rglob('test_*.py'):
    current=Path('tests')/old.relative_to(root/'baseline/tests')
    def assertions(path):
        return [ast.dump(n,include_attributes=False) for n in ast.walk(ast.parse(path.read_text())) if isinstance(n,ast.Assert)]
    assert assertions(old)==assertions(current),str(current)
print(json.dumps(dict(original_ids=len(b),current_ids=len(c),removed=sorted(b-c),added=sorted(c-b),network=sorted(network)),indent=2))

```

</details>
