### PR TITLE
Benchmark Python runtimes for parser workloads.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Python runtime guidance.** Document controlled CPython 3.10–3.13 parser
+  benchmarks and a separate 3.14 dependency-environment comparison, with
+  compatibility results and reproducible measurements for macOS arm64.
 - **Lower field-decoding overhead.** Specialize shallow compact field-state paths
   and store Huffman operation/count lookups in compact byte tables.
 - **Less interval-frame copying.** Read team values at sampling boundaries after

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ Skadistats once open-sourced SMOKE (Cython-based rather than pure Python), but i
 
 Requires Python 3.10+.
 
+For parser workloads on macOS arm64, consult the
+[runtime study](docs/deep-dives/parser-performance.md#cpython-runtime-study)
+before choosing a Python version. It compares CPython 3.10–3.14 and documents
+the dependency constraints and compatibility checks behind its guidance.
+
 > [!IMPORTANT]
 > Parquet export requires either `pyarrow` or `fastparquet` in your environment.
 

--- a/docs/deep-dives/parser-performance.md
+++ b/docs/deep-dives/parser-performance.md
@@ -184,10 +184,10 @@ native pandas 3 environment on newer Python minors.
 | CPython | Fast suite | All offline tests | Full OpenDota parity |
 |---|---|---|---|
 | 3.10.21 | 3854 passed, 3 skipped, 62 deselected in 11.30s | 3915 passed, 3 skipped, 1 deselected in 258.39s (0:04:18) | 982 PASS; 0 WARN; 0 FAIL; 3 informational SKIP |
-| 3.11.16 | 3818 passed, 3 skipped, 62 deselected in 10.43s | 3879 passed, 3 skipped, 1 deselected in 563.45s (0:09:23) | In progress |
-| 3.12.14 | 3818 passed, 3 skipped, 62 deselected in 9.39s | 3879 passed, 3 skipped, 1 deselected in 558.58s (0:09:18) | In progress |
+| 3.11.16 | 3818 passed, 3 skipped, 62 deselected in 10.43s | 3879 passed, 3 skipped, 1 deselected in 563.45s (0:09:23) | 982 PASS; 0 WARN; 0 FAIL; 3 informational SKIP |
+| 3.12.14 | 3818 passed, 3 skipped, 62 deselected in 9.39s | 3879 passed, 3 skipped, 1 deselected in 558.58s (0:09:18) | 982 PASS; 0 WARN; 0 FAIL; 3 informational SKIP |
 | 3.13.15 | 3818 passed, 3 skipped, 62 deselected in 10.37s | Not selected | Not selected |
-| 3.14.7 | 1 failed, 3817 passed, 3 skipped, 62 deselected in 29.21s | 1 failed, 3878 passed, 3 skipped, 1 deselected in 539.59s (0:08:59) | In progress |
+| 3.14.7 | 1 failed, 3817 passed, 3 skipped, 62 deselected in 29.21s | 1 failed, 3878 passed, 3 skipped, 1 deselected in 539.59s (0:08:59) | 982 PASS; 0 WARN; 0 FAIL; 3 informational SKIP |
 
 Python 3.14.7 with pandas 3.0.1 fails the existing
 `tests/test_bulk.py::TestParseManyToDataframe::test_match_path_column_is_string`
@@ -240,11 +240,11 @@ SHA-256:
 
 ### Reproduction and provenance
 
-The [study record](https://github.com/whanyu1212/gem-dota/issues/159) preserves complete bootstrap and benchmark
+The [study PR](https://github.com/whanyu1212/gem-dota/pull/179) preserves complete bootstrap and benchmark
 scripts, commands, common/native constraints, all installed package manifests,
 binary-wheel URLs and hashes, executable paths, build configuration, individual
 measurements, load observations, and compatibility/skip results in linked
-reproduction notes. Temporary runtimes, environments, wheels, scripts, and
+reproduction notes. The [complete scripts](https://github.com/whanyu1212/gem-dota/pull/179#issuecomment-5564141791), [primary measurements](https://github.com/whanyu1212/gem-dota/pull/179#issuecomment-5564142377), and [fixed follow-ups](https://github.com/whanyu1212/gem-dota/pull/179#issuecomment-5564142779) are available directly. Temporary runtimes, environments, wheels, scripts, and
 outputs were removed only after publication was verified.
 
 To reproduce the controlled configuration, use the exact source commit and

--- a/docs/deep-dives/parser-performance.md
+++ b/docs/deep-dives/parser-performance.md
@@ -4,7 +4,9 @@ Runtime builds, dependencies, replay duration, patch, entity volume, and enabled
 extractors all affect parse time. This page records measured results and their
 limits; historical optimization measurements are preserved below.
 
-## CPython runtime study — 7 September 2026 {#cpython-runtime-study}
+## CPython runtime study
+
+Study date: 7 September 2026.
 
 This study measures source commit
 `3d1b734b60ba418b8c1324bc9cf1fb5c7688fbc8`, after the optimizations through

--- a/docs/deep-dives/parser-performance.md
+++ b/docs/deep-dives/parser-performance.md
@@ -1,11 +1,276 @@
 # Parser Performance
 
-This page records the Python parser optimization work completed after the
-September 2026 baseline profile. It is a maintainer reference, not a performance
-guarantee: replay duration, patch, entity volume, enabled extractors, Python
-version, and hardware all affect parse time.
+Runtime builds, dependencies, replay duration, patch, entity volume, and enabled
+extractors all affect parse time. This page records measured results and their
+limits; historical optimization measurements are preserved below.
 
-## Benchmark fixture and method
+## CPython runtime study — 7 September 2026 {#cpython-runtime-study}
+
+This study measures source commit
+`3d1b734b60ba418b8c1324bc9cf1fb5c7688fbc8`, after the optimizations through
+[#178](https://github.com/whanyu1212/gem-dota/pull/178). It does not change Gem's
+Python 3.10+ requirement. The earlier measurements below remain historical;
+they are not the baseline for this comparison.
+
+### Environment and dependency control
+
+The host was an Apple M2 Mac14,15 with 16 GiB RAM, running macOS 26.6.2 arm64
+on AC power with Low Power Mode disabled. All interpreters were standard,
+GIL-enabled arm64 `install_only` builds from Astral's
+[20260901 release](https://github.com/astral-sh/python-build-standalone/releases/tag/20260901),
+built with Clang 22.1.3. No Rosetta, free-threaded, prerelease, or enabled JIT
+builds were included. `PYTHONHASHSEED=0` and `PYTHON_JIT=0` were set; build
+configuration and GIL/JIT introspection were checked where available.
+
+| Label | CPython | Production dependencies |
+|---|---|---|
+| A | 3.10.21 | Common Python 3.10 lock selection |
+| B | 3.11.16 | Same common versions as A |
+| C | 3.12.14 | Same common versions as A |
+| D | 3.13.15 | Same common versions as A |
+| E | 3.14.7 | Native Python 3.14 lock selection |
+
+A–D use 43 identical production dependency versions, including NumPy 2.2.6,
+pandas 2.3.3, and IPython 8.38.0. These are marker-independent constraints
+materialized from the existing lock's Python 3.10 selection, including its
+compatibility backports. Matching versions still use interpreter-specific
+binary wheels. E uses 40 native dependencies, including NumPy 2.4.2, pandas
+3.0.1, and IPython 9.11.0. E therefore compares a **runtime and dependency
+environment**; its differences cannot be attributed entirely to CPython.
+
+All environments installed the same `gem_dota-0.7.1-py3-none-any.whl`, SHA-256
+`9070de91fb18289ce1461de0f919be9f912f040511ddfff7a795eebf38754bbd`.
+The wheel also includes 553 pre-existing ignored report PNGs (14,120,517
+uncompressed bytes). A clean archived-source rebuild has identical shared
+entries except `RECORD`, but omits those icons and therefore has a different
+wheel hash. Restoring the recorded assets and pinning `uv_build==0.9.8`
+reproduced the measured wheel hash exactly. The asset manifest and restore
+script are preserved with the reproduction notes. Exact reconstruction requires
+those existing PNG bytes; the manifest alone cannot recreate them on a fresh
+checkout. A clean-source experiment can use a different wheel hash consistently
+across runtimes; the assets are report
+resources, not parser inputs. All five runtimes used the same measured wheel.
+Installation used uv 0.9.8, hash-checked binary production requirements,
+explicit interpreter paths, and isolated environments. Installed versions,
+wheel provenance, dependency consistency, and the installed Gem import path
+were verified. Test tools lived in separate environments and did not change
+production pins. The project environment, lockfile, and global tools were
+preserved.
+
+### Measurement protocol
+
+Each scenario/replay used three fresh processes per runtime, with one parse
+per process: 60 timed parses in total. Sequential blocks were A/B/C/D/E,
+E/D/C/B/A, and C/A/E/B/D. No tests, profiling, or other benchmark workloads ran
+concurrently. Lazy imports were preloaded; normal garbage collection remained
+enabled, with a collection immediately before timing. Core parser construction
+was outside the timer. Public timing included extractor setup and result
+assembly. Startup, imports, serialization, and hashing were excluded.
+
+Elapsed time, user CPU, and process peak RSS were captured before serialization.
+Peak RSS includes earlier process allocations and is **not retained-result
+memory**. Three observations expose variation but cannot establish a universal
+ranking across hardware, builds, replay patches, or dependency versions.
+
+The short fixture `8822520406.dem` is 98,983,300 bytes, SHA-256
+`5f976ab73b2efb0e4eca9f7f14d5980f3aae5f63e7952e16a8497eeded57d39d`.
+The long TI2026 fixture `8856501050.dem` is 385,487,555 bytes, SHA-256
+`0f7577525b995347ed9df0c793cc8661c2a9db4ee176bf35cb5dd940e5af17e2`.
+
+
+### Every production dependency difference
+
+| Package | A–D | E |
+|---|---|---|
+| exceptiongroup | 1.3.1 | Absent |
+| ipython | 8.38.0 | 9.11.0 |
+| ipython-pygments-lexers | Absent | 1.1.1 |
+| numpy | 2.2.6 | 2.4.2 |
+| pandas | 2.3.3 | 3.0.1 |
+| pytz | 2026.1.post1 | Absent |
+| typing-extensions | 4.15.0 | Absent |
+| tzdata | 2025.3 | Absent |
+
+### Primary measurements
+
+Medians of three runs; times in seconds, peak RSS in MiB. The parenthesized elapsed range shows all three observations. Full-precision individual measurements and start/end load averages are preserved in the reproduction notes.
+
+| Scenario | Replay | CPython | Elapsed (range) | User CPU | Peak RSS |
+|---|---|---|---:|---:|---:|
+| public | 8822520406 | 3.10.21 | 45.714 (44.801–46.597) | 45.140 | 196.33 |
+| public | 8822520406 | 3.11.16 | 29.804 (29.764–30.514) | 29.680 | 196.03 |
+| public | 8822520406 | 3.12.14 | 30.554 (30.322–31.934) | 29.901 | 193.00 |
+| public | 8822520406 | 3.13.15 | 34.361 (34.105–34.524) | 33.953 | 182.30 |
+| public | 8822520406 | 3.14.7 | 28.016 (28.016–28.594) | 27.866 | 180.62 |
+| public | 8856501050 | 3.10.21 | 147.273 (143.437–148.238) | 145.423 | 624.12 |
+| public | 8856501050 | 3.11.16 | 96.829 (96.604–98.373) | 95.875 | 587.34 |
+| public | 8856501050 | 3.12.14 | 96.414 (95.539–99.154) | 95.780 | 576.64 |
+| public | 8856501050 | 3.13.15 | 111.055 (109.191–113.694) | 110.586 | 582.25 |
+| public | 8856501050 | 3.14.7 | 90.189 (89.728–91.367) | 89.187 | 607.31 |
+| core | 8822520406 | 3.10.21 | 35.889 (35.820–36.198) | 35.650 | 166.06 |
+| core | 8822520406 | 3.11.16 | 23.181 (22.997–23.468) | 23.063 | 167.89 |
+| core | 8822520406 | 3.12.14 | 23.924 (23.696–23.954) | 23.694 | 167.84 |
+| core | 8822520406 | 3.13.15 | 27.214 (26.566–27.960) | 27.126 | 169.66 |
+| core | 8822520406 | 3.14.7 | 21.775 (21.598–21.803) | 21.654 | 172.02 |
+| core | 8856501050 | 3.10.21 | 124.749 (122.408–125.827) | 124.216 | 425.72 |
+| core | 8856501050 | 3.11.16 | 79.589 (79.279–82.361) | 78.939 | 428.41 |
+| core | 8856501050 | 3.12.14 | 80.972 (80.668–84.278) | 80.412 | 429.81 |
+| core | 8856501050 | 3.13.15 | 93.835 (92.417–95.300) | 92.933 | 418.53 |
+| core | 8856501050 | 3.14.7 | 75.997 (75.623–77.230) | 75.689 | 416.81 |
+
+Observed 1-minute host load ranged from 2.48 to 5.34. User CPU range divided by its median stayed below 4.5% in every primary scenario/runtime. Host load is an observation, not proof of an idle machine; sequential reordered blocks reduce but cannot remove session effects.
+
+### Interpretation and runtime guidance
+
+The provisional validation candidate was E (3.14.7), selected by the lowest
+geometric mean of the two public elapsed medians. Relative to A=1.000, scores
+were E=0.613, B=0.655, C=0.661, D=0.753. Public CPU, then newer minor version,
+were the declared tie-breakers; neither was needed. E is the only environment
+within 5% of the overall best score, but its changed dependencies and failed
+compatibility assertion prevent a recommendation.
+
+Within the controlled A–D comparison, B and C form a close group: their public
+scores differ by about 1%, and their relative per-block directions vary. Both
+reduce median public elapsed and CPU time by approximately 33–35% versus A
+on each replay, with improvements in all three blocks. This meets the timing
+threshold of at least 5% improvement in both metrics on both replays and at
+least two improving blocks. It does not resolve a uniquely fastest runtime.
+
+The original core runs showed consistently higher peak RSS for E on the short
+replay and for B/C on both replays. The predeclared anomaly checks covered
+mixed block directions, CPU range/median above 10%, median RSS increases above
+10%, and smaller consistent increases. The same checks were extended from E
+to B/C because they were the strongest passing configurations under common
+pins. Five comparisons received one fixed three-pair follow-up each (30
+additional parses), ordered candidate/A, A/candidate, candidate/A. No further
+timing rounds were taken.
+
+| Core follow-up | Replay | Median candidate peak RSS MiB | Median paired A peak RSS MiB | Difference of medians |
+|---|---|---:|---:|---:|
+| E/A | 8822520406 | 172.109 | 165.984 | +3.69% |
+| B/A | 8822520406 | 168.062 | 166.109 | +1.18% |
+| B/A | 8856501050 | 442.172 | 428.781 | +3.12% |
+| C/A | 8822520406 | 167.734 | 166.016 | +1.04% |
+| C/A | 8856501050 | 429.172 | 425.750 | +0.80% |
+
+These follow-ups retain the small core memory increases. Higher pre-parse
+high-water marks are consistent with a runtime/dependency startup-footprint
+contribution, but do not prove it. Both readings use `ru_maxrss`; subtracting
+them does not measure retained memory or isolate parser allocations. The
+precise cause of the differences remains unresolved.
+
+The final C/A long-core follow-up was unstable. C user CPU observations were
+78.922, 166.522, and 165.390 seconds; A observations were 122.944, 158.052, and
+250.125 seconds. Near the end, the host reported AC power but a 4% battery
+that was discharging; Low Power Mode remained off and thermal status was
+unavailable. This is evidence of session instability, not proof of a specific
+power or thermal cause. Those observations are preserved separately and do
+not replace the primary results or support a clean follow-up ranking.
+
+The primary public timing benefits are clear, but the unresolved core memory
+tradeoffs and unstable final follow-up prevent an unconditional performance
+recommendation under this study's acceptance rules.
+
+
+For practical installation decisions, the fast common-pin configurations are
+worth evaluating for a parser-heavy workload, but this study does not select
+an unconditional preferred runtime. Preserve Python 3.10+ compatibility and
+validate the actual dependency environment you intend to install. In
+particular, the passing common-pin results do not validate the repository's
+native pandas 3 environment on newer Python minors.
+
+### Compatibility validation
+
+| CPython | Fast suite | All offline tests | Full OpenDota parity |
+|---|---|---|---|
+| 3.10.21 | 3854 passed, 3 skipped, 62 deselected in 11.30s | 3915 passed, 3 skipped, 1 deselected in 258.39s (0:04:18) | 982 PASS; 0 WARN; 0 FAIL; 3 informational SKIP |
+| 3.11.16 | 3818 passed, 3 skipped, 62 deselected in 10.43s | 3879 passed, 3 skipped, 1 deselected in 563.45s (0:09:23) | In progress |
+| 3.12.14 | 3818 passed, 3 skipped, 62 deselected in 9.39s | 3879 passed, 3 skipped, 1 deselected in 558.58s (0:09:18) | In progress |
+| 3.13.15 | 3818 passed, 3 skipped, 62 deselected in 10.37s | Not selected | Not selected |
+| 3.14.7 | 1 failed, 3817 passed, 3 skipped, 62 deselected in 29.21s | 1 failed, 3878 passed, 3 skipped, 1 deselected in 539.59s (0:08:59) | In progress |
+
+Python 3.14.7 with pandas 3.0.1 fails the existing
+`tests/test_bulk.py::TestParseManyToDataframe::test_match_path_column_is_string`
+assertion (`dtype == object`); pandas instead returns its default string dtype.
+No assertion or production dependency was changed to hide this failure. This
+blocks a compatibility recommendation for E, even though its parser JSON
+matches. Pandas documents this behavior in its
+[3.0 release notes](https://pandas.pydata.org/docs/whatsnew/v3.0.0.html#dedicated-string-data-type-by-default).
+The current lock also selects pandas 3.0.1 on Python 3.11–3.13. Passing B/C/D
+checks with common pandas 2.3.3 pins do not validate those native-lock
+environments, and this failure is not established as a CPython 3.14 defect.
+
+The 36 fewer generated tests on Python 3.11+ result from `IntFlag` iteration:
+`list(EntityOp)` yields five atomic members there, versus nine named members
+on 3.10. The named-member overlap parametrization therefore changes from
+9×9 to 9×5 cases. The exhaustive 32×32 mask check still runs on every runtime;
+no tests were deleted.
+
+Every pytest run has the same three skips: optional pyarrow coverage
+(`tests/test_bulk.py:250`), an optional Parquet engine
+(`tests/test_parquet_export.py:56`), and the existing optimized-away flag case
+(`tests/test_field_decoder.py:208`). Fast selection deselects 62 marked tests;
+offline selection deselects only the live network test. Full parity uses the
+existing references for 8868259993, 8860187335, and 8856501050 with unchanged
+thresholds (325, 326, and 331 passing fields per runtime). Each replay reports
+one informational `teamfights/total_count` skip for the expanded OpenDota
+pipeline's deaths≥3 convention. No required local fixtures were missing.
+
+Validation timings are not parser performance measurements. Initial untimed
+metadata/fast checks overlapped, as did baseline offline/parity checks; all
+were stopped before the timing matrix began. Subsequent compatibility checks
+ran concurrently across separate runtime environments, only after all timed measurements finished. Their elapsed durations include contention and should not be compared as runtime benchmarks.
+
+### Public output equality
+
+All 15 public results per replay were byte-identical across runtimes and
+repetitions, using `json.dumps(gem.to_dict(result), sort_keys=True,
+separators=(",", ":")).encode()` with `PYTHONHASHSEED=0`. Arrays were not reordered
+and numeric values were not rounded to manufacture agreement.
+
+| Replay | JSON bytes | Players | Combat events | Wards | Teamfights / OpenDota teamfights | Draft events |
+|---|---:|---:|---:|---:|---:|---:|
+| 8822520406 | 30,401,205 | 10 | 44,686 | 60 | 24 / 3 | 24 |
+| 8856501050 | 187,363,261 | 10 | 272,400 | 221 | 36 / 10 | 24 |
+
+SHA-256:
+
+- `8822520406`: `3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427`
+- `8856501050`: `1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e`
+
+### Reproduction and provenance
+
+The [study record](https://github.com/whanyu1212/gem-dota/issues/159) preserves complete bootstrap and benchmark
+scripts, commands, common/native constraints, all installed package manifests,
+binary-wheel URLs and hashes, executable paths, build configuration, individual
+measurements, load observations, and compatibility/skip results in linked
+reproduction notes. Temporary runtimes, environments, wheels, scripts, and
+outputs were removed only after publication was verified.
+
+To reproduce the controlled configuration, use the exact source commit and
+Astral artifacts, build one wheel, then install it into an isolated environment
+with the published common constraints. Use the published bootstrap instead of
+assuming a plain `uv sync` on Python 3.11/3.12 produces the tested environment.
+Keep test dependencies in separate constrained environments. No dependency
+pins or Python-version requirements in Gem were changed by this study.
+
+<details><summary>Runtime archive SHA-256 hashes</summary>
+
+| CPython | SHA-256 |
+|---|---|
+| 3.10.21 | `cee232aabfb6790eec78f3cca935caeb7bd4eedca4dcb0a10dbcdb4302320b38` |
+| 3.11.16 | `50424fa409e8ae84b82a3052522f64695b47dff2158b70bb7358e0ebd6c085c9` |
+| 3.12.14 | `3ee3ee547cedfeb7c2b16b2b7156039f7b470bb8f857e226fd3d2eb11db83c76` |
+| 3.13.15 | `b9054a9d3d54f4cb5573d44907fddb29874b08909bde73f29f2868cf872223ee` |
+| 3.14.7 | `30daa970c7d223530120f1693cd3c6fa4c0c0d31ef158710b0dd77f286a5b23e` |
+
+</details>
+
+Final hotspot profiling and the Rust boundary decision remain under [#158](https://github.com/whanyu1212/gem-dota/issues/158). This study makes no claims about Linux, x86, other CPython builds, or JIT/free-threaded configurations.
+
+## Historical optimization work (#143–#156)
+
+### Benchmark fixture and method
 
 The common benchmark is
 `tests/fixtures/opendota/8822520406.dem`, a 98,983,300-byte DreamLeague Season 29
@@ -23,7 +288,7 @@ Instrumented profiles are not used as elapsed-time benchmarks because profiler
 overhead is substantial. Each optimization PR recorded the median of three full
 parses and checked a normalized `ParsedMatch` against its preceding baseline.
 
-## Baseline
+### Baseline
 
 The original profile at commit `ed6d7a5` measured:
 
@@ -41,7 +306,7 @@ small helper methods invoked once per path component.
 See [issue #143](https://github.com/whanyu1212/gem-dota/issues/143) for the full
 historical function table and memory breakdown.
 
-## Optimization sequence
+### Optimization sequence
 
 Five deliberately separate changes addressed the measured Python hot paths:
 
@@ -60,7 +325,7 @@ about 31% and 29% lower, but that longer-range comparison spans separate
 measurement sessions and should be treated as directional rather than a
 controlled benchmark.
 
-## Correctness gates
+### Correctness gates
 
 Each pass retained public callback and entity APIs and compared normalized output
 with the preceding implementation. After the final pass, the normalized
@@ -73,7 +338,7 @@ variable-table decoder models; serializer cache isolation; invalid paths; entity
 creation, updates, deletion, and recycled slots. Full replay tests add output and
 OpenDota parity coverage.
 
-## Memory and remaining work
+### Memory and remaining work
 
 The final pass recorded median peak RSS of 228.2 MB, about 1.9% above its
 immediately preceding public baseline. Its parse-scoped decoder caches were


### PR DESCRIPTION
Closes #159.

Measure the optimized parser at `3d1b734b60ba418b8c1324bc9cf1fb5c7688fbc8` on five pinned Astral macOS arm64 CPython builds. Only README.md, CHANGELOG.md, and docs/deep-dives/parser-performance.md change; production code, dependencies, the lockfile, Python 3.10+ compatibility, and CI remain unchanged.

## Results and interpretation

- The controlled 3.10–3.13 comparison uses the same 43 production versions selected by the Python 3.10 lock branch. The separately labeled 3.14 environment uses 40 native dependencies. All five install the same Gem wheel.
- Common-pin 3.11/3.12 public elapsed and CPU medians are approximately 33–35% lower than 3.10 on both replays, improving in every block. They form a close group rather than a uniquely fastest runtime.
- The 3.14 environment has the lowest public score, but pandas 3's string dtype fails an existing dataframe assertion. The current lock also selects pandas 3 on 3.11–3.13, so the passing common-pin results do not validate those native-lock environments.
- Small core RSS increases remain unexplained. A late fixed follow-up became unstable while the host reported a low, discharging battery; no specific power/thermal cause is claimed. No unconditional preferred runtime is selected.
- All 30 public outputs are byte-identical within each replay. Initial measurements and all fixed follow-ups are preserved separately: **60 primary parses plus 30 follow-up parses**. Historical optimization results remain historical; the final hotspot profile and Rust decision stay under #158.

## Public medians

Seconds for elapsed/user CPU; MiB for process peak RSS, captured before serialization. Peak RSS is not retained-result memory.

| CPython | Short elapsed / CPU / RSS | Long elapsed / CPU / RSS |
|---|---:|---:|
| 3.10.21 | 45.714 / 45.140 / 196.328 | 147.273 / 145.423 / 624.125 |
| 3.11.16 | 29.804 / 29.680 / 196.031 | 96.829 / 95.875 / 587.344 |
| 3.12.14 | 30.554 / 29.901 / 193.000 | 96.414 / 95.780 / 576.641 |
| 3.13.15 | 34.361 / 33.953 / 182.297 | 111.055 / 110.586 / 582.250 |
| 3.14.7 | 28.016 / 27.866 / 180.625 | 90.189 / 89.187 / 607.312 |

SHA-256 of sorted-key compact public JSON, identical across all runtimes and repetitions:

- `8822520406`: `3b0844312187a2856743092e991ab425878d64e101d91cf8f9c83bb2b3580427`
- `8856501050`: `1e8d1f6f172d7bc39abd6b2a338539b231395780e599b9b8fbf44068128a9e5e`

The measured wheel includes 553 pre-existing ignored report PNGs. Its parser source and all shared entries match a clean source-archive build except `RECORD`. Restoring the recorded assets and pinning uv_build 0.9.8 reproduces the measured wheel hash exactly. Exact reconstruction requires those existing asset bytes; their manifest cannot recreate missing files. The same wheel was used in every measured environment.

## Compatibility validation

| CPython | Fast suite | All offline tests | Full OpenDota parity |
|---|---|---|---|
| 3.10.21 | 3854 passed, 3 skipped, 62 deselected in 11.30s | 3915 passed, 3 skipped, 1 deselected in 258.39s (0:04:18) | 982 PASS; 0 WARN; 0 FAIL; 3 informational SKIP |
| 3.11.16 | 3818 passed, 3 skipped, 62 deselected in 10.43s | 3879 passed, 3 skipped, 1 deselected in 563.45s (0:09:23) | 982 PASS; 0 WARN; 0 FAIL; 3 informational SKIP |
| 3.12.14 | 3818 passed, 3 skipped, 62 deselected in 9.39s | 3879 passed, 3 skipped, 1 deselected in 558.58s (0:09:18) | 982 PASS; 0 WARN; 0 FAIL; 3 informational SKIP |
| 3.13.15 | 3818 passed, 3 skipped, 62 deselected in 10.37s | Not selected | Not selected |
| 3.14.7 | 1 failed, 3817 passed, 3 skipped, 62 deselected in 29.21s | 1 failed, 3878 passed, 3 skipped, 1 deselected in 539.59s (0:08:59) | 982 PASS; 0 WARN; 0 FAIL; 3 informational SKIP |

Python 3.14.7 with pandas 3.0.1 fails the existing
`tests/test_bulk.py::TestParseManyToDataframe::test_match_path_column_is_string`
assertion (`dtype == object`); pandas instead returns its default string dtype.
No assertion or production dependency was changed to hide this failure. This
blocks a compatibility recommendation for E, even though its parser JSON
matches. Pandas documents this behavior in its
[3.0 release notes](https://pandas.pydata.org/docs/whatsnew/v3.0.0.html#dedicated-string-data-type-by-default).
The current lock also selects pandas 3.0.1 on Python 3.11–3.13. Passing B/C/D
checks with common pandas 2.3.3 pins do not validate those native-lock
environments, and this failure is not established as a CPython 3.14 defect.

The 36 fewer generated tests on Python 3.11+ result from `IntFlag` iteration:
`list(EntityOp)` yields five atomic members there, versus nine named members
on 3.10. The named-member overlap parametrization therefore changes from
9×9 to 9×5 cases. The exhaustive 32×32 mask check still runs on every runtime;
no tests were deleted.

Every pytest run has the same three skips: optional pyarrow coverage
(`tests/test_bulk.py:250`), an optional Parquet engine
(`tests/test_parquet_export.py:56`), and the existing optimized-away flag case
(`tests/test_field_decoder.py:208`). Fast selection deselects 62 marked tests;
offline selection deselects only the live network test. Full parity uses the
existing references for 8868259993, 8860187335, and 8856501050 with unchanged
thresholds (325, 326, and 331 passing fields per runtime). Each replay reports
one informational `teamfights/total_count` skip for the expanded OpenDota
pipeline's deaths≥3 convention. No required local fixtures were missing.

Validation timings are not parser performance measurements. Initial untimed
metadata/fast checks overlapped, as did baseline offline/parity checks; all
were stopped before the timing matrix began. Subsequent compatibility checks
ran concurrently across separate runtime environments, only after all timed measurements finished. Their elapsed durations include contention and should not be compared as runtime benchmarks.

Repository Ruff lint, format-check (156 files), mypy (88 source files), and the final documentation build passed. Generated API-reference files were restored to keep the approved three-file scope. VitePress emitted its existing bundle-size warning. The PR's CI and distribution build run unchanged; PyPI publishing is intentionally skipped on a PR. Latest-head CI is checked before marking ready.

## Complete reproduction evidence

These notes preserve exact environment/bootstrap commands, complete benchmark and validation scripts, common/native constraints, every installed package manifest and production wheel provenance, all individual/median measurements and host-load observations, output hashes, and skip details. Runtime artifacts are the verified [Astral 20260901 builds](https://github.com/astral-sh/python-build-standalone/releases/tag/20260901). The [pandas 3 release notes](https://pandas.pydata.org/docs/whatsnew/v3.0.0.html#dedicated-string-data-type-by-default) explain the observed string-dtype change.

- [Runtime study evidence 1: Reproduction commands and complete scripts](https://github.com/whanyu1212/gem-dota/pull/179#issuecomment-5564141791)
- [Runtime study evidence 2: Primary measurements and host load](https://github.com/whanyu1212/gem-dota/pull/179#issuecomment-5564142377)
- [Runtime study evidence 3: Fixed follow-up measurements](https://github.com/whanyu1212/gem-dota/pull/179#issuecomment-5564142779)
- [Runtime study evidence 4: Python 3.10.21 manifests and wheel provenance](https://github.com/whanyu1212/gem-dota/pull/179#issuecomment-5564143128)
- [Runtime study evidence 5: Python 3.11.16 manifests and wheel provenance](https://github.com/whanyu1212/gem-dota/pull/179#issuecomment-5564143429)
- [Runtime study evidence 6: Python 3.12.14 manifests and wheel provenance](https://github.com/whanyu1212/gem-dota/pull/179#issuecomment-5564143733)
- [Runtime study evidence 7: Python 3.13.15 manifests and wheel provenance](https://github.com/whanyu1212/gem-dota/pull/179#issuecomment-5564144030)
- [Runtime study evidence 8: Python 3.14.7 manifests and wheel provenance](https://github.com/whanyu1212/gem-dota/pull/179#issuecomment-5564144341)
- [Runtime study evidence 9: Validation, environment, and compatibility evidence](https://github.com/whanyu1212/gem-dota/pull/179#issuecomment-5564188815)
- [Runtime study evidence 10: Report asset provenance (1–280)](https://github.com/whanyu1212/gem-dota/pull/179#issuecomment-5564144747)
- [Runtime study evidence 11: Report asset provenance (281–553)](https://github.com/whanyu1212/gem-dota/pull/179#issuecomment-5564145093)

Temporary runtimes, environments, scripts, wheels, and generated benchmark outputs are removed after publication and CI verification. Existing project environments, tools, fixtures, and icon caches are preserved.
