### PR TITLE
Prepare v0.8.0: parser performance and bounded batch export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-09-08
+
+Reduces parser lookup, decoding, and sampling overhead and bounds outstanding
+replay results during batch Parquet export. Public APIs, result models, and
+Python 3.10+ support remain unchanged.
+
 ### Fixed
 
 - Bound outstanding replay results during batch Parquet export and release each match after writing. Parquet export now documents a cooperative batch deadline, including writing, and preserves partial outputs on failure.
-
 
 ### Changed
 - **Parser record compatibility study.** Evaluate slotted records and document
@@ -41,6 +46,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Lower entity-operation check overhead.** `EntityOp.has()` checks flag values
   directly, avoiding `IntFlag` operation overhead in extractor callbacks while
   preserving overlap semantics and integer-mask compatibility.
+
+### Compatibility and known limitations
+
+- **Batch Parquet timeout.** `parse_many_to_parquet()` uses one cooperative
+  deadline covering parsing and interleaved writing after path collection.
+  Running parses and synchronous writes are not forcibly interrupted; cleanup
+  can exceed the deadline and partial outputs remain on failure. Other batch
+  APIs retain their existing timeout behavior.
+- **Existing PyArrow limitation.** Full-replay export with PyArrow 21.0.0 can
+  fail on an empty `ability_targets` struct. The batch-memory study used the
+  supported Fastparquet engine for both revisions; this release does not change
+  engine selection or resolve that serialization limitation.
+- **Performance scope.** Improvements depend on workload and environment.
+  Large-batch throughput measurements were inconclusive under host contention;
+  bounded result retention does not imply constant total RSS or a guaranteed
+  throughput improvement. See the [parser performance studies](docs/deep-dives/parser-performance.md)
+  and [batch-export measurements](https://github.com/whanyu1212/gem-dota/pull/181#issuecomment-5572954464).
 
 ## [0.7.1] - 2026-09-04
 
@@ -687,7 +709,8 @@ combat-log layers. The supported top-level API (`gem.parse`, `gem.ParsedMatch`,
 - CLI and example scripts, including HTML match report.
 - Validation, fuzzing, and parser robustness foundations.
 
-[Unreleased]: https://github.com/whanyu1212/gem-dota/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/whanyu1212/gem-dota/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/whanyu1212/gem-dota/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/whanyu1212/gem-dota/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/whanyu1212/gem-dota/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/whanyu1212/gem-dota/compare/v0.5.1...v0.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gem-dota"
-version = "0.7.1"
+version = "0.8.0"
 description = "Dota 2 Source 2 replay parser for data science and ML workflows"
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -448,7 +448,7 @@ wheels = [
 
 [[package]]
 name = "gem-dota"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "ipykernel" },


### PR DESCRIPTION
## Summary

Prepare **0.8.0 — Parser performance and bounded batch export** from merged main (`aeb4838`). Move the accumulated optimization, runtime-guidance, test-fixture and batch-export entries into the dated release section, retain an empty Unreleased section, and update changelog comparison links.

Set the project version to 0.8.0 in `pyproject.toml` and its own `uv.lock` record. No dependency versions, production code or public APIs change. Python 3.10+ remains supported.

Release notes explicitly describe the cooperative Parquet batch deadline, partial-output behavior, existing PyArrow empty-struct limitation, and inconclusive large-batch throughput measurements. They do not promise a universal speedup.

## Validation

- `uv lock --offline`: only Gem's version changed.
- `uv run ruff check src tests examples scripts`: passed.
- `uv run ruff format --check src/ tests/`: 158 files passed.
- `uv run mypy src/gem/`: 88 files passed.
- `uv run pytest -q`: **3,893 passed, 5 skipped, 62 deselected** in 7.98 seconds. Four skips require optional Parquet support; one is the existing decoder flag optimization skip.
- `uv build`: wheel and sdist built successfully.
- `uvx twine check dist/gem_dota-0.8.0*`: both passed.
- Wheel import/public API smoke, packaged data presence, wheel/sdist version and Python requirement checks passed.
- The unchanged production tree already passed **3,958 offline tests with one decoder skip**, plus real optional-engine tests and 2,520 output comparisons in [#181](https://github.com/whanyu1212/gem-dota/pull/181). Those expensive checks were not repeated for this metadata-only change.

## Publication

This PR prepares the release; no `v0.8.0` tag or published release has been created. After merge, tag the verified release commit and push the tag to trigger the existing PyPI workflow, then publish the GitHub release using the 0.8.0 changelog. The release script is not run here because it creates the release commit/tag immediately; equivalent version, lock, check and build steps were performed for review first.
