### PR TITLE
Use bulk reads for string-table payloads.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Lower string-table payload overhead.** Use bulk byte reads for larger payloads,
+  preserving partial-byte packing and truncated-input behavior.
 - **Less repeated test setup.** Share read-only replay results across integration
   checks and separate fast, offline, and live-network test commands.
 - **Lower player sampling overhead.** Reuse guarded player-ID resolutions and

--- a/src/gem/binary/reader.py
+++ b/src/gem/binary/reader.py
@@ -233,6 +233,8 @@ class BitReader:
 
         Full bytes are emitted in stream order. If ``n`` is not divisible by
         8, the final output byte contains the remaining low-order bits.
+        Larger valid requests use bulk byte reads. Small and truncated requests
+        retain byte-by-byte reads, including partial consumption on failure.
 
         Args:
             n: Number of bits to read (need not be a multiple of 8).
@@ -240,6 +242,13 @@ class BitReader:
         Returns:
             bytes: The bits packed into ceil(n/8) bytes.
         """
+        if n >= 24 and n <= self.rem_bits():
+            full_bytes, remainder = divmod(n, 8)
+            data = self.read_bytes(full_bytes)
+            if remainder:
+                data += bytes((self.read_bits(remainder),))
+            return data
+
         out = bytearray()
         while n >= 8:
             out.append(self._read_byte())

--- a/tests/binary/test_reader.py
+++ b/tests/binary/test_reader.py
@@ -427,6 +427,105 @@ class TestReadBytesUnaligned:
 
 
 class TestReadBitsAsBytes:
+    @staticmethod
+    def _original(reader, n):
+        out = bytearray()
+        while n >= 8:
+            out.append(reader._read_byte())
+            n -= 8
+        if n > 0:
+            out.append(reader.read_bits(n))
+        return bytes(out)
+
+    @pytest.mark.parametrize("offset", range(8))
+    @pytest.mark.parametrize("prefetch", [0, 8, 32])
+    def test_matches_original_and_mixed_continuation(self, offset, prefetch):
+        patterns = [bytes(96), b"\xff" * 96, bytes(range(96)), b"\xaa\x55" * 48]
+        for data in patterns:
+            for n in (0, 1, 7, 8, 15, 16, 23, 24, 25, 31, 32, 255, 256, 257, 511):
+                candidate, original = BitReader(data), BitReader(data)
+                for r in (candidate, original):
+                    if offset:
+                        r.read_bits(offset)
+                    if prefetch:
+                        r.peek_bits(prefetch)
+                actual = candidate.read_bits_as_bytes(n)
+                assert actual == self._original(original, n)
+                expected = (int.from_bytes(data, "little") >> offset) & ((1 << n) - 1)
+                assert actual == expected.to_bytes((n + 7) // 8, "little")
+                assert candidate.position() == original.position()
+                assert candidate.rem_bits() == original.rem_bits()
+                assert candidate.read_bits(3) == original.read_bits(3)
+                assert candidate.read_bytes(3) == original.read_bytes(3)
+                assert candidate.peek_bits(13) == original.peek_bits(13)
+                candidate.skip_bits(5)
+                original.skip_bits(5)
+                assert candidate.read_boolean() == original.read_boolean()
+                while original.rem_bits():
+                    width = min(17, original.rem_bits())
+                    assert candidate.read_bits(width) == original.read_bits(width)
+                assert candidate.position() == original.position()
+                assert candidate.rem_bits() == 0
+
+    @pytest.mark.parametrize("offset", range(8))
+    @pytest.mark.parametrize("prefetch", [False, True])
+    def test_boundaries_and_truncation_match_original(self, offset, prefetch):
+        for size in (1, 2, 3, 4, 8, 33):
+            data = bytes(range(size))
+            available = size * 8 - offset
+            for n in (available, available + 1, available + 7, available + 8, available + 33):
+                candidate, original = BitReader(data), BitReader(data)
+                for r in (candidate, original):
+                    if offset:
+                        r.read_bits(offset)
+                    if prefetch:
+                        r.peek_bits(min(available, 32))
+                if n == available:
+                    assert candidate.read_bits_as_bytes(n) == self._original(original, n)
+                    assert candidate.position() == original.position()
+                    assert candidate.rem_bits() == original.rem_bits() == 0
+                else:
+                    with pytest.raises(BufferReadError) as expected:
+                        self._original(original, n)
+                    with pytest.raises(BufferReadError) as actual:
+                        candidate.read_bits_as_bytes(n)
+                    assert type(actual.value) is type(expected.value)
+                    assert str(actual.value) == str(expected.value)
+                    assert tuple(getattr(candidate, k) for k in BitReader.__slots__) == tuple(
+                        getattr(original, k) for k in BitReader.__slots__
+                    )
+
+    @pytest.mark.parametrize("n", [0, -1, -8, -100])
+    def test_nonpositive_lengths_do_not_change_state(self, n):
+        for data in (b"", bytes(range(8))):
+            r = BitReader(data)
+            if data:
+                r.read_bits(3)
+            before = tuple(getattr(r, k) for k in BitReader.__slots__)
+            assert r.read_bits_as_bytes(n) == b""
+            assert tuple(getattr(r, k) for k in BitReader.__slots__) == before
+
+    @pytest.mark.parametrize("offset", range(8))
+    @pytest.mark.parametrize("remainder", [0, 1, 7])
+    def test_large_reads_use_bulk_reader(self, monkeypatch, offset, remainder):
+        calls = []
+        bulk = BitReader.read_bytes
+
+        def tracked_bulk(reader, n):
+            calls.append(n)
+            return bulk(reader, n)
+
+        def unexpected_byte(reader):
+            pytest.fail("large valid payload used the per-byte loop")
+
+        monkeypatch.setattr(BitReader, "read_bytes", tracked_bulk)
+        monkeypatch.setattr(BitReader, "_read_byte", unexpected_byte)
+        r = BitReader(bytes(range(96)))
+        if offset:
+            r.read_bits(offset)
+        assert len(r.read_bits_as_bytes(256 + remainder)) == 32 + bool(remainder)
+        assert calls == [32]
+
     def test_exact_multiple_of_8(self):
         r = BitReader(b"\xab\xcd")
         result = r.read_bits_as_bytes(16)

--- a/tests/test_string_table.py
+++ b/tests/test_string_table.py
@@ -693,6 +693,37 @@ class TestVarintBitCounts:
 class TestFixedSizeUserData:
     """user_data_fixed_size=True path: value is exactly user_data_size_bits bits."""
 
+    @pytest.mark.parametrize("width", [25, 31, 257])
+    def test_consecutive_partial_byte_payloads(self, parse_string_table, width):
+        values = [(1 << width) - 1, (1 << (width - 1)) | 5, 0]
+        bits = []
+        for value in values:
+            bits.extend([1, 0, 1])  # sequential index, no key, value present
+            bits.extend((value >> i) & 1 for i in range(width))
+        items = parse_string_table(_pack_bits(bits), 3, "test", True, width, 0, False)
+        assert [(item.index, item.key, item.value) for item in items] == [
+            (i, "", value.to_bytes((width + 7) // 8, "little")) for i, value in enumerate(values)
+        ]
+
+    @pytest.mark.parametrize("compressed", [False, True])
+    def test_consecutive_large_variable_payloads(self, parse_string_table, compressed):
+        values = [bytes(range(256)) * 4, b"second payload" * 32, b"last"]
+        bits = []
+        for i, value in enumerate(values):
+            bits.extend(
+                _build_entry_bits(
+                    incr=True,
+                    key=f"entry{i}",
+                    value=snappy.compress(value) if compressed else value,
+                    flags=int(compressed),
+                    compressed=compressed,
+                )
+            )
+        items = parse_string_table(_pack_bits(bits), 3, "test", False, 0, int(compressed), False)
+        assert [(item.index, item.key, item.value) for item in items] == [
+            (i, f"entry{i}", value) for i, value in enumerate(values)
+        ]
+
     def test_fixed_size_8bit(self, parse_string_table):
         # 8-bit fixed value: the parser reads user_data_size_bits=8 bits directly.
         bits: list[int] = []


### PR DESCRIPTION
## Summary

Larger string-table payload reads currently loop over every byte in Python. Route valid requests of at least 24 bits through the existing bulk byte reader, then append any remaining low-order bits. Keep the original loop for small and truncated requests so failure messages and partial consumption remain unchanged.

Closes #168.

No public API, generic reader primitives, string-table callers, dependencies, or test tiers change. The three-byte cutoff follows `read_bytes()`'s existing tiny-read fallback. Zero and negative integer requests retain their existing empty-result behavior.

## References and compatibility

Inspected Manta `reader.go::readBitsAsBytes`, Clarity `BitStream32/64::readBitsIntoByteArray` and `S2StringTableEmitter`, and OpenDota `Parse.java` EntityNames consumers. These establish byte order, low-order partial-byte packing, and downstream string-table use. Gem's original implementation is the compatibility oracle, including truncated-input exception text and reader state.

Regression tests compare bytes against both the original loop and an independent integer bit-slicing oracle across every alignment and prefetched state, then exercise mixed continuation reads. Boundary/failure tests compare the original exception and all cursor/cache fields. Consecutive fixed-width partial-byte, large variable-width, and compressed string-table entries preserve subsequent decoding. Instrumented unit tests prohibit the per-byte path for valid bulk reads.

Independent static review found no actionable issues.

## Validation

Commands used the same existing uv-managed CPython 3.10.4 environment throughout. Direct `.venv/bin/python -m ...` invocations avoid changing dependencies between measurements.

| Check | Result |
|---|---|
| `uv run pytest tests/binary/test_reader.py tests/test_string_table.py -q` | 214 passed |
| `.venv/bin/python -m pytest -q -rs` | 3,770 passed, 3 skipped, 62 deselected; 6.14 s |
| `.venv/bin/python -m pytest -q -rs -m "not network"` | 3,831 passed, 3 skipped, 1 deselected; 287.67 s |
| `.venv/bin/python -m ruff check .` | Passed |
| `.venv/bin/python -m ruff format --check src/ tests/` | 156 files already formatted |
| `.venv/bin/python -m mypy src/gem/` | 88 source files passed |
| Pre-commit hooks | Ruff, format, merge-conflict check and mypy passed; YAML/TOML hooks had no applicable files |
| Offline full OpenDota parity | 982 PASS, 0 WARN, 0 FAIL; details below |
| GitHub CI on `078833b2a4f868b6bbe0bbe3a751c4a68ba36c11` | [CI passed](https://github.com/whanyu1212/gem-dota/actions/runs/34027218637/job/101470229749), [distribution build passed](https://github.com/whanyu1212/gem-dota/actions/runs/34027218677/job/101470229872) |

Pytest skips are `test_bulk.py` (optional pyarrow absent), `test_parquet_export.py` (optional Parquet engine absent), and the existing `test_field_decoder.py` optimized-away flag case. The one deselected offline test is live network integration. No required replay or reference JSON is missing. Each parity run skips only the existing informational teamfight-count comparison; thresholds are unchanged. PyPI publishing is intentionally skipped for a PR. No live downloads were needed.

## Interpretation of replay measurements

Final review identified two lazy extractor-module imports included in the original public timings. A separate fresh-process public benchmark preloads both modules before timing; its complete results are reported below. The original data remains visible rather than being silently replaced. The microbenchmark is a documented representative 120-case sweep, not a full 336-case cross-product.

Whole-replay timing is noisy on this host. The initial short-public median CPU favored B, while the follow-up favored C; short-core CPU comparisons also changed direction. Long-public median elapsed/user CPU was about 2.5% lower for C, while long-core medians were about 1.3%/0.9% higher. The individual measurements and load readings below are retained in full; these results do not establish a uniform end-to-end speedup or a consistent CPU regression.

No systematic memory regression was observed across the replay measurements and follow-up controls. Short-replay RSS differences changed direction between batches; long-replay medians remained essentially unchanged. A separate bytes-backed core diagnostic found only a 124-byte candidate increase in peak traced and post-GC allocations, with matching leading allocation sites. This supports memory acceptance for the tested workloads. RSS variability remains unexplained; no RSS improvement or specific residency cause is claimed. Tracemalloc measures tracked Python allocations, not total process memory, and this diagnostic covers one replay and one pair.

For `8822520406`, the import-preloaded public medians were B/C 53.883/52.263 s elapsed, 53.711/52.033 s user CPU, and 218.484/218.328 MiB peak RSS (3.01% lower median elapsed for C in this batch). For `8856501050`, the import-preloaded public medians were B/C 175.631/170.200 s elapsed, 172.886/167.434 s user CPU, and 640.141/637.969 MiB peak RSS (3.09% lower median elapsed for C in this batch). These batch-specific gains do not remove the host-load and cross-batch variability described above.

## Replay measurements

CPython 3.10.4, macOS 26.6.2 arm64, Apple M2, 16 GiB RAM; same existing virtual environment and fixtures. No coverage/profiling during timing. Top-level imports and core-parser construction precede timing; the initial public runs also include two lazy extractor-module imports (intervals and smoke_vision), corrected in the separate preloaded runs below; serialization/hash follow timing and peak-RSS capture. RSS is the process high-water mark in MiB. All runs sequential; pair order B/C, C/B, B/C. B is main `6e912cfa4a8ad941a83fb3b494ecc5bd4bb03bc8`; C is this PR.

| Replay | Scenario | Variant | Elapsed s (3 runs) | User CPU s (3 runs) | Peak RSS MiB (3 runs) | Median elapsed / CPU / RSS |
|---|---|---|---|---|---|---|
|8822520406|public|B|105.235, 89.773, 74.424|100.558, 86.325, 72.846|195.781, 197.219, 203.516|89.773 / 86.325 / 197.219|
|8822520406|public|C|110.258, 94.790, 68.493|102.421, 88.309, 67.882|190.766, 195.297, 200.859|94.790 / 88.309 / 195.297|
|8822520406|core|B|54.905, 46.564, 54.966|54.259, 46.266, 53.709|153.750, 158.562, 140.500|54.905 / 53.709 / 153.750|
|8822520406|core|C|50.249, 47.986, 46.398|49.618, 47.093, 46.095|160.594, 159.906, 174.297|47.986 / 47.093 / 160.594|
|8856501050|public|B|203.582, 204.560, 199.884|200.269, 200.683, 195.876|603.891, 632.781, 632.672|203.582 / 200.269 / 632.672|
|8856501050|public|C|198.460, 202.924, 194.512|195.147, 198.684, 191.203|636.625, 603.484, 633.500|198.460 / 195.147 / 633.500|
|8856501050|core|B|165.488, 158.651, 160.633|162.448, 157.081, 159.214|433.250, 433.391, 433.828|160.633 / 159.214 / 433.391|
|8856501050|core|C|153.061, 162.738, 170.296|151.776, 160.585, 166.233|434.109, 433.875, 414.703|162.738 / 160.585 / 433.875|

### Public timings with lazy modules preloaded

Final review identified two extractor modules imported lazily by gem.parse(). These fresh B/C, C/B, B/C pairs explicitly preload both modules before timing. The initial runs remain above for transparency; use this table for public timing with those imports excluded.

| Replay | Variant | Elapsed s (3 runs) | User CPU s (3 runs) | Peak RSS MiB (3 runs) | Median elapsed / CPU / RSS |
|---|---|---|---|---|---|
|8822520406|B|55.488, 53.381, 53.883|54.277, 53.212, 53.711|209.250, 218.484, 218.578|53.883 / 53.711 / 218.484|
|8822520406|C|51.589, 52.425, 52.263|51.435, 52.191, 52.033|218.312, 218.328, 218.578|52.263 / 52.033 / 218.328|
|8856501050|B|176.506, 173.868, 175.631|174.299, 171.650, 172.886|651.969, 640.141, 635.297|175.631 / 172.886 / 640.141|
|8856501050|C|170.200, 169.636, 170.646|167.426, 167.434, 168.541|596.766, 644.438, 637.969|170.200 / 167.434 / 637.969|

### Follow-up short-replay controls

Added because the initial short public median CPU and core RSS were higher for C amid substantial drift. Same code, interpreter, fixtures and timing protocol; reverse-balanced pair order C/B, B/C, C/B. Reported separately rather than replacing the initial results.

| Scenario | Variant | Elapsed s (3 runs) | User CPU s (3 runs) | Peak RSS MiB (3 runs) | Median elapsed / CPU / RSS |
|---|---|---|---|---|---|
|public|B|64.060, 65.344, 59.215|62.963, 63.769, 58.355|180.875, 179.703, 194.609|64.060 / 62.963 / 180.875|
|public|C|67.160, 58.260, 57.399|65.420, 57.537, 56.812|178.406, 201.719, 203.406|58.260 / 57.537 / 201.719|
|core|B|44.292, 42.783, 48.293|43.063, 42.062, 47.853|141.469, 156.234, 160.766|44.292 / 43.063 / 156.234|
|core|C|44.563, 48.284, 54.710|43.550, 45.161, 52.643|151.328, 140.203, 159.953|48.284 / 45.161 / 151.328|

### Individual host load (1/5/15-minute averages)

- `control-core-8822520406-0-B`: start 3.95/4.10/4.07; end 3.64/3.99/4.03.
- `control-core-8822520406-0-C`: start 3.32/3.96/4.02; end 3.95/4.10/4.07.
- `control-core-8822520406-1-B`: start 3.64/3.99/4.03; end 4.62/4.17/4.09.
- `control-core-8822520406-1-C`: start 4.62/4.17/4.09; end 4.30/4.11/4.07.
- `control-core-8822520406-2-B`: start 5.04/4.36/4.16; end 4.50/4.30/4.15.
- `control-core-8822520406-2-C`: start 4.30/4.11/4.07; end 5.04/4.36/4.16.
- `control-public-8822520406-0-B`: start 6.09/4.56/4.18; end 4.66/4.46/4.17.
- `control-public-8822520406-0-C`: start 4.85/4.13/4.01; end 6.09/4.56/4.18.
- `control-public-8822520406-1-B`: start 4.66/4.46/4.17; end 4.48/4.37/4.15.
- `control-public-8822520406-1-C`: start 4.52/4.38/4.15; end 4.17/4.33/4.15.
- `control-public-8822520406-2-B`: start 3.77/4.12/4.08; end 3.32/3.96/4.02.
- `control-public-8822520406-2-C`: start 3.99/4.29/4.13; end 3.58/4.09/4.07.
- `core-8822520406-0-B`: start 3.53/4.45/4.21; end 3.82/4.33/4.17.
- `core-8822520406-0-C`: start 3.82/4.33/4.17; end 3.11/4.04/4.08.
- `core-8822520406-1-B`: start 3.69/4.05/4.08; end 3.58/3.98/4.05.
- `core-8822520406-1-C`: start 3.11/4.04/4.08; end 3.69/4.05/4.08.
- `core-8822520406-2-B`: start 3.58/3.98/4.05; end 3.82/3.95/4.03.
- `core-8822520406-2-C`: start 3.82/3.95/4.03; end 4.10/4.01/4.04.
- `core-8856501050-0-B`: start 4.00/3.82/3.85; end 5.04/4.15/3.95.
- `core-8856501050-0-C`: start 5.04/4.15/3.95; end 3.67/3.84/3.85.
- `core-8856501050-1-B`: start 3.58/4.16/4.02; end 3.85/4.00/3.97.
- `core-8856501050-1-C`: start 3.67/3.84/3.85; end 3.58/4.16/4.02.
- `core-8856501050-2-B`: start 3.85/4.00/3.97; end 5.01/4.26/4.06.
- `core-8856501050-2-C`: start 5.01/4.26/4.06; end 4.85/4.13/4.01.
- `preloaded-public-8822520406-0-B`: start 2.38/2.52/2.97; end 2.99/2.65/2.99.
- `preloaded-public-8822520406-0-C`: start 2.83/2.62/2.98; end 2.39/2.52/2.92.
- `preloaded-public-8822520406-1-B`: start 2.56/2.54/2.90; end 2.80/2.59/2.89.
- `preloaded-public-8822520406-1-C`: start 2.39/2.52/2.92; end 2.56/2.54/2.90.
- `preloaded-public-8822520406-2-B`: start 2.80/2.59/2.89; end 2.44/2.56/2.86.
- `preloaded-public-8822520406-2-C`: start 2.44/2.56/2.86; end 2.28/2.50/2.82.
- `preloaded-public-8856501050-0-B`: start 2.28/2.50/2.82; end 2.92/2.65/2.82.
- `preloaded-public-8856501050-0-C`: start 2.77/2.63/2.81; end 4.24/3.19/3.00.
- `preloaded-public-8856501050-1-B`: start 3.46/3.28/3.08; end 3.47/3.35/3.14.
- `preloaded-public-8856501050-1-C`: start 4.64/3.31/3.04; end 3.00/3.19/3.04.
- `preloaded-public-8856501050-2-B`: start 3.47/3.36/3.15; end 2.50/2.98/3.02.
- `preloaded-public-8856501050-2-C`: start 2.50/2.96/3.02; end 3.04/3.05/3.04.
- `public-8822520406-0-B`: start 3.65/4.16/3.57; end 4.87/4.48/3.77.
- `public-8822520406-0-C`: start 6.48/4.91/3.99; end 4.64/4.79/4.06.
- `public-8822520406-1-B`: start 4.22/4.79/4.16; end 5.62/5.27/4.41.
- `public-8822520406-1-C`: start 5.38/4.95/4.12; end 4.22/4.79/4.16.
- `public-8822520406-2-B`: start 5.33/5.21/4.40; end 3.53/4.71/4.27.
- `public-8822520406-2-C`: start 3.53/4.71/4.27; end 3.53/4.45/4.21.
- `public-8856501050-0-B`: start 4.10/4.01/4.04; end 2.80/3.50/3.83.
- `public-8856501050-0-C`: start 2.70/3.45/3.80; end 3.41/3.43/3.72.
- `public-8856501050-1-B`: start 7.26/4.75/4.15; end 3.73/3.99/3.93.
- `public-8856501050-1-C`: start 3.03/3.34/3.68; end 7.85/4.77/4.15.
- `public-8856501050-2-B`: start 3.54/3.94/3.92; end 4.14/3.98/3.92.
- `public-8856501050-2-C`: start 3.83/3.91/3.90; end 3.64/3.74/3.82.

### Byte-identical public output

- `8822520406`: `3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427`; all 20 output files (timing, controls, instrumentation) compared byte-for-byte (30,401,205 bytes each).
- `8856501050`: `1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e`; all 14 output files (timing, controls, instrumentation) compared byte-for-byte (187,363,261 bytes each).

## Allocation diagnostic (not timing evidence)

One fresh baseline/candidate short-core pair used ReplayParser(bytes), retaining the same 98,983,300 input bytes before measurement. tracemalloc started after imports/input setup; peak RSS was captured before snapshots/serialization. This separates Python heap allocation from mapped replay pages; it does not establish the cause of all RSS variation.

| Variant | Traced peak MiB | Traced current MiB | Post-GC MiB | RSS MiB |
|---|---|---|---|---|
|B|21.741573|20.899760|20.838584|200.671875|
|C|21.741692|20.899879|20.838702|170.234375|
The candidate differs by only 124 traced bytes. Short-replay RSS differences reverse across repeated sets; long-replay RSS medians are essentially unchanged. No repeatable material memory regression was observed, and no RSS improvement is claimed.

## Instrumentation (separate from timing)

- `instrument-8822520406-B`: `{"bulk_calls": 0, "bulk_eligible": 113355, "byte_calls": 3681646, "bytes": 3681646, "max_bits": 65872, "remainder_0": 113358, "remainder_1": 0, "remainder_2": 1, "remainder_3": 0, "remainder_4": 0, "remainder_5": 0, "remainder_6": 0, "remainder_7": 0, "requests": 113359, "small": 4, "truncated": 0}`; public hash `3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427`.
- `instrument-8822520406-C`: `{"bulk_calls": 113355, "bulk_eligible": 113355, "byte_calls": 6, "bytes": 3681646, "max_bits": 65872, "remainder_0": 113358, "remainder_1": 0, "remainder_2": 1, "remainder_3": 0, "remainder_4": 0, "remainder_5": 0, "remainder_6": 0, "remainder_7": 0, "requests": 113359, "small": 4, "truncated": 0}`; public hash `3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427`.
- `instrument-8856501050-B`: `{"bulk_calls": 0, "bulk_eligible": 410470, "byte_calls": 13914615, "bytes": 13914615, "max_bits": 19752, "remainder_0": 410474, "remainder_1": 0, "remainder_2": 1, "remainder_3": 0, "remainder_4": 0, "remainder_5": 0, "remainder_6": 0, "remainder_7": 0, "requests": 410475, "small": 5, "truncated": 0}`; public hash `1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e`.
- `instrument-8856501050-C`: `{"bulk_calls": 410470, "bulk_eligible": 410470, "byte_calls": 8, "bytes": 13914615, "max_bits": 19752, "remainder_0": 410474, "remainder_1": 0, "remainder_2": 1, "remainder_3": 0, "remainder_4": 0, "remainder_5": 0, "remainder_6": 0, "remainder_7": 0, "requests": 410475, "small": 5, "truncated": 0}`; public hash `1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e`.

## Microbenchmarks

Scope deviation: this is a representative 120-case size/alignment sweep rather than the full 336-case cross-product. It covers every requested size, offset, remainder, and cache state, while avoiding repeated large-payload runs at every alignment. Size-by-alignment interactions outside the listed cases were not benchmarked; correctness tests cover all alignments separately.
Headline values below are medians of the three process medians; operations include construction/setup and continuation, not only the payload method body.

- 32 bytes, offset 0, prefetch False: B 8.236 µs, C 1.309 µs (6.29x).
- 32 bytes, offset 7, prefetch True: B 13.633 µs, C 3.215 µs (4.24x).
- Across all measured cases with at least 32 complete bytes, the minimum case-median speedup was 3.04x. Tiny-read measurements, including guard overhead, are retained in the table.

<details><summary>All 120 cases, including three process medians per revision</summary>

Each cell lists three fresh-process medians in microseconds per operation; each process uses five repetitions of 10,000 operations per case. An operation includes reader construction, offset setup, optional 32-bit prefetch, payload read, and 13-bit continuation. Payload data is constructed outside timing. The size sweep uses aligned offset 0 and unaligned offset 7 for every size; the 32-byte alignment sweep covers all offsets 0–7. Every selected size/offset covers all three remainders and both cache states (120 cases). Prefetch 0/1 indicates absent/present. B/C process order is B,C,C,B,B,C. These are operation-level measurements, not replay speedup predictions.

| Bytes | Offset | Remainder | Prefetch | B µs (3 process medians) | C µs (3 process medians) |
|---|---|---|---|---|---|
|0|0|0|0|0.966, 0.910, 0.969|1.073, 1.150, 0.955|
|0|0|0|1|1.126, 1.060, 1.117|1.213, 1.411, 1.100|
|0|0|1|0|1.261, 1.197, 1.271|1.719, 1.566, 1.247|
|0|0|1|1|1.415, 1.343, 1.427|1.678, 1.798, 1.374|
|0|0|7|0|1.278, 1.211, 1.284|1.428, 1.610, 1.240|
|0|0|7|1|1.400, 1.335, 1.381|1.584, 1.759, 1.299|
|0|7|0|0|1.226, 1.168, 1.194|1.360, 1.454, 1.161|
|0|7|0|1|1.668, 1.593, 1.620|1.836, 2.080, 1.567|
|0|7|1|0|1.481, 1.410, 1.433|1.637, 1.724, 1.442|
|0|7|1|1|1.939, 1.852, 1.878|2.523, 2.265, 1.910|
|0|7|7|0|1.482, 1.447, 1.438|1.752, 1.719, 1.440|
|0|7|7|1|1.956, 1.913, 1.881|2.449, 2.265, 1.900|
|1|0|0|0|1.266, 1.243, 1.219|1.563, 1.467, 1.256|
|1|0|0|1|1.489, 1.519, 1.438|1.760, 1.635, 1.439|
|1|0|1|0|1.518, 1.491, 1.470|1.917, 1.666, 1.490|
|1|0|1|1|1.766, 1.715, 1.696|2.172, 1.935, 1.706|
|1|0|7|0|1.512, 1.485, 1.471|1.754, 1.573, 1.478|
|1|0|7|1|1.732, 1.708, 1.680|2.023, 1.817, 1.699|
|1|7|0|0|1.571, 1.536, 1.512|1.820, 1.636, 1.529|
|1|7|0|1|2.035, 1.987, 1.973|2.227, 2.120, 2.006|
|1|7|1|0|1.843, 1.802, 1.789|2.012, 1.918, 1.838|
|1|7|1|1|2.309, 2.249, 2.236|2.519, 2.418, 2.307|
|1|7|7|0|2.155, 2.104, 2.091|2.372, 2.237, 2.180|
|1|7|7|1|2.302, 2.247, 2.233|2.515, 2.367, 2.303|
|2|0|0|0|1.551, 1.507, 1.506|1.695, 1.605, 1.556|
|2|0|0|1|1.831, 1.793, 1.774|2.012, 1.978, 1.844|
|2|0|1|0|1.802, 1.753, 1.752|1.880, 1.985, 1.813|
|2|0|1|1|2.019, 2.079, 2.029|2.171, 2.198, 2.102|
|2|0|7|0|1.737, 1.811, 1.733|1.900, 1.960, 1.828|
|2|0|7|1|2.349, 2.460, 2.346|2.510, 2.683, 2.466|
|2|7|0|0|2.222, 2.342, 2.198|2.381, 2.518, 2.297|
|2|7|0|1|2.318, 2.471, 2.310|2.491, 2.631, 2.335|
|2|7|1|0|2.454, 2.620, 2.440|2.698, 2.629, 2.483|
|2|7|1|1|2.554, 2.711, 2.582|2.748, 2.738, 2.543|
|2|7|7|0|2.444, 2.559, 2.455|2.627, 2.649, 2.576|
|2|7|7|1|2.542, 2.646, 2.551|2.723, 2.742, 2.646|
|3|0|0|0|1.716, 1.793, 1.729|1.309, 1.311, 1.267|
|3|0|0|1|2.434, 2.607, 2.423|2.175, 2.105, 2.119|
|3|0|1|0|1.969, 2.088, 1.949|1.639, 1.580, 1.588|
|3|0|1|1|2.682, 2.686, 2.679|2.518, 2.519, 2.439|
|3|0|7|0|1.962, 1.963, 1.978|1.630, 1.638, 1.571|
|3|0|7|1|2.683, 2.690, 2.770|2.524, 2.516, 2.444|
|3|7|0|0|2.533, 2.480, 2.630|2.287, 2.273, 2.185|
|3|7|0|1|2.616, 2.638, 2.708|2.397, 2.391, 2.278|
|3|7|1|0|2.771, 2.682, 2.905|2.646, 2.529, 2.470|
|3|7|1|1|2.843, 2.737, 2.956|2.729, 2.627, 2.546|
|3|7|7|0|2.762, 2.726, 2.877|2.629, 2.515, 2.461|
|3|7|7|1|2.870, 2.805, 2.953|2.736, 2.895, 2.563|
|32|0|0|0|8.236, 7.669, 8.313|1.309, 1.366, 1.226|
|32|0|0|1|9.293, 8.921, 9.368|2.354, 2.353, 2.200|
|32|0|1|0|8.487, 7.908, 8.378|2.968, 1.660, 1.548|
|32|0|1|1|9.529, 8.884, 9.320|3.068, 3.075, 2.535|
|32|0|7|0|8.460, 8.143, 8.319|1.819, 1.654, 1.526|
|32|0|7|1|9.437, 8.871, 9.338|2.827, 2.699, 2.517|
|32|1|0|0|13.271, 12.996, 13.524|3.187, 3.020, 2.834|
|32|1|0|1|13.400, 12.975, 13.632|3.650, 3.338, 3.247|
|32|1|1|0|13.546, 12.898, 13.611|3.577, 3.290, 3.146|
|32|1|1|1|13.733, 13.053, 22.091|4.020, 4.205, 3.603|
|32|1|7|0|13.952, 13.321, 22.314|3.367, 4.232, 3.159|
|32|1|7|1|14.116, 12.994, 22.554|4.548, 4.945, 3.584|
|32|2|0|0|13.646, 12.749, 13.454|3.388, 3.768, 2.812|
|32|2|0|1|13.356, 12.730, 13.536|3.645, 4.644, 3.229|
|32|2|1|0|13.516, 12.907, 13.994|3.982, 4.630, 3.131|
|32|2|1|1|13.632, 13.276, 14.229|4.235, 4.548, 3.540|
|32|2|7|0|13.503, 13.041, 14.155|3.759, 3.702, 3.227|
|32|2|7|1|13.579, 13.352, 13.805|4.007, 3.943, 3.632|
|32|3|0|0|13.813, 12.719, 13.509|3.183, 3.072, 2.894|
|32|3|0|1|13.809, 13.119, 13.608|3.743, 3.372, 3.300|
|32|3|1|0|13.916, 13.199, 13.729|4.097, 3.197, 3.221|
|32|3|1|1|13.605, 12.986, 13.796|5.223, 3.821, 3.382|
|32|3|7|0|13.455, 12.823, 14.069|4.544, 3.177, 3.189|
|32|3|7|1|13.458, 12.973, 14.278|4.546, 3.822, 3.618|
|32|4|0|0|13.786, 12.655, 13.891|3.606, 3.159, 2.886|
|32|4|0|1|14.030, 12.772, 13.564|3.859, 3.434, 3.341|
|32|4|1|0|14.888, 12.852, 13.695|3.724, 3.336, 3.231|
|32|4|1|1|14.327, 13.577, 13.855|3.984, 3.980, 3.571|
|32|4|7|0|13.964, 13.421, 13.718|3.555, 3.314, 3.215|
|32|4|7|1|14.133, 13.434, 13.826|4.026, 3.597, 3.600|
|32|5|0|0|13.856, 12.834, 13.889|3.218, 2.876, 2.819|
|32|5|0|1|13.587, 12.955, 14.020|3.675, 3.170, 3.210|
|32|5|1|0|13.715, 13.339, 14.185|3.800, 3.094, 3.107|
|32|5|1|1|14.295, 13.265, 13.814|4.230, 3.492, 3.537|
|32|5|7|0|13.884, 13.258, 13.708|3.560, 3.059, 3.108|
|32|5|7|1|13.752, 13.570, 13.847|4.366, 3.479, 3.509|
|32|6|0|0|13.487, 12.720, 13.439|3.408, 2.767, 2.793|
|32|6|0|1|13.712, 12.830, 14.080|3.915, 3.160, 3.220|
|32|6|1|0|13.722, 13.357, 14.125|3.847, 3.092, 3.146|
|32|6|1|1|14.151, 13.110, 14.346|4.005, 3.490, 3.555|
|32|6|7|0|14.189, 12.852, 13.834|3.501, 3.080, 3.120|
|32|6|7|1|14.462, 13.036, 13.834|3.762, 3.428, 3.525|
|32|7|0|0|14.006, 13.789, 13.827|3.001, 2.766, 2.809|
|32|7|0|1|13.633, 13.297, 13.723|3.433, 3.161, 3.215|
|32|7|1|0|13.754, 13.208, 13.862|3.352, 3.051, 3.150|
|32|7|1|1|14.056, 13.979, 14.356|3.648, 3.485, 3.587|
|32|7|7|0|13.463, 12.961, 14.188|3.217, 3.031, 3.114|
|32|7|7|1|13.968, 13.275, 14.406|3.977, 3.488, 3.502|
|256|0|0|0|56.049, 53.572, 56.050|1.299, 1.203, 1.244|
|256|0|0|1|65.906, 56.330, 58.654|2.326, 2.119, 2.269|
|256|0|1|0|67.585, 59.063, 56.443|1.629, 1.480, 1.518|
|256|0|1|1|71.835, 66.940, 58.365|2.616, 2.452, 2.619|
|256|0|7|0|76.818, 61.664, 56.404|1.565, 1.480, 1.586|
|256|0|7|1|70.075, 66.972, 58.323|2.562, 2.433, 2.618|
|256|7|0|0|110.402, 111.219, 96.599|3.286, 3.069, 3.328|
|256|7|0|1|103.003, 103.856, 98.831|3.739, 3.497, 3.782|
|256|7|1|0|101.553, 102.285, 97.748|3.507, 3.416, 3.659|
|256|7|1|1|108.085, 96.988, 97.389|3.914, 3.841, 4.096|
|256|7|7|0|116.198, 101.970, 98.154|3.457, 3.396, 3.645|
|256|7|7|1|123.286, 94.194, 97.843|3.907, 3.827, 4.099|
|4096|0|0|0|1134.952, 1041.521, 899.640|1.305, 1.285, 1.389|
|4096|0|0|1|1068.724, 1220.899, 899.885|2.364, 2.308, 2.502|
|4096|0|1|0|1103.004, 1621.150, 899.338|1.690, 1.664, 1.786|
|4096|0|1|1|1070.445, 1407.382, 898.062|2.877, 2.737, 2.918|
|4096|0|7|0|1063.013, 1327.922, 899.879|1.740, 1.675, 1.770|
|4096|0|7|1|1098.597, 1216.208, 904.646|2.800, 2.698, 2.901|
|4096|7|0|0|1797.207, 1770.071, 1530.487|11.541, 11.165, 11.708|
|4096|7|0|1|1718.060, 1754.817, 1530.369|12.173, 12.278, 12.187|
|4096|7|1|0|1748.474, 1528.009, 1533.208|12.722, 12.688, 12.199|
|4096|7|1|1|1521.087, 1532.462, 1533.529|14.157, 13.152, 12.643|
|4096|7|7|0|1537.299, 1534.290, 1530.900|17.058, 12.230, 12.148|
|4096|7|7|1|1718.078, 1531.555, 1532.067|18.407, 12.772, 13.019|

</details>

## Offline OpenDota parity

- `8868259993`: 325 PASS, 0 WARN, 0 FAIL, 1 SKIP; errors: [].
  - 1 × SKIP `teamfights/total_count`: OpenDota applies deaths>=3 filtering over its expanded event pipeline. Count comparison is informational only.
- `8860187335`: 326 PASS, 0 WARN, 0 FAIL, 1 SKIP; errors: [].
  - 1 × SKIP `teamfights/total_count`: OpenDota applies deaths>=3 filtering over its expanded event pipeline. Count comparison is informational only.
- `8856501050`: 331 PASS, 0 WARN, 0 FAIL, 1 SKIP; errors: [].
  - 1 × SKIP `teamfights/total_count`: OpenDota applies deaths>=3 filtering over its expanded event pipeline. Count comparison is informational only.

## Exact reproduction

Run from the candidate checkout with the same uv-managed CPython 3.10.4 environment and local fixtures. Scripts below are preserved as run; adjust the checkout/temp paths if reproducing elsewhere. Start with a fresh temporary directory: the replay driver skips existing result files. The first baseline public run was started separately before candidate implementation; the driver then completed the remaining B/C, C/B, B/C pairs using the preserved baseline tree.

```bash
mkdir -p /private/tmp/gem-168/baseline
git archive 6e912cfa4a8ad941a83fb3b494ecc5bd4bb03bc8 | tar -x -C /private/tmp/gem-168/baseline
# Save the scripts below in /private/tmp/gem-168/.
PYTHONHASHSEED=0 .venv/bin/python /private/tmp/gem-168/bench.py replay /private/tmp/gem-168/baseline --replay tests/fixtures/opendota/8822520406.dem --out /private/tmp/gem-168/public-8822520406-0-B.json
.venv/bin/python /private/tmp/gem-168/run_replays.py
.venv/bin/python /private/tmp/gem-168/run_remaining.py
.venv/bin/python /private/tmp/gem-168/run_preloaded.py
.venv/bin/python /private/tmp/gem-168/report.py
```

`run_remaining.py` runs the additional short-replay controls, repository checks, offline parity, one allocation-diagnostic pair, separate replay instrumentation, and three fresh microbenchmark processes per revision, sequentially. Parity receives local reference JSON explicitly; it makes no OpenDota requests. Every child uses `PYTHONHASHSEED=0`. The microbenchmark uses a reduced 120-case sweep, not the full 336-case cross-product: sizes 0/1/2/3/32/256/4096 at offsets 0/7, plus the remaining offsets at 32 bytes; every selected size/offset uses remainders 0/1/7 and both fresh/prefetched states. Each process records five repetitions of 10,000 operations per case. `run_preloaded.py` adds fresh public pairs with the two lazy extractor-module imports moved before timing; the original scripts are retained unchanged for reproducing the earlier measurements.

<details><summary>bench.py</summary>

```python
import argparse, gc, hashlib, json, os, platform, resource, statistics, sys, time
from pathlib import Path
p=argparse.ArgumentParser()
p.add_argument('kind', choices=['replay','micro','instrument'])
p.add_argument('source')
p.add_argument('--scenario',default='public')
p.add_argument('--replay')
p.add_argument('--out',required=True)
a=p.parse_args()
sys.path.insert(0,str(Path(a.source)/'src'))
import gem
from gem.binary.reader import BitReader
from gem.parser import ReplayParser
meta={'source':a.source,'python':sys.version,'platform':platform.platform(),'module':gem.__file__,'load_start':os.getloadavg()}
if a.kind in ('replay','instrument'):
    counts={}
    if a.kind=='instrument':
        counts.update(dict.fromkeys(('requests','small','truncated','bulk_eligible','bytes','max_bits','byte_calls','bulk_calls'),0))
        counts.update({f'remainder_{i}':0 for i in range(8)})
        original=BitReader.read_bits_as_bytes
        byte=BitReader._read_byte
        bulk=BitReader.read_bytes
        active=False
        def wrapped(self,n):
            global active
            counts['requests']=counts.get('requests',0)+1
            counts['max_bits']=max(counts.get('max_bits',0),n)
            key='small' if n<24 else 'truncated' if n>self.rem_bits() else 'bulk_eligible'
            counts[key]=counts.get(key,0)+1
            counts['bytes']=counts.get('bytes',0)+max(n//8,0)
            key=f'remainder_{n%8}'
            counts[key]=counts.get(key,0)+1
            active=True
            try: return original(self,n)
            finally: active=False
        def wrapped_byte(self):
            if active: counts['byte_calls']=counts.get('byte_calls',0)+1
            return byte(self)
        def wrapped_bulk(self,n):
            if active: counts['bulk_calls']=counts.get('bulk_calls',0)+1
            return bulk(self,n)
        BitReader.read_bits_as_bytes=wrapped
        BitReader._read_byte=wrapped_byte
        BitReader.read_bytes=wrapped_bulk
    parser=ReplayParser(a.replay) if a.scenario=='core' else None
    gc.collect()
    cpu=resource.getrusage(resource.RUSAGE_SELF).ru_utime
    start=time.perf_counter()
    result=gem.parse(a.replay) if parser is None else parser.parse()
    elapsed=time.perf_counter()-start
    usage=resource.getrusage(resource.RUSAGE_SELF)
    row={**meta,'scenario':a.scenario,'replay':a.replay,'elapsed':elapsed,'user':usage.ru_utime-cpu,'rss_bytes':usage.ru_maxrss*(1 if sys.platform=='darwin' else 1024),'load_end':os.getloadavg(),'counts':counts}
    if a.scenario=='public':
        data=json.dumps(gem.to_dict(result),sort_keys=True,separators=(',',':')).encode()
        row['sha256']=hashlib.sha256(data).hexdigest()
        Path(a.out+'.public.json').write_bytes(data)
    Path(a.out).write_text(json.dumps(row,indent=2))
    print(json.dumps(row),flush=True)
else:
    rows=[]
    for size in (0,1,2,3,32,256,4096):
        for offset in range(8):
            if size != 32 and offset not in (0,7):
                continue
            for remainder in (0,1,7):
                for prefetch in (False,True):
                    data=bytes((i*37+11)&255 for i in range(size+16))
                    n=size*8+remainder
                    def operation():
                        r=BitReader(data)
                        if offset: r.read_bits(offset)
                        if prefetch: r.peek_bits(32)
                        r.read_bits_as_bytes(n)
                        r.read_bits(13)
                    samples=[]
                    for _ in range(5):
                        start=time.perf_counter()
                        for j in range(10000): operation()
                        samples.append((time.perf_counter()-start)*1e9/10000)
                    print('case',size,offset,remainder,prefetch,round(statistics.median(samples)),flush=True)
                    rows.append({'size':size,'offset':offset,'remainder':remainder,'prefetch':prefetch,'ns':samples,'median_ns':statistics.median(samples)})
        Path(a.out).write_text(json.dumps({**meta,'rows':rows,'load_end':os.getloadavg()}))
        print('completed size',size,flush=True)

```

</details>

<details><summary>bench_preloaded.py</summary>

```python
import argparse, gc, hashlib, json, os, platform, resource, statistics, sys, time
from pathlib import Path
p=argparse.ArgumentParser()
p.add_argument('kind', choices=['replay','micro','instrument'])
p.add_argument('source')
p.add_argument('--scenario',default='public')
p.add_argument('--replay')
p.add_argument('--out',required=True)
a=p.parse_args()
sys.path.insert(0,str(Path(a.source)/'src'))
import gem
from gem.binary.reader import BitReader
from gem.parser import ReplayParser
if a.kind == 'replay':
    import gem.extractors.intervals
    import gem.extractors.smoke_vision
meta={'source':a.source,'python':sys.version,'platform':platform.platform(),'module':gem.__file__,'load_start':os.getloadavg()}
if a.kind in ('replay','instrument'):
    counts={}
    if a.kind=='instrument':
        counts.update(dict.fromkeys(('requests','small','truncated','bulk_eligible','bytes','max_bits','byte_calls','bulk_calls'),0))
        counts.update({f'remainder_{i}':0 for i in range(8)})
        original=BitReader.read_bits_as_bytes
        byte=BitReader._read_byte
        bulk=BitReader.read_bytes
        active=False
        def wrapped(self,n):
            global active
            counts['requests']=counts.get('requests',0)+1
            counts['max_bits']=max(counts.get('max_bits',0),n)
            key='small' if n<24 else 'truncated' if n>self.rem_bits() else 'bulk_eligible'
            counts[key]=counts.get(key,0)+1
            counts['bytes']=counts.get('bytes',0)+max(n//8,0)
            key=f'remainder_{n%8}'
            counts[key]=counts.get(key,0)+1
            active=True
            try: return original(self,n)
            finally: active=False
        def wrapped_byte(self):
            if active: counts['byte_calls']=counts.get('byte_calls',0)+1
            return byte(self)
        def wrapped_bulk(self,n):
            if active: counts['bulk_calls']=counts.get('bulk_calls',0)+1
            return bulk(self,n)
        BitReader.read_bits_as_bytes=wrapped
        BitReader._read_byte=wrapped_byte
        BitReader.read_bytes=wrapped_bulk
    parser=ReplayParser(a.replay) if a.scenario=='core' else None
    gc.collect()
    cpu=resource.getrusage(resource.RUSAGE_SELF).ru_utime
    start=time.perf_counter()
    result=gem.parse(a.replay) if parser is None else parser.parse()
    elapsed=time.perf_counter()-start
    usage=resource.getrusage(resource.RUSAGE_SELF)
    row={**meta,'scenario':a.scenario,'replay':a.replay,'elapsed':elapsed,'user':usage.ru_utime-cpu,'rss_bytes':usage.ru_maxrss*(1 if sys.platform=='darwin' else 1024),'load_end':os.getloadavg(),'counts':counts}
    if a.scenario=='public':
        data=json.dumps(gem.to_dict(result),sort_keys=True,separators=(',',':')).encode()
        row['sha256']=hashlib.sha256(data).hexdigest()
        Path(a.out+'.public.json').write_bytes(data)
    Path(a.out).write_text(json.dumps(row,indent=2))
    print(json.dumps(row),flush=True)
else:
    rows=[]
    for size in (0,1,2,3,32,256,4096):
        for offset in range(8):
            if size != 32 and offset not in (0,7):
                continue
            for remainder in (0,1,7):
                for prefetch in (False,True):
                    data=bytes((i*37+11)&255 for i in range(size+16))
                    n=size*8+remainder
                    def operation():
                        r=BitReader(data)
                        if offset: r.read_bits(offset)
                        if prefetch: r.peek_bits(32)
                        r.read_bits_as_bytes(n)
                        r.read_bits(13)
                    samples=[]
                    for _ in range(5):
                        start=time.perf_counter()
                        for j in range(10000): operation()
                        samples.append((time.perf_counter()-start)*1e9/10000)
                    print('case',size,offset,remainder,prefetch,round(statistics.median(samples)),flush=True)
                    rows.append({'size':size,'offset':offset,'remainder':remainder,'prefetch':prefetch,'ns':samples,'median_ns':statistics.median(samples)})
        Path(a.out).write_text(json.dumps({**meta,'rows':rows,'load_end':os.getloadavg()}))
        print('completed size',size,flush=True)

```

</details>

<details><summary>run_preloaded.py</summary>

```python
import json, os, subprocess, sys
from pathlib import Path
root=Path('/Users/hanyuwu/Study/gem')
out=Path('/private/tmp/gem-168')
env={**os.environ,'PYTHONHASHSEED':'0'}
for replay in ('8822520406','8856501050'):
    for scenario in ('public',):
        for block, order in enumerate(('BC','CB','BC')):
            for variant in order:
                dest=out/f'preloaded-{scenario}-{replay}-{block}-{variant}.json'
                if dest.exists(): continue
                source=out/'baseline' if variant=='B' else root
                cmd=[sys.executable,str(out/'bench_preloaded.py'),'replay',str(source),'--scenario',scenario,'--replay',str(root/f'tests/fixtures/opendota/{replay}.dem'),'--out',str(dest)]
                print('START',dest.name,flush=True)
                subprocess.run(cmd,env=env,check=True,cwd=root)
print('REPLAY TIMINGS COMPLETE',flush=True)

```

</details>

<details><summary>run_replays.py</summary>

```python
import json, os, subprocess, sys
from pathlib import Path
root=Path('/Users/hanyuwu/Study/gem')
out=Path('/private/tmp/gem-168')
env={**os.environ,'PYTHONHASHSEED':'0'}
for replay in ('8822520406','8856501050'):
    for scenario in ('public','core'):
        for block, order in enumerate(('BC','CB','BC')):
            for variant in order:
                dest=out/f'{scenario}-{replay}-{block}-{variant}.json'
                if dest.exists(): continue
                source=out/'baseline' if variant=='B' else root
                cmd=[sys.executable,str(out/'bench.py'),'replay',str(source),'--scenario',scenario,'--replay',str(root/f'tests/fixtures/opendota/{replay}.dem'),'--out',str(dest)]
                print('START',dest.name,flush=True)
                subprocess.run(cmd,env=env,check=True,cwd=root)
print('REPLAY TIMINGS COMPLETE',flush=True)

```

</details>

<details><summary>run_remaining.py</summary>

```python
import os, subprocess, sys
from pathlib import Path
root=Path('/Users/hanyuwu/Study/gem')
out=Path('/private/tmp/gem-168')
env={**os.environ,'PYTHONHASHSEED':'0'}
def run(args,log):
    print('START',log,flush=True)
    with (out/log).open('w') as f:
        p=subprocess.run(args,cwd=root,env=env,stdout=f,stderr=subprocess.STDOUT)
    print('DONE',log,p.returncode,flush=True)
    if p.returncode: raise SystemExit(p.returncode)
# Investigate initial short-replay CPU/RSS differences with reverse-balanced pairs.
for scenario in ('public','core'):
    for block, order in enumerate(('CB','BC','CB')):
        for v in order:
            source=out/'baseline' if v=='B' else root
            name=f'control-{scenario}-8822520406-{block}-{v}'
            run([sys.executable,str(out/'bench.py'),'replay',str(source),'--scenario',scenario,'--replay',str(root/'tests/fixtures/opendota/8822520406.dem'),'--out',str(out/(name+'.json'))],name+'.log')
run([sys.executable,'-m','ruff','check','.'],'lint.log')
run([sys.executable,'-m','ruff','format','--check','src/','tests/'],'format.log')
run([sys.executable,'-m','mypy','src/gem/'],'mypy.log')
run([sys.executable,'-m','pytest','-q','-rs'],'fast.log')
run([sys.executable,'-m','pytest','-q','-rs','-m','not network'],'offline.log')
run([sys.executable,str(out/'parity.py')],'parity.log')
for replay in ('8822520406','8856501050'):
    for v in ('B','C'):
        source=out/'baseline' if v=='B' else root
        run([sys.executable,str(out/'bench.py'),'instrument',str(source),'--replay',str(root/f'tests/fixtures/opendota/{replay}.dem'),'--out',str(out/f'instrument-{replay}-{v}.json')],f'instrument-{replay}-{v}.log')
for block, order in enumerate(('BC','CB','BC')):
    for v in order:
        source=out/'baseline' if v=='B' else root
        run([sys.executable,str(out/'bench.py'),'micro',str(source),'--out',str(out/f'micro-{block}-{v}.json')],f'micro-{block}-{v}.log')
print('ALL COMPLETE',flush=True)

```

</details>

<details><summary>parity.py</summary>

```python
import json, sys
from pathlib import Path
root=Path('/Users/hanyuwu/Study/gem')
sys.path.insert(0,str(root))
from scripts.validate_opendota import validate_match, results_to_jsonable
results=[]
for match_id in (8868259993,8860187335,8856501050):
    fixture=root/f'tests/fixtures/opendota/{match_id}.dem'
    od=json.loads(fixture.with_suffix('.opendota.json').read_text())
    result=validate_match(match_id,fixture,od=od,mode='full')
    results.append(result)
    print(match_id,result.passed,result.warned,result.failed,result.skipped,result.errors,flush=True)
Path('/private/tmp/gem-168/parity.json').write_text(json.dumps(results_to_jsonable(results),indent=2))
assert all(not r.errors and r.failed==0 for r in results)
# Allocation diagnostic: isolate Python heap from file-backed mmap residency.
import gc, os, subprocess
gc.collect()
for variant,source in [('B','/private/tmp/gem-168/baseline'),('C',str(root))]:
    print('START bytes-backed allocation diagnostic',variant,flush=True)
    subprocess.run([sys.executable,'/private/tmp/gem-168/memory.py',source,f'/private/tmp/gem-168/memory-{variant}.json'],env={**os.environ,'PYTHONHASHSEED':'0'},check=True)

```

</details>

<details><summary>memory.py</summary>

```python
import gc, hashlib, json, platform, resource, sys, tracemalloc
from pathlib import Path
source=Path(sys.argv[1])
sys.path.insert(0,str(source/'src'))
from gem.parser import ReplayParser
replay=Path('/Users/hanyuwu/Study/gem/tests/fixtures/opendota/8822520406.dem').read_bytes()
parser=ReplayParser(replay)
gc.collect()
tracemalloc.start(1)
parser.parse()
current, peak=tracemalloc.get_traced_memory()
rss=resource.getrusage(resource.RUSAGE_SELF).ru_maxrss*(1 if sys.platform=='darwin' else 1024)
gc.collect()
post_gc=tracemalloc.get_traced_memory()[0]
top=tracemalloc.take_snapshot().statistics('lineno')[:15]
tracemalloc.stop()
row={'source':str(source),'python':sys.version,'platform':platform.platform(),'input_bytes':len(replay),'input_sha256':hashlib.sha256(replay).hexdigest(),'traced_current':current,'traced_peak':peak,'traced_post_gc':post_gc,'rss_bytes':rss,'top':[str(x) for x in top]}
Path(sys.argv[2]).write_text(json.dumps(row,indent=2))
print(json.dumps(row),flush=True)

```

</details>

<details><summary>report.py</summary>

```python
import collections, glob, json, statistics
from pathlib import Path
p=Path('/private/tmp/gem-168')
lines=[]
def add(s=''):
 if s.startswith('|') and lines and lines[-1] and not lines[-1].startswith('|'): lines.append('')
 lines.append(s)
 if s.startswith('#'): lines.append('')
def med(values): return statistics.median(values)
add('## Replay measurements')
add('CPython 3.10.4, macOS 26.6.2 arm64, Apple M2, 16 GiB RAM; same existing virtual environment and fixtures. No coverage/profiling during timing. Top-level imports and core-parser construction precede timing; the initial public runs also include two lazy extractor-module imports (intervals and smoke_vision), corrected in the separate preloaded runs below; serialization/hash follow timing and peak-RSS capture. RSS is the process high-water mark in MiB. All runs sequential; pair order B/C, C/B, B/C. B is main `6e912cfa4a8ad941a83fb3b494ecc5bd4bb03bc8`; C is this PR.')
add()
add('| Replay | Scenario | Variant | Elapsed s (3 runs) | User CPU s (3 runs) | Peak RSS MiB (3 runs) | Median elapsed / CPU / RSS |')
add('|---|---|---|---|---|---|---|')
for replay in ('8822520406','8856501050'):
 for scenario in ('public','core'):
  for v in 'BC':
   rows=[json.loads((p/f'{scenario}-{replay}-{i}-{v}.json').read_text()) for i in range(3)]
   values=[[r[k]/(2**20 if k=='rss_bytes' else 1) for r in rows] for k in ('elapsed','user','rss_bytes')]
   add('|'+ '|'.join([replay,scenario,v,*[', '.join(f'{x:.3f}' for x in xs) for xs in values], ' / '.join(f'{med(xs):.3f}' for xs in values)])+'|')
add()
add('### Public timings with lazy modules preloaded')
add('Final review identified two extractor modules imported lazily by gem.parse(). These fresh B/C, C/B, B/C pairs explicitly preload both modules before timing. The initial runs remain above for transparency; use this table for public timing with those imports excluded.')
add('| Replay | Variant | Elapsed s (3 runs) | User CPU s (3 runs) | Peak RSS MiB (3 runs) | Median elapsed / CPU / RSS |')
add('|---|---|---|---|---|---|')
for replay in ('8822520406','8856501050'):
 for v in 'BC':
  rows=[json.loads((p/f'preloaded-public-{replay}-{i}-{v}.json').read_text()) for i in range(3)]
  values=[[r[k]/(2**20 if k=='rss_bytes' else 1) for r in rows] for k in ('elapsed','user','rss_bytes')]
  add('|'+ '|'.join([replay,v,*[', '.join(f'{x:.3f}' for x in xs) for xs in values], ' / '.join(f'{med(xs):.3f}' for xs in values)])+'|')
add()
add('### Follow-up short-replay controls')
add('Added because the initial short public median CPU and core RSS were higher for C amid substantial drift. Same code, interpreter, fixtures and timing protocol; reverse-balanced pair order C/B, B/C, C/B. Reported separately rather than replacing the initial results.')
add('| Scenario | Variant | Elapsed s (3 runs) | User CPU s (3 runs) | Peak RSS MiB (3 runs) | Median elapsed / CPU / RSS |')
add('|---|---|---|---|---|---|')
for scenario in ('public','core'):
 for v in 'BC':
  rows=[json.loads((p/f'control-{scenario}-8822520406-{i}-{v}.json').read_text()) for i in range(3)]
  values=[[r[k]/(2**20 if k=='rss_bytes' else 1) for r in rows] for k in ('elapsed','user','rss_bytes')]
  add('|'+ '|'.join([scenario,v,*[', '.join(f'{x:.3f}' for x in xs) for xs in values], ' / '.join(f'{med(xs):.3f}' for xs in values)])+'|')
add()
add('### Individual host load (1/5/15-minute averages)')
for f in sorted(p.glob('*.json')):
 if not f.name.startswith(('public-','core-','control-','preloaded-')) or f.name.endswith('.public.json'): continue
 row=json.loads(f.read_text())
 add(f"- `{f.stem}`: start {'/'.join(f'{v:.2f}' for v in row['load_start'])}; end {'/'.join(f'{v:.2f}' for v in row['load_end'])}.")
add()
add('### Byte-identical public output')
for replay in ('8822520406','8856501050'):
 files=list(p.glob(f'*{replay}*.json.public.json'))
 reference=files[0].read_bytes()
 assert len(files)==(20 if replay=='8822520406' else 14) and all(f.read_bytes()==reference for f in files)
 import hashlib
 add(f'- `{replay}`: `{hashlib.sha256(reference).hexdigest()}`; all {len(files)} output files (timing, controls, instrumentation) compared byte-for-byte ({len(reference):,} bytes each).')
add()
add('## Allocation diagnostic (not timing evidence)')
add('One fresh baseline/candidate short-core pair used ReplayParser(bytes), retaining the same 98,983,300 input bytes before measurement. tracemalloc started after imports/input setup; peak RSS was captured before snapshots/serialization. This separates Python heap allocation from mapped replay pages; it does not establish the cause of all RSS variation.')
add('| Variant | Traced peak MiB | Traced current MiB | Post-GC MiB | RSS MiB |')
add('|---|---|---|---|---|')
for v in 'BC':
 r=json.loads((p/f'memory-{v}.json').read_text())
 add('|'+v+'|'+'|'.join(f'{r[k]/2**20:.6f}' for k in ('traced_peak','traced_current','traced_post_gc','rss_bytes'))+'|')
add('The candidate differs by only 124 traced bytes. Short-replay RSS differences reverse across repeated sets; long-replay RSS medians are essentially unchanged. No repeatable material memory regression was observed, and no RSS improvement is claimed.')
add()
add('## Instrumentation (separate from timing)')
for f in sorted(p.glob('instrument-*.json')):
 if f.name.endswith('.public.json'): continue
 r=json.loads(f.read_text())
 add(f"- `{f.stem}`: `{json.dumps(r['counts'],sort_keys=True)}`; public hash `{r['sha256']}`.")
add()
add('## Microbenchmarks')
data={v:[json.loads((p/f'micro-{i}-{v}.json').read_text())['rows'] for i in range(3)] for v in 'BC'}
assert all(len(rows)==120 for vs in data.values() for rows in vs)
add('Scope deviation: this is a representative 120-case size/alignment sweep rather than the full 336-case cross-product. It covers every requested size, offset, remainder, and cache state, while avoiding repeated large-payload runs at every alignment. Size-by-alignment interactions outside the listed cases were not benchmarked; correctness tests cover all alignments separately.')
add('Headline values below are medians of the three process medians; operations include construction/setup and continuation, not only the payload method body.')
add()
for offset,prefetch in ((0,False),(7,True)):
 i=next(i for i,r in enumerate(data['B'][0]) if (r['size'],r['offset'],r['remainder'],r['prefetch'])==(32,offset,0,prefetch))
 b=med(data['B'][j][i]['median_ns'] for j in range(3))
 c=med(data['C'][j][i]['median_ns'] for j in range(3))
 add(f'- 32 bytes, offset {offset}, prefetch {prefetch}: B {b/1000:.3f} µs, C {c/1000:.3f} µs ({b/c:.2f}x).')
ratios=[med(data['B'][j][i]['median_ns'] for j in range(3))/med(data['C'][j][i]['median_ns'] for j in range(3)) for i,r in enumerate(data['B'][0]) if r['size']>=32]
add(f'- Across all measured cases with at least 32 complete bytes, the minimum case-median speedup was {min(ratios):.2f}x. Tiny-read measurements, including guard overhead, are retained in the table.')
add()
add('<details><summary>All 120 cases, including three process medians per revision</summary>\n')
add('Each cell lists three fresh-process medians in microseconds per operation; each process uses five repetitions of 10,000 operations per case. An operation includes reader construction, offset setup, optional 32-bit prefetch, payload read, and 13-bit continuation. Payload data is constructed outside timing. The size sweep uses aligned offset 0 and unaligned offset 7 for every size; the 32-byte alignment sweep covers all offsets 0–7. Every selected size/offset covers all three remainders and both cache states (120 cases). Prefetch 0/1 indicates absent/present. B/C process order is B,C,C,B,B,C. These are operation-level measurements, not replay speedup predictions.')
add()
add('| Bytes | Offset | Remainder | Prefetch | B µs (3 process medians) | C µs (3 process medians) |')
add('|---|---|---|---|---|---|')
for i,row in enumerate(data['B'][0]):
 add('|'+ '|'.join([str(row[k]) for k in ('size','offset','remainder')]+[str(int(row['prefetch']))]+[', '.join(f"{data[v][j][i]['median_ns']/1000:.3f}" for j in range(3)) for v in 'BC'])+'|')
add()
add('</details>')
add()
add('## Offline OpenDota parity')
for r in json.loads((p/'parity.json').read_text()):
 add(f"- `{r['match_id']}`: {r['passed']} PASS, {r['warned']} WARN, {r['failed']} FAIL, {r['skipped']} SKIP; errors: {r['errors']}.")
 for (status,name,note),n in collections.Counter((f['status'],f['name'],f['note']) for f in r['fields'] if f['status']!='PASS').items():
  add(f'  - {n} × {status} `{name}`: {note}')
(p/'measurements.md').write_text('\n'.join(lines)+'\n')
print('measurement bytes',len((p/'measurements.md').read_bytes()))

```

</details>

<details><summary>Installed dependency versions</summary>

```text
appnope==0.1.4
asttokens==3.0.1
cfgv==3.5.0
comm==0.2.3
coverage==7.13.4
cramjam==2.11.0
debugpy==1.8.20
decorator==5.2.1
distlib==0.4.0
exceptiongroup==1.3.1
executing==2.2.1
filelock==3.25.0
-e file:///Users/hanyuwu/Study/gem
identify==2.6.17
iniconfig==2.3.0
ipykernel==7.2.0
ipython==8.38.0
jedi==0.19.2
jinja2==3.1.6
jupyter-client==8.8.0
jupyter-core==5.9.1
librt==0.8.1
markdown==3.10.2
markdown-it-py==4.0.0
markupsafe==3.0.3
matplotlib-inline==0.2.1
mdurl==0.1.2
mypy==1.19.1
mypy-extensions==1.1.0
narwhals==2.17.0
nest-asyncio==1.6.0
nodeenv==1.10.0
numpy==2.2.6
packaging==26.0
pandas==2.3.3
parso==0.8.6
pathspec==1.0.4
pexpect==4.9.0
pillow==12.1.1
platformdirs==4.9.4
plotly==6.6.0
pluggy==1.6.0
pre-commit==4.5.1
prompt-toolkit==3.0.52
protobuf==7.34.0
protoc-wheel-0==30.2
psutil==7.2.2
ptyprocess==0.7.0
pure-eval==0.2.3
pygments==2.19.2
pymdown-extensions==10.21
pytest==9.0.2
pytest-cov==7.0.0
python-dateutil==2.9.0.post0
python-discovery==1.1.1
python-snappy==0.7.3
pytz==2026.1.post1
pyyaml==6.0.3
pyzmq==27.1.0
rich==14.3.3
ruff==0.15.5
six==1.17.0
stack-data==0.6.3
tomli==2.4.0
tornado==6.5.5
traitlets==5.14.3
typing-extensions==4.15.0
tzdata==2025.3
virtualenv==21.1.0
wcwidth==0.6.0
zstandard==0.25.0
```

</details>

## Release hygiene and cleanup

Only the binary reader, its regression tests, string-table tests, and changelog are changed. Generated protobuf files, replay artifacts, public APIs, dependencies, and test tiers are unchanged. Benchmark scripts, source copies, and generated outputs were temporary; their reproduction details are preserved above and the local investigation directory is removed before delivery.
