### PR TITLE
Stop draft polling after the game-start tick.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Less draft polling.** Stop scanning draft slots after the game-start tick,
+  preserving start-tick assignments and late hero-name resolution.
 - **Lower string-table payload overhead.** Use bulk byte reads for larger payloads,
   preserving partial-byte packing and truncated-input behavior.
 - **Less repeated test setup.** Share read-only replay results across integration

--- a/src/gem/extractors/draft.py
+++ b/src/gem/extractors/draft.py
@@ -240,6 +240,14 @@ class DraftExtractor:
             self._grp = None
             return
         self._grp = entity
+        # The marker is set before this callback, so finish its tick to retain
+        # draft fields arriving with or immediately after the start update.
+        if (
+            self._parser is not None
+            and self._parser.game_start_tick is not None
+            and self._parser.tick > self._parser.game_start_tick
+        ):
+            return
         self._check_draft(entity)
 
     def _check_draft(self, entity: Entity) -> None:

--- a/tests/test_ability_courier_draft_stuns.py
+++ b/tests/test_ability_courier_draft_stuns.py
@@ -34,6 +34,7 @@ def _make_entity(class_name: str, state: dict | None = None):
 class FakeParser:
     def __init__(self, tick: int = 0) -> None:
         self.tick = tick
+        self.game_start_tick = None
         self._entity_handlers = []
         self.entity_manager = None
         self.string_tables = type("ST", (), {"get_by_name": lambda self, n: None})()

--- a/tests/test_draft_extractor.py
+++ b/tests/test_draft_extractor.py
@@ -7,6 +7,8 @@ needed — all tests use fake objects and bundled data only.
 
 from __future__ import annotations
 
+import pytest
+
 from gem.extractors.draft import (
     _HERO_ID_TO_NPC,
     DraftEvent,
@@ -522,6 +524,7 @@ class TestOnEntity:
         class FakeParser:
             def __init__(self) -> None:
                 self.tick = 0
+                self.game_start_tick = None
                 self.entity_manager = None
                 self._handlers: list = []
 
@@ -600,3 +603,166 @@ class TestOnEntity:
         )
         ext._on_entity(entity, EntityOp.UPDATED)
         assert ext.draft_events == []
+
+
+def _attached_draft():
+    from gem.parser import ReplayParser
+    from gem.state.entities import EntityManager
+
+    parser = ReplayParser(b"")
+    parser.entity_manager = EntityManager({}, parser.string_tables)
+    # ReplayParser transfers these registrations when send tables are decoded.
+    for registration in parser._entity_callbacks:
+        parser.entity_manager._on_entity_filtered(
+            registration.callback,
+            class_names=registration.class_names,
+            class_prefixes=registration.class_prefixes,
+        )
+    extractor = DraftExtractor()
+    extractor.attach(parser)
+    return parser, extractor, parser.entity_manager.tracker._dispatch
+
+
+class TestDraftPollingCutoff:
+    def test_pre_start_replacements_and_idempotency(self):
+        from gem.state.entities import EntityOp
+
+        parser, ext, dispatch = _attached_draft()
+        entity = _make_entity(
+            "CDOTAGamerulesProxy",
+            {
+                "m_pGameRules.m_BannedHeroes.0000": 4,
+                "m_pGameRules.m_SelectedHeroes.0000": 28,
+                "m_pGameRules.m_iActiveTeam": 2,
+            },
+        )
+        parser.tick = 10
+        dispatch(entity, EntityOp.CREATED_ENTERED)
+        dispatch(entity, EntityOp.UPDATED)
+        parser.tick = 20
+        entity._state["m_pGameRules.m_SelectedHeroes.0000"] = 4
+        entity._state["m_pGameRules.m_iActiveTeam"] = 3
+        dispatch(entity, EntityOp.UPDATED)
+        assert ext.draft_events == [
+            DraftEvent(10, 0, 4, "npc_dota_hero_axe", False, 2),
+            DraftEvent(10, 0, 28, "npc_dota_hero_pudge", True, 2),
+            DraftEvent(20, 0, 4, "npc_dota_hero_axe", True, 3),
+        ]
+
+    def test_start_update_and_same_tick_are_scanned(self, monkeypatch):
+        from unittest.mock import Mock
+
+        from gem.state.entities import EntityOp
+
+        parser, ext, dispatch = _attached_draft()
+        scan = Mock(wraps=ext._check_draft)
+        monkeypatch.setattr(ext, "_check_draft", scan)
+        # The first reconstructed entity already contains the start marker.
+        entity = _make_entity(
+            "CDOTAGamerulesProxy",
+            {
+                "m_pGameRules.m_flGameStartTime": 100.0,
+                "m_pGameRules.m_BannedHeroes.0000": 4,
+            },
+        )
+        dispatch(entity, EntityOp.CREATED_ENTERED)
+        assert parser.game_start_tick == 0
+        entity._state["m_pGameRules.m_SelectedHeroes.0000"] = 28
+        dispatch(entity, EntityOp.UPDATED)
+        assert scan.call_count == 2
+        expected = list(ext.draft_events)
+        assert [(e.hero_id, e.is_pick, e.tick) for e in expected] == [(4, False, 0), (28, True, 0)]
+        parser.tick = 1
+        entity._state["m_pGameRules.m_SelectedHeroes.0000"] = 4
+        entity._state["m_pGameRules.m_BannedHeroes.0001"] = 28
+        dispatch(entity, EntityOp.UPDATED)
+        assert scan.call_count == 2
+        assert ext.draft_events == expected
+        dispatch(entity, EntityOp.DELETED_LEFT)
+        assert ext._grp is None
+        replacement = _make_entity("CDOTAGamerulesProxy", dict(entity._state))
+        dispatch(replacement, EntityOp.CREATED_ENTERED)
+        dispatch(replacement, EntityOp.UPDATED_ENTERED)
+        assert ext._grp is replacement
+        assert scan.call_count == 2
+
+    def test_missing_marker_continues_polling(self):
+        from gem.state.entities import EntityOp
+
+        parser, ext, dispatch = _attached_draft()
+        entity = _make_entity("CDOTAGamerulesProxy")
+        for tick, hero in ((0, 4), (100_000, 28)):
+            parser.tick = tick
+            entity._state["m_pGameRules.m_SelectedHeroes.0000"] = hero
+            dispatch(entity, EntityOp.UPDATED)
+        assert parser.game_start_tick is None
+        assert [e.tick for e in ext.draft_events] == [0, 100_000]
+        standalone = DraftExtractor()
+        standalone._on_entity(entity, EntityOp.UPDATED)
+        assert standalone.draft_events[0].hero_id == 28
+
+    def test_late_player_resource_resolves_names(self):
+        from gem.state.entities import EntityOp
+
+        parser, ext, dispatch = _attached_draft()
+        entity = _make_entity(
+            "CDOTAGamerulesProxy",
+            {
+                "m_pGameRules.m_flGameStartTime": 100.0,
+                "m_pGameRules.m_SelectedHeroes.0000": 9998,
+            },
+        )
+        dispatch(entity, EntityOp.CREATED)
+        assert ext.draft_events[0].hero_name == ""
+        parser.tick = 100
+        resource = _make_entity(
+            "CDOTA_PlayerResource",
+            {
+                "m_vecPlayerTeamData.0000.m_nSelectedHeroID": 9998,
+                "m_vecPlayerTeamData.0000.m_hSelectedHero": 1,
+            },
+        )
+        dispatch(resource, EntityOp.UPDATED)
+        assert ext._live_id_to_npc == {}
+        hero = _make_entity("CDOTA_Unit_Hero_Axe")
+        hero.index = 1
+        parser.entity_manager.entities = [entity, hero]
+        dispatch(resource, EntityOp.UPDATED)
+        ext.finalize()
+        assert ext.draft_events[0].hero_name == "npc_dota_hero_axe"
+
+    @pytest.mark.parametrize("include_start", [False, True])
+    def test_truncated_stream_preserves_collected_draft(self, monkeypatch, include_start):
+        from contextlib import nullcontext
+
+        from gem.state.entities import EntityOp
+
+        parser, ext, dispatch = _attached_draft()
+        entity = _make_entity("CDOTAGamerulesProxy")
+
+        def stream():
+            yield 10, 0, {"m_pGameRules.m_BannedHeroes.0000": 4}
+            if include_start:
+                yield (
+                    20,
+                    0,
+                    {
+                        "m_pGameRules.m_flGameStartTime": 100.0,
+                        "m_pGameRules.m_SelectedHeroes.0000": 28,
+                    },
+                )
+                yield 21, 0, {"m_pGameRules.m_SelectedHeroes.0000": 4}
+            raise EOFError("truncated test stream")
+
+        def update(_kind, state):
+            entity._state.update(state)
+            dispatch(entity, EntityOp.UPDATED)
+
+        monkeypatch.setattr("gem.parser.DemoStream", lambda _source: nullcontext(stream()))
+        monkeypatch.setattr(parser, "_dispatch_outer", update)
+        parser.parse()
+        ext.finalize()
+        assert isinstance(parser.parse_error, EOFError)
+        assert [(e.hero_id, e.tick) for e in ext.draft_events] == (
+            [(4, 10), (28, 20)] if include_start else [(4, 10)]
+        )


### PR DESCRIPTION
## Summary

Stop scanning the 14 ban and 10 pick slots once parsing advances beyond the game-start tick. Keep every update on the start tick: ReplayParser sets its marker before DraftExtractor receives that same entity update, which can contain draft assignments. PlayerResource updates and final hero-name resolution continue normally.

Closes #167.

The approved acceptance refinement is zero `_check_draft()` calls at ticks **greater than** `game_start_tick`, rather than zero calls immediately after marker assignment. No extra callback or lifecycle flag is added. Missing markers and unattached extractor calls retain polling; tick zero is a valid marker. Deletion and `_grp` tracking remain unchanged. No public API, dependency, decoder, or test-tier changes.

## References and regression coverage

Manta `entity.go` and Clarity `Entities.java` establish field application and entity notification behavior; OpenDota `Parse.java` establishes draft fields and hero-name resolution. Gem's parser registration order and ordered entity dispatch determine the inclusive boundary. The original extractor is the compatibility oracle for existing replay output.

Tests cover pre-start replacements/idempotency, actual parser/tracker callback order, first reconstruction with a start marker, subsequent same-tick updates, start tick zero, later-tick suppression, missing markers, deletion/recreation/re-entry, delayed PlayerResource handles, final name resolution, and truncated streams before/after start. Existing assertions remain intact. Independent static review found no actionable issues.

## Validation

Same existing uv-managed CPython 3.10.4 environment throughout. Direct `.venv/bin/python -m ...` invocations were used after uv encountered a sandboxed cache access; dependencies were unchanged.

| Command | Result |
|---|---|
| `.venv/bin/python -m pytest tests/test_draft_extractor.py tests/test_parser.py tests/test_ability_courier_draft_stuns.py -q` | 171 passed, 10 deselected; 0.27 s |
| `.venv/bin/python -m pytest -q -rs` | 3,776 passed, 3 skipped, 62 deselected; 5.66 s |
| `.venv/bin/python -m pytest -q -rs -m "not network"` | 3,837 passed, 3 skipped, 1 deselected; 265.70 s |
| `.venv/bin/python -m ruff check src/ tests/` | Passed |
| `.venv/bin/python -m ruff format --check src/ tests/` | Passed |
| `.venv/bin/python -m mypy src/gem/` | Passed |

The three pytest skips are optional pyarrow (`test_bulk.py`), optional Parquet engine (`test_parquet_export.py`), and an existing optimized-away field-decoder flag case (`test_field_decoder.py`). The offline deselection is the live network test. No required local fixtures are missing. No live downloads are required.

CI passed on `8031a628301e6dcd3d379084993d699b9206d724`: [CI](https://github.com/whanyu1212/gem-dota/actions/runs/34034318181/job/101489490837), [distribution build](https://github.com/whanyu1212/gem-dota/actions/runs/34034318227/job/101489491017). PyPI publishing is intentionally skipped on PRs. Pre-commit Ruff, formatting, merge-conflict, and mypy checks passed; YAML/TOML hooks had no applicable files.

## Interpretation

The candidate removes all later-tick scans on all eight full corpus replays, preserving the complete 24-event draft and final hero-name map for each. On the benchmark fixtures this removes 36,215 and 100,214 scans, respectively; the single scan on the start tick is intentionally retained.

The short replay's median elapsed time fell from 52.546 to 51.605 s (1.79%), and median user CPU fell from 52.396 to 51.116 s (2.44%). Median RSS changed from 217.359 to 217.625 MiB (+0.266 MiB).

The long replay's median elapsed time changed from 170.723 to 171.050 s (+0.19%), while median user CPU changed from 168.697 to 168.643 s (-0.03%). Every paired elapsed comparison favored baseline slightly; CPU comparisons were mixed. This establishes no long-replay speedup. Median RSS was lower for the candidate, but process high-water marks vary and no general memory-saving claim is made. No material systematic CPU or memory regression was observed; core controls were not needed for the essentially neutral long-replay CPU result. Three processes per revision provide limited precision, and host load is recorded below.

All seven saved public outputs per benchmark replay (six timing runs plus one instrumented run) are byte-identical. Full parity passed with 982 PASS, no warnings/failures, and only the three existing informational teamfight-count skips. No required validation was skipped.
## Measurements and output validation

CPython 3.10.4, macOS 26.6.2 arm64, Apple M2, 16 GiB RAM. Same virtual environment, source options, and fixtures. Public API imports, including lazy extractor modules, precede timing; JSON/hash follow parse timing and peak-RSS capture. No profiling or coverage during timed runs. Fresh processes run sequentially in B/C, C/B, B/C order. The first baseline run preceded implementation and the remaining runs followed correctness validation. B is main `1a040cdbda0584c50d830aa1e93664f8b21436f7`; C is this PR. RSS is process high-water mark in MiB.

| Replay | Variant | Elapsed s (3 runs) | User CPU s (3 runs) | RSS MiB (3 runs) | Median elapsed / CPU / RSS |
|---|---|---|---|---|---|
|8822520406|B|52.546, 55.741, 52.542|51.959, 55.107, 52.396|207.406, 218.297, 217.359|52.546 / 52.396 / 217.359|
|8822520406|C|51.605, 52.845, 51.599|51.066, 52.648, 51.116|217.625, 217.375, 217.703|51.605 / 51.116 / 217.625|
|8856501050|B|170.723, 171.113, 169.783|168.697, 168.885, 167.473|650.594, 681.125, 642.516|170.723 / 168.697 / 650.594|
|8856501050|C|171.050, 172.988, 170.859|168.643, 170.212, 168.209|638.250, 645.047, 619.297|171.050 / 168.643 / 638.250|

### Host load (1/5/15-minute averages)

- `public-8822520406-0-B`: start [2.44091796875, 2.25830078125, 2.5498046875]; end [2.5595703125, 2.34326171875, 2.56494140625].
- `public-8822520406-0-C`: start [3.13525390625, 3.482421875, 3.25]; end [3.29296875, 3.49267578125, 3.26708984375].
- `public-8822520406-1-B`: start [3.5703125, 3.5302734375, 3.29248046875]; end [3.63623046875, 3.5595703125, 3.31787109375].
- `public-8822520406-1-C`: start [3.29296875, 3.49267578125, 3.26708984375]; end [3.5703125, 3.5302734375, 3.29248046875].
- `public-8822520406-2-B`: start [3.5849609375, 3.5498046875, 3.31591796875]; end [2.9990234375, 3.41259765625, 3.27880859375].
- `public-8822520406-2-C`: start [2.9189453125, 3.388671875, 3.27099609375]; end [2.6015625, 3.22021484375, 3.21337890625].
- `public-8856501050-0-B`: start [2.6015625, 3.22021484375, 3.21337890625]; end [2.744140625, 2.97900390625, 3.107421875].
- `public-8856501050-0-C`: start [2.68408203125, 2.96240234375, 3.1005859375]; end [3.10546875, 2.9765625, 3.07275390625].
- `public-8856501050-1-B`: start [2.69384765625, 2.97216796875, 3.05517578125]; end [2.80615234375, 2.966796875, 3.041015625].
- `public-8856501050-1-C`: start [3.0166015625, 2.9599609375, 3.06640625]; end [3.00244140625, 3.0400390625, 3.07958984375].
- `public-8856501050-2-B`: start [2.83544921875, 2.9677734375, 3.0400390625]; end [2.60498046875, 2.7900390625, 2.947265625].
- `public-8856501050-2-C`: start [2.81884765625, 2.82958984375, 2.958984375]; end [3.7724609375, 3.06005859375, 3.0166015625].

### Public output hashes

- `8822520406`: `3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427`; all seven baseline/candidate/instrumented outputs byte-identical (30,401,205 bytes each).
- `8856501050`: `1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e`; all seven baseline/candidate/instrumented outputs byte-identical (187,363,261 bytes each).

### Draft instrumentation across all eight local full replays

Original and candidate extractors observe the same decoded stream. This avoids parser-input differences when comparing lifecycle behavior; instrumented times are not speed evidence. The two benchmark fixtures use public parsing; other corpus replays attach only the two draft extractors to core parsing. Every parse completed without parse_error, and complete events plus live hero-name maps matched. No baseline event was first discovered after the start tick.

| Replay | Start tick | B scans before/on/after | C scans before/on/after | Final events |
|---|---|---|---|---|
|8821954344|22476|11232/1/100319|11232/1/0|24|
|8822520406|30206|15096/1/36215|15096/1/0|24|
|8822593932|29448|14719/1/53890|14719/1/0|24|
|8855188139|22509|11249/1/56022|11249/1/0|24|
|8855242704|24315|12151/1/77440|12151/1/0|24|
|8856501050|24263|12127/1/100214|12127/1/0|24|
|8860187335|20315|10154/1/59280|10154/1/0|24|
|8868259993|21872|10932/1/31012|10932/1/0|24|

<details><summary>All callback, scan, new-event, and live-map update counts</summary>

- `8821954344` B: `{"gamerules_after": 100319, "gamerules_before": 11232, "gamerules_on": 1, "live_map_updates_after": 9246, "live_map_updates_before": 159, "new_events_after": 0, "new_events_before": 24, "new_events_on": 0, "player_resource_after": 9246, "player_resource_before": 159, "scans_after": 100319, "scans_before": 11232, "scans_on": 1}`; C: `{"gamerules_after": 100319, "gamerules_before": 11232, "gamerules_on": 1, "live_map_updates_after": 9246, "live_map_updates_before": 159, "new_events_before": 24, "new_events_on": 0, "player_resource_after": 9246, "player_resource_before": 159, "scans_before": 11232, "scans_on": 1}`.
- `8822520406` B: `{"gamerules_after": 36215, "gamerules_before": 15096, "gamerules_on": 1, "live_map_updates_after": 1630, "live_map_updates_before": 92, "new_events_after": 0, "new_events_before": 24, "new_events_on": 0, "player_resource_after": 1630, "player_resource_before": 92, "scans_after": 36215, "scans_before": 15096, "scans_on": 1}`; C: `{"gamerules_after": 36215, "gamerules_before": 15096, "gamerules_on": 1, "live_map_updates_after": 1630, "live_map_updates_before": 92, "new_events_before": 24, "new_events_on": 0, "player_resource_after": 1630, "player_resource_before": 92, "scans_before": 15096, "scans_on": 1}`.
- `8822593932` B: `{"gamerules_after": 53890, "gamerules_before": 14719, "gamerules_on": 1, "live_map_updates_after": 3972, "live_map_updates_before": 76, "new_events_after": 0, "new_events_before": 24, "new_events_on": 0, "player_resource_after": 3972, "player_resource_before": 76, "scans_after": 53890, "scans_before": 14719, "scans_on": 1}`; C: `{"gamerules_after": 53890, "gamerules_before": 14719, "gamerules_on": 1, "live_map_updates_after": 3972, "live_map_updates_before": 76, "new_events_before": 24, "new_events_on": 0, "player_resource_after": 3972, "player_resource_before": 76, "scans_before": 14719, "scans_on": 1}`.
- `8855188139` B: `{"gamerules_after": 56022, "gamerules_before": 11249, "gamerules_on": 1, "live_map_updates_after": 2621, "live_map_updates_before": 96, "new_events_after": 0, "new_events_before": 24, "new_events_on": 0, "player_resource_after": 2621, "player_resource_before": 96, "scans_after": 56022, "scans_before": 11249, "scans_on": 1}`; C: `{"gamerules_after": 56022, "gamerules_before": 11249, "gamerules_on": 1, "live_map_updates_after": 2621, "live_map_updates_before": 96, "new_events_before": 24, "new_events_on": 0, "player_resource_after": 2621, "player_resource_before": 96, "scans_before": 11249, "scans_on": 1}`.
- `8855242704` B: `{"gamerules_after": 77440, "gamerules_before": 12151, "gamerules_on": 1, "live_map_updates_after": 4551, "live_map_updates_before": 48, "new_events_after": 0, "new_events_before": 24, "new_events_on": 0, "player_resource_after": 4551, "player_resource_before": 48, "scans_after": 77440, "scans_before": 12151, "scans_on": 1}`; C: `{"gamerules_after": 77440, "gamerules_before": 12151, "gamerules_on": 1, "live_map_updates_after": 4551, "live_map_updates_before": 48, "new_events_before": 24, "new_events_on": 0, "player_resource_after": 4551, "player_resource_before": 48, "scans_before": 12151, "scans_on": 1}`.
- `8856501050` B: `{"gamerules_after": 100214, "gamerules_before": 12127, "gamerules_on": 1, "live_map_updates_after": 6033, "live_map_updates_before": 60, "new_events_after": 0, "new_events_before": 24, "new_events_on": 0, "player_resource_after": 6033, "player_resource_before": 60, "scans_after": 100214, "scans_before": 12127, "scans_on": 1}`; C: `{"gamerules_after": 100214, "gamerules_before": 12127, "gamerules_on": 1, "live_map_updates_after": 6033, "live_map_updates_before": 60, "new_events_before": 24, "new_events_on": 0, "player_resource_after": 6033, "player_resource_before": 60, "scans_before": 12127, "scans_on": 1}`.
- `8860187335` B: `{"gamerules_after": 59280, "gamerules_before": 10154, "gamerules_on": 1, "live_map_updates_after": 4593, "live_map_updates_before": 73, "new_events_after": 0, "new_events_before": 24, "new_events_on": 0, "player_resource_after": 4593, "player_resource_before": 73, "scans_after": 59280, "scans_before": 10154, "scans_on": 1}`; C: `{"gamerules_after": 59280, "gamerules_before": 10154, "gamerules_on": 1, "live_map_updates_after": 4593, "live_map_updates_before": 73, "new_events_before": 24, "new_events_on": 0, "player_resource_after": 4593, "player_resource_before": 73, "scans_before": 10154, "scans_on": 1}`.
- `8868259993` B: `{"gamerules_after": 31012, "gamerules_before": 10932, "gamerules_on": 1, "live_map_updates_after": 1101, "live_map_updates_before": 99, "new_events_after": 0, "new_events_before": 24, "new_events_on": 0, "player_resource_after": 1101, "player_resource_before": 99, "scans_after": 31012, "scans_before": 10932, "scans_on": 1}`; C: `{"gamerules_after": 31012, "gamerules_before": 10932, "gamerules_on": 1, "live_map_updates_after": 1101, "live_map_updates_before": 99, "new_events_before": 24, "new_events_on": 0, "player_resource_after": 1101, "player_resource_before": 99, "scans_before": 10932, "scans_on": 1}`.

</details>

### Full offline OpenDota parity

- `8868259993`: 325 PASS, 0 WARN, 0 FAIL. Skips: [{"name": "teamfights/total_count", "note": "OpenDota applies deaths>=3 filtering over its expanded event pipeline. Count comparison is informational only."}].
- `8860187335`: 326 PASS, 0 WARN, 0 FAIL. Skips: [{"name": "teamfights/total_count", "note": "OpenDota applies deaths>=3 filtering over its expanded event pipeline. Count comparison is informational only."}].
- `8856501050`: 331 PASS, 0 WARN, 0 FAIL. Skips: [{"name": "teamfights/total_count", "note": "OpenDota applies deaths>=3 filtering over its expanded event pipeline. Count comparison is informational only."}].

## Exact reproduction

Use the same uv-managed virtual environment and local fixtures. Run from the candidate checkout; adjust hard-coded checkout/temp paths in the preserved scripts if reproducing elsewhere. Start with a fresh temporary directory because the timing driver skips existing result files.

```bash
mkdir -p /private/tmp/gem-167/baseline
git archive 1a040cdbda0584c50d830aa1e93664f8b21436f7 | tar -x -C /private/tmp/gem-167/baseline
# Save the scripts below in /private/tmp/gem-167/.
PYTHONHASHSEED=0 .venv/bin/python /private/tmp/gem-167/bench.py /private/tmp/gem-167/baseline tests/fixtures/opendota/8822520406.dem /private/tmp/gem-167/public-8822520406-0-B.json
# The first baseline run preceded implementation; then apply the PR changes.
.venv/bin/python -m pytest tests/test_draft_extractor.py tests/test_parser.py tests/test_ability_courier_draft_stuns.py -q
.venv/bin/python -m pytest -q -rs
.venv/bin/python /private/tmp/gem-167/run_validation.py
PYTHONHASHSEED=0 .venv/bin/python /private/tmp/gem-167/parity.py
.venv/bin/python /private/tmp/gem-167/run_replays.py
.venv/bin/python /private/tmp/gem-167/report.py
```

The original run overlapped parity with corpus instrumentation, both untimed correctness checks. All correctness work finished before the remaining timed runs; no timing processes ran concurrently. The reproduction commands above serialize those checks for convenience. Parity receives existing JSON explicitly, so it makes no OpenDota requests. Instrumentation asserts complete event and live-map equivalence, identical unaffected callback counts, zero later-tick candidate scans, and zero baseline new events after the cutoff. Public timed outputs and the two instrumented public outputs are compared byte-for-byte by report.py.

<details><summary>bench.py</summary>

```python
import argparse, gc, hashlib, json, os, platform, resource, sys, time
from pathlib import Path
p=argparse.ArgumentParser()
p.add_argument('source');p.add_argument('replay');p.add_argument('out')
a=p.parse_args()
sys.path.insert(0,str(Path(a.source)/'src'))
import gem
import gem.extractors.intervals
import gem.extractors.smoke_vision
from gem.parser import ReplayParser
meta=dict(python=sys.version,platform=platform.platform(),source=gem.__file__,load_start=os.getloadavg())
gc.collect()
cpu=resource.getrusage(resource.RUSAGE_SELF).ru_utime
start=time.perf_counter()
result=gem.parse(a.replay)
elapsed=time.perf_counter()-start
usage=resource.getrusage(resource.RUSAGE_SELF)
row=dict(**meta,elapsed=elapsed,user=usage.ru_utime-cpu,rss_bytes=usage.ru_maxrss*(1 if sys.platform=='darwin' else 1024),load_end=os.getloadavg())
data=json.dumps(gem.to_dict(result),sort_keys=True,separators=(',',':')).encode()
row['sha256']=hashlib.sha256(data).hexdigest()
Path(a.out+'.public.json').write_bytes(data)
Path(a.out).write_text(json.dumps(row,indent=2))
print(json.dumps(row),flush=True)

```

</details>

<details><summary>instrument.py</summary>

```python
import argparse, dataclasses, hashlib, importlib.util, json, sys
from pathlib import Path
p=argparse.ArgumentParser();p.add_argument('replay');p.add_argument('out');a=p.parse_args()
root=Path('/Users/hanyuwu/Study/gem');sys.path.insert(0,str(root/'src'))
import gem
import gem.extractors.draft as draft
from gem.parser import ReplayParser
from gem.state.entities import EntityOp
spec=importlib.util.spec_from_file_location('original_draft','/private/tmp/gem-167/baseline/src/gem/extractors/draft.py')
original=importlib.util.module_from_spec(spec);sys.modules[spec.name]=original;spec.loader.exec_module(original)
instances=[]
class Counts:
    def __init__(self):
        super().__init__();self.counts={};instances.append(self)
    def bump(self,key,n=1):self.counts[key]=self.counts.get(key,0)+n
    def phase(self):
        start=self._parser.game_start_tick
        return 'before' if start is None or self._parser.tick<start else 'on' if self._parser.tick==start else 'after'
    def _on_entity(self,entity,op):
        name=entity.get_class_name()
        if name=='CDOTAGamerulesProxy':self.bump('gamerules_'+self.phase())
        elif name=='CDOTA_PlayerResource':self.bump('player_resource_'+self.phase())
        super()._on_entity(entity,op)
    def _update_live_map(self,entity):
        self.bump("live_map_updates_"+self.phase())
        super()._update_live_map(entity)
    def _check_draft(self,entity):
        phase=self.phase();self.bump('scans_'+phase)
        size=len(self.draft_events);super()._check_draft(entity)
        self.bump('new_events_'+phase,len(self.draft_events)-size)
class Baseline(Counts,original.DraftExtractor):pass
class Candidate(Counts,draft.DraftExtractor):
    def attach(self,parser):
        super().attach(parser)
        self.oracle=Baseline();self.oracle.attach(parser)
draft.DraftExtractor=Candidate
is_public=Path(a.replay).stem in ('8822520406','8856501050')
if is_public:
    result=gem.parse(a.replay);candidate=instances[0];parser=candidate._parser
else:
    parser=ReplayParser(a.replay);candidate=Candidate();candidate.attach(parser);parser.parse();candidate.finalize()
assert parser.parse_error is None,repr(parser.parse_error)
candidate.oracle.finalize()
events=lambda e:[dataclasses.asdict(v) for v in e.draft_events]
assert events(candidate)==events(candidate.oracle)
assert candidate._live_id_to_npc==candidate.oracle._live_id_to_npc
for key,value in candidate.oracle.counts.items():
    if not key.startswith(('scans_after','new_events_after')):
        assert candidate.counts.get(key,0)==value,(key,value,candidate.counts)
assert candidate.counts.get('scans_after',0)==0
assert candidate.oracle.counts.get('new_events_after',0)==0
row=dict(replay=a.replay,game_start_tick=parser.game_start_tick,candidate=candidate.counts,baseline=candidate.oracle.counts,events=events(candidate))
if is_public:
    data=json.dumps(gem.to_dict(result),sort_keys=True,separators=(',',':')).encode()
    row['sha256']=hashlib.sha256(data).hexdigest();Path(a.out+'.public.json').write_bytes(data)
Path(a.out).write_text(json.dumps(row,indent=2));print(json.dumps(row),flush=True)

```

</details>

<details><summary>run_validation.py</summary>

```python
import os,subprocess,sys
from pathlib import Path
root=Path('/Users/hanyuwu/Study/gem');out=Path('/private/tmp/gem-167');env={**os.environ,'PYTHONHASHSEED':'0'}
checks={'lint':['ruff','check','src/','tests/'],'format':['ruff','format','--check','src/','tests/'],'mypy':['mypy','src/gem/'],'offline':['pytest','-q','-rs','-m','not network']}
for name,args in checks.items():
    print('START',name,flush=True)
    with (out/f'{name}.log').open('w') as log:subprocess.run([sys.executable,'-m',*args],cwd=root,env=env,stdout=log,stderr=subprocess.STDOUT,check=True)
for replay in sorted((root/'tests/fixtures/opendota').glob('*.dem')):
    print('START instrument',replay.stem,flush=True)
    subprocess.run([sys.executable,str(out/'instrument.py'),str(replay),str(out/f'instrument-{replay.stem}.json')],cwd=root,env=env,check=True)

```

</details>

<details><summary>parity.py</summary>

```python
import json,sys
from pathlib import Path
root=Path('/Users/hanyuwu/Study/gem');sys.path[:0]=[str(root),str(root/'src')]
from scripts.validate_opendota import validate_match
rows=[]
for mid in (8868259993,8860187335,8856501050):
    path=root/f'tests/fixtures/opendota/{mid}.dem'
    od=json.loads(path.with_suffix('.opendota.json').read_text())
    r=validate_match(mid,path,od=od,mode='full')
    row=dict(match=mid,passed=r.passed,warned=r.warned,failed=r.failed,errors=r.errors,skips=[dict(name=f.name,note=f.note) for f in r.all_fields if f.skip])
    rows.append(row);print(json.dumps(row),flush=True)
    assert not r.errors and r.failed==0
Path('/private/tmp/gem-167/parity.json').write_text(json.dumps(rows,indent=2))

```

</details>

<details><summary>run_replays.py</summary>

```python
import os,subprocess,sys
from pathlib import Path
root=Path('/Users/hanyuwu/Study/gem');out=Path('/private/tmp/gem-167');env={**os.environ,'PYTHONHASHSEED':'0'}
for replay in ('8822520406','8856501050'):
    for block,order in enumerate(('BC','CB','BC')):
        for v in order:
            dest=out/f'public-{replay}-{block}-{v}.json'
            if dest.exists():continue
            source=out/'baseline' if v=='B' else root
            print('START',dest.name,flush=True)
            subprocess.run([sys.executable,str(out/'bench.py'),str(source),str(root/f'tests/fixtures/opendota/{replay}.dem'),str(dest)],cwd=root,env=env,check=True)
print('REPLAY TIMINGS COMPLETE',flush=True)

```

</details>

<details><summary>report.py</summary>

```python
import hashlib,json,statistics
from pathlib import Path
p=Path('/private/tmp/gem-167');lines=[]
def add(s=''):lines.append(s)
add('## Measurements and output validation\n')
add('CPython 3.10.4, macOS 26.6.2 arm64, Apple M2, 16 GiB RAM. Same virtual environment, source options, and fixtures. Public API imports, including lazy extractor modules, precede timing; JSON/hash follow parse timing and peak-RSS capture. No profiling or coverage during timed runs. Fresh processes run sequentially in B/C, C/B, B/C order. The first baseline run preceded implementation and the remaining runs followed correctness validation. B is main `1a040cdbda0584c50d830aa1e93664f8b21436f7`; C is this PR. RSS is process high-water mark in MiB.\n')
add('| Replay | Variant | Elapsed s (3 runs) | User CPU s (3 runs) | RSS MiB (3 runs) | Median elapsed / CPU / RSS |')
add('|---|---|---|---|---|---|')
medians={}
for replay in ('8822520406','8856501050'):
 medians[replay]={}
 for v in 'BC':
  rows=[json.loads((p/f'public-{replay}-{i}-{v}.json').read_text()) for i in range(3)]
  vals=[[r[k]/(2**20 if k=='rss_bytes' else 1) for r in rows] for k in ('elapsed','user','rss_bytes')]
  medians[replay][v]=[statistics.median(xs) for xs in vals]
  add('|'+ '|'.join([replay,v,*[', '.join(f'{x:.3f}' for x in xs) for xs in vals], ' / '.join(f'{statistics.median(xs):.3f}' for xs in vals)])+'|')
add('\n### Host load (1/5/15-minute averages)\n')
for f in sorted(p.glob('public-*.json')):
 if f.name.endswith('.public.json'):continue
 r=json.loads(f.read_text())
 add(f"- `{f.stem}`: start {r['load_start']}; end {r['load_end']}.")
add('\n### Public output hashes\n')
for replay in ('8822520406','8856501050'):
 files=list(p.glob(f'*{replay}*.json.public.json'));reference=files[0].read_bytes()
 assert len(files)==7 and all(f.read_bytes()==reference for f in files)
 add(f'- `{replay}`: `{hashlib.sha256(reference).hexdigest()}`; all seven baseline/candidate/instrumented outputs byte-identical ({len(reference):,} bytes each).')
add('\n### Draft instrumentation across all eight local full replays\n')
add('Original and candidate extractors observe the same decoded stream. This avoids parser-input differences when comparing lifecycle behavior; instrumented times are not speed evidence. The two benchmark fixtures use public parsing; other corpus replays attach only the two draft extractors to core parsing. Every parse completed without parse_error, and complete events plus live hero-name maps matched. No baseline event was first discovered after the start tick.\n')
add('| Replay | Start tick | B scans before/on/after | C scans before/on/after | Final events |')
add('|---|---|---|---|---|')
files=sorted(p.glob('instrument-*.json'));files=[f for f in files if not f.name.endswith('.public.json')];assert len(files)==8
for f in files:
 r=json.loads(f.read_text());counts=lambda v:'/'.join(str(r[v].get('scans_'+phase,0)) for phase in ('before','on','after'))
 add(f"|{Path(r['replay']).stem}|{r['game_start_tick']}|{counts('baseline')}|{counts('candidate')}|{len(r['events'])}|")
add('\n<details><summary>All callback, scan, new-event, and live-map update counts</summary>\n')
for f in files:
 r=json.loads(f.read_text())
 add(f"- `{Path(r['replay']).stem}` B: `{json.dumps(r['baseline'],sort_keys=True)}`; C: `{json.dumps(r['candidate'],sort_keys=True)}`.")
add('\n</details>\n')
add('### Full offline OpenDota parity\n')
for r in json.loads((p/'parity.json').read_text()):
 assert not r['errors'] and r['failed']==0
 add(f"- `{r['match']}`: {r['passed']} PASS, {r['warned']} WARN, {r['failed']} FAIL. Skips: {json.dumps(r['skips'])}.")
(p/'measurements.md').write_text('\n'.join(lines)+'\n')
(p/'medians.json').write_text(json.dumps(medians,indent=2))
print(json.dumps(medians,indent=2))

```

</details>

<details><summary>Installed distributions</summary>

```text
Jinja2==3.1.6
Markdown==3.10.2
MarkupSafe==3.0.3
PyYAML==6.0.3
Pygments==2.19.2
appnope==0.1.4
asttokens==3.0.1
cfgv==3.5.0
comm==0.2.3
coverage==7.13.4
cramjam==2.11.0
debugpy==1.8.20
decorator==5.2.1
distlib==0.4.0
exceptiongroup==1.3.1
executing==2.2.1
filelock==3.25.0
gem-dota==0.7.1
identify==2.6.17
iniconfig==2.3.0
ipykernel==7.2.0
ipython==8.38.0
jedi==0.19.2
jupyter_client==8.8.0
jupyter_core==5.9.1
librt==0.8.1
markdown-it-py==4.0.0
matplotlib-inline==0.2.1
mdurl==0.1.2
mypy==1.19.1
mypy_extensions==1.1.0
narwhals==2.17.0
nest-asyncio==1.6.0
nodeenv==1.10.0
numpy==2.2.6
packaging==26.0
pandas==2.3.3
parso==0.8.6
pathspec==1.0.4
pexpect==4.9.0
pillow==12.1.1
platformdirs==4.9.4
plotly==6.6.0
pluggy==1.6.0
pre_commit==4.5.1
prompt_toolkit==3.0.52
protobuf==7.34.0
protoc-wheel-0==30.2
psutil==7.2.2
ptyprocess==0.7.0
pure_eval==0.2.3
pymdown-extensions==10.21
pytest-cov==7.0.0
pytest==9.0.2
python-dateutil==2.9.0.post0
python-discovery==1.1.1
python-snappy==0.7.3
pytz==2026.1.post1
pyzmq==27.1.0
rich==14.3.3
ruff==0.15.5
six==1.17.0
stack-data==0.6.3
tomli==2.4.0
tornado==6.5.5
traitlets==5.14.3
typing_extensions==4.15.0
tzdata==2025.3
virtualenv==21.1.0
wcwidth==0.6.0
zstandard==0.25.0
```

</details>

## Cleanup

Benchmark source copies, scripts, logs, and generated output were temporary. Their reproduction details are preserved above; the local investigation directory is removed before delivery. Only the draft extractor, focused tests/parser doubles, and changelog are tracked changes.
