### PR TITLE
Specialize shallow FieldState paths and compact the Huffman table.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Lower field-decoding overhead.** Specialize shallow compact field-state paths
+  and store Huffman operation/count lookups in compact byte tables.
 - **Less interval-frame copying.** Read team values at sampling boundaries after
   the initial interval, preserving minute-zero history and terminal counters.
 - **Less draft polling.** Stop scanning draft slots after the game-start tick,

--- a/src/gem/schema/field_path/__init__.py
+++ b/src/gem/schema/field_path/__init__.py
@@ -2,14 +2,12 @@
 
 The implementation is split into models, operations, Huffman, and sequence
 modules, but callers should continue to import from ``gem.schema.field_path``.
-``__all__`` lists the stable public surface. The underscore-prefixed names
-re-exported below (``_HUFF_DECODE_TABLE``, ``_HUFF_TABLE_BITS``) are internal
-Huffman-table details shared with tests — importable by name, but not part of
-the public contract.
+``__all__`` lists the stable public surface. The underscore-prefixed name
+``_HUFF_TABLE_BITS`` re-exported below is an internal Huffman-table detail
+shared with tests — importable by name, but not part of the public contract.
 """
 
 from gem.schema.field_path.huffman import (
-    _HUFF_DECODE_TABLE as _HUFF_DECODE_TABLE,
     _HUFF_TABLE_BITS as _HUFF_TABLE_BITS,
     HUFF_TREE,
 )

--- a/src/gem/schema/field_path/huffman.py
+++ b/src/gem/schema/field_path/huffman.py
@@ -50,10 +50,10 @@ def _build_huffman_tree(weights: list[int]) -> _HNode:
     return heap[0][2]
 
 
-def _build_decode_table(root: _HNode, table_bits: int) -> list[tuple[int, int]]:
+def _build_decode_table(root: _HNode, table_bits: int) -> tuple[bytes, bytes]:
     """Build a flat O(1) decode table from the Huffman tree.
 
-    Each entry ``table[i] = (op_index, bits_consumed)`` covers all ``table_bits``-
+    Entries ``ops[i]`` and ``bits[i]`` cover all ``table_bits``-
     bit integers whose leading bits match the Huffman code for ``op_index``.
     Shorter codes fill multiple entries (one per possible suffix).
 
@@ -62,11 +62,12 @@ def _build_decode_table(root: _HNode, table_bits: int) -> list[tuple[int, int]]:
         table_bits: Width of the table in bits (``2**table_bits`` entries).
 
     Returns:
-        List of ``(op_index, bits_consumed)`` tuples, indexed by the
+        Parallel bytes of operation indices and consumed-bit counts, indexed by the
         ``table_bits``-bit integer peeked from the bit stream.
     """
     size = 1 << table_bits
-    table: list[tuple[int, int]] = [(0, 0)] * size
+    ops = bytearray(size)
+    bits = bytearray(size)
 
     stack: list[tuple[_HNode, int, int]] = [(root, 0, 0)]  # node, code, depth
     while stack:
@@ -74,14 +75,16 @@ def _build_decode_table(root: _HNode, table_bits: int) -> list[tuple[int, int]]:
         if node.is_leaf:
             suffix_count = 1 << (table_bits - depth)
             for s in range(suffix_count):
-                table[code | (s << depth)] = (node.value, depth)
+                index = code | (s << depth)
+                ops[index] = node.value
+                bits[index] = depth
         else:
             if node.left is not None:
                 stack.append((node.left, code, depth + 1))
             if node.right is not None:
                 stack.append((node.right, code | (1 << depth), depth + 1))
 
-    return table
+    return bytes(ops), bytes(bits)
 
 
 def _tree_depth(node: _HNode) -> int:
@@ -102,4 +105,4 @@ def _tree_depth(node: _HNode) -> int:
 
 HUFF_TREE: _HNode = _build_huffman_tree([op.weight for op in FIELD_PATH_OPS])
 _HUFF_TABLE_BITS: int = _tree_depth(HUFF_TREE)
-_HUFF_DECODE_TABLE: list[tuple[int, int]] = _build_decode_table(HUFF_TREE, _HUFF_TABLE_BITS)
+_HUFF_OPS, _HUFF_BITS = _build_decode_table(HUFF_TREE, _HUFF_TABLE_BITS)

--- a/src/gem/schema/field_path/path_sequence.py
+++ b/src/gem/schema/field_path/path_sequence.py
@@ -6,7 +6,8 @@ import struct
 from typing import TYPE_CHECKING
 
 from gem.schema.field_path.huffman import (
-    _HUFF_DECODE_TABLE,
+    _HUFF_BITS,
+    _HUFF_OPS,
     _HUFF_TABLE_BITS,
     HUFF_TREE,
 )
@@ -38,7 +39,8 @@ def _read_compact_field_paths(r: BitReader) -> list[CompactFieldPath]:
     fp = FieldPath()
     paths: list[CompactFieldPath] = []
     ops = FIELD_PATH_OPS
-    table = _HUFF_DECODE_TABLE
+    table_ops = _HUFF_OPS
+    table_consumed = _HUFF_BITS
     table_bits = _HUFF_TABLE_BITS
     mask = (1 << table_bits) - 1
 
@@ -63,7 +65,8 @@ def _read_compact_field_paths(r: BitReader) -> list[CompactFieldPath]:
                 else:
                     break
             bits = r._bit_val & mask
-            op_idx, consumed = table[bits]
+            op_idx = table_ops[bits]
+            consumed = table_consumed[bits]
             # Inline skip_bits(consumed).
             r._bit_val >>= consumed
             r._bit_count -= consumed

--- a/src/gem/schema/field_state.py
+++ b/src/gem/schema/field_state.py
@@ -66,6 +66,24 @@ class FieldState:
     def _get_compact(self, path: CompactFieldPath) -> FieldValue:
         """Read an internal compact path without materializing a FieldPath."""
         state = self._state
+        depth = len(path)
+        if depth == 1:
+            idx = path[0]
+            if len(state) < idx + 2:
+                return None
+            return state[idx]
+        if depth == 2:
+            idx = path[0]
+            if len(state) < idx + 2:
+                return None
+            child = state[idx]
+            if not isinstance(child, FieldState):
+                return None
+            state = child._state
+            idx = path[1]
+            if len(state) < idx + 2:
+                return None
+            return state[idx]
         last = len(path) - 1
         for i, idx in enumerate(path):
             if len(state) < idx + 2:
@@ -112,6 +130,32 @@ class FieldState:
     def _set_compact(self, path: CompactFieldPath, value: FieldValue) -> None:
         """Write an internal compact path without materializing a FieldPath."""
         state = self._state
+        depth = len(path)
+        if depth == 1:
+            idx = path[0]
+            current_len = len(state)
+            if current_len < idx + 2:
+                state.extend([None] * (max(idx + 2, current_len * 2) - current_len))
+            if not isinstance(state[idx], FieldState):
+                state[idx] = value
+            return
+        if depth == 2:
+            idx = path[0]
+            current_len = len(state)
+            if current_len < idx + 2:
+                state.extend([None] * (max(idx + 2, current_len * 2) - current_len))
+            current = state[idx]
+            if not isinstance(current, FieldState):
+                current = FieldState()
+                state[idx] = current
+            state = current._state
+            idx = path[1]
+            current_len = len(state)
+            if current_len < idx + 2:
+                state.extend([None] * (max(idx + 2, current_len * 2) - current_len))
+            if not isinstance(state[idx], FieldState):
+                state[idx] = value
+            return
         last = len(path) - 1
         for i, idx in enumerate(path):
             current_len = len(state)

--- a/src/gem/schema/field_state.py
+++ b/src/gem/schema/field_state.py
@@ -84,7 +84,7 @@ class FieldState:
             if len(state) < idx + 2:
                 return None
             return state[idx]
-        last = len(path) - 1
+        last = depth - 1
         for i, idx in enumerate(path):
             if len(state) < idx + 2:
                 return None
@@ -156,7 +156,7 @@ class FieldState:
             if not isinstance(state[idx], FieldState):
                 state[idx] = value
             return
-        last = len(path) - 1
+        last = depth - 1
         for i, idx in enumerate(path):
             current_len = len(state)
             if current_len < idx + 2:

--- a/tests/test_field_path.py
+++ b/tests/test_field_path.py
@@ -4,8 +4,6 @@ Tests for gem.schema.field_path — Huffman field path decoding.
 Reference: manta/field_path.go, manta/huffman.go
 """
 
-from typing import Any
-
 import pytest
 
 
@@ -280,65 +278,209 @@ class TestDecodeTableCrossValidation:
         This directly catches any divergence in the decode table without
         requiring a full parse.
         """
-        try:
-            from gem.schema.field_path import _HUFF_DECODE_TABLE, _HUFF_TABLE_BITS
-        except ImportError:
-            pytest.skip("decode table not yet implemented")
-        from gem.schema.field_path import FIELD_PATH_OPS, HUFF_TREE, FieldPath
-
-        mismatches = 0
-        total = 0
+        from gem.schema.field_path.path_sequence import _read_compact_field_paths
 
         for buf, pos, bit_val, bit_count in captured_buffers:
-            # Restore identical reader state for both implementations
-            def make_reader(
-                _buf: bytes = buf,
-                _pos: int = pos,
-                _bit_val: int = bit_val,
-                _bit_count: int = bit_count,
-            ) -> Any:
-                r = reader_cls(_buf)
-                r._pos = _pos
-                r._bit_val = _bit_val
-                r._bit_count = _bit_count
+
+            def make_reader(buf=buf, pos=pos, bit_val=bit_val, bit_count=bit_count):
+                r = reader_cls(buf)
+                r._pos, r._bit_val, r._bit_count = pos, bit_val, bit_count
                 return r
 
-            # Tree-walk reference
-            ref_paths = _read_field_paths_tree_walk(make_reader())
+            reference = make_reader()
+            expected = [fp.to_tuple() for fp in _read_field_paths_tree_walk(reference)]
+            compact = make_reader()
+            assert _read_compact_field_paths(compact) == expected
+            public = make_reader()
+            from gem.schema.field_path import read_field_paths
 
-            # Table-based candidate
-            r_new = make_reader()
-            fp = FieldPath()
-            new_paths = []
-            table = _HUFF_DECODE_TABLE
-            table_bits = _HUFF_TABLE_BITS
-            ops = FIELD_PATH_OPS
-            while not fp.done:
-                if r_new.rem_bits() >= table_bits:
-                    bits = r_new.peek_bits(table_bits)
-                    op_idx, consumed = table[bits]
-                    r_new.skip_bits(consumed)
+            assert [fp.to_tuple() for fp in read_field_paths(public)] == expected
+            assert compact.position() == public.position() == reference.position()
+            assert compact.rem_bits() == public.rem_bits() == reference.rem_bits()
+
+
+def _original_decode(r, table):
+    import struct
+
+    from gem.schema.field_path import _HUFF_TABLE_BITS, FIELD_PATH_OPS, HUFF_TREE, FieldPath
+
+    fp = FieldPath()
+    paths = []
+    ops = FIELD_PATH_OPS
+    table_bits = _HUFF_TABLE_BITS
+    mask = (1 << table_bits) - 1
+
+    buf = r._buf
+    size = r._size
+    unpack_from = struct.unpack_from
+
+    while not fp.done:
+        # Inline rem_bits: (size - pos) * 8 + bit_count.
+        if (size - r._pos) * 8 + r._bit_count >= table_bits:
+            # Inline peek_bits(table_bits): refill then read without consuming.
+            while table_bits > r._bit_count:
+                remaining = size - r._pos
+                if remaining >= 4:
+                    r._bit_val |= unpack_from("<I", buf, r._pos)[0] << r._bit_count
+                    r._pos += 4
+                    r._bit_count += 32
+                elif remaining > 0:
+                    r._bit_val |= buf[r._pos] << r._bit_count
+                    r._pos += 1
+                    r._bit_count += 8
                 else:
-                    node = HUFF_TREE
-                    while not node.is_leaf:
-                        node = node.right if r_new.read_bits(1) else node.left
-                    op_idx = node.value
-                ops[op_idx].fn(r_new, fp)
-                if not fp.done:
-                    new_paths.append(fp.copy())
+                    break
+            bits = r._bit_val & mask
+            op_idx, consumed = table[bits]
+            # Inline skip_bits(consumed).
+            r._bit_val >>= consumed
+            r._bit_count -= consumed
+        else:
+            # Fallback: tree walk for the last few bits.
+            node = HUFF_TREE
+            while not node.is_leaf:
+                node = node.right if r.read_bits(1) else node.left  # type: ignore[assignment]
+            op_idx = node.value
 
-            ref_tuples = [p.to_tuple() for p in ref_paths]
-            new_tuples = [p.to_tuple() for p in new_paths]
+        ops[op_idx].fn(r, fp)
+        if not fp.done:
+            path = fp.path
+            last = fp.last
+            if last == 0:
+                paths.append((path[0],))
+            elif last == 1:
+                paths.append((path[0], path[1]))
+            elif last == 2:
+                paths.append((path[0], path[1], path[2]))
+            elif last == 3:
+                paths.append((path[0], path[1], path[2], path[3]))
+            elif last == 4:
+                paths.append((path[0], path[1], path[2], path[3], path[4]))
+            elif last == 5:
+                paths.append((path[0], path[1], path[2], path[3], path[4], path[5]))
+            else:
+                paths.append((path[0], path[1], path[2], path[3], path[4], path[5], path[6]))
 
-            total += 1
-            if ref_tuples != new_tuples:
-                mismatches += 1
-                if mismatches <= 3:
-                    pytest.fail(
-                        f"Mismatch on snapshot #{total}:\n"
-                        f"  ref[:{min(5, len(ref_tuples))}] = {ref_tuples[:5]}\n"
-                        f"  new[:{min(5, len(new_tuples))}] = {new_tuples[:5]}\n"
-                        f"  ref_len={len(ref_tuples)} new_len={len(new_tuples)}"
+    return paths
+
+
+@pytest.fixture(scope="module")
+def original_table():
+    from gem.schema.field_path import _HUFF_TABLE_BITS, HUFF_TREE
+
+    table = [(0, 0)] * (1 << _HUFF_TABLE_BITS)
+    stack = [(HUFF_TREE, 0, 0)]
+    while stack:
+        node, code, depth = stack.pop()
+        if node.is_leaf:
+            for suffix in range(1 << (_HUFF_TABLE_BITS - depth)):
+                table[code | (suffix << depth)] = (node.value, depth)
+        else:
+            stack.append((node.left, code, depth + 1))
+            stack.append((node.right, code | (1 << depth), depth + 1))
+    return table
+
+
+def _reader_state(r):
+    return r._pos, r._bit_val, r._bit_count, r.position(), r.rem_bits()
+
+
+def _decode_outcome(call):
+    try:
+        return call()
+    except Exception as exc:
+        return type(exc), str(exc)
+
+
+def _exact_reader(bits, prefetched=0):
+    from gem.binary.reader import BitReader
+
+    # Align at the front so truncations have no invented trailing zero bits.
+    padding = -len(bits) % 8
+    r = BitReader(_bits_to_bytes("0" * padding + bits))
+    r.read_bits(padding)
+    if prefetched:
+        r.peek_bits(min(prefetched, r.rem_bits()))
+    return r
+
+
+def _codes():
+    from gem.schema.field_path import FIELD_PATH_OPS, HUFF_TREE
+
+    result = {}
+    stack = [(HUFF_TREE, "")]
+    while stack:
+        node, bits = stack.pop()
+        if node.is_leaf:
+            result[FIELD_PATH_OPS[node.value].name] = bits
+        else:
+            stack.extend([(node.left, bits + "0"), (node.right, bits + "1")])
+    return result
+
+
+class TestPackedHuffman:
+    def test_every_entry_matches_original_and_tree(self, original_table):
+        from gem.schema.field_path import _HUFF_TABLE_BITS, FIELD_PATH_OPS, HUFF_TREE
+        from gem.schema.field_path.huffman import _HUFF_BITS, _HUFF_OPS
+
+        assert type(_HUFF_OPS) is bytes and type(_HUFF_BITS) is bytes
+        assert len(_HUFF_OPS) == len(_HUFF_BITS) == 1 << _HUFF_TABLE_BITS == 131072
+        assert set(_HUFF_OPS) == set(range(len(FIELD_PATH_OPS)))
+        assert min(_HUFF_BITS) > 0 and max(_HUFF_BITS) == 17
+        for index, expected in enumerate(original_table):
+            node, depth = HUFF_TREE, 0
+            while not node.is_leaf:
+                node = node.right if (index >> depth) & 1 else node.left
+                depth += 1
+            assert (_HUFF_OPS[index], _HUFF_BITS[index]) == expected == (node.value, depth)
+
+    @pytest.mark.parametrize("prefetched", [0, 8, 16, 17, 18, 24, 32])
+    def test_truncations_and_malformed_sequences_match_original(self, original_table, prefetched):
+        from gem.schema.field_path.path_sequence import _read_compact_field_paths
+
+        codes = _codes()
+        finish = codes["FieldPathEncodeFinish"]
+        sequences = [
+            codes["PlusOne"] * 24 + finish,
+            codes["PlusN"] + "0" * 12 + finish,
+            codes["PushOneLeftDeltaNRightNonZeroPack6Bits"] + "001101" + finish,
+            codes["PushOneLeftDeltaZeroRightZero"] * 7 + finish,
+            codes["PopOnePlusOne"] + finish,
+        ]
+        for bits in sequences:
+            for end in range(len(bits) + 1):
+                candidate = _exact_reader(bits[:end], prefetched)
+                original = _exact_reader(bits[:end], prefetched)
+                assert _decode_outcome(
+                    lambda candidate=candidate: _read_compact_field_paths(candidate)
+                ) == (
+                    _decode_outcome(
+                        lambda original=original: _original_decode(original, original_table)
                     )
+                )
+                assert _reader_state(candidate) == _reader_state(original)
 
-        assert mismatches == 0, f"{mismatches}/{total} snapshots had mismatches"
+    @pytest.mark.parametrize("offset", range(8))
+    @pytest.mark.parametrize("prefetched", [0, 17, 32])
+    def test_consecutive_sequences_and_following_reads(self, original_table, offset, prefetched):
+        from gem.binary.reader import BitReader
+        from gem.schema.field_path.path_sequence import _read_compact_field_paths
+
+        bits = "0" * offset + "010" + "0010" + "10100111" * 8
+        readers = [BitReader(_bits_to_bytes(bits)) for _ in range(2)]
+        for r in readers:
+            r.read_bits(offset)
+            if prefetched:
+                r.peek_bits(prefetched)
+        candidate, original = readers
+        for _ in range(2):
+            assert _read_compact_field_paths(candidate) == _original_decode(
+                original, original_table
+            )
+            assert _reader_state(candidate) == _reader_state(original)
+        assert candidate.read_bits(3) == original.read_bits(3)
+        assert candidate.peek_bits(7) == original.peek_bits(7)
+        candidate.skip_bits(7)
+        original.skip_bits(7)
+        assert candidate.read_bytes(3) == original.read_bytes(3)
+        assert _reader_state(candidate) == _reader_state(original)

--- a/tests/test_field_state.py
+++ b/tests/test_field_state.py
@@ -6,7 +6,8 @@ Reference: manta/field_state.go
 import pytest
 
 from gem.schema.field_path import FieldPath
-from gem.schema.field_state import FieldState
+from gem.schema.field_path.models import CompactFieldPath
+from gem.schema.field_state import FieldState, FieldValue
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -545,3 +546,150 @@ class TestFieldStateIsolation:
         fs1.set(_make_fp(0, 0), "in_fs1")
         # fs2 has no children, so fp(0,0) should return None
         assert fs2.get(_make_fp(0, 0)) is None
+
+
+class _OriginalFieldState(FieldState):
+    def _get_compact(self, path: CompactFieldPath) -> FieldValue:
+        """Read an internal compact path without materializing a FieldPath."""
+        state = self._state
+        last = len(path) - 1
+        for i, idx in enumerate(path):
+            if len(state) < idx + 2:
+                return None
+            if i == last:
+                return state[idx]
+            child = state[idx]
+            if not isinstance(child, FieldState):
+                return None
+            state = child._state
+        return None
+
+    def _set_compact(self, path: CompactFieldPath, value: FieldValue) -> None:
+        """Write an internal compact path without materializing a FieldPath."""
+        state = self._state
+        last = len(path) - 1
+        for i, idx in enumerate(path):
+            current_len = len(state)
+            if current_len < idx + 2:
+                new_len = max(idx + 2, current_len * 2)
+                state.extend([None] * (new_len - current_len))
+
+            current = state[idx]
+            if i == last:
+                if not isinstance(current, FieldState):
+                    state[idx] = value
+                return
+            if not isinstance(current, FieldState):
+                current = FieldState()
+                state[idx] = current
+            state = current._state
+
+
+def _outcome(call):
+    try:
+        return call()
+    except (IndexError, TypeError) as exc:
+        return type(exc), str(exc)
+
+
+class TestShallowCompactEquivalence:
+    @pytest.mark.parametrize("depth", range(1, 8))
+    def test_operations_match_original_and_public(self, depth):
+        states = [FieldState(), _OriginalFieldState(), FieldState()]
+        value = object()
+        for index in (0, 6, 7, 8, 15, 16, 100):
+            path = (index,) * depth
+            for i, state in enumerate(states):
+                read = (
+                    (lambda state=state, path=path: state.get(_make_fp(*path)))
+                    if i == 2
+                    else (lambda state=state, path=path: state._get_compact(path))
+                )
+                assert read() is None
+                if i == 2:
+                    state.set(_make_fp(*path), value)
+                else:
+                    state._set_compact(path, value)
+                assert read() is value
+            assert _state_tree(states[0]) == _state_tree(states[1]) == _state_tree(states[2])
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            (),
+            (-1,),
+            (-8,),
+            (-9,),
+            (True,),
+            (False, True),
+            (7, -9),
+            (0, -1),
+            (0, -8),
+            (0, -9),
+            (-9, 0),
+            (1.5,),
+            ("x",),
+            (7, 1.5),
+            (7, "x"),
+        ],
+    )
+    def test_index_behavior_and_partial_failure(self, path):
+        candidate, original, public = FieldState(), _OriginalFieldState(), FieldState()
+        assert (
+            _outcome(lambda: candidate._get_compact(path))
+            == _outcome(lambda: original._get_compact(path))
+            == _outcome(lambda: public.get(_make_fp(*path)))
+        )
+        assert (
+            _outcome(lambda: candidate._set_compact(path, 42))
+            == _outcome(lambda: original._set_compact(path, 42))
+            == _outcome(lambda: public.set(_make_fp(*path), 42))
+        )
+        assert _state_tree(candidate) == _state_tree(original) == _state_tree(public)
+
+    @pytest.mark.parametrize("depth", [1, 2])
+    def test_extra_slot_bound_does_not_read_populated_last_slot(self, depth):
+        state = FieldState()
+        leaf = state
+        if depth == 2:
+            leaf = FieldState()
+            state._state[0] = leaf
+        leaf._state[7] = object()
+        before = _state_tree(state)
+        assert state._get_compact((0,) * (depth - 1) + (7,)) is None
+        assert _state_tree(state) == before
+
+    def test_aliases_children_and_mixed_depth_writes(self):
+        class Child(FieldState):
+            pass
+
+        state = FieldState()
+        root_storage = state._state
+        child = Child()
+        child_storage = child._state
+        state._state[7] = child
+        value = object()
+        state._set_compact((7, 100), value)
+        assert state._state is root_storage and len(root_storage) == 16
+        assert state._state[7] is child and child._state is child_storage
+        assert len(child_storage) == 102 and state._get_compact((7, 100)) is value
+        for replacement in (None, 0, object(), FieldState()):
+            state._set_compact((7,), replacement)
+            assert state._get_compact((7,)) is child
+        state._set_compact((7, 100, 0), value)
+        terminal = state._get_compact((7, 100))
+        for replacement in (None, 0, object(), FieldState()):
+            state._set_compact((7, 100), replacement)
+            assert state._get_compact((7, 100)) is terminal
+        assert state._get_compact((7, 100, 0)) is value
+
+    def test_compact_paths_bypass_helpers(self, monkeypatch):
+        def fail(*args):
+            pytest.fail("compact path dispatched through a helper")
+
+        for name in ("get", "set", "_ensure", "_has_slot", "_is_child"):
+            monkeypatch.setattr(FieldState, name, fail)
+        state = FieldState()
+        for path in ((100,), (100, 100), (100, 100, 100)):
+            state._set_compact(path, 42)
+            assert state._get_compact(path) == 42


### PR DESCRIPTION
## Summary

Specialize depth-one and depth-two compact FieldState traversal, and replace the 131,072-entry Huffman tuple table with parallel immutable byte tables. Keep deeper traversal, public mutable FieldPath/get/set behavior, Huffman tree construction, reader refill/fallback, and output unchanged.

Closes #161.

The fast paths preserve the extra-slot `index + 2` bound (also relied on by player-ID guards), in-place growth, child/subclass identity, leaf-child protection, Python index behavior, and partial mutations on failure. The obsolete `_HUFF_DECODE_TABLE` re-export was explicitly private and is removed; the stable public `__all__` is unchanged. No dependencies, Python requirements, test tiers, caches, or other parser optimizations change.

## References and tests

Manta [`field_state.go`](https://github.com/dotabuff/manta/blob/096933cf157ace54902463ff0599ea46a6673f98/field_state.go), [`field_path.go`](https://github.com/dotabuff/manta/blob/096933cf157ace54902463ff0599ea46a6673f98/field_path.go), and [`huffman.go`](https://github.com/dotabuff/manta/blob/096933cf157ace54902463ff0599ea46a6673f98/huffman.go) establish growth, child preservation, and Huffman ordering. Clarity [`NestedArrayEntityState`](https://github.com/skadistats/clarity/blob/7fb3f1d07564a12efa99194d45cfbf5762ba5910/src/main/java/skadistats/clarity/model/state/NestedArrayEntityState.java), [`FieldOpHuffmanTree`](https://github.com/skadistats/clarity/blob/7fb3f1d07564a12efa99194d45cfbf5762ba5910/src/main/java/skadistats/clarity/io/s2/FieldOpHuffmanTree.java), and [`S2FieldReader`](https://github.com/skadistats/clarity/blob/7fb3f1d07564a12efa99194d45cfbf5762ba5910/src/main/java/skadistats/clarity/io/s2/S2FieldReader.java) cross-check nested traversal and operation decoding; its different capacity/copy-on-write design is not imported. OpenDota [`Parse.java`](https://github.com/odota/parser/blob/e58a668f72866531b9a4e0293387163e8a927f5b/src/main/java/opendota/Parse.java) establishes downstream field usage. Gem's original compact methods and optimized decoder are frozen as test-only compatibility oracles.

New tests compare complete trees/capacities, identities, missing values, sparse growth, interleaved depths, protected children, negative/boolean/invalid indices, and post-failure partial state. Every packed table entry matches both the original tuple builder and an independent tree walk. Captured real buffers exercise the production decoder and public wrapper. Bit-exact truncation, malformed sequences, offsets/prefetches, consecutive sequences, following reads, exceptions, and reader cache state match the original decoder.

Independent static review found no actionable correctness issues; AST checks verified the frozen originals match baseline behavior.

## Validation

Used the same existing uv-managed CPython 3.10.4 virtual environment. Direct module invocations avoid an unavailable uv cache path; dependencies were not changed.

| Command | Result |
|---|---|
| `.venv/bin/python -m pytest tests/test_field_state.py tests/test_field_path.py tests/test_field_path_ops.py tests/test_field_reader.py tests/test_entities.py tests/test_players_extractor.py tests/test_fuzz.py -q -rs` | 2,127 passed; 2.69 s |
| `.venv/bin/python -m pytest -q -rs` | 3,854 passed, 3 skipped, 62 deselected; 5.57 s |
| `.venv/bin/python -m pytest -q -rs -m "not network"` | 3,915 passed, 3 skipped, 1 deselected; 394.02 s |
| `.venv/bin/python -m ruff check src/ tests/` | Passed |
| `.venv/bin/python -m ruff format --check src/ tests/` | Passed |
| `.venv/bin/python -m mypy src/gem/` | Passed, 88 source files |

Pytest skips: optional pyarrow in `test_bulk.py`, optional Parquet engine in `test_parquet_export.py`, and the existing optimized-away flag case in `test_field_decoder.py`. Offline deselection is live network integration. No required local fixture is missing.

Pre-commit Ruff/format/conflict/mypy hooks passed; YAML/TOML hooks had no applicable files. CI passed on commit `14d218e59da9ff24345422ef92dd903acb3b4808`: [CI](https://github.com/whanyu1212/gem-dota/actions/runs/34043721875/job/101514931116), [distribution build](https://github.com/whanyu1212/gem-dota/actions/runs/34043721910/job/101514931226). PyPI publishing is intentionally skipped for PRs. Independent protocol review found and corrected a lookup microbenchmark local-binding mismatch before any micro timings; no other actionable protocol issues remain.

During the initial short public timing block, `pmset -g custom` reported AC configuration `lowpowermode 0`. `pmset -g therm` could not expose thermal/performance/CPU-power status (error `0xe00002bc`); thermal throttling cannot be confirmed or excluded from these data. No power settings or other host applications were changed.

## Performance assessment

Shallow hit/overwrite microbenchmarks improve by 22.5–28.5%; missing-value and child-preservation cases also improve. Generic depth-three reads/writes cost 7.0%/5.2% more, and depth-seven controls cost 3.2%/1.9% more. These dispatch costs remain visible after reusing the already-computed path length. There is no deeper-path specialization in this change.

Packed Huffman lookups cost 8.9% more in the isolated indexing benchmark; production decoding over the first 200 captured buffers costs 2.5% more. This is a storage optimization with a small isolated CPU cost. The corpus is a bounded sample, not every replay field-path buffer. Huffman-only core replay CPU medians are -1.0% (short) and +0.5% (long), with mixed block directions; the replay measurements do not establish a systematic decoder CPU regression.

Core replay CPU improves consistently: shallow-only beats baseline in every block across both fixtures, with median changes of -1.4%/-3.6%; combined beats baseline in every block, with median changes of -3.3%/-3.7%. Combined versus shallow-only CPU medians are -2.0%/-0.2%, so the isolated replay measurements do not show a consistent Huffman slowdown.

Public replay timing is inconclusive. Original combined CPU medians are -0.4% (short) and +3.7% (long), while long-replay block changes are +10.1%, -6.1%, and -3.5%. Long baseline CPU alone ranges from 176.1 to 221.3 seconds. Load averages are recorded, but they do not prove the cause of CPU variation. No stable public-parse speedup is claimed.

Two fixed follow-ups investigated the largest anomalies without discarding the original runs. The original short-public shallow-only median CPU increase of 11.5% did not recur: all three additional pairs favor shallow-only, with a -2.8% median. The original short-core combined median peak-RSS increase of 10.7% also did not recur systematically; follow-up combined median peak RSS is 153.672 versus 161.656 MiB (-4.9%), with CPU -4.4%. The original short-core shallow-only RSS median was also +8.8%, with mixed block directions, and remains disclosed rather than being presented as an isolated memory improvement.

Original public peak-RSS medians are mixed: combined is +2.8% on the short replay and -0.3% on the long replay. Core-long Huffman-only and combined peak RSS fall in every block (median -2.4%/-2.0%). These observations support a precise table-storage claim, not a general process-memory guarantee.

Direct table storage falls from 8,388,664 to 262,210 bytes: 96.9% less, saving 7.75 MiB. Separate single-process current-RSS observations after parsing/GC, with results alive, are 119.656 to 109.469 MiB (short B to C) and 316.031 to 307.094 MiB (long B to C). These supplemental observations also show lower post-import RSS for packed variants. They are individual observations, not replicated estimates of process-memory savings.

Acceptance is supported by identical output, passing regression/parity/CI checks, measured shallow-path gains and retained-table reduction, consistent core CPU improvements, and targeted follow-ups that did not reproduce a consistent CPU or peak-RSS regression. Original inconclusive measurements and isolated microbenchmark costs are preserved below.

## Replay measurements

CPython 3.10.4, macOS 26.6.2 arm64, Apple M2, 16 GiB RAM; identical virtual environment, fixtures and options. B = baseline b5e470a; S = shallow-only; H = Huffman-only; C = combined. Forty-eight sequential fresh-process runs in B/S/H/C, C/H/S/B, S/B/C/H blocks for each scenario/replay. The first public B run preceded implementation; the remaining runs followed correctness checks and microbenchmarks. No tests or instrumentation ran concurrently with timing. Lazy imports precede parse timing; serialization/hashing follow elapsed/user CPU and peak-RSS capture. Core parser construction precedes timing. RSS is the process high-water mark.

| Mode / replay | Variant | Elapsed s (3 runs) | User CPU s (3 runs) | Peak RSS MiB (3 runs) | Median elapsed / CPU / RSS |
|---|---|---|---|---|---|
|public-8822520406|B|53.207, 70.313, 54.021|52.420, 69.570, 53.663|196.875, 217.891, 203.484|54.021 / 53.663 / 203.484|
|public-8822520406|S|52.474, 72.838, 60.254|51.864, 71.486, 59.822|217.312, 208.312, 205.219|60.254 / 59.822 / 208.312|
|public-8822520406|H|53.993, 76.035, 53.476|53.690, 74.284, 53.210|209.359, 196.922, 209.000|53.993 / 53.690 / 209.000|
|public-8822520406|C|53.926, 60.548, 51.451|53.427, 59.859, 51.268|194.172, 210.000, 209.188|53.926 / 53.427 / 209.188|
|public-8856501050|B|206.320, 225.779, 178.733|200.329, 221.280, 176.069|614.422, 626.203, 635.891|206.320 / 200.329 / 626.203|
|public-8856501050|S|232.441, 210.410, 171.864|226.742, 205.804, 169.518|631.578, 618.953, 622.047|210.410 / 205.804 / 622.047|
|public-8856501050|H|210.930, 191.495, 176.421|207.274, 186.965, 174.327|621.531, 570.953, 624.422|191.495 / 186.965 / 621.531|
|public-8856501050|C|226.362, 219.555, 172.284|220.616, 207.720, 169.941|580.906, 626.562, 624.500|219.555 / 207.720 / 624.500|
|core-8822520406|B|43.780, 42.564, 43.857|43.048, 42.304, 43.585|173.422, 142.625, 142.328|43.780 / 43.048 / 142.625|
|core-8822520406|S|43.096, 42.254, 42.900|42.466, 42.038, 42.660|166.062, 155.219, 143.109|42.900 / 42.466 / 155.219|
|core-8822520406|H|43.220, 42.700, 42.767|43.069, 42.242, 42.625|139.922, 144.578, 140.656|42.767 / 42.625 / 140.656|
|core-8822520406|C|41.127, 41.766, 41.922|40.908, 41.635, 41.796|157.859, 165.297, 152.938|41.766 / 41.635 / 157.859|
|core-8856501050|B|153.600, 152.345, 152.020|151.153, 151.657, 150.931|433.781, 433.672, 433.391|152.345 / 151.153 / 433.672|
|core-8856501050|S|146.844, 151.127, 145.659|145.753, 150.006, 144.893|433.453, 431.656, 433.438|146.844 / 145.753 / 433.438|
|core-8856501050|H|150.187, 154.595, 152.771|149.342, 153.410, 151.839|424.422, 412.875, 423.422|152.771 / 151.839 / 423.422|
|core-8856501050|C|147.239, 144.627, 146.144|146.497, 143.977, 145.523|422.391, 424.969, 425.000|146.144 / 145.523 / 424.969|

Within-block CPU changes supplement the independent medians above; ordered runs are not simultaneous controls. Positive values are slower.

| Scenario | Comparison | CPU change by block (%) |
|---|---|---|
|public/8822520406|S/B|-1.06, +2.75, +11.48|
|public/8822520406|H/B|+2.42, +6.78, -0.84|
|public/8822520406|C/S|+3.01, -16.26, -14.30|
|public/8822520406|C/B|+1.92, -13.96, -4.46|
|public/8856501050|S/B|+13.18, -6.99, -3.72|
|public/8856501050|H/B|+3.47, -15.51, -0.99|
|public/8856501050|C/S|-2.70, +0.93, +0.25|
|public/8856501050|C/B|+10.13, -6.13, -3.48|
|core/8822520406|S/B|-1.35, -0.63, -2.12|
|core/8822520406|H/B|+0.05, -0.15, -2.20|
|core/8822520406|C/S|-3.67, -0.96, -2.02|
|core/8822520406|C/B|-4.97, -1.58, -4.10|
|core/8856501050|S/B|-3.57, -1.09, -4.00|
|core/8856501050|H/B|-1.20, +1.16, +0.60|
|core/8856501050|C/S|+0.51, -4.02, +0.43|
|core/8856501050|C/B|-3.08, -5.06, -3.58|

<details><summary>Host load: start/end 1-, 5-, 15-minute averages</summary>

- `core-8822520406-0-B`: [3.072265625, 3.18115234375, 3.53564453125] → [3.1103515625, 3.16015625, 3.5087890625].
- `core-8822520406-0-C`: [3.22802734375, 3.2099609375, 3.4912109375] → [3.83349609375, 3.3310546875, 3.5205078125].
- `core-8822520406-0-H`: [3.6962890625, 3.28125, 3.53271484375] → [3.22802734375, 3.2099609375, 3.4912109375].
- `core-8822520406-0-S`: [3.18115234375, 3.173828125, 3.51123046875] → [3.6962890625, 3.28125, 3.53271484375].
- `core-8822520406-1-B`: [3.99609375, 3.6201171875, 3.60595703125] → [4.255859375, 3.716796875, 3.63916015625].
- `core-8822520406-1-C`: [3.83349609375, 3.3310546875, 3.5205078125] → [3.33447265625, 3.2548828125, 3.48095703125].
- `core-8822520406-1-H`: [3.33447265625, 3.2548828125, 3.48095703125] → [5.01025390625, 3.70556640625, 3.63525390625].
- `core-8822520406-1-S`: [5.01025390625, 3.70556640625, 3.63525390625] → [3.99609375, 3.6201171875, 3.60595703125].
- `core-8822520406-2-B`: [3.6044921875, 3.615234375, 3.60400390625] → [3.74560546875, 3.63818359375, 3.61083984375].
- `core-8822520406-2-C`: [3.74560546875, 3.63818359375, 3.61083984375] → [3.34912109375, 3.5419921875, 3.57470703125].
- `core-8822520406-2-H`: [3.34912109375, 3.5419921875, 3.57470703125] → [3.05078125, 3.43310546875, 3.5322265625].
- `core-8822520406-2-S`: [4.255859375, 3.716796875, 3.63916015625] → [3.6044921875, 3.615234375, 3.60400390625].
- `core-8856501050-0-B`: [3.05078125, 3.43310546875, 3.5322265625] → [3.30810546875, 3.5126953125, 3.55419921875].
- `core-8856501050-0-C`: [3.46142578125, 3.5439453125, 3.54345703125] → [3.60400390625, 3.58447265625, 3.5556640625].
- `core-8856501050-0-H`: [3.51416015625, 3.41455078125, 3.4990234375] → [3.46142578125, 3.5439453125, 3.54345703125].
- `core-8856501050-0-S`: [3.283203125, 3.50390625, 3.55078125] → [3.51416015625, 3.41455078125, 3.4990234375].
- `core-8856501050-1-B`: [4.33154296875, 4.15673828125, 3.8125] → [2.8349609375, 3.5791015625, 3.625].
- `core-8856501050-1-C`: [4.11572265625, 3.69091796875, 3.59326171875] → [3.90576171875, 3.6875, 3.59716796875].
- `core-8856501050-1-H`: [3.9130859375, 3.6923828125, 3.59912109375] → [4.0654296875, 3.72021484375, 3.61328125].
- `core-8856501050-1-S`: [3.89990234375, 3.69140625, 3.603515625] → [4.33154296875, 4.15673828125, 3.8125].
- `core-8856501050-2-B`: [2.82666015625, 3.21533203125, 3.46044921875] → [3.8662109375, 3.47802734375, 3.5234375].
- `core-8856501050-2-C`: [3.8662109375, 3.47802734375, 3.5234375] → [3.603515625, 3.51123046875, 3.52392578125].
- `core-8856501050-2-H`: [3.603515625, 3.51123046875, 3.52392578125] → [3.7080078125, 3.55908203125, 3.53271484375].
- `core-8856501050-2-S`: [2.8349609375, 3.5791015625, 3.625] → [2.6376953125, 3.185546875, 3.45166015625].
- `public-8822520406-0-B`: [3.02734375, 3.51513671875, 3.6552734375] → [2.9853515625, 3.38818359375, 3.595703125].
- `public-8822520406-0-C`: [3.32470703125, 4.177734375, 4.5361328125] → [3.4755859375, 4.0693359375, 4.47216796875].
- `public-8822520406-0-H`: [3.63427734375, 4.4140625, 4.640625] → [3.32470703125, 4.177734375, 4.5361328125].
- `public-8822520406-0-S`: [3.68798828125, 4.53173828125, 4.6943359375] → [3.63427734375, 4.4140625, 4.640625].
- `public-8822520406-1-B`: [4.134765625, 4.138671875, 4.40185546875] → [3.68798828125, 3.96630859375, 4.3115234375].
- `public-8822520406-1-C`: [3.4375, 4.05126953125, 4.46337890625] → [3.46435546875, 3.94921875, 4.39404296875].
- `public-8822520406-1-H`: [3.46435546875, 3.94921875, 4.39404296875] → [4.05029296875, 4.08349609375, 4.41064453125].
- `public-8822520406-1-S`: [4.5263671875, 4.181640625, 4.443359375] → [4.14697265625, 4.14111328125, 4.404296875].
- `public-8822520406-2-B`: [3.48291015625, 3.8505859375, 4.23974609375] → [2.7490234375, 3.58349609375, 4.1142578125].
- `public-8822520406-2-C`: [2.7490234375, 3.58349609375, 4.1142578125] → [3.41064453125, 3.63134765625, 4.0986328125].
- `public-8822520406-2-H`: [3.61767578125, 3.67041015625, 4.109375] → [4.44140625, 3.9375, 4.1845703125].
- `public-8822520406-2-S`: [3.68798828125, 3.96630859375, 4.3115234375] → [3.48291015625, 3.8505859375, 4.23974609375].
- `public-8856501050-0-B`: [4.32568359375, 3.921875, 4.17724609375] → [4.9365234375, 4.146484375, 4.1875].
- `public-8856501050-0-C`: [2.77978515625, 3.60693359375, 3.99462890625] → [4.7197265625, 4.0400390625, 4.07666015625].
- `public-8856501050-0-H`: [3.50146484375, 4.17529296875, 4.24755859375] → [2.8125, 3.65576171875, 4.01953125].
- `public-8856501050-0-S`: [6.62451171875, 4.626953125, 4.359375] → [3.21484375, 4.14697265625, 4.23876953125].
- `public-8856501050-1-B`: [4.27099609375, 4.08984375, 4.06103515625] → [3.8408203125, 4.0419921875, 4.05517578125].
- `public-8856501050-1-C`: [4.26416015625, 3.97216796875, 4.0517578125] → [4.33447265625, 4.16748046875, 4.1083984375].
- `public-8856501050-1-H`: [3.97509765625, 4.095703125, 4.0830078125] → [4.11474609375, 4.017578125, 4.046875].
- `public-8856501050-1-S`: [4.15087890625, 4.03173828125, 4.05126953125] → [3.494140625, 3.9404296875, 4.009765625].
- `public-8856501050-2-B`: [3.88232421875, 3.8779296875, 3.96826171875] → [3.2705078125, 3.62744140625, 3.845703125].
- `public-8856501050-2-C`: [3.37548828125, 3.638671875, 3.8466796875] → [3.12890625, 3.38623046875, 3.69775390625].
- `public-8856501050-2-H`: [3.0283203125, 3.3564453125, 3.68310546875] → [3.09375, 3.18798828125, 3.54248046875].
- `public-8856501050-2-S`: [3.9580078125, 4.05712890625, 4.06005859375] → [3.9560546875, 3.8916015625, 3.97412109375].

</details>

## Public output equivalence

- `8822520406`: SHA-256 `3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427`; all 14 baseline/isolated/combined/instrumented files are byte-identical (30,401,205 bytes each).
- `8856501050`: SHA-256 `1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e`; all 14 baseline/isolated/combined/instrumented files are byte-identical (187,363,261 bytes each).

## Microbenchmarks

Nanoseconds per operation; median of all 15 repetitions (three fresh processes × five repetitions), with each process median also shown. Field cases use 200,000 calls/repetition; growth includes fresh tree construction. Lookup uses 1,000,000 operations/repetition with a full-cycle deterministic index stride. Captured decoder uses ten passes over the same first 200 canonical buffers/repetition, including reader restoration. No profiler timings.

| Case | Baseline process medians | Optimized process medians | Overall B / optimized |
|---|---|---|---|
|field/get-hit-1|240.82, 226.05, 226.43|164.77, 163.07, 158.48|226.43 / 161.90|
|field/set-overwrite-1|304.19, 292.71, 295.97|220.75, 216.91, 212.10|296.11 / 216.91|
|field/get-hit-2|345.04, 335.41, 337.49|263.73, 255.38, 258.75|337.49 / 258.30|
|field/set-overwrite-2|406.81, 413.24, 422.11|318.14, 322.36, 321.25|414.28 / 321.25|
|field/get-hit-3|443.09, 434.90, 447.42|480.09, 475.24, 470.99|443.09 / 474.22|
|field/set-overwrite-3|525.68, 512.26, 528.90|552.79, 558.43, 540.64|525.68 / 552.79|
|field/get-hit-7|812.49, 795.93, 820.61|838.75, 792.79, 845.08|812.66 / 838.75|
|field/set-overwrite-7|927.21, 899.25, 913.28|936.07, 885.13, 930.99|913.28 / 930.99|
|field/get-miss-root|219.62, 213.29, 219.38|150.23, 141.38, 149.52|217.48 / 149.27|
|field/get-miss-child|318.52, 308.12, 312.19|238.37, 228.78, 243.45|312.17 / 238.37|
|field/get-miss-nonchild|281.83, 273.82, 277.00|204.74, 193.11, 204.49|277.88 / 204.47|
|field/set-preserve-1|276.63, 270.51, 272.57|192.96, 181.96, 194.00|272.58 / 192.80|
|field/set-preserve-2|391.44, 382.47, 393.81|294.28, 279.83, 291.65|391.14 / 291.54|
|field/grow-root|1359.12, 1282.18, 1286.23|1271.51, 1154.73, 1204.98|1290.49 / 1204.98|
|field/grow-nested|1905.60, 1803.45, 1803.79|1803.83, 1653.44, 1704.50|1810.48 / 1704.50|
|huffman/table-lookup|57.31, 57.53, 57.45|60.76, 63.44, 62.54|57.45 / 62.54|
|huffman/captured-decode-per-buffer|109829.06, 112033.65, 111792.98|112254.50, 114509.46, 114442.46|111743.42 / 114505.83|

<details><summary>All microbenchmark repetitions (ns/op)</summary>

- `micro-field-0-B`: `{"get-hit-1": [236.22833483386785, 243.36499976925552, 240.81874988041818, 241.25021009240297, 240.76187517493963], "get-hit-2": [346.03396023157984, 344.20124953612685, 346.02729021571577, 344.7539597982541, 345.0360399438068], "get-hit-3": [447.0260447124019, 445.9495801711455, 442.3425003187731, 443.08645999990404, 441.52479502372444], "get-hit-7": [811.8970802752301, 806.5535395871848, 812.4881255207583, 814.9983297334984, 813.0754152080044], "get-miss-child": [321.62729010451585, 318.7202103435993, 318.51896026637405, 317.29770998936146, 305.09958043694496], "get-miss-nonchild": [281.5054199891165, 282.61124971322715, 280.5085404543206, 282.68812457099557, 281.82708541862667], "get-miss-root": [223.69937505573034, 222.78187505435199, 219.6202054619789, 216.3752046180889, 218.68062496650964], "grow-nested": [1905.6004198500887, 1898.1412501307204, 1906.3843751791865, 1904.2299996363, 1911.7483298759905], "grow-root": [1359.117710380815, 1350.799580104649, 1359.3883346766233, 1356.9531246321276, 1362.3172952793539], "set-overwrite-1": [304.1883301921189, 308.53457981720567, 304.6074998565018, 303.5929147154093, 301.0602103313431], "set-overwrite-2": [394.05458490364254, 387.1847898699343, 406.80812555365264, 419.0104198642075, 417.898545274511], "set-overwrite-3": [523.1960449600592, 525.6833345629275, 527.8943752637133, 524.6402049669996, 526.0735447518528], "set-overwrite-7": [924.8489601304755, 927.2149996832013, 930.1343752304092, 933.0845851218328, 926.7395798815414], "set-preserve-1": [276.1466649826616, 276.6279154457152, 277.2477100370452, 273.3712497865781, 277.7335449354723], "set-preserve-2": [397.5091699976474, 391.13520469982177, 391.44354523159564, 392.65020517632365, 387.9987500840798]}`
- `micro-field-0-S`: `{"get-hit-1": [160.66666459664702, 164.8833299987018, 160.10750026907772, 164.76520977448672, 165.5016647418961], "get-hit-2": [263.72854015789926, 264.14396008476615, 261.604170082137, 258.29583464656025, 264.22583498060703], "get-hit-3": [458.8783346116543, 477.3145850049332, 482.3497898178175, 481.99354496318847, 480.09499965701247], "get-hit-7": [802.1385449683294, 838.7454197509214, 845.9133352153003, 831.1583299655467, 843.5675001237541], "get-miss-child": [238.37124987039715, 239.67875051312149, 237.4702098313719, 235.88562500663102, 239.54979493282738], "get-miss-nonchild": [204.46917042136192, 204.97666497249156, 204.7091646818444, 206.7222900222987, 204.73895536269993], "get-miss-root": [149.15312523953617, 150.84729006048292, 150.23166954051703, 149.7831247979775, 150.61520971357822], "grow-nested": [1825.4704150604084, 1786.9585403241217, 1810.0433348445222, 1793.3179147075862, 1803.8329150294885], "grow-root": [1271.513334941119, 1268.6191697139293, 1318.6616700841114, 1276.4879153110087, 1271.0333347786218], "set-overwrite-1": [221.801670268178, 220.7527100108564, 218.39541499502957, 220.7081246888265, 222.77000010944903], "set-overwrite-2": [328.05020979139954, 322.8470851900056, 308.4843751275912, 300.5908301565796, 318.13957961276174], "set-overwrite-3": [552.458125166595, 552.3862497648224, 556.920210365206, 555.3356249583885, 552.790624788031], "set-overwrite-7": [938.0897902883589, 936.0710449982435, 942.3279197653756, 934.0706252260134, 932.8664600616321], "set-preserve-1": [194.2493749083951, 192.11416481994092, 192.96145532280207, 193.5768750263378, 192.80312524642795], "set-preserve-2": [291.8447903357446, 296.2297946214676, 294.27833505906165, 295.8062500692904, 290.7947899075225]}`
- `micro-field-1-B`: `{"get-hit-1": [224.72749988082796, 226.18375020101666, 225.95125017687678, 226.15750029217452, 226.0514599038288], "get-hit-2": [334.2950000660494, 335.08583495859057, 335.40916512720287, 336.4312497433275, 335.85583500098437], "get-hit-3": [435.99166499916464, 438.40833532158285, 434.89854491781443, 433.38750023394823, 433.8762501720339], "get-hit-7": [793.3162502013147, 795.926459832117, 789.9647951126099, 797.1668749814853, 812.6560447271913], "get-miss-child": [307.24416486918926, 308.1233351258561, 308.98083525244147, 307.68791504669935, 308.31624986603856], "get-miss-nonchild": [273.1660450808704, 277.8766700066626, 276.833749958314, 273.5652099363506, 273.8164598122239], "get-miss-root": [213.28792034182698, 213.2277050986886, 213.29521026927978, 213.48625014070421, 213.2045797770843], "grow-nested": [1809.9368753610179, 1798.7502051983029, 1803.4535448532552, 1810.4841647436842, 1802.268125466071], "grow-root": [1331.0093752807006, 1285.4593753581867, 1282.1770802838728, 1274.3558350484818, 1276.0381249245256], "set-overwrite-1": [288.2306248648092, 292.711874935776, 287.2181253042072, 295.09353975299746, 299.01687521487474], "set-overwrite-2": [413.3097897283733, 410.90896003879607, 410.44833546038717, 413.2366646081209, 418.40791469439864], "set-overwrite-3": [513.0833352450281, 513.3541650138795, 512.1462501119822, 511.82437513489276, 512.2583353659138], "set-overwrite-7": [896.1568749509752, 898.8687500823289, 904.8725001048297, 899.2489549564198, 903.7972899386659], "set-preserve-1": [272.58125017397106, 272.5339599419385, 270.5081249587238, 267.28353986982256, 267.62104011140764], "set-preserve-2": [382.4731253553182, 383.40687518939376, 382.30583479162306, 380.4072953062132, 386.87770487740636]}`
- `micro-field-1-S`: `{"get-hit-1": [162.92062471620739, 163.91395474784076, 163.06853969581425, 163.13416475895792, 161.89708490855992], "get-hit-2": [255.38291491102427, 253.0479151755571, 257.8450000146404, 257.8156249364838, 254.52375004533678], "get-hit-3": [470.23520979564637, 476.25624982174486, 475.74020514730364, 475.23583518341184, 469.2256252747029], "get-hit-7": [850.0081248348579, 792.5075001548976, 776.493750163354, 792.7922951057553, 794.8287500767037], "get-miss-child": [222.81541489064693, 227.4683298310265, 228.77666517160833, 228.9854147238657, 230.5479149799794], "get-miss-nonchild": [191.953539615497, 194.9050003895536, 193.10791976749897, 194.4812503643334, 192.2781253233552], "get-miss-root": [141.30999974440783, 140.98541461862624, 141.4964598370716, 145.28708474244922, 141.3756253896281], "grow-nested": [1652.7970851166174, 1646.7329149600118, 1653.4385445993394, 1678.1229147454724, 1679.447295027785], "grow-root": [1196.8816700391471, 1156.6114600282162, 1154.2843747884035, 1154.733125003986, 1153.5391700454056], "set-overwrite-1": [217.77958027087152, 216.909580049105, 217.507915222086, 216.34291508235037, 216.86437481548637], "set-overwrite-2": [324.58728994242847, 322.35999999102205, 300.23146013263613, 323.0664599686861, 319.399795262143], "set-overwrite-3": [558.7016651406884, 555.5045796791092, 558.4302096394822, 558.7674997514114, 549.998750211671], "set-overwrite-7": [883.0664597917348, 886.2520853290334, 883.338954881765, 885.1270849118009, 885.7641700888053], "set-preserve-1": [184.21333457808942, 180.99375010933727, 180.8531250571832, 181.95624987129122, 184.50833449605852], "set-preserve-2": [281.44145966507494, 281.9497900782153, 277.94562513008714, 279.83145497273654, 276.2818749761209]}`
- `micro-field-2-B`: `{"get-hit-1": [226.29353974480182, 226.16500034928322, 229.68749981373549, 226.42957977950573, 226.71791492030025], "get-hit-2": [338.37520983070135, 339.20437505003065, 336.80312510114163, 337.4897950561717, 337.48332993127406], "get-hit-3": [447.41978985257447, 449.96103970333934, 445.06416539661586, 446.66396046523005, 456.4177105203271], "get-hit-7": [820.6062501994893, 820.3552046325058, 830.3354150848463, 824.9460399383679, 816.8727054726332], "get-miss-child": [312.1741651557386, 321.8304202891886, 313.6235399870202, 309.7579150926322, 312.1899999678135], "get-miss-nonchild": [275.82604496274143, 276.99646016117185, 282.00895991176367, 278.86708499863744, 276.41499997116625], "get-miss-root": [216.3387497421354, 217.48208499047905, 219.68291490338743, 219.38333462458104, 222.0954146469012], "grow-nested": [1796.9012499088421, 1798.9468754967675, 1803.7929147249088, 1826.799794798717, 1838.7979199178517], "grow-root": [1328.1829201150686, 1290.488539962098, 1285.0393750704825, 1286.2256250809878, 1281.5114547265694], "set-overwrite-1": [296.5283300727606, 295.75229506008327, 296.10500030685216, 295.9733351599425, 295.7849996164441], "set-overwrite-2": [414.34937505982816, 422.10874962620437, 414.2793745268136, 425.0385402701795, 426.7439601244405], "set-overwrite-3": [528.783539775759, 528.8974998984486, 526.2477102223784, 533.9760455535725, 539.4224997144192], "set-overwrite-7": [929.6439599711448, 920.891459682025, 911.4070853684098, 913.2764599053189, 906.5933298552409], "set-preserve-1": [268.87541986070573, 271.3389601558447, 272.5697949063033, 276.08228963799775, 277.6247903238982], "set-preserve-2": [400.64416476525366, 394.8677098378539, 393.22395459748805, 393.80687521770597, 380.6945797987282]}`
- `micro-field-2-S`: `{"get-hit-1": [157.84666989929974, 158.12645491678268, 158.48312468733639, 158.90083508566022, 158.65770517848432], "get-hit-2": [254.16083517484364, 253.65395995322618, 258.7522898102179, 262.73395982570946, 260.96624962519854], "get-hit-3": [468.8266647281125, 470.456454786472, 471.68333490844816, 470.9941701730713, 474.21583032701164], "get-hit-7": [837.1504198294133, 844.5131249027327, 850.9395853616297, 850.2489549573511, 845.0837497366592], "get-miss-child": [240.05624989513308, 246.88708013854918, 243.24604484718293, 244.0187497995794, 243.44853998627514], "get-miss-nonchild": [203.13895482104272, 204.48791969101876, 205.1679149735719, 201.93916512653232, 204.60499974433333], "get-miss-root": [149.17250024154782, 149.26833508070558, 149.52291501685977, 149.97333521023393, 150.49270470626652], "grow-nested": [1730.0077097024769, 1704.9210402183235, 1696.9389596488327, 1704.5020801015198, 1701.6935453284532], "grow-root": [1241.3318746257573, 1229.929585242644, 1204.9750000005588, 1198.8883349113166, 1191.4877098752186], "set-overwrite-1": [212.49999990686774, 212.19458023551852, 212.0289602316916, 212.09791477303952, 212.0668749557808], "set-overwrite-2": [321.25187513884157, 316.3208352634683, 319.5787500590086, 327.63729454018176, 325.0902099534869], "set-overwrite-3": [546.9820799771696, 538.5752097936347, 537.3918748227879, 540.6372947618365, 556.7700002575293], "set-overwrite-7": [943.2112501235679, 926.2379200663418, 925.4914545454085, 941.2035398418084, 930.9904149267823], "set-preserve-1": [193.4418745804578, 193.99916986003518, 194.84729040414095, 196.53062510769814, 190.2104145847261], "set-preserve-2": [291.5406250394881, 291.6458295658231, 292.2124997712672, 292.8208344383165, 291.17625032085925]}`
- `micro-huffman-0-B`: `{"captured-decode-per-buffer": [114931.6665250808, 107599.45848258212, 108153.0834781006, 109829.06247954816, 110402.29146601632], "table-lookup": [62.24829098209739, 57.31154198292643, 58.54329199064523, 54.05754200182855, 54.74120797589421]}`
- `micro-huffman-0-H`: `{"captured-decode-per-buffer": [121176.45848775283, 115262.89553148672, 111384.16652102023, 110871.16651469842, 112254.50003985316], "table-lookup": [64.84666606411338, 60.62737491447478, 63.28179209958762, 60.634333989582956, 60.75845903251321]}`
- `micro-huffman-1-B`: `{"captured-decode-per-buffer": [120878.20854503661, 113285.89549520984, 111150.47946805134, 112033.64602988586, 110890.9584581852], "table-lookup": [64.66795806773007, 57.52991698682308, 58.474292047321796, 57.36674997024238, 56.05954094789922]}`
- `micro-huffman-1-H`: `{"captured-decode-per-buffer": [118945.72951132432, 114509.45801334456, 114505.83301484585, 115845.37499584258, 114294.33297598734], "table-lookup": [64.9772499455139, 66.0035409964621, 63.44141694717109, 60.70133298635483, 60.69091602694243]}`
- `micro-huffman-2-B`: `{"captured-decode-per-buffer": [120846.79148392752, 112207.14601222426, 111743.41652076691, 111792.97952912748, 110753.14600020647], "table-lookup": [65.52887510042638, 58.83741704747081, 57.45104106608778, 55.57570792734623, 55.56895805057138]}`
- `micro-huffman-2-H`: `{"captured-decode-per-buffer": [122239.64603617787, 114356.04147845879, 114364.18752418831, 114442.45849270374, 114696.25000609085], "table-lookup": [65.2995000127703, 62.53733392804861, 63.30812501255422, 60.6374170165509, 60.74754206929356]}`

</details>

## Initial FieldState microbenchmark investigation

The first shallow variant redundantly recomputed len(path) on generic paths. It measured 6.5% slower depth-three reads and 4.8% slower writes. The implementation now reuses its already-computed depth; the unchanged generic loop remains. Initial repetitions are retained below; corrected results appear in the main table. Correctness/parity/candidate instrumentation were rerun after the correction.

<details><summary>All initial FieldState repetitions (ns/op)</summary>

- `micro-field-0-B` before depth reuse: `{"get-hit-1": [233.21208485867828, 242.39249993115666, 242.31333518400788, 241.93437537178397, 238.36937500163913], "get-hit-2": [345.72687465697527, 345.67374968901277, 338.75833498314023, 348.2710401294753, 347.09104453213513], "get-hit-3": [447.7014602161944, 451.2658348539844, 450.44625003356487, 452.2245848784223, 445.5895849969238], "get-hit-7": [831.6908299457282, 828.9608301129192, 821.0404199780896, 827.9168751323596, 828.4308348083869], "get-miss-child": [320.81895507872105, 319.74999990779907, 304.48000004980713, 296.4420849457383, 320.7774995826185], "get-miss-nonchild": [281.84062510263175, 279.8758354038, 279.9427101854235, 283.6845850106329, 282.9258347628638], "get-miss-root": [220.21166514605284, 225.40375008247793, 232.20687464345247, 219.96187511831522, 220.61478986870497], "grow-nested": [1931.886459933594, 1953.6093750502914, 1950.9416655637324, 1952.5152101414276, 1934.0112496865913], "grow-root": [1364.823539624922, 1385.2520799264312, 1375.66396035254, 1382.224164553918, 1378.9904152508825], "set-overwrite-1": [308.6910455022007, 305.41062471456826, 307.63021029997617, 307.87082971073687, 308.61062521580607], "set-overwrite-2": [421.65333521552384, 422.82291513402015, 425.6945848464966, 418.24187501333654, 420.81812454853207], "set-overwrite-3": [536.1293751047924, 532.0810398552567, 539.4716648152098, 535.3279149858281, 530.2302050404251], "set-overwrite-7": [929.8502100864425, 927.844374673441, 924.3189549306408, 919.8533347807825, 923.0470849433914], "set-preserve-1": [277.62999990954995, 278.62645976711065, 278.47437479067594, 277.4070797022432, 276.14166494458914], "set-preserve-2": [387.71437481045723, 393.988955183886, 394.07604024745524, 391.62541506811976, 390.4750000219792]}`
- `micro-field-0-S` before depth reuse: `{"get-hit-1": [161.51583520695567, 164.39332976005971, 163.71958481613547, 163.5622896719724, 161.95853997487575], "get-hit-2": [257.8352048294619, 258.27812496572733, 257.5033303583041, 254.53791487962005, 255.85728988517073], "get-hit-3": [451.18458045180887, 451.95667014922947, 458.75374984461814, 458.6197901517153, 458.9247953845188], "get-hit-7": [816.8314601061866, 826.1552051408216, 819.9110446730629, 816.919170320034, 828.625624999404], "get-miss-child": [229.49541977141052, 231.25604493543506, 231.8931248737499, 229.8025001073256, 229.82875001616776], "get-miss-nonchild": [199.54312534537166, 203.27041973359883, 199.34520474635065, 198.74167046509683, 199.02187515981495], "get-miss-root": [146.25958516262472, 146.79145475383848, 146.41312474850565, 146.66187518741935, 146.50291472207755], "grow-nested": [1687.6972903264686, 1673.087709932588, 1681.910835322924, 1680.6014598114416, 1677.826670347713], "grow-root": [1202.491875155829, 1189.3758352380246, 1162.3139551375061, 1162.845414946787, 1166.1227099830285], "set-overwrite-1": [213.82000006269664, 218.28687516972423, 218.57833489775658, 219.92833469994366, 217.88729529362172], "set-overwrite-2": [318.39895993471146, 323.4512498602271, 323.9691653288901, 320.6052101450041, 309.31874993257225], "set-overwrite-3": [532.4385449057445, 531.8799999076873, 534.6724996343255, 532.712500425987, 535.0787501083687], "set-overwrite-7": [907.907914952375, 928.2097948016599, 925.5358297377825, 920.0887498445809, 934.680420323275], "set-preserve-1": [187.8564601065591, 186.8668751558289, 187.25708010606468, 186.55958003364503, 184.35041536577046], "set-preserve-2": [280.99604009184986, 283.6335398023948, 281.9904201896861, 283.9562500594184, 286.5464548813179]}`
- `micro-field-1-B` before depth reuse: `{"get-hit-1": [242.57791519630698, 243.20208525750786, 244.5324999280274, 244.8493748670444, 245.06646033842114], "get-hit-2": [348.5789545811713, 350.2879152074456, 350.7654200075194, 350.4970850190148, 352.3522900650278], "get-hit-3": [450.9918752592057, 467.4662498291582, 461.3635450368747, 477.4758353596554, 504.5797902857885], "get-hit-7": [873.1595851713791, 867.8200002759695, 894.647705135867, 877.1204150980338, 875.4441700875759], "get-miss-child": [320.02062536776066, 319.30957979056984, 321.0662497440353, 320.17812482081354, 319.04603994917125], "get-miss-nonchild": [285.0870799738914, 285.1354202721268, 285.09958006907254, 285.27499991469085, 285.3964548557997], "get-miss-root": [223.35958026815206, 222.85437502432615, 222.96250041108578, 222.5489600095898, 222.20916987862438], "grow-nested": [2771.1493748938665, 1906.5529201179743, 1871.6485449112952, 1864.2820848617703, 1851.8879153998569], "grow-root": [1336.8966698180884, 1484.5508348662406, 1344.5966702420264, 1307.3952100239694, 1284.039585152641], "set-overwrite-1": [309.62749966420233, 309.5560398651287, 309.9191648652777, 310.9152050456032, 308.9541650842875], "set-overwrite-2": [429.9358295975253, 429.82812505215406, 426.5395796392113, 427.99229035153985, 426.833545207046], "set-overwrite-3": [609.9945848109201, 626.1854199692607, 659.3231251463294, 597.3327101673931, 590.7370848581195], "set-overwrite-7": [951.3404150493443, 936.4029200514778, 935.7172902673483, 936.8656249716878, 939.9525000480935], "set-preserve-1": [283.81958545651287, 278.6970802117139, 278.463545255363, 278.7264599464834, 279.6785451937467], "set-preserve-2": [399.8470847727731, 392.1949997311458, 386.7693751817569, 386.20687555521727, 386.87833468429744]}`
- `micro-field-1-S` before depth reuse: `{"get-hit-1": [153.5033353138715, 152.36208506394178, 152.3554150480777, 152.9970800038427, 153.36874988861382], "get-hit-2": [240.80854491330683, 245.20270992070436, 250.46937516890466, 250.46229013241827, 254.42854501307008], "get-hit-3": [479.77874986827374, 479.45333004463464, 478.36979501880705, 479.777290020138, 483.2275002263486], "get-hit-7": [843.9543750137091, 841.5772946318612, 848.2639549765736, 839.101875317283, 851.5020849881694], "get-miss-child": [237.14874987490475, 235.807080171071, 232.78000007849187, 232.37750050611794, 247.07853968720886], "get-miss-nonchild": [207.07416988443583, 203.4841652493924, 214.66082951519638, 211.82729047723114, 212.83333015162498], "get-miss-root": [151.7137500923127, 148.92520499415696, 145.7756251329556, 145.88249963708222, 146.65041991975158], "grow-nested": [1788.768540136516, 1779.4974998105317, 1818.9310398884118, 1799.3189551634714, 1777.3085396038368], "grow-root": [1416.112084989436, 1286.715205060318, 1239.9139598710462, 1242.1714549418539, 1248.9787500817329], "set-overwrite-1": [204.73437500186265, 204.2777050519362, 204.48708499316126, 204.6870847698301, 203.69999983813614], "set-overwrite-2": [311.1102100228891, 310.6577100697905, 310.5035447515547, 311.04749999940395, 313.41000052634627], "set-overwrite-3": [563.0702100461349, 560.5652101803571, 564.4983350066468, 555.5470852414146, 567.4347898457199], "set-overwrite-7": [941.791670047678, 937.4689596006647, 935.6950002256781, 937.4972950899974, 934.14812523406], "set-preserve-1": [208.48833490163088, 199.5914604049176, 205.2010444458574, 200.83145529497415, 197.4177098600194], "set-preserve-2": [308.6531249573454, 301.27333477139473, 306.36687530204654, 306.5368748502806, 305.25770504027605]}`
- `micro-field-2-B` before depth reuse: `{"get-hit-1": [240.90646009426564, 234.90791500080377, 234.52291497960687, 235.29125028289855, 234.48958003427833], "get-hit-2": [350.9235451929271, 344.95375002734363, 342.8191697457805, 344.56312481779605, 345.46062524896115], "get-hit-3": [441.1358298966661, 443.5191652737558, 448.49687488749623, 442.4487502546981, 440.86687499657273], "get-hit-7": [808.3725004689768, 817.5804151687771, 807.981044636108, 805.1620848709717, 813.2016647141427], "get-miss-child": [325.3975004190579, 322.16332969255745, 320.91000000946224, 321.556045091711, 320.4218752216548], "get-miss-nonchild": [284.7954153548926, 284.4579145312309, 283.46520964987576, 278.0850004637614, 278.02854019682854], "get-miss-root": [219.29062495473772, 221.78562474437058, 215.8097951905802, 216.4049999555573, 220.8731247810647], "grow-nested": [1800.3352102823555, 1801.2912501581013, 1800.2299999352545, 1799.966455437243, 1801.9320798339322], "grow-root": [1331.0466648545116, 1301.2197898933664, 1281.4604147570208, 1283.6412497563288, 1283.7625003885478], "set-overwrite-1": [297.28228983003646, 296.7514604097232, 297.11645969655365, 299.4283346924931, 303.73479472473264], "set-overwrite-2": [417.11062483955175, 418.99624979123473, 430.03083497751504, 417.7710396470502, 419.05083460733294], "set-overwrite-3": [517.1066697221249, 518.5718752909452, 528.310204972513, 532.5120850466192, 514.869790058583], "set-overwrite-7": [914.9487502872944, 905.8364602969959, 913.5760396020487, 904.8379154410213, 909.879999817349], "set-preserve-1": [273.9085449138656, 271.90395980142057, 272.3435399821028, 274.0389545215294, 279.6402102103457], "set-preserve-2": [392.0193749945611, 390.8600000431761, 400.86041495669633, 389.58000019192696, 388.7612500693649]}`
- `micro-field-2-S` before depth reuse: `{"get-hit-1": [153.57042022515088, 153.3737499266863, 152.7764549246058, 154.84875009860843, 153.19625032134354], "get-hit-2": [251.76083494443446, 252.797084976919, 251.91958528012037, 256.0554147930816, 259.81125014368445], "get-hit-3": [486.8381249252707, 485.4358301963657, 492.4931249115616, 504.9383349251002, 489.23042020760477], "get-hit-7": [860.1087500574067, 854.7660399926826, 849.2277102777734, 842.0545852277428, 882.2331251576543], "get-miss-child": [236.79353995248675, 234.83708500862122, 233.7197947781533, 233.78562531434, 234.30354543961585], "get-miss-nonchild": [202.04000000376254, 202.84896017983556, 206.2262495746836, 203.21979478467256, 199.4922902667895], "get-miss-root": [152.4854201124981, 150.72875015903264, 154.70749989617616, 148.01312470808625, 146.09562524128705], "grow-nested": [1705.1987495506182, 1712.9914602264762, 1712.080420111306, 1711.2829198595136, 1709.1591650387272], "grow-root": [1248.9699997240677, 1210.8906253706664, 1196.052290033549, 1195.015205303207, 1189.1527101397514], "set-overwrite-1": [210.67354537080973, 211.05374966282398, 211.8695800891146, 211.75958507228643, 211.9152102386579], "set-overwrite-2": [320.18708530813456, 336.17812499869615, 326.51854446157813, 325.30499971471727, 321.81708491407335], "set-overwrite-3": [563.1066701607779, 563.7545848730952, 566.5066646179184, 583.2162499427795, 561.2579151056707], "set-overwrite-7": [943.2429150911048, 944.7389550041407, 949.5316649554297, 936.6864548064768, 943.91958496999], "set-preserve-1": [189.69458527863026, 187.34082987066358, 188.00187506712973, 190.50937495194376, 188.08770517352968], "set-preserve-2": [285.3385399794206, 288.6958350427449, 287.07104502245784, 292.9918753216043, 297.6274996763095]}`

</details>

## Separate memory measurements

One fresh untimed public parse per variant/replay supplements the three-run peak-RSS measurements above. Current RSS is measured through the existing psutil installation after imports and after parsing/GC, while the result remains alive. These individual current-RSS observations are not medians. Table size counts the list and distinct tuples for B/S, or both bytes containers for H/C; shared small integers are not counted repeatedly.

| Replay | Variant | Post-import RSS MiB | Retained-result RSS MiB | Table bytes |
|---|---|---|---|---|
|8822520406|B|47.453|119.656|8388664|
|8822520406|S|47.172|126.391|8388664|
|8822520406|H|38.766|108.859|262210|
|8822520406|C|38.625|109.469|262210|
|8856501050|B|47.297|316.031|8388664|
|8856501050|S|47.234|315.953|8388664|
|8856501050|H|38.891|307.750|262210|
|8856501050|C|38.250|307.094|262210|

## Separate operation instrumentation

- `8822520406` B = C: `{"decode": {"fallback": 18941, "table": 15216537}, "get_depth": {"1": 417524, "2": 1606100, "3": 2077325}, "set_depth": {"1": 5476492, "2": 3830746, "3": 599826, "4": 17935, "5": 37546, "6": 200, "7": 60}, "sha256": "3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427"}`.
- `8856501050` B = C: `{"decode": {"fallback": 36840, "table": 53588018}, "get_depth": {"1": 1510599, "2": 5534858, "3": 5700986}, "set_depth": {"1": 16568336, "2": 17747453, "3": 2515871, "4": 52736, "5": 41175, "6": 200, "7": 60}, "sha256": "1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e"}`.

Counters wrap compact reads/writes and inject increments into the existing table/fallback branches in memory. They do not change tracked source and are never enabled for timing or memory measurements.

## Full offline OpenDota parity

- `8868259993`: 325 PASS, 0 WARN, 0 FAIL; skips: [{"name": "teamfights/total_count", "note": "OpenDota applies deaths>=3 filtering over its expanded event pipeline. Count comparison is informational only."}].
- `8860187335`: 326 PASS, 0 WARN, 0 FAIL; skips: [{"name": "teamfights/total_count", "note": "OpenDota applies deaths>=3 filtering over its expanded event pipeline. Count comparison is informational only."}].
- `8856501050`: 331 PASS, 0 WARN, 0 FAIL; skips: [{"name": "teamfights/total_count", "note": "OpenDota applies deaths>=3 filtering over its expanded event pipeline. Count comparison is informational only."}].

## Fixed short-replay follow-ups

The initial short-public block showed a +11.5% shallow-only median CPU increase with mixed pair directions and large within-variant variation. We fixed three additional public S/B, B/S, S/B pairs while the planned matrix was still running. After the short-core block showed higher combined median peak RSS, we also fixed three core C/B, B/C, C/B pairs. Both follow-ups ran after the planned matrix; no measurements were discarded. Results are reported separately.

### public follow-up

| Variant | Elapsed s (3 runs) | User CPU s (3 runs) | Peak RSS MiB (3 runs) | Median elapsed / CPU / RSS |
|---|---|---|---|---|
|B|55.717, 57.700, 56.572|55.547, 56.747, 56.194|217.531, 203.922, 205.344|56.572 / 56.194 / 205.344|
|S|54.199, 55.130, 54.940|53.466, 54.800, 54.613|217.438, 203.781, 204.109|54.940 / 54.613 / 204.109|

- `followup-short-0-B`: load start [3.599609375, 3.4794921875, 3.49853515625]; end [2.97802734375, 3.32666015625, 3.43994140625].
- `followup-short-0-S`: load start [3.1298828125, 3.43994140625, 3.48974609375]; end [3.599609375, 3.4794921875, 3.49853515625].
- `followup-short-1-B`: load start [2.97802734375, 3.32666015625, 3.43994140625]; end [3.5029296875, 3.3916015625, 3.4521484375].
- `followup-short-1-S`: load start [3.5029296875, 3.3916015625, 3.4521484375]; end [3.5087890625, 3.37646484375, 3.4384765625].
- `followup-short-2-B`: load start [2.9775390625, 3.25732421875, 3.3876953125]; end [2.8623046875, 3.18017578125, 3.34912109375].
- `followup-short-2-S`: load start [3.5087890625, 3.37646484375, 3.4384765625]; end [2.9755859375, 3.26171875, 3.39013671875].

### core follow-up

| Variant | Elapsed s (3 runs) | User CPU s (3 runs) | Peak RSS MiB (3 runs) | Median elapsed / CPU / RSS |
|---|---|---|---|---|
|B|44.466, 45.056, 44.630|44.142, 44.732, 44.291|152.625, 166.781, 161.656|44.630 / 44.291 / 161.656|
|C|42.209, 42.717, 43.764|41.999, 42.348, 43.502|165.656, 148.844, 153.672|42.717 / 42.348 / 153.672|

- `followup-core-0-B`: load start [3.98876953125, 3.3828125, 3.41015625]; end [3.82275390625, 3.4208984375, 3.421875].
- `followup-core-0-C`: load start [2.8623046875, 3.18017578125, 3.34912109375]; end [3.98876953125, 3.3828125, 3.41015625].
- `followup-core-1-B`: load start [3.82275390625, 3.4208984375, 3.421875]; end [3.40576171875, 3.35986328125, 3.39794921875].
- `followup-core-1-C`: load start [3.40576171875, 3.35986328125, 3.39794921875]; end [4.0078125, 3.59814453125, 3.48681640625].
- `followup-core-2-B`: load start [3.67626953125, 3.55419921875, 3.47509765625]; end [3.3916015625, 3.4912109375, 3.45458984375].
- `followup-core-2-C`: load start [4.0078125, 3.59814453125, 3.48681640625]; end [3.67626953125, 3.55419921875, 3.47509765625].

All six public follow-up outputs also match the original short-replay public JSON byte-for-byte.

## Exact reproduction

Use the same existing virtual environment and local fixtures from the candidate checkout. Adjust hard-coded checkout/temp paths if reproducing elsewhere. Start with an empty temporary directory; the timing driver preserves existing result files.

```bash
mkdir -p /private/tmp/gem-161/baseline
git archive b5e470a8eec259bb2db4c59ca098934c20c6732e | tar -x -C /private/tmp/gem-161/baseline
# Save the scripts from the linked reproduction comment in /private/tmp/gem-161/.
PYTHONHASHSEED=0 .venv/bin/python /private/tmp/gem-161/bench.py /private/tmp/gem-161/baseline public tests/fixtures/opendota/8822520406.dem /private/tmp/gem-161/public-8822520406-0-B.json
# In the original run, implementation followed this fresh baseline.
.venv/bin/python /private/tmp/gem-161/variants.py
.venv/bin/python /private/tmp/gem-161/checks.py
PYTHONHASHSEED=0 .venv/bin/python /private/tmp/gem-161/parity.py
PYTHONHASHSEED=0 .venv/bin/python /private/tmp/gem-161/instrument_runs.py
.venv/bin/python /private/tmp/gem-161/micro_runs.py
.venv/bin/python /private/tmp/gem-161/replays.py
.venv/bin/python /private/tmp/gem-161/followup.py
.venv/bin/python /private/tmp/gem-161/followup_report.py
.venv/bin/python /private/tmp/gem-161/memory_runs.py
.venv/bin/python /private/tmp/gem-161/report.py
```

The original run overlapped correctness checks, parity, and instrumentation. The commands above serialize them for convenience. Microbenchmarks, replay timings, and separate memory runs are sequential, with no other local validation running concurrently. The existing uv-managed CPython environment is invoked directly after uv encountered a cache-access permission error; no dependencies were changed. Parity receives existing OpenDota JSON explicitly and performs no downloads.


Complete scripts, isolated/initial source diffs, and installed dependency versions: [reproduction notes](https://github.com/whanyu1212/gem-dota/pull/178#issuecomment-5561097763).
