### PR TITLE
Bound memory during batch Parquet export.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Bound outstanding replay results during batch Parquet export and release each match after writing. Parquet export now documents a cooperative batch deadline, including writing, and preserves partial outputs on failure.
+
+
 ### Changed
 - **Parser record compatibility study.** Evaluate slotted records and document
   their memory tradeoffs while retaining public dataclass dictionaries, dynamic

--- a/docs/guides/09_cli.md
+++ b/docs/guides/09_cli.md
@@ -131,6 +131,21 @@ python -m gem batch replays/ --format parquet --output ./out
 #     ...
 ```
 
+Parquet batch export writes completed replays serially in the parent process.
+At most one replay per worker is outstanding, including completed matches waiting
+for export. Slow writing applies backpressure instead of accumulating the batch.
+Memory still includes worker processes, in-flight matches, IPC buffers, and one
+match's complete DataFrame collection. Input and returned path metadata grow with
+batch size; lowering `--workers` reduces the in-flight match limit.
+
+For the Python API, `parse_many_to_parquet(..., timeout=seconds)` uses one
+cooperative batch deadline after path collection, including parsing and writing.
+Running parses and synchronous writes are not forcibly interrupted, so shutdown
+can exceed the deadline. Parse failures are skipped; executor failures, export
+errors, and timeouts propagate. Files already written, including partial exports,
+remain on disk after failure. Duplicate replay stems retain the existing serial
+overwrite behavior.
+
 ### Concatenated DataFrames
 
 `--format dataframe` concatenates each table across all parsed replays and writes one

--- a/docs/reference/batch.md
+++ b/docs/reference/batch.md
@@ -46,7 +46,7 @@ def parse_many(source: str | Path | Sequence[str | Path], *, workers: int | None
 
 Parse multiple replays in parallel and return a result per replay.
 
-Source: [src/gem/replays/batch.py:116](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/replays/batch.py#L116)
+Source: [src/gem/replays/batch.py:124](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/replays/batch.py#L124)
 
 ### `parse_many_to_dataframe`
 
@@ -56,7 +56,7 @@ def parse_many_to_dataframe(source: str | Path | Sequence[str | Path], *, worker
 
 Parse multiple replays and concatenate results into per-table DataFrames.
 
-Source: [src/gem/replays/batch.py:189](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/replays/batch.py#L189)
+Source: [src/gem/replays/batch.py:197](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/replays/batch.py#L197)
 
 ### `parse_many_to_parquet`
 
@@ -66,7 +66,7 @@ def parse_many_to_parquet(source: str | Path | Sequence[str | Path], output_dir:
 
 Parse multiple replays and write each to its own parquet subdirectory.
 
-Source: [src/gem/replays/batch.py:235](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/replays/batch.py#L235)
+Source: [src/gem/replays/batch.py:243](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/replays/batch.py#L243)
 
 ### Top-level classes
 
@@ -78,7 +78,7 @@ class ParseResult
 
 Outcome of parsing a single replay.
 
-Source: [src/gem/replays/batch.py:39](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/replays/batch.py#L39)
+Source: [src/gem/replays/batch.py:47](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/replays/batch.py#L47)
 
 #### Dataclass fields
 
@@ -96,4 +96,4 @@ Signature: `def ParseResult.ok(self) -> bool`
 
 Return ``True`` when parsing succeeded.
 
-Source: [src/gem/replays/batch.py:53](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/replays/batch.py#L53)
+Source: [src/gem/replays/batch.py:61](https://github.com/whanyu1212/gem-dota/blob/main/src/gem/replays/batch.py#L61)

--- a/src/gem/replays/batch.py
+++ b/src/gem/replays/batch.py
@@ -9,7 +9,7 @@ Provides three public functions:
   ``match_path`` column added for provenance).
 - :func:`parse_many_to_parquet` — parse-and-write each replay into its own
   subdirectory under ``output_dir``, one ``.parquet`` file per table.
-  Replays are processed and discarded one at a time to keep memory bounded.
+  Outstanding replays are bounded by the worker count and exported serially.
 
 All three functions use ``ProcessPoolExecutor`` for true parallelism (CPU-bound
 work) and display a Rich progress bar by default.
@@ -19,9 +19,17 @@ from __future__ import annotations
 
 import os
 from collections.abc import Sequence
-from concurrent.futures import Future, ProcessPoolExecutor, as_completed
+from concurrent.futures import (
+    FIRST_COMPLETED,
+    Future,
+    ProcessPoolExecutor,
+    TimeoutError,
+    as_completed,
+    wait,
+)
 from dataclasses import dataclass
 from pathlib import Path
+from time import monotonic
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -244,8 +252,11 @@ def parse_many_to_parquet(
 ) -> list[Path]:
     """Parse multiple replays and write each to its own parquet subdirectory.
 
-    Each replay is written and discarded immediately to keep memory usage
-    bounded regardless of batch size.  The output layout is::
+    At most one replay per worker is outstanding, including completed matches
+    waiting for the parent to export them. Full-match memory scales with this
+    limit and the largest in-flight matches, plus one export's DataFrame
+    collection and process/IPC buffers. Input and returned path metadata still
+    grow with batch size. The output layout is::
 
         output_dir/
           <replay_stem>/
@@ -259,25 +270,105 @@ def parse_many_to_parquet(
         workers: Number of worker processes (default: ``os.cpu_count()``).
         recursive: Scan subdirectories when *source* is a directory.
         progress: Show a Rich progress bar while parsing.
-        timeout: Per-replay timeout in seconds.
+        timeout: Cooperative batch deadline in seconds, including parsing and
+            writing after path collection. Running parses and synchronous writes
+            are not interrupted, so shutdown can exceed the deadline. ``None``
+            means no limit.
         index: Whether to include the DataFrame index in parquet output.
 
     Returns:
-        List of all parquet file paths written.
-    """
-    from gem import to_parquet
+        List of all parquet file paths written, grouped in completion-driven
+        replay order. Replays already ready together have no defined internal order.
 
-    results = parse_many(
-        source, workers=workers, recursive=recursive, progress=progress, timeout=timeout
+    Raises:
+        TimeoutError: If the batch deadline expires.
+        Exception: Executor or export failures propagate; ordinary parse failures
+            are skipped. Previously written and partially written files remain
+            after failure or timeout.
+    """
+    from rich.progress import (
+        BarColumn,
+        MofNCompleteColumn,
+        Progress,
+        TextColumn,
+        TimeElapsedColumn,
     )
 
+    from gem import to_parquet
+
+    paths = _collect_paths(source, recursive=recursive)
+    deadline = None if timeout is None else monotonic() + timeout
+    n_workers = min(workers or os.cpu_count() or 1, len(paths))
     out_root = Path(output_dir)
     written: list[Path] = []
+    rich_progress = (
+        Progress(
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TimeElapsedColumn(),
+        )
+        if progress
+        else None
+    )
 
-    for result in results:
-        if not result.ok or result.match is None:
-            continue
-        subdir = out_root / result.path.stem
-        written.extend(to_parquet(result.match, subdir, index=index))
+    def remaining() -> float | None:
+        if deadline is None:
+            return None
+        seconds = deadline - monotonic()
+        if seconds <= 0:
+            raise TimeoutError("Batch Parquet export timed out")
+        return seconds
 
+    def execute() -> None:
+        pending: set[Future[tuple[Path, ParsedMatch | None, Exception | None]]] = set()
+        done: set[Future[tuple[Path, ParsedMatch | None, Exception | None]]] = set()
+        sources = iter(paths)
+        pool = ProcessPoolExecutor(max_workers=n_workers)
+
+        def submit_next() -> None:
+            path = next(sources, None)
+            if path is not None:
+                remaining()
+                pending.add(pool.submit(_parse_one, path))
+
+        try:
+            for _ in range(n_workers):
+                submit_next()
+            while pending:
+                done = wait(pending, timeout=remaining(), return_when=FIRST_COMPLETED)[0]
+                remaining()
+                while done:
+                    future = done.pop()
+                    pending.remove(future)
+                    try:
+                        path, match, error = future.result()
+                        try:
+                            if rich_progress is not None:
+                                rich_progress.advance(task_id)
+                            if error is None and match is not None:
+                                remaining()
+                                written.extend(to_parquet(match, out_root / path.stem, index=index))
+                            remaining()
+                        finally:
+                            del match, error
+                    finally:
+                        del future
+                    # Refill only after exporting and releasing the completed result.
+                    submit_next()
+        finally:
+            try:
+                pool.shutdown(wait=True, cancel_futures=True)
+            finally:
+                done.clear()
+                pending.clear()
+
+    if rich_progress is not None:
+        with rich_progress:
+            task_id = rich_progress.add_task(
+                f"[cyan]Parsing {len(paths)} replay(s)…[/cyan]", total=len(paths)
+            )
+            execute()
+    else:
+        execute()
     return written

--- a/tests/test_batch_parquet_bounded.py
+++ b/tests/test_batch_parquet_bounded.py
@@ -1,0 +1,299 @@
+"""Scheduling and lifetime regressions for bounded batch Parquet export."""
+
+from __future__ import annotations
+
+import gc
+import multiprocessing
+import weakref
+from concurrent.futures import Future, ProcessPoolExecutor, TimeoutError
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import gem
+from gem.replays import batch
+from gem.results.models import ParsedMatch
+
+
+class ControlledPool:
+    def __init__(self, max_workers):
+        self.max_workers = max_workers
+        self.jobs = {}
+        self.submitted = []
+        self.closed = False
+        self.on_submit = lambda path: None
+
+    def submit(self, fn, path):
+        self.on_submit(path)
+        future = Future()
+        self.jobs[path] = future
+        self.submitted.append(path)
+        return future
+
+    def complete(self, path, error=None):
+        future = self.jobs.pop(path)
+        future.set_result((path, None if error else ParsedMatch(match_id=int(path.stem)), error))
+        return future
+
+    def shutdown(self, *, wait, cancel_futures):
+        assert wait and cancel_futures
+        self.closed = True
+        for future in self.jobs.values():
+            future.cancel()
+        self.jobs.clear()
+
+
+@pytest.fixture
+def scheduler(monkeypatch):
+    pools = []
+
+    def create(max_workers):
+        pool = ControlledPool(max_workers)
+        pools.append(pool)
+        return pool
+
+    monkeypatch.setattr(batch, "ProcessPoolExecutor", create)
+    return pools
+
+
+def test_slow_writer_bounds_work_and_releases_results(monkeypatch, tmp_path, scheduler):
+    paths = [Path(f"{i}.dem") for i in range(7)]
+    exported = []
+    matches = []
+
+    def wait(futures, **kwargs):
+        pool = scheduler[0]
+        assert len(futures) <= 2
+        # Complete the later submission first; no input-order blocking.
+        path = list(pool.jobs)[-1]
+        completed = pool.complete(path)
+        return {completed}, set(futures) - {completed}
+
+    def export(match, output, *, index):
+        pool = scheduler[0]
+        assert index
+        assert len(pool.submitted) - len(exported) == 2 or len(pool.submitted) == len(paths)
+        assert match.match_id == int(output.name)
+        matches.append(weakref.ref(match))
+        # While the writer is busy, every remaining parse can complete. There
+        # must still be no submission beyond the original bounded window.
+        for path in list(pool.jobs):
+            pool.complete(path)
+        exported.append(match.match_id)
+        return [output / "match.parquet"]
+
+    def check_released(path):
+        gc.collect()
+        assert all(ref() is None for ref in matches)
+
+    def next_completion(futures, **kwargs):
+        pool = scheduler[0]
+        pool.on_submit = check_released
+        ready = {f for f in futures if f.done()}
+        return (ready, set(futures) - ready) if ready else wait(futures, **kwargs)
+
+    monkeypatch.setattr(batch, "wait", next_completion)
+    monkeypatch.setattr(gem, "to_parquet", export)
+    written = gem.parse_many_to_parquet(paths, tmp_path, workers=2, progress=False, index=True)
+    assert exported[0] == 1
+    assert sorted(exported) == list(range(7))
+    assert written == [tmp_path / str(i) / "match.parquet" for i in exported]
+    assert scheduler[0].closed
+    gc.collect()
+    assert all(ref() is None for ref in matches)
+
+
+@pytest.mark.parametrize("failure", ["parse", "future", "export", "submit", "interrupt"])
+def test_failures_and_cleanup(monkeypatch, tmp_path, scheduler, failure):
+    paths = [Path(f"{i}.dem") for i in range(5)]
+    exported = []
+    marker = tmp_path / "partial.parquet"
+
+    def wait(futures, **kwargs):
+        pool = scheduler[0]
+        path = next(iter(pool.jobs))
+        if failure == "future":
+            future = pool.jobs.pop(path)
+            future.set_exception(RuntimeError("worker transport"))
+        else:
+            future = pool.complete(
+                path, ValueError("bad replay") if path.stem == "0" and failure == "parse" else None
+            )
+        if failure == "submit":
+
+            def fail(path):
+                raise RuntimeError("submission")
+
+            pool.on_submit = fail
+        return {future}, set()
+
+    def export(match, output, *, index):
+        marker.write_text("partial")
+        exported.append(match.match_id)
+        if failure == "export":
+            raise OSError("disk failure")
+        if failure == "interrupt":
+            raise KeyboardInterrupt()
+        return [output / "match.parquet"]
+
+    monkeypatch.setattr(batch, "wait", wait)
+    monkeypatch.setattr(gem, "to_parquet", export)
+    if failure == "parse":
+        written = gem.parse_many_to_parquet(paths, tmp_path, workers=2, progress=False)
+        assert exported == [1, 2, 3, 4]
+        assert len(written) == 4
+    else:
+        expected = {
+            "future": RuntimeError,
+            "export": OSError,
+            "submit": RuntimeError,
+            "interrupt": KeyboardInterrupt,
+        }[failure]
+        with pytest.raises(expected):
+            gem.parse_many_to_parquet(paths, tmp_path, workers=2, progress=False)
+        assert len(scheduler[0].submitted) == 2
+        assert marker.exists() == (failure != "future")
+    assert scheduler[0].closed
+    assert not scheduler[0].jobs
+
+
+@pytest.mark.parametrize("where", ["initial", "wait", "write", "final_write"])
+def test_cooperative_deadline(monkeypatch, tmp_path, scheduler, where):
+    clock = [0.0]
+    monkeypatch.setattr(batch, "monotonic", lambda: clock[0])
+    paths = [Path(f"{i}.dem") for i in range(1 if where == "final_write" else 4)]
+    marker = tmp_path / "written.parquet"
+
+    def wait(futures, *, timeout, return_when):
+        assert timeout == 10.0
+        if where == "wait":
+            clock[0] = 10.0
+            return set(), set(futures)
+        pool = scheduler[0]
+        return {pool.complete(next(iter(pool.jobs)))}, set()
+
+    def export(match, output, *, index):
+        marker.write_text("complete")
+        clock[0] = 11.0
+        return [marker]
+
+    monkeypatch.setattr(batch, "wait", wait)
+    monkeypatch.setattr(gem, "to_parquet", export)
+    with pytest.raises(TimeoutError, match="Batch Parquet export timed out"):
+        gem.parse_many_to_parquet(
+            paths, tmp_path, workers=2, progress=False, timeout=0 if where == "initial" else 10
+        )
+    assert marker.exists() == (where in {"write", "final_write"})
+    assert len(scheduler[0].submitted) == (0 if where == "initial" else min(2, len(paths)))
+    assert scheduler[0].closed
+
+
+@pytest.mark.parametrize("progress", [False, True])
+def test_progress_and_parse_failure(monkeypatch, tmp_path, scheduler, progress):
+    events = []
+
+    class Progress:
+        def __init__(self, *args):
+            pass
+
+        def __enter__(self):
+            events.append("enter")
+            return self
+
+        def __exit__(self, *args):
+            events.append("exit")
+
+        def add_task(self, description, *, total):
+            assert total == 2
+            return 7
+
+        def advance(self, task_id):
+            assert task_id == 7
+            events.append("advance")
+
+    def wait(futures, **kwargs):
+        pool = scheduler[0]
+        return {pool.complete(next(iter(pool.jobs)), ValueError("corrupt"))}, set()
+
+    monkeypatch.setattr("rich.progress.Progress", Progress)
+    monkeypatch.setattr(batch, "wait", wait)
+    assert (
+        gem.parse_many_to_parquet(["0.dem", "1.dem"], tmp_path, workers=8, progress=progress) == []
+    )
+    assert scheduler[0].max_workers == 2
+    assert events == (["enter", "advance", "advance", "exit"] if progress else [])
+
+
+def test_empty_input_keeps_executor_validation(tmp_path):
+    with pytest.raises(ValueError, match="max_workers must be greater than 0"):
+        gem.parse_many_to_parquet([], tmp_path, progress=False)
+
+
+@pytest.mark.parametrize("index", [False, True])
+def test_spawned_parquet_roundtrip(tmp_path, monkeypatch, index):
+    pytest.importorskip("pyarrow")
+    replay = Path(__file__).parent / "fixtures/ti14_finals_g3_xg_vs_falcons_truncated.dem"
+    source = tmp_path / "inputs"
+    source.mkdir()
+    (source / "nested").mkdir()
+    for path in [source / "first.dem", source / "nested/second.dem"]:
+        path.symlink_to(replay.resolve())
+    monkeypatch.setattr(
+        batch,
+        "ProcessPoolExecutor",
+        lambda **kw: ProcessPoolExecutor(mp_context=multiprocessing.get_context("spawn"), **kw),
+    )
+    expected = gem.to_parquet(gem.parse(replay), tmp_path / "expected", index=index)
+    written = gem.parse_many_to_parquet(
+        source, tmp_path / "actual", workers=1, recursive=True, progress=False, index=index
+    )
+    assert {p.parent.name for p in written} == {"first", "second"}
+    assert len(written) == 2 * len(expected)
+    for p in written:
+        pd.testing.assert_frame_equal(
+            pd.read_parquet(p), pd.read_parquet(tmp_path / "expected" / p.name)
+        )
+
+
+def test_failure_traceback_releases_other_results(monkeypatch, tmp_path, scheduler):
+    refs = []
+
+    def wait(futures, **kwargs):
+        pool = scheduler[0]
+        first = pool.complete(Path("0.dem"))
+        second = pool.complete(Path("1.dem"))
+        refs.append(weakref.ref(second.result()[1]))
+        return {first}, {second}
+
+    def export(match, output, *, index):
+        raise OSError("write failed")
+
+    monkeypatch.setattr(batch, "wait", wait)
+    monkeypatch.setattr(gem, "to_parquet", export)
+    with pytest.raises(OSError) as caught:
+        gem.parse_many_to_parquet(["0.dem", "1.dem"], tmp_path, workers=2, progress=False)
+    assert caught.value.__traceback__ is not None
+    gc.collect()
+    assert refs[0]() is None
+
+
+def test_duplicate_stems_still_write_serially(monkeypatch, tmp_path, scheduler):
+    paths = [Path("a/0.dem"), Path("b/0.dem"), Path("c/1.dem")]
+    outputs = []
+
+    def wait(futures, **kwargs):
+        pool = scheduler[0]
+        return {pool.complete(next(iter(pool.jobs)))}, set()
+
+    def export(match, output, *, index):
+        outputs.append(output)
+        return [output / "one.parquet", output / "two.parquet"]
+
+    monkeypatch.setattr(batch, "wait", wait)
+    monkeypatch.setattr(gem, "to_parquet", export)
+    written = gem.parse_many_to_parquet(paths, tmp_path, workers=2, progress=False)
+    assert outputs == [tmp_path / "0", tmp_path / "0", tmp_path / "1"]
+    assert written == [
+        output / name for output in outputs for name in ["one.parquet", "two.parquet"]
+    ]

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -31,6 +31,9 @@ class _SyncExecutor:
     def __exit__(self, *args):
         pass
 
+    def shutdown(self, *, wait=True, cancel_futures=False):
+        pass
+
     def submit(self, fn, *args, **kwargs):
         future: concurrent.futures.Future = concurrent.futures.Future()
         try:


### PR DESCRIPTION
## Summary

Closes #169.

Batch Parquet export previously retained every parsed match before writing any output. This change limits outstanding replays to one per effective worker, exports completed matches serially in the parent, and releases their future/result references before submitting replacement work. A slow writer applies backpressure. `parse_many()` and `parse_many_to_dataframe()` retain their existing behavior.

Full-match retention now scales with the worker limit and largest in-flight matches, plus one export's complete DataFrame collection and process/IPC overhead. Input paths and returned paths still grow with batch size; this is not a constant-total-RSS guarantee.

## Compatibility and failure behavior

- Preserve per-match tables/path order, `index`, recursive discovery, worker capping, ordinary parse-failure skipping, and serial duplicate-stem overwrite behavior. Processing is completion-driven; already-ready replays have no defined internal order.
- Use the approved cooperative batch deadline after path collection, including interleaved writes. Check before submissions/exports, after exports and while waiting. Running parses and synchronous writes cannot be forcibly interrupted, so shutdown can exceed the deadline.
- Propagate executor/export failures and interruptions, cancel unstarted work, wait for running workers, clear pending references and close progress. Previously written and partially written files remain.
- Reference inspection of Manta/Clarity replay execution and OpenDota output assembly supports preserving parsing/export semantics; these references do not define Gem's scheduling. Cancellation and waiting shutdown follow [Python's executor lifecycle](https://docs.python.org/3.10/library/concurrent.futures.html#concurrent.futures.Executor.shutdown).

No production changes outside `replays/batch.py`, dependencies, lockfile, public signatures, test tiers or CI configuration changes.

## Validation

- Focused batch/Parquet: **37 passed**, including real spawned workers and PyArrow round trips with both index settings; bounded-scheduler tests rerun after review corrections: **17 passed**.
- Fast suite: **3,897 passed, 1 skipped, 62 deselected**.
- All offline: **3,958 passed, 1 skipped, 1 deselected**. Only skip: decoder flag optimised away for the tested range. Live draft test intentionally excluded; no missing local replay fixture or engine-related skip.
- Ruff lint/format, mypy and documentation build passed. Existing documentation chunk-size advisory remains. CI and distribution build passed; PR PyPI publishing intentionally skipped.
- All **18 real batch runs / 126 exports / 2,520 tables** completed and matched baseline exactly, including normalized returned-path inventories. Every corresponding Parquet file happened to be byte-identical; exact logical comparison is available when bytes differ.
- Independent synthetic instrumentation with 12 inputs and two workers: peak live matches and unexported work **12 → 2**; exported candidate matches were collectible before refill. Controlled asynchronous tests cover slow writing, completion order, exceptions, timeout and traceback-held references.

## Measurements and limitations

Three sequential fresh-process pairs per batch size, B/C, C/B, B/C; two workers, progress off, timeout none, index false. Same CPython 3.10.4/macOS arm64 host, dependencies and repeated short/medium/long replay groups.

| Replays | Median elapsed, baseline → candidate | Median parent peak RSS | Parent change |
|---|---:|---:|---:|
| 3 | 384.56 → 336.16 s | 3.194 → 2.652 GiB | -17.0% |
| 6 | 565.27 → 556.10 s | 3.918 → 3.323 GiB | -15.2% |
| 12 | 1,442.22 → 2,035.79 s | 4.373 → 3.394 GiB | -22.4% |

The 12-replay elapsed median was **41.2% longer** and pair directions were mixed under substantial host contention. The observations do not isolate the scheduling cost or demonstrate absence of a throughput regression. Backpressure can reduce parse/write overlap. A quiet paired follow-up is needed to quantify that cost; no end-to-end speedup is claimed. All individual measurements, ranges, aggregate RSS, load and power observations are preserved below.

The unchanged full-replay baseline failed under PyArrow 21.0.0 on an empty `ability_targets` struct. Accepted full-replay measurements/comparisons use the already-supported Fastparquet 2024.11.0 engine for both revisions; production engine selection and serialization remain unchanged. PyArrow passed the focused truncated-replay tests. This existing serialization limitation is outside #169.

## Reproduction and evidence

- [Complete bootstrap, benchmark, comparison and lifetime scripts](https://github.com/whanyu1212/gem-dota/pull/181#issuecomment-5569933255)
- [Exact validation commands, skips, package manifests and wheel provenance](https://github.com/whanyu1212/gem-dota/pull/181#issuecomment-5572897812)
- [All measurements, medians, raw observations, fixture/output hashes and interpretation](https://github.com/whanyu1212/gem-dota/pull/181#issuecomment-5572954464)

Worker-side export, public streaming APIs, collision-policy changes and Rust profiling remain deferred.
