### PR TITLE
Read interval team state at sampling boundaries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Less interval-frame copying.** Read team values at sampling boundaries after
+  the initial interval, preserving minute-zero history and terminal counters.
 - **Less draft polling.** Stop scanning draft slots after the game-start tick,
   preserving start-tick assignments and late hero-name resolution.
 - **Lower string-table payload overhead.** Use bulk byte reads for larger payloads,

--- a/src/gem/extractors/intervals.py
+++ b/src/gem/extractors/intervals.py
@@ -155,11 +155,10 @@ class IntervalExtractor:
         self._data_dire: Entity | None = None
         # Per-team-slot team-data history, kept to the two most recent observed
         # frames as ``(observed_tick, (gold, xp, lh, dn, net_worth))``. The
-        # production tick-start path reads ``cur`` after its one-tick deferral
-        # for regular boundaries; minute zero reads it immediately.
-        # ``prev`` preserves the entity-callback compatibility path, where the
-        # latest frame strictly before a crossing is required. Entities mutate
-        # in place, so values are copied eagerly rather than held by reference.
+        # tick-start path retains these copies until its first successful batch
+        # to preserve minute-zero prior-frame selection, then reads live entities
+        # at boundaries. The entity-callback compatibility path keeps history
+        # throughout parsing to select a frame strictly before each crossing.
         self._prev_data_radiant: dict[int, _TeamDataFrame] = {}
         self._prev_data_dire: dict[int, _TeamDataFrame] = {}
         self._cur_data_radiant: dict[int, _TeamDataFrame] = {}
@@ -342,7 +341,8 @@ class IntervalExtractor:
                 self._data_radiant = None
             else:
                 self._data_radiant = entity
-                self._record_team_data(entity, self._cur_data_radiant, self._prev_data_radiant)
+                if not self._tick_start_driven or self._last_emitted_time_s is None:
+                    self._record_team_data(entity, self._cur_data_radiant, self._prev_data_radiant)
                 self._record_team_counters(entity, TEAM_RADIANT)
                 if not self._tick_start_driven:
                     self._maybe_emit()
@@ -353,7 +353,8 @@ class IntervalExtractor:
                 self._data_dire = None
             else:
                 self._data_dire = entity
-                self._record_team_data(entity, self._cur_data_dire, self._prev_data_dire)
+                if not self._tick_start_driven or self._last_emitted_time_s is None:
+                    self._record_team_data(entity, self._cur_data_dire, self._prev_data_dire)
                 self._record_team_counters(entity, TEAM_DIRE)
                 if not self._tick_start_driven:
                     self._maybe_emit()
@@ -483,6 +484,12 @@ class IntervalExtractor:
         if emitted:
             if initial_boundary:
                 self._initial_boundary_pending = False
+            if self._tick_start_driven and self._last_emitted_time_s is None:
+                # Only the initial sample needs previous-frame selection.
+                self._cur_data_radiant.clear()
+                self._prev_data_radiant.clear()
+                self._cur_data_dire.clear()
+                self._prev_data_dire.clear()
             self._last_emitted_time_s = boundary_time_s
             self._last_emitted_tick = self._parser.tick
             self._next_interval_s = boundary_time_s + self._interval_s
@@ -646,16 +653,18 @@ class IntervalExtractor:
     ) -> tuple[int, int, int, int, int]:
         """Return the team-data values for an interval boundary.
 
-        Normal boundaries use the latest recorded frame strictly before the
+        Compatibility boundaries use the latest recorded frame strictly before the
         crossing tick, matching OpenDota's entity dispatch order. Tick-driven
         minute zero prefers the prior observed frame because Gem detects the
         rounded clock crossing one entity update after Clarity; terminal and
         compatibility-path boundaries can select the live frame explicitly.
+        After the initial tick-driven sample, read the retained entity directly;
+        tick-start dispatch precedes the next tick's entity mutations.
 
         Args:
             team: ``TEAM_RADIANT`` or ``TEAM_DIRE``.
             team_slot: The player's team slot, 0-4.
-            data_entity: The live data entity for the team (fallback source).
+            data_entity: The live team entity, also used when history is unavailable.
             emit_tick: The tick of the boundary emit.
             use_live: Select the current frame without the boundary nudge.
             prefer_previous: Select the prior observed frame when available.
@@ -663,21 +672,22 @@ class IntervalExtractor:
         Returns:
             ``(gold, xp, lh, dn, net_worth)`` for the boundary frame.
         """
-        cur = self._cur_data_radiant if team == TEAM_RADIANT else self._cur_data_dire
-        prev = self._prev_data_radiant if team == TEAM_RADIANT else self._prev_data_dire
-        cur_frame = cur.get(team_slot)
-        prev_frame = prev.get(team_slot)
-        if prefer_previous:
-            if prev_frame is not None:
-                return prev_frame[1]
-            if cur_frame is not None:
+        if not self._tick_start_driven or self._last_emitted_time_s is None:
+            cur = self._cur_data_radiant if team == TEAM_RADIANT else self._cur_data_dire
+            prev = self._prev_data_radiant if team == TEAM_RADIANT else self._prev_data_dire
+            cur_frame = cur.get(team_slot)
+            prev_frame = prev.get(team_slot)
+            if prefer_previous:
+                if prev_frame is not None:
+                    return prev_frame[1]
+                if cur_frame is not None:
+                    return cur_frame[1]
+            if use_live and cur_frame is not None:
                 return cur_frame[1]
-        if use_live and cur_frame is not None:
-            return cur_frame[1]
-        if cur_frame is not None and cur_frame[0] < emit_tick:
-            return cur_frame[1]
-        if prev_frame is not None and prev_frame[0] < emit_tick:
-            return prev_frame[1]
+            if cur_frame is not None and cur_frame[0] < emit_tick:
+                return cur_frame[1]
+            if prev_frame is not None and prev_frame[0] < emit_tick:
+                return prev_frame[1]
         fields = data_entity._resolve_fields(_TEAM_DATA_FIELDS)
         offset = team_slot * len(_TEAM_DATA_FIELD_NAMES)
         return (

--- a/tests/test_intervals_extractor.py
+++ b/tests/test_intervals_extractor.py
@@ -821,3 +821,201 @@ def test_team_counters_track_last_observed_values():
         ),
         0,
     )
+
+
+@pytest.mark.parametrize("tick_driven", [False, True])
+@pytest.mark.parametrize("first_time", [0, 60])
+def test_frame_capture_lifetime_matches_sampling_mode(monkeypatch, tick_driven, first_time):
+    from unittest.mock import Mock
+
+    ext = IntervalExtractor()
+    parser_type = TickStartFakeParser if tick_driven else FakeParser
+    parser = parser_type(tick=10, game_time_s=None)
+    ext.attach(parser)
+    capture = Mock(wraps=ext._record_team_data)
+    counters = Mock(wraps=ext._record_team_counters)
+    monkeypatch.setattr(ext, "_record_team_data", capture)
+    monkeypatch.setattr(ext, "_record_team_counters", counters)
+    radiant, dire = _radiant_data(), _dire_data()
+    ext._on_entity(radiant, EntityOp.UPDATED)
+    parser.tick = 11
+    ext._on_entity(radiant, EntityOp.UPDATED)
+    ext._on_entity(dire, EntityOp.UPDATED)
+    assert ext._prev_data_radiant
+    assert not ext.snapshots
+    parser.game_time_s = first_time
+    if tick_driven:
+        parser.fire_tick_start(11)
+        parser.tick = 12
+        parser.fire_tick_start(12)
+    else:
+        ext._on_entity(_ent("CDOTAGamerulesProxy"), EntityOp.UPDATED)
+    # Missing PlayerResource must not discard the history needed by minute zero.
+    assert ext._cur_data_radiant and ext._prev_data_radiant
+    ext._on_entity(_player_resource(), EntityOp.UPDATED)
+    if tick_driven:
+        parser.tick = 13
+        parser.fire_tick_start(13)
+    assert len(ext.snapshots) == 2
+    histories = (
+        ext._cur_data_radiant,
+        ext._prev_data_radiant,
+        ext._cur_data_dire,
+        ext._prev_data_dire,
+    )
+    assert any(histories) is not tick_driven
+    previous_calls = capture.call_count
+    parser.tick += 1
+    ext._on_entity(radiant, EntityOp.UPDATED)
+    ext._on_entity(dire, EntityOp.UPDATED)
+    assert capture.call_count == previous_calls + (0 if tick_driven else 2)
+    assert counters.call_count == 5
+
+
+@pytest.mark.parametrize("radiant_name", ["CDOTADataRadiant", "CDOTA_DataRadiant"])
+@pytest.mark.parametrize("dire_name", ["CDOTADataDire", "CDOTA_DataDire"])
+def test_later_tick_boundaries_read_latest_complete_team_values(radiant_name, dire_name):
+    from gem.extractors.intervals import IntervalSnapshot
+
+    ext = IntervalExtractor()
+    parser = TickStartFakeParser(tick=0, game_time_s=0)
+    ext.attach(parser)
+    radiant, dire = _radiant_data(), _dire_data()
+    radiant.cls.name, dire.cls.name = radiant_name, dire_name
+    ext._on_entity(_player_resource(), EntityOp.UPDATED)
+    ext._on_entity(radiant, EntityOp.CREATED)
+    ext._on_entity(dire, EntityOp.CREATED)
+    parser.fire_tick_start(0)
+    parser.tick = 1800
+    parser.game_time_s = 60
+    parser.fire_tick_start(1800)
+    radiant._state.update(_radiant_data_with(1200, 900, 24, 4, 1800)._state)
+    ext._on_entity(radiant, EntityOp.UPDATED)
+    radiant._state.update(_radiant_data_with(1500, 1100, 30, 5, 2200)._state)
+    ext._on_entity(radiant, EntityOp.UPDATED)
+    parser.fire_tick_start(1800)
+    assert len(ext.snapshots) == 2
+    parser.tick = 1801
+    parser.fire_tick_start(1801)
+    assert ext.snapshots[2:] == [
+        IntervalSnapshot(1801, 60, 0, 1, 2, 1, gold=1500, xp=1100, lh=30, dn=5, net_worth=2200),
+        IntervalSnapshot(1801, 60, 1, 132, 3, 4, gold=600, xp=450, lh=16, dn=1, net_worth=1200),
+    ]
+    # The subsequent tick's deltas must not change the already emitted batch.
+    radiant._state["m_vecDataTeam.0001.m_iTotalEarnedGold"] = 9999
+    ext._on_entity(radiant, EntityOp.UPDATED)
+    parser.fire_tick_start(1801)
+    assert len(ext.snapshots) == 4
+    assert ext.snapshots[2].gold == 1500
+    ext._on_entity(radiant, EntityOp.DELETED)
+    replacement = _radiant_data_with(2000, 1700, 35, 6, 2700)
+    replacement.serial = 1
+    ext._on_entity(replacement, EntityOp.CREATED_ENTERED)
+    ext._on_entity(replacement, EntityOp.UPDATED_ENTERED)
+    parser.tick = 3600
+    parser.game_time_s = 120
+    parser.fire_tick_start(3600)
+    parser.tick = 3601
+    parser.fire_tick_start(3601)
+    assert ext.snapshots[4] == IntervalSnapshot(
+        3601, 120, 0, 1, 2, 1, gold=2000, xp=1700, lh=35, dn=6, net_worth=2700
+    )
+
+
+@pytest.mark.parametrize("invalid", [None, "missing", 1.5])
+@pytest.mark.parametrize("tick_driven", [False, True])
+def test_counter_last_valid_history_survives_frame_optimization(invalid, tick_driven):
+    ext = IntervalExtractor()
+    parser = (TickStartFakeParser if tick_driven else FakeParser)(tick=0, game_time_s=0)
+    ext.attach(parser)
+    ext._on_entity(_player_resource(), EntityOp.UPDATED)
+    radiant, dire = _radiant_data(), _dire_data()
+    key = "m_vecDataTeam.0001.m_iCampsStacked"
+    radiant._state[key] = 9
+    ext._on_entity(radiant, EntityOp.UPDATED)
+    ext._on_entity(dire, EntityOp.UPDATED)
+    if tick_driven:
+        parser.fire_tick_start(0)
+    assert ext.snapshots
+    radiant._state[key] = invalid
+    ext._on_entity(radiant, EntityOp.UPDATED)
+    assert ext.team_counters(0)["camps_stacked"] == 9
+    radiant._state.pop(key)
+    ext._on_entity(radiant, EntityOp.UPDATED)
+    ext._on_entity(radiant, EntityOp.DELETED)
+    assert ext.team_counters(0)["camps_stacked"] == 9
+    replacement = _radiant_data()
+    ext._on_entity(replacement, EntityOp.CREATED)
+    assert ext.team_counters(0)["camps_stacked"] == 9
+    ext._on_game_end(parser.tick)
+    replacement._state[key] = 0
+    ext._on_entity(replacement, EntityOp.UPDATED)
+    assert ext.team_counters(0)["camps_stacked"] == 0
+
+
+@pytest.mark.parametrize(
+    "end_time,expected_times", [(59, [0]), (60, [0, 60]), (75, [0, 60]), (76, [0])]
+)
+def test_tick_driven_terminal_recovery_uses_final_live_values(end_time, expected_times):
+    from gem.parser import ReplayParser
+
+    ext = IntervalExtractor()
+    parser = ReplayParser(b"")
+    ext.attach(parser)
+    radiant = _radiant_data()
+    ext._on_entity(_player_resource(), EntityOp.UPDATED)
+    ext._on_entity(radiant, EntityOp.UPDATED)
+    ext._on_entity(_dire_data(), EntityOp.UPDATED)
+    parser.game_time_s = 0
+    ext._on_tick_start(0)
+    parser.tick = 1800
+    parser.combat_log_time_s = end_time
+    # Game end is deferred until all packet entity deltas have been applied.
+    parser._pending_game_end_tick = parser.tick
+    radiant._state.update(_radiant_data_with(5000, 4000, 80, 7, 7000)._state)
+    ext._on_entity(radiant, EntityOp.UPDATED)
+    parser._flush_game_end()
+    parser._flush_game_end()
+    assert sorted({snap.time_s for snap in ext.snapshots}) == expected_times
+    if len(expected_times) == 2:
+        from gem.extractors.intervals import IntervalSnapshot
+
+        assert ext.snapshots[2] == IntervalSnapshot(
+            1800, 60, 0, 1, 2, 1, gold=5000, xp=4000, lh=80, dn=7, net_worth=7000
+        )
+    parser.game_time_s = 120
+    ext._on_tick_start(3600)
+    ext._on_tick_start(3601)
+    assert sorted({snap.time_s for snap in ext.snapshots}) == expected_times
+
+
+@pytest.mark.parametrize("sample_before_truncation", [False, True])
+def test_truncated_tick_driven_stream_retains_initial_or_completed_state(
+    monkeypatch, sample_before_truncation
+):
+    from contextlib import nullcontext
+
+    from gem.parser import ReplayParser
+
+    ext = IntervalExtractor()
+    parser = ReplayParser(b"")
+    ext.attach(parser)
+    ext._on_entity(_player_resource(), EntityOp.UPDATED)
+    ext._on_entity(_radiant_data(), EntityOp.UPDATED)
+    ext._on_entity(_dire_data(), EntityOp.UPDATED)
+
+    def stream():
+        yield 0, 0, b""
+        raise EOFError("truncated interval test")
+
+    def update(_kind, _data):
+        if sample_before_truncation:
+            parser.game_time_s = 0
+            ext._on_tick_start(0)
+
+    monkeypatch.setattr("gem.parser.DemoStream", lambda _source: nullcontext(stream()))
+    monkeypatch.setattr(parser, "_dispatch_outer", update)
+    parser.parse()
+    assert isinstance(parser.parse_error, EOFError)
+    assert len(ext.snapshots) == (2 if sample_before_truncation else 0)
+    assert bool(ext._cur_data_radiant) is not sample_before_truncation


### PR DESCRIPTION
## Summary

Read live team values at tick-driven sampling boundaries after the initial successful interval batch, instead of copying five values for every slot on every team-data update. Retain initial frame history for minute-zero previous-frame selection and delayed initialization; clear that history only after the first batch is built. Parsers without tick-start callbacks keep their existing two-frame algorithm throughout parsing.

Closes #165.

### Approved scope adjustment

Terminal-counter capture is deliberately unchanged. It retains the last valid value per field even after missing/wrong-type updates, deletion, or entity replacement; reading only final entity state cannot reproduce that history. Safe counter-read elimination needs additional historical change tracking and is deferred. This PR therefore eliminates **post-initial tick-driven interval-frame copies**, not every per-update team-data read. Initialization history also remains intentional.

No new lifecycle flags, callbacks, public signatures/types, finalization APIs, dependencies, or test tiers. Player/hero mapping, existing field-access plans, one-tick regular-boundary deferral, and the terminal grace window remain unchanged. Counter capture continues after game end.

## References and regression coverage

Inspected Manta entity update application, Clarity `AbstractFileRunner` tick-start dispatch and entity notifications, and OpenDota `Parse.java` interval/counter fields. Gem's existing previous-frame minute zero and last-valid counter history remain the compatibility oracle.

Regression tests preserve existing assertions and cover delayed initialization, missing clocks/resources, first samples at zero/nonzero boundaries, mode-specific history retention/clearing, complete snapshot values, repeated network ticks, multiple same-tick deltas, class aliases, deletion/replacement/re-entry, final packet deltas, grace-window endpoints, duplicate suppression, truncated streams, and counter history through invalid/missing values and post-game updates. Existing tests retain coach-aware mappings, missing-team handling, minute-zero bounty exclusion, and nonzero pre-horn earnings.

Independent static review found no correctness defects; stale history comments identified during review were updated.

## Validation

All commands used the same existing uv-managed CPython 3.10.4 environment; direct module invocations avoid changing dependencies.

| Command | Result |
|---|---|
| `.venv/bin/python -m pytest tests/test_intervals_extractor.py tests/test_intervals_axis_integration.py tests/test_match_builder.py tests/test_parser.py tests/test_ml_running_totals.py -q` | 281 passed, 5 deselected; 0.62 s |
| `.venv/bin/python -m pytest -q -rs` | 3,796 passed, 3 skipped, 62 deselected; 7.09 s |
| `.venv/bin/python -m pytest -q -rs -m "not network"` | 3,857 passed, 3 skipped, 1 deselected; 330.58 s |
| `.venv/bin/python -m ruff check src/ tests/` | Passed |
| `.venv/bin/python -m ruff format --check src/ tests/` | Passed |
| `.venv/bin/python -m mypy src/gem/` | Passed |
| Pre-commit | Ruff, format, conflict check, mypy passed; YAML/TOML hooks had no applicable files |

Pytest skips: optional pyarrow (`test_bulk.py`), optional Parquet engine (`test_parquet_export.py`), and an existing optimized-away field-decoder flag case (`test_field_decoder.py`). The offline deselection is live network integration. No required fixture is missing; no live downloads are needed.

CI passed on `91bcb4ec21171d22416edaf9885974b49713e31f`: [CI](https://github.com/whanyu1212/gem-dota/actions/runs/34038444224/job/101500700784), [distribution build](https://github.com/whanyu1212/gem-dota/actions/runs/34038444223/job/101500700789). PyPI publishing is intentionally skipped for PRs. Independent review of the instrumentation and benchmark scripts found no actionable issues.

Across the eight decoded streams, post-initial frame captures fall from 701,635 to zero, eliminating 17,540,875 typed frame-read calls. Initial capture counts remain 6,963 in both variants; the candidate performs 21,550 boundary field reads instead. All 708,598 counter captures remain unchanged. Complete interval snapshots, all ten player series, and terminal counter histories/results match for every replay.

## Performance interpretation

The planned long-replay block measured median elapsed/user CPU changes of -2.1%/-2.1%, with median peak RSS -1.3%. The initial short-replay block measured +12.1% elapsed/+11.3% CPU and +1.5% median RSS, with CPU pair changes of +21.7%, +16.9%, and -2.5%. These mixed directions required investigation rather than an improvement claim.

A fixed additional short-replay block, ordered C/B, B/C, C/B and retained separately below, did not reproduce the increase: median elapsed/CPU changed -1.6%/-1.4%; CPU was lower in all three candidate pairs (-2.0%, -1.4%, -2.6%). Median RSS was 217.391 versus 217.469 MiB (+0.04%). Host load and both variants' CPU times varied substantially over the session. Load averages alone do not identify the cause; the repeated block establishes that the initial increase was not systematic across these measurements. No core control was needed after the fixed follow-up showed no consistent CPU or memory regression.

Acceptance evidence is unchanged output and counter history, passing required validation, and verified elimination of post-initial frame copies. The measurements support a modest improvement in the later short block and the long-block medians, but are not a stable estimate of end-to-end speedup. Both blocks and every run are retained below. No profiler timings are used as performance evidence.

## Measurements

CPython 3.10.4, macOS 26.6.2 arm64, Apple M2, 16 GiB RAM; same virtual environment and local fixtures. The planned timing block uses sequential fresh processes in B/C, C/B, B/C order; the fixed follow-up block is reported separately. Imports, including lazy API modules, precede timing; serialization/hash follow elapsed/user CPU and peak-RSS capture. No tests, instrumentation, or coverage run concurrently with timed parses. First baseline precedes implementation; the remaining timing runs follow correctness checks. B is main `4d0835ab1ef1217a07c582f0dfb4a30c057c081f`; C is this PR. RSS is the process high-water mark.

| Replay | Variant | Elapsed s (3 runs) | User CPU s (3 runs) | RSS MiB (3 runs) | Median elapsed / CPU / RSS |
|---|---|---|---|---|---|
|8822520406|B|52.998, 58.629, 63.598|52.140, 57.044, 61.311|203.484, 197.766, 202.453|58.629 / 57.044 / 202.453|
|8822520406|C|65.739, 70.692, 61.161|63.466, 66.691, 59.779|208.938, 205.562, 198.594|65.739 / 63.466 / 205.562|
|8856501050|B|190.932, 180.639, 174.162|186.988, 177.075, 171.600|621.734, 632.781, 636.703|180.639 / 177.075 / 632.781|
|8856501050|C|176.859, 184.276, 175.597|173.406, 180.632, 172.714|610.406, 632.844, 624.312|176.859 / 173.406 / 624.312|

### Host load (1/5/15-minute averages)

- `public-8822520406-0-B`: start [3.17822265625, 2.48876953125, 2.28369140625]; end [3.28759765625, 2.658203125, 2.35791015625].
- `public-8822520406-0-C`: start [3.49853515625, 5.09716796875, 4.4306640625]; end [4.95703125, 5.21923828125, 4.52587890625].
- `public-8822520406-1-B`: start [5.27001953125, 5.48681640625, 4.7021484375]; end [5.1181640625, 5.39208984375, 4.71337890625].
- `public-8822520406-1-C`: start [5.20068359375, 5.26513671875, 4.5458984375]; end [5.55517578125, 5.5458984375, 4.71826171875].
- `public-8822520406-2-B`: start [4.7880859375, 5.31884765625, 4.69140625]; end [5.23828125, 5.4111328125, 4.77099609375].
- `public-8822520406-2-C`: start [5.298828125, 5.4208984375, 4.77783203125]; end [10.14404296875, 6.97412109375, 5.41259765625].
- `public-8856501050-0-B`: start [9.73193359375, 6.94091796875, 5.41015625]; end [6.04345703125, 7.06884765625, 5.8330078125].
- `public-8856501050-0-C`: start [5.6484375, 6.95068359375, 5.8056640625]; end [5.1455078125, 5.65576171875, 5.439453125].
- `public-8856501050-1-B`: start [3.75634765625, 4.99462890625, 5.21728515625]; end [4.01025390625, 4.65966796875, 5.03369140625].
- `public-8856501050-1-C`: start [5.1162109375, 5.63330078125, 5.43359375]; end [3.9892578125, 5.080078125, 5.24951171875].
- `public-8856501050-2-B`: start [4.2421875, 4.68701171875, 5.03857421875]; end [3.62646484375, 4.29931640625, 4.8193359375].
- `public-8856501050-2-C`: start [3.52978515625, 4.255859375, 4.7978515625]; end [3.27880859375, 3.90576171875, 4.552734375].

### Public output hashes

- `8822520406`: `3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427`; all seven baseline/candidate/instrumented files are byte-identical (30,401,205 bytes each).
- `8856501050`: `1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e`; all seven baseline/candidate/instrumented files are byte-identical (187,363,261 bytes each).

### Corpus instrumentation

Original and candidate extractors observe the same decoded streams in separate instrumentation processes. The two benchmark fixtures use public parsing; the other six attach only the paired interval extractors to core parsing. Every parse completes without parse_error. Complete snapshots, all ten player series, internal counter histories, and returned counters match. Typed field reads count calls to Entity._get_int32_resolved beneath frame capture, boundary reads, or counter capture; these are operation counts, not timing evidence.

| Replay | Snapshots | Frame captures B before/after | Frame captures C before/after | Counter captures B = C | Boundary typed reads B / C |
|---|---|---|---|---|---|
|8821954344|970|740/145073|740/0|145813|0 / 4800|
|8822520406|240|700/44861|700/0|45561|0 / 1150|
|8822593932|440|601/71491|601/0|72092|0 / 2150|
|8855188139|410|872/68986|872/0|69858|0 / 2000|
|8855242704|690|1750/103904|1750/0|105654|0 / 3400|
|8856501050|930|486/140774|486/0|141260|0 / 4600|
|8860187335|510|651/93358|651/0|94009|0 / 2500|
|8868259993|200|1163/33188|1163/0|34351|0 / 950|

<details><summary>All instrumentation counts and snapshot hashes</summary>

- `8821954344`: `{"baseline": {"boundary_calls": 970, "counters_calls": 145813, "counters_field_reads": 4374390, "frames_after_calls": 145073, "frames_after_field_reads": 3626825, "frames_before_calls": 740, "frames_before_field_reads": 18500}, "candidate": {"boundary_calls": 970, "boundary_field_reads": 4800, "counters_calls": 145813, "counters_field_reads": 4374390, "frames_before_calls": 740, "frames_before_field_reads": 18500}, "replay": "/Users/hanyuwu/Study/gem/tests/fixtures/opendota/8821954344.dem", "snapshot_sha256": "15946111830e1aaf657e046f75483c2e9d6f931c2d337d3d33c7ac1d5115a1dd", "snapshots": 970}`.
- `8822520406`: `{"baseline": {"boundary_calls": 240, "counters_calls": 45561, "counters_field_reads": 1366830, "frames_after_calls": 44861, "frames_after_field_reads": 1121525, "frames_before_calls": 700, "frames_before_field_reads": 17500}, "candidate": {"boundary_calls": 240, "boundary_field_reads": 1150, "counters_calls": 45561, "counters_field_reads": 1366830, "frames_before_calls": 700, "frames_before_field_reads": 17500}, "replay": "/Users/hanyuwu/Study/gem/tests/fixtures/opendota/8822520406.dem", "sha256": "3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427", "snapshot_sha256": "32727d9289dbade3946f161fae534bf15a96346b402e1fad9362fa32d53038f3", "snapshots": 240}`.
- `8822593932`: `{"baseline": {"boundary_calls": 440, "counters_calls": 72092, "counters_field_reads": 2162760, "frames_after_calls": 71491, "frames_after_field_reads": 1787275, "frames_before_calls": 601, "frames_before_field_reads": 15025}, "candidate": {"boundary_calls": 440, "boundary_field_reads": 2150, "counters_calls": 72092, "counters_field_reads": 2162760, "frames_before_calls": 601, "frames_before_field_reads": 15025}, "replay": "/Users/hanyuwu/Study/gem/tests/fixtures/opendota/8822593932.dem", "snapshot_sha256": "aebaa9dbcd7e69bef7e2750e556b4e6187d5ddf7b17465d9725b58a994f9c290", "snapshots": 440}`.
- `8855188139`: `{"baseline": {"boundary_calls": 410, "counters_calls": 69858, "counters_field_reads": 2095740, "frames_after_calls": 68986, "frames_after_field_reads": 1724650, "frames_before_calls": 872, "frames_before_field_reads": 21800}, "candidate": {"boundary_calls": 410, "boundary_field_reads": 2000, "counters_calls": 69858, "counters_field_reads": 2095740, "frames_before_calls": 872, "frames_before_field_reads": 21800}, "replay": "/Users/hanyuwu/Study/gem/tests/fixtures/opendota/8855188139.dem", "snapshot_sha256": "3e235e827a93d8dade28dc5699270b6b6299c1c3c525a267bcaf9ac46ae88f8c", "snapshots": 410}`.
- `8855242704`: `{"baseline": {"boundary_calls": 690, "counters_calls": 105654, "counters_field_reads": 3169620, "frames_after_calls": 103904, "frames_after_field_reads": 2597600, "frames_before_calls": 1750, "frames_before_field_reads": 43750}, "candidate": {"boundary_calls": 690, "boundary_field_reads": 3400, "counters_calls": 105654, "counters_field_reads": 3169620, "frames_before_calls": 1750, "frames_before_field_reads": 43750}, "replay": "/Users/hanyuwu/Study/gem/tests/fixtures/opendota/8855242704.dem", "snapshot_sha256": "893820cce3f2ce05a88813ac8161adbff814850e9be0c0d16870250c6918be50", "snapshots": 690}`.
- `8856501050`: `{"baseline": {"boundary_calls": 930, "counters_calls": 141260, "counters_field_reads": 4237800, "frames_after_calls": 140774, "frames_after_field_reads": 3519350, "frames_before_calls": 486, "frames_before_field_reads": 12150}, "candidate": {"boundary_calls": 930, "boundary_field_reads": 4600, "counters_calls": 141260, "counters_field_reads": 4237800, "frames_before_calls": 486, "frames_before_field_reads": 12150}, "replay": "/Users/hanyuwu/Study/gem/tests/fixtures/opendota/8856501050.dem", "sha256": "1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e", "snapshot_sha256": "8b5c53af8e47c7911ef36821348c9eff03b5d4e81a4124e39b056cb0ce3a4679", "snapshots": 930}`.
- `8860187335`: `{"baseline": {"boundary_calls": 510, "counters_calls": 94009, "counters_field_reads": 2820270, "frames_after_calls": 93358, "frames_after_field_reads": 2333950, "frames_before_calls": 651, "frames_before_field_reads": 16275}, "candidate": {"boundary_calls": 510, "boundary_field_reads": 2500, "counters_calls": 94009, "counters_field_reads": 2820270, "frames_before_calls": 651, "frames_before_field_reads": 16275}, "replay": "/Users/hanyuwu/Study/gem/tests/fixtures/opendota/8860187335.dem", "snapshot_sha256": "73f5506623229adebf27d4f2f152166dea11d83da61124d0682a591348f505b4", "snapshots": 510}`.
- `8868259993`: `{"baseline": {"boundary_calls": 200, "counters_calls": 34351, "counters_field_reads": 1030530, "frames_after_calls": 33188, "frames_after_field_reads": 829700, "frames_before_calls": 1163, "frames_before_field_reads": 29075}, "candidate": {"boundary_calls": 200, "boundary_field_reads": 950, "counters_calls": 34351, "counters_field_reads": 1030530, "frames_before_calls": 1163, "frames_before_field_reads": 29075}, "replay": "/Users/hanyuwu/Study/gem/tests/fixtures/opendota/8868259993.dem", "snapshot_sha256": "7208a015c1662071a703b0eb44a564ec70f85fa5b8e0cca9318a9c2d2d69fe53", "snapshots": 200}`.

</details>

### Full offline OpenDota parity

- `8868259993`: 325 PASS, 0 WARN, 0 FAIL. Skips: [{"name": "teamfights/total_count", "note": "OpenDota applies deaths>=3 filtering over its expanded event pipeline. Count comparison is informational only."}].
- `8860187335`: 326 PASS, 0 WARN, 0 FAIL. Skips: [{"name": "teamfights/total_count", "note": "OpenDota applies deaths>=3 filtering over its expanded event pipeline. Count comparison is informational only."}].
- `8856501050`: 331 PASS, 0 WARN, 0 FAIL. Skips: [{"name": "teamfights/total_count", "note": "OpenDota applies deaths>=3 filtering over its expanded event pipeline. Count comparison is informational only."}].

## Fixed short-replay follow-up

The initial short-replay block showed a +11.3% median CPU increase with mixed pair directions. Before this follow-up, we fixed three additional fresh-process pairs in C/B, B/C, C/B order; no runs were discarded. These use the same benchmark script and environment after the original schedule completed. Results are reported separately rather than replacing the first block.

| Variant | Elapsed s | User CPU s | RSS MiB | Median elapsed / CPU / RSS |
|---|---|---|---|---|
|B|53.441, 53.180, 52.646|53.159, 52.749, 52.204|217.391, 213.594, 217.469|53.180 / 52.749 / 217.391|
|C|52.753, 52.345, 51.115|52.083, 52.016, 50.850|217.469, 217.688, 217.266|52.345 / 52.016 / 217.469|

All six follow-up outputs also match the original short-replay public JSON byte-for-byte.

- `followup-short-0-B`: load start [3.23681640625, 3.7470703125, 4.43896484375]; end [3.0166015625, 3.59033203125, 4.33447265625].
- `followup-short-0-C`: load start [3.13037109375, 3.84423828125, 4.51904296875]; end [3.23681640625, 3.7470703125, 4.43896484375].
- `followup-short-1-B`: load start [3.0166015625, 3.59033203125, 4.33447265625]; end [3.2744140625, 3.576171875, 4.2822265625].
- `followup-short-1-C`: load start [3.2744140625, 3.576171875, 4.2822265625]; end [3.53759765625, 3.5859375, 4.23974609375].
- `followup-short-2-B`: load start [3.27197265625, 3.50048828125, 4.1650390625]; end [3.48583984375, 3.515625, 4.1318359375].
- `followup-short-2-C`: load start [3.53759765625, 3.5859375, 4.23974609375]; end [3.3828125, 3.52587890625, 4.17822265625].

## Exact reproduction

Use the same uv-managed environment and local fixtures, from the candidate checkout. Adjust the hard-coded checkout/temp paths if reproducing elsewhere. Start with a fresh temporary directory; the timing driver skips existing result files.

```bash
mkdir -p /private/tmp/gem-165/baseline
git archive 4d0835ab1ef1217a07c582f0dfb4a30c057c081f | tar -x -C /private/tmp/gem-165/baseline
# Save the scripts below in /private/tmp/gem-165/.
PYTHONHASHSEED=0 .venv/bin/python /private/tmp/gem-165/bench.py /private/tmp/gem-165/baseline tests/fixtures/opendota/8822520406.dem /private/tmp/gem-165/public-8822520406-0-B.json
# In the original run, implementation followed this baseline.
.venv/bin/python -m pytest tests/test_intervals_extractor.py tests/test_intervals_axis_integration.py tests/test_match_builder.py tests/test_parser.py tests/test_ml_running_totals.py -q
.venv/bin/python /private/tmp/gem-165/checks.py
.venv/bin/python /private/tmp/gem-165/corpus.py
PYTHONHASHSEED=0 .venv/bin/python /private/tmp/gem-165/parity.py
.venv/bin/python /private/tmp/gem-165/replays.py
.venv/bin/python /private/tmp/gem-165/report.py
# Fixed follow-up to investigate the mixed initial short-replay measurements:
.venv/bin/python /private/tmp/gem-165/followup.py
.venv/bin/python /private/tmp/gem-165/followup_report.py
```

The original run overlapped checks/corpus instrumentation, then parity/corpus instrumentation. These are untimed correctness checks. All completed before the remaining replay timings. The commands above serialize those checks for convenience. Parity receives existing OpenDota JSON explicitly and performs no downloads. The two instrumented public outputs and all timed outputs are compared byte-for-byte in report.py. No instrumentation timings are used for speed claims.

<details><summary>bench.py</summary>

```python
import argparse,gc,hashlib,json,os,platform,resource,sys,time
from pathlib import Path
p=argparse.ArgumentParser();p.add_argument('source');p.add_argument('replay');p.add_argument('out');a=p.parse_args()
sys.path.insert(0,str(Path(a.source)/'src'))
import gem
import gem.extractors.intervals
import gem.extractors.smoke_vision
meta=dict(python=sys.version,platform=platform.platform(),source=gem.__file__,load_start=os.getloadavg())
gc.collect();cpu=resource.getrusage(resource.RUSAGE_SELF).ru_utime;start=time.perf_counter()
result=gem.parse(a.replay)
elapsed=time.perf_counter()-start;usage=resource.getrusage(resource.RUSAGE_SELF)
r=dict(**meta,elapsed=elapsed,user=usage.ru_utime-cpu,rss_bytes=usage.ru_maxrss*(1 if sys.platform=='darwin' else 1024),load_end=os.getloadavg())
data=json.dumps(gem.to_dict(result),sort_keys=True,separators=(',',':')).encode();r['sha256']=hashlib.sha256(data).hexdigest()
Path(a.out+'.public.json').write_bytes(data);Path(a.out).write_text(json.dumps(r,indent=2));print(json.dumps(r),flush=True)

```

</details>

<details><summary>instrument.py</summary>

```python
import argparse,dataclasses,hashlib,importlib.util,json,sys
from pathlib import Path
p=argparse.ArgumentParser();p.add_argument('replay');p.add_argument('out');a=p.parse_args()
root=Path('/Users/hanyuwu/Study/gem');sys.path.insert(0,str(root/'src'))
import gem
import gem.extractors.intervals as intervals
from gem.parser import ReplayParser
from gem.state.entities import Entity
spec=importlib.util.spec_from_file_location('original_intervals','/private/tmp/gem-165/baseline/src/gem/extractors/intervals.py');original=importlib.util.module_from_spec(spec);sys.modules[spec.name]=original;spec.loader.exec_module(original)
active=None;instances=[];read=Entity._get_int32_resolved

def counted_read(entity,field):
    if active:
        instance,kind=active;instance.bump(kind+'_field_reads')
    return read(entity,field)
Entity._get_int32_resolved=counted_read
class Counts:
    def __init__(self,*args,**kwargs):
        super().__init__(*args,**kwargs);self.counts={};instances.append(self)
    def bump(self,key,n=1):self.counts[key]=self.counts.get(key,0)+n
    def counted(self,kind,method,*args,**kwargs):
        global active
        self.bump(kind+'_calls');previous=active;active=(self,kind)
        try:return method(*args,**kwargs)
        finally:active=previous
    def _record_team_data(self,*args):
        phase='before' if self._last_emitted_time_s is None else 'after'
        return self.counted('frames_'+phase,super()._record_team_data,*args)
    def _record_team_counters(self,*args):
        return self.counted('counters',super()._record_team_counters,*args)
    def _team_data_values(self,*args,**kwargs):
        return self.counted('boundary',super()._team_data_values,*args,**kwargs)
class Baseline(Counts,original.IntervalExtractor):pass
class Candidate(Counts,intervals.IntervalExtractor):
    def attach(self,parser):
        super().attach(parser);self.oracle=Baseline();self.oracle.attach(parser)
intervals.IntervalExtractor=Candidate
public=Path(a.replay).stem in ('8822520406','8856501050')
if public:
    result=gem.parse(a.replay);candidate=instances[0];parser=candidate._parser
else:
    parser=ReplayParser(a.replay);candidate=Candidate();candidate.attach(parser);parser.parse()
assert parser.parse_error is None,repr(parser.parse_error)
baseline=candidate.oracle
snaps=lambda e:[dataclasses.asdict(s) for s in e.snapshots]
assert snaps(candidate)==snaps(baseline),'snapshot mismatch'
assert candidate._team_counters==baseline._team_counters,'counter history mismatch'
for pid in range(10):
    assert dataclasses.asdict(candidate.series(pid))==dataclasses.asdict(baseline.series(pid))
    assert candidate.team_counters(pid)==baseline.team_counters(pid)
assert candidate.counts.get('frames_after_calls',0)==0
for key in ('frames_before_calls','frames_before_field_reads','counters_calls','counters_field_reads','boundary_calls'):
    assert candidate.counts.get(key,0)==baseline.counts.get(key,0),(key,candidate.counts,baseline.counts)
r=dict(replay=a.replay,candidate=candidate.counts,baseline=baseline.counts,snapshots=len(candidate.snapshots),snapshot_sha256=hashlib.sha256(json.dumps(snaps(candidate),sort_keys=True).encode()).hexdigest())
if public:
    data=json.dumps(gem.to_dict(result),sort_keys=True,separators=(',',':')).encode();r['sha256']=hashlib.sha256(data).hexdigest();Path(a.out+'.public.json').write_bytes(data)
Path(a.out).write_text(json.dumps(r,indent=2));print(json.dumps(r),flush=True)

```

</details>

<details><summary>checks.py</summary>

```python
import os,subprocess,sys
from pathlib import Path
root=Path('/Users/hanyuwu/Study/gem');p=Path('/private/tmp/gem-165');env={**os.environ,'PYTHONHASHSEED':'0'}
checks={'lint':['ruff','check','src/','tests/'],'format':['ruff','format','--check','src/','tests/'],'mypy':['mypy','src/gem/'],'fast':['pytest','-q','-rs'],'offline':['pytest','-q','-rs','-m','not network']}
for name,args in checks.items():
    print('START',name,flush=True)
    with (p/f'{name}.log').open('w') as f:subprocess.run([sys.executable,'-m',*args],cwd=root,env=env,stdout=f,stderr=subprocess.STDOUT,check=True)

```

</details>

<details><summary>corpus.py</summary>

```python
import os,subprocess,sys
from pathlib import Path
root=Path('/Users/hanyuwu/Study/gem');p=Path('/private/tmp/gem-165');env={**os.environ,'PYTHONHASHSEED':'0'}
for replay in sorted((root/'tests/fixtures/opendota').glob('*.dem')):
    print('START',replay.stem,flush=True)
    subprocess.run([sys.executable,str(p/'instrument.py'),str(replay),str(p/f'instrument-{replay.stem}.json')],env=env,cwd=root,check=True)

```

</details>

<details><summary>parity.py</summary>

```python
import json,sys
from pathlib import Path
root=Path('/Users/hanyuwu/Study/gem');sys.path[:0]=[str(root),str(root/'src')]
from scripts.validate_opendota import validate_match
rows=[]
for mid in (8868259993,8860187335,8856501050):
    f=root/f'tests/fixtures/opendota/{mid}.dem'
    r=validate_match(mid,f,od=json.loads(f.with_suffix('.opendota.json').read_text()),mode='full')
    row=dict(match=mid,passed=r.passed,warned=r.warned,failed=r.failed,errors=r.errors,skips=[dict(name=x.name,note=x.note) for x in r.all_fields if x.skip]);rows.append(row);print(json.dumps(row),flush=True)
    assert not r.errors and r.failed==0
Path('/private/tmp/gem-165/parity.json').write_text(json.dumps(rows,indent=2))

```

</details>

<details><summary>replays.py</summary>

```python
import os,subprocess,sys
from pathlib import Path
root=Path('/Users/hanyuwu/Study/gem');p=Path('/private/tmp/gem-165');env={**os.environ,'PYTHONHASHSEED':'0'}
for replay in ('8822520406','8856501050'):
 for block,order in enumerate(('BC','CB','BC')):
  for v in order:
   dest=p/f'public-{replay}-{block}-{v}.json'
   if dest.exists():continue
   print('START',dest.name,flush=True)
   subprocess.run([sys.executable,str(p/'bench.py'),str(p/'baseline' if v=='B' else root),str(root/f'tests/fixtures/opendota/{replay}.dem'),str(dest)],cwd=root,env=env,check=True)
print('TIMING COMPLETE',flush=True)

```

</details>

<details><summary>report.py</summary>

```python
import hashlib,json,statistics
from pathlib import Path
p=Path('/private/tmp/gem-165');lines=[]
def add(s=''):lines.append(s)
add('## Measurements\n')
add('CPython 3.10.4, macOS 26.6.2 arm64, Apple M2, 16 GiB RAM; same virtual environment and local fixtures. The planned timing block uses sequential fresh processes in B/C, C/B, B/C order; the fixed follow-up block is reported separately. Imports, including lazy API modules, precede timing; serialization/hash follow elapsed/user CPU and peak-RSS capture. No tests, instrumentation, or coverage run concurrently with timed parses. First baseline precedes implementation; the remaining timing runs follow correctness checks. B is main `4d0835ab1ef1217a07c582f0dfb4a30c057c081f`; C is this PR. RSS is the process high-water mark.\n')
add('| Replay | Variant | Elapsed s (3 runs) | User CPU s (3 runs) | RSS MiB (3 runs) | Median elapsed / CPU / RSS |')
add('|---|---|---|---|---|---|')
medians={}
for replay in ('8822520406','8856501050'):
 medians[replay]={}
 for v in 'BC':
  rows=[json.loads((p/f'public-{replay}-{i}-{v}.json').read_text()) for i in range(3)]
  vals=[[r[k]/(2**20 if k=='rss_bytes' else 1) for r in rows] for k in ('elapsed','user','rss_bytes')]
  medians[replay][v]=[statistics.median(xs) for xs in vals]
  add('|'+ '|'.join([replay,v,*[', '.join(f'{x:.3f}' for x in xs) for xs in vals], ' / '.join(f'{statistics.median(xs):.3f}' for xs in vals)])+'|')
add('\n### Host load (1/5/15-minute averages)\n')
for f in sorted(p.glob('public-*.json')):
 if f.name.endswith('.public.json'):continue
 r=json.loads(f.read_text());add(f"- `{f.stem}`: start {r['load_start']}; end {r['load_end']}.")
add('\n### Public output hashes\n')
for replay in ('8822520406','8856501050'):
 files=list(p.glob(f'*{replay}*.json.public.json'));reference=files[0].read_bytes()
 assert len(files)==7 and all(f.read_bytes()==reference for f in files)
 add(f'- `{replay}`: `{hashlib.sha256(reference).hexdigest()}`; all seven baseline/candidate/instrumented files are byte-identical ({len(reference):,} bytes each).')
add('\n### Corpus instrumentation\n')
add('Original and candidate extractors observe the same decoded streams in separate instrumentation processes. The two benchmark fixtures use public parsing; the other six attach only the paired interval extractors to core parsing. Every parse completes without parse_error. Complete snapshots, all ten player series, internal counter histories, and returned counters match. Typed field reads count calls to Entity._get_int32_resolved beneath frame capture, boundary reads, or counter capture; these are operation counts, not timing evidence.\n')
add('| Replay | Snapshots | Frame captures B before/after | Frame captures C before/after | Counter captures B = C | Boundary typed reads B / C |')
add('|---|---|---|---|---|---|')
files=[f for f in sorted(p.glob('instrument-*.json')) if not f.name.endswith('.public.json')];assert len(files)==8
for f in files:
 r=json.loads(f.read_text());b=r['baseline'];c=r['candidate'];assert c.get('frames_after_calls',0)==0
 add(f"|{Path(r['replay']).stem}|{r['snapshots']}|{b.get('frames_before_calls',0)}/{b.get('frames_after_calls',0)}|{c.get('frames_before_calls',0)}/{c.get('frames_after_calls',0)}|{b['counters_calls']}|{b.get('boundary_field_reads',0)} / {c.get('boundary_field_reads',0)}|")
add('\n<details><summary>All instrumentation counts and snapshot hashes</summary>\n')
for f in files:
 r=json.loads(f.read_text());add(f"- `{Path(r['replay']).stem}`: `{json.dumps(r,sort_keys=True)}`.")
add('\n</details>\n')
add('### Full offline OpenDota parity\n')
for r in json.loads((p/'parity.json').read_text()):
 assert not r['errors'] and r['failed']==0
 add(f"- `{r['match']}`: {r['passed']} PASS, {r['warned']} WARN, {r['failed']} FAIL. Skips: {json.dumps(r['skips'])}.")
(p/'measurements.md').write_text('\n'.join(lines)+'\n');(p/'medians.json').write_text(json.dumps(medians,indent=2));print(json.dumps(medians,indent=2))

```

</details>

<details><summary>followup.py</summary>

```python
import os,subprocess,sys
from pathlib import Path
root=Path('/Users/hanyuwu/Study/gem');p=Path('/private/tmp/gem-165');env={**os.environ,'PYTHONHASHSEED':'0'}
for block,order in enumerate(('CB','BC','CB')):
 for v in order:
  dest=p/f'followup-short-{block}-{v}.json'
  print('START',dest.name,flush=True)
  subprocess.run([sys.executable,str(p/'bench.py'),str(p/'baseline' if v=='B' else root),str(root/'tests/fixtures/opendota/8822520406.dem'),str(dest)],cwd=root,env=env,check=True)
print('FOLLOWUP COMPLETE',flush=True)

```

</details>

<details><summary>followup_report.py</summary>

```python
import json,statistics
from pathlib import Path
p=Path('/private/tmp/gem-165');lines=['## Fixed short-replay follow-up','',
'The initial short-replay block showed a +11.3% median CPU increase with mixed pair directions. Before this follow-up, we fixed three additional fresh-process pairs in C/B, B/C, C/B order; no runs were discarded. These use the same benchmark script and environment after the original schedule completed. Results are reported separately rather than replacing the first block.','',
'| Variant | Elapsed s | User CPU s | RSS MiB | Median elapsed / CPU / RSS |','|---|---|---|---|---|']
medians={}
reference=(p/'public-8822520406-0-B.json.public.json').read_bytes()
for v in 'BC':
 rows=[json.loads((p/f'followup-short-{i}-{v}.json').read_text()) for i in range(3)]
 vals=[[r[k]/(2**20 if k=='rss_bytes' else 1) for r in rows] for k in ('elapsed','user','rss_bytes')]
 medians[v]=[statistics.median(xs) for xs in vals]
 lines.append('|'+ '|'.join([v,*[', '.join(f'{x:.3f}' for x in xs) for xs in vals], ' / '.join(f'{statistics.median(xs):.3f}' for xs in vals)])+'|')
 for i in range(3):assert (p/f'followup-short-{i}-{v}.json.public.json').read_bytes()==reference
lines+=['','All six follow-up outputs also match the original short-replay public JSON byte-for-byte.','']
for f in sorted(p.glob('followup-short-*.json')):
 if f.name.endswith('.public.json'):continue
 r=json.loads(f.read_text());lines.append(f"- `{f.stem}`: load start {r['load_start']}; end {r['load_end']}.")
(p/'followup-measurements.md').write_text('\n'.join(lines)+'\n');(p/'followup-medians.json').write_text(json.dumps(medians,indent=2));print(json.dumps(medians,indent=2))

```

</details>

<details><summary>Installed distributions</summary>

```text
Jinja2==3.1.6
Markdown==3.10.2
MarkupSafe==3.0.3
PyYAML==6.0.3
Pygments==2.19.2
appnope==0.1.4
asttokens==3.0.1
cfgv==3.5.0
comm==0.2.3
coverage==7.13.4
cramjam==2.11.0
debugpy==1.8.20
decorator==5.2.1
distlib==0.4.0
exceptiongroup==1.3.1
executing==2.2.1
filelock==3.25.0
gem-dota==0.7.1
identify==2.6.17
iniconfig==2.3.0
ipykernel==7.2.0
ipython==8.38.0
jedi==0.19.2
jupyter_client==8.8.0
jupyter_core==5.9.1
librt==0.8.1
markdown-it-py==4.0.0
matplotlib-inline==0.2.1
mdurl==0.1.2
mypy==1.19.1
mypy_extensions==1.1.0
narwhals==2.17.0
nest-asyncio==1.6.0
nodeenv==1.10.0
numpy==2.2.6
packaging==26.0
pandas==2.3.3
parso==0.8.6
pathspec==1.0.4
pexpect==4.9.0
pillow==12.1.1
platformdirs==4.9.4
plotly==6.6.0
pluggy==1.6.0
pre_commit==4.5.1
prompt_toolkit==3.0.52
protobuf==7.34.0
protoc-wheel-0==30.2
psutil==7.2.2
ptyprocess==0.7.0
pure_eval==0.2.3
pymdown-extensions==10.21
pytest-cov==7.0.0
pytest==9.0.2
python-dateutil==2.9.0.post0
python-discovery==1.1.1
python-snappy==0.7.3
pytz==2026.1.post1
pyzmq==27.1.0
rich==14.3.3
ruff==0.15.5
six==1.17.0
stack-data==0.6.3
tomli==2.4.0
tornado==6.5.5
traitlets==5.14.3
typing_extensions==4.15.0
tzdata==2025.3
virtualenv==21.1.0
wcwidth==0.6.0
zstandard==0.25.0
```

</details>

Temporary baseline source, scripts, logs, and replay outputs will be removed locally after this complete reproduction record is published and verified. No investigation artifacts are tracked.
